### PR TITLE
Improve some lexer error messages

### DIFF
--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -1366,31 +1366,45 @@ renderParseErrors s = \case
             <> style ErrorSite (fromString open)
             <> ".\n\n"
             <> excerpt
-        L.InvalidWordyId _id ->
+        L.InvalidWordyId id ->
           Pr.lines
-            [ "This identifier isn't valid syntax: ",
+            [ "The identifier " <> style Code id <> " isn't valid syntax: ",
               "",
               excerpt,
               "Here's a few examples of valid syntax: "
-                <> style Code "abba1', snake_case, Foo.zoink!, 🌻"
+                <> style Code "abba1'"
+                <> ", "
+                <> style Code "snake_case"
+                <> ", "
+                <> style Code "Foo.zoink!"
+                <> ", and "
+                <> style Code "🌻"
             ]
-        L.ReservedWordyId _id ->
+        L.ReservedWordyId id ->
           Pr.lines
-            [ "The identifier used here isn't allowed to be a reserved keyword: ",
-              "",
-              excerpt
-            ]
-        L.InvalidSymbolyId _id ->
-          Pr.lines
-            [ "This infix identifier isn't valid syntax: ",
+            [ "The identifier " <> style Code id <> " used here is a reserved keyword: ",
               "",
               excerpt,
-              "Here's a few valid examples: "
-                <> style Code "++, Float./, `List.map`"
+              Pr.wrap $
+                "You can avoid this problem either by renaming the identifier or wrapping it in backticks (like "
+                  <> style Code ("`" <> id <> "`")
+                  <> ")."
             ]
-        L.ReservedSymbolyId _id ->
+        L.InvalidSymbolyId id ->
           Pr.lines
-            [ "This identifier is reserved by Unison and can't be used as an operator: ",
+            [ "The infix identifier " <> style Code id <> " isn’t valid syntax: ",
+              "",
+              excerpt,
+              "Here are a few valid examples: "
+                <> style Code "++"
+                <> ", "
+                <> style Code "Float./"
+                <> ", and "
+                <> style Code "`List.map`"
+            ]
+        L.ReservedSymbolyId id ->
+          Pr.lines
+            [ "The identifier " <> style Code id <> " is reserved by Unison and can't be used as an operator: ",
               "",
               excerpt
             ]

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -126,6 +126,10 @@ styleAnnotated sty a = (,sty) <$> rangeForAnnotated a
 style :: s -> String -> Pretty (AnnotatedText s)
 style sty str = Pr.lit . AT.annotate sty $ fromString str
 
+-- | Applies the color highlighting for `Code`, but also quotes the code, to separate it from the containing context.
+quoteCode :: String -> Pretty ColorText
+quoteCode = Pr.backticked . style Code
+
 stylePretty :: Color -> Pretty ColorText -> Pretty ColorText
 stylePretty = Pr.map . AT.annotate
 
@@ -1368,21 +1372,21 @@ renderParseErrors s = \case
             <> excerpt
         L.InvalidWordyId id ->
           Pr.lines
-            [ "The identifier " <> style Code id <> " isn't valid syntax: ",
+            [ "The identifier, " <> quoteCode id <> ", isn't valid syntax: ",
               "",
               excerpt,
               "Here's a few examples of valid syntax: "
-                <> style Code "abba1'"
+                <> quoteCode "abba1'"
                 <> ", "
-                <> style Code "snake_case"
+                <> quoteCode "snake_case"
                 <> ", "
-                <> style Code "Foo.zoink!"
+                <> quoteCode "Foo.zoink!"
                 <> ", and "
-                <> style Code "🌻"
+                <> quoteCode "🌻"
             ]
         L.ReservedWordyId id ->
           Pr.lines
-            [ "The identifier " <> style Code id <> " used here is a reserved keyword: ",
+            [ "The identifier, " <> quoteCode id <> ", used here is a reserved keyword: ",
               "",
               excerpt,
               Pr.wrap $
@@ -1392,19 +1396,19 @@ renderParseErrors s = \case
             ]
         L.InvalidSymbolyId id ->
           Pr.lines
-            [ "The infix identifier " <> style Code id <> " isn’t valid syntax: ",
+            [ "The infix identifier, " <> quoteCode id <> ", isn’t valid syntax: ",
               "",
               excerpt,
               "Here are a few valid examples: "
-                <> style Code "++"
+                <> quoteCode "++"
                 <> ", "
-                <> style Code "Float./"
+                <> quoteCode "Float./"
                 <> ", and "
-                <> style Code "`List.map`"
+                <> quoteCode "List.map"
             ]
         L.ReservedSymbolyId id ->
           Pr.lines
-            [ "The identifier " <> style Code id <> " is reserved by Unison and can't be used as an operator: ",
+            [ "The identifier, " <> quoteCode id <> ", is reserved by Unison and can't be used as an operator: ",
               "",
               excerpt
             ]
@@ -1458,11 +1462,12 @@ renderParseErrors s = \case
               "",
               excerpt,
               Pr.wrap $
-                "I was expecting some digits after the '.',"
-                  <> "for example: "
-                  <> style Code (n <> "0")
+                "I was expecting some digits after the "
+                  <> quoteCode "."
+                  <> ", for example: "
+                  <> quoteCode (n <> "0")
                   <> "or"
-                  <> Pr.group (style Code (n <> "1e37") <> ".")
+                  <> Pr.group (quoteCode (n <> "1e37") <> ".")
             ]
         L.MissingExponent n ->
           Pr.lines
@@ -1472,7 +1477,7 @@ renderParseErrors s = \case
               Pr.wrap $
                 "I was expecting some digits for the exponent,"
                   <> "for example: "
-                  <> Pr.group (style Code (n <> "37") <> ".")
+                  <> Pr.group (quoteCode (n <> "37") <> ".")
             ]
         L.TextLiteralMissingClosingQuote _txt ->
           Pr.lines
@@ -1488,7 +1493,7 @@ renderParseErrors s = \case
               "",
               "I only know about the following escape characters:",
               "",
-              let s ch = style Code (fromString $ "\\" <> [ch])
+              let s ch = quoteCode (fromString $ "\\" <> [ch])
                in Pr.indentN 2 $ intercalateMap "," s (fst <$> L.escapeChars)
             ]
         L.LayoutError ->
@@ -1719,7 +1724,7 @@ renderParseErrors s = \case
           let msg =
                 mconcat
                   [ "This looks like the start of an expression here but I was expecting a binding.",
-                    "\nDid you mean to use a single " <> style Code ":",
+                    "\nDid you mean to use a single " <> quoteCode ":",
                     " here for a type signature?",
                     "\n\n",
                     tokenAsErrorSite s t

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -1370,20 +1370,6 @@ renderParseErrors s = \case
             <> style ErrorSite (fromString open)
             <> ".\n\n"
             <> excerpt
-        L.InvalidWordyId id ->
-          Pr.lines
-            [ "The identifier, " <> quoteCode id <> ", isn't valid syntax: ",
-              "",
-              excerpt,
-              "Here's a few examples of valid syntax: "
-                <> quoteCode "abba1'"
-                <> ", "
-                <> quoteCode "snake_case"
-                <> ", "
-                <> quoteCode "Foo.zoink!"
-                <> ", and "
-                <> quoteCode "🌻"
-            ]
         L.ReservedWordyId id ->
           Pr.lines
             [ "The identifier, " <> quoteCode id <> ", used here is a reserved keyword: ",

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -1372,7 +1372,7 @@ renderParseErrors s = \case
             <> excerpt
         L.ReservedWordyId id ->
           Pr.lines
-            [ "The identifier, " <> quoteCode id <> ", used here is a reserved keyword: ",
+            [ "The identifier " <> quoteCode id <> " used here is a reserved keyword: ",
               "",
               excerpt,
               Pr.wrap $
@@ -1382,7 +1382,7 @@ renderParseErrors s = \case
             ]
         L.InvalidSymbolyId id ->
           Pr.lines
-            [ "The infix identifier, " <> quoteCode id <> ", isn’t valid syntax: ",
+            [ "The infix identifier " <> quoteCode id <> " isn’t valid syntax: ",
               "",
               excerpt,
               "Here are a few valid examples: "
@@ -1394,7 +1394,7 @@ renderParseErrors s = \case
             ]
         L.ReservedSymbolyId id ->
           Pr.lines
-            [ "The identifier, " <> quoteCode id <> ", is reserved by Unison and can't be used as an operator: ",
+            [ "The identifier " <> quoteCode id <> " is reserved by Unison and can't be used as an operator: ",
               "",
               excerpt
             ]

--- a/unison-src/transcripts/error-messages.output.md
+++ b/unison-src/transcripts/error-messages.output.md
@@ -19,8 +19,8 @@ x = 1. -- missing some digits after the decimal
   
       1 | x = 1. -- missing some digits after the decimal
   
-  I was expecting some digits after the '.', for example: 1.0 or
-  1.1e37.
+  I was expecting some digits after the `.` , for example: `1.0`
+  or `1.1e37`.
 
 ```
 ```unison
@@ -36,7 +36,7 @@ x = 1e -- missing an exponent
       1 | x = 1e -- missing an exponent
   
   I was expecting some digits for the exponent, for example:
-  1e37.
+  `1e37`.
 
 ```
 ```unison
@@ -52,7 +52,7 @@ x = 1e- -- missing an exponent
       1 | x = 1e- -- missing an exponent
   
   I was expecting some digits for the exponent, for example:
-  1e-37.
+  `1e-37`.
 
 ```
 ```unison
@@ -68,7 +68,7 @@ x = 1E+ -- missing an exponent
       1 | x = 1E+ -- missing an exponent
   
   I was expecting some digits for the exponent, for example:
-  1e+37.
+  `1e+37`.
 
 ```
 ### Hex, octal, and bytes literals
@@ -343,7 +343,7 @@ use.keyword.in.namespace = 1
 
   Loading changes detected in scratch.u.
 
-  The identifier namespace used here is a reserved keyword: 
+  The identifier, `namespace`, used here is a reserved keyword: 
   
       1 | use.keyword.in.namespace = 1
   

--- a/unison-src/transcripts/error-messages.output.md
+++ b/unison-src/transcripts/error-messages.output.md
@@ -343,10 +343,12 @@ use.keyword.in.namespace = 1
 
   Loading changes detected in scratch.u.
 
-  The identifier used here isn't allowed to be a reserved keyword: 
+  The identifier namespace used here is a reserved keyword: 
   
       1 | use.keyword.in.namespace = 1
   
+  You can avoid this problem either by renaming the identifier
+  or wrapping it in backticks (like `namespace` ).
 
 ```
 ```unison

--- a/unison-src/transcripts/error-messages.output.md
+++ b/unison-src/transcripts/error-messages.output.md
@@ -343,7 +343,7 @@ use.keyword.in.namespace = 1
 
   Loading changes detected in scratch.u.
 
-  The identifier, `namespace`, used here is a reserved keyword: 
+  The identifier `namespace` used here is a reserved keyword: 
   
       1 | use.keyword.in.namespace = 1
   

--- a/unison-src/transcripts/generic-parse-errors.output.md
+++ b/unison-src/transcripts/generic-parse-errors.output.md
@@ -30,10 +30,12 @@ namespace.blah = 1
 
   Loading changes detected in scratch.u.
 
-  The identifier used here isn't allowed to be a reserved keyword: 
+  The identifier namespace used here is a reserved keyword: 
   
       1 | namespace.blah = 1
   
+  You can avoid this problem either by renaming the identifier
+  or wrapping it in backticks (like `namespace` ).
 
 ```
 ```unison

--- a/unison-src/transcripts/generic-parse-errors.output.md
+++ b/unison-src/transcripts/generic-parse-errors.output.md
@@ -30,7 +30,7 @@ namespace.blah = 1
 
   Loading changes detected in scratch.u.
 
-  The identifier, `namespace`, used here is a reserved keyword: 
+  The identifier `namespace` used here is a reserved keyword: 
   
       1 | namespace.blah = 1
   

--- a/unison-src/transcripts/generic-parse-errors.output.md
+++ b/unison-src/transcripts/generic-parse-errors.output.md
@@ -30,7 +30,7 @@ namespace.blah = 1
 
   Loading changes detected in scratch.u.
 
-  The identifier namespace used here is a reserved keyword: 
+  The identifier, `namespace`, used here is a reserved keyword: 
   
       1 | namespace.blah = 1
   

--- a/unison-syntax/src/Unison/Syntax/Lexer.hs
+++ b/unison-syntax/src/Unison/Syntax/Lexer.hs
@@ -95,8 +95,7 @@ parseFailure :: EP.ParseError [Char] (Token Err) -> P a
 parseFailure e = PI.ParsecT $ \s _ _ _ eerr -> eerr e s
 
 data Err
-  = InvalidWordyId String
-  | ReservedWordyId String
+  = ReservedWordyId String
   | InvalidSymbolyId String
   | ReservedSymbolyId String
   | InvalidShortHash String


### PR DESCRIPTION
## Overview

The message mentioned in #5060 was incorrect. This also uses the passed-in `id` for that message and related messages (removing the reliance on ANSI colors for conveying where the error is). And it adds a suggestion on how to avoid the error.

It also does some minor adjustment of highlighting – styling individual identifiers rather than a list of them.

Fixes #5060.