### PR TITLE
bugfix: merge involving constructor deletion

### DIFF
--- a/unison-merge/src/Unison/Merge/Diff.hs
+++ b/unison-merge/src/Unison/Merge/Diff.hs
@@ -9,6 +9,7 @@ import Data.Semialign (alignWith)
 import Data.Set qualified as Set
 import Data.These (These (..))
 import U.Codebase.Reference (TypeReference)
+import Unison.ConstructorReference (GConstructorReference (..))
 import Unison.DataDeclaration (Decl)
 import Unison.DataDeclaration qualified as DataDeclaration
 import Unison.Hash (Hash (Hash))
@@ -17,6 +18,7 @@ import Unison.Merge.Database (MergeDatabase (..))
 import Unison.Merge.DeclNameLookup (DeclNameLookup)
 import Unison.Merge.DeclNameLookup qualified as DeclNameLookup
 import Unison.Merge.DiffOp (DiffOp (..))
+import Unison.Merge.PartialDeclNameLookup (PartialDeclNameLookup (..))
 import Unison.Merge.Synhash
 import Unison.Merge.Synhashed (Synhashed (..))
 import Unison.Merge.ThreeWay (ThreeWay (..))
@@ -30,6 +32,7 @@ import Unison.PrettyPrintEnv (PrettyPrintEnv (..))
 import Unison.PrettyPrintEnv qualified as Ppe
 import Unison.Reference (Reference' (..), TypeReferenceId)
 import Unison.Referent (Referent)
+import Unison.Referent qualified as Referent
 import Unison.Sqlite (Transaction)
 import Unison.Symbol (Symbol)
 import Unison.Syntax.Name qualified as Name
@@ -48,52 +51,14 @@ import Unison.Util.Defns (Defns (..), DefnsF2, DefnsF3, zipDefnsWith)
 nameBasedNamespaceDiff ::
   MergeDatabase ->
   TwoWay DeclNameLookup ->
-  Map Name [Maybe Name] ->
+  PartialDeclNameLookup ->
   ThreeWay (Defns (BiMultimap Referent Name) (BiMultimap TypeReference Name)) ->
   Transaction (TwoWay (DefnsF3 (Map Name) DiffOp Synhashed Referent TypeReference))
-nameBasedNamespaceDiff db declNameLookups lcaDeclToConstructors defns = do
-  lcaHashes <-
-    synhashDefnsWith
-      hashTerm
-      ( \name -> \case
-          ReferenceBuiltin builtin -> pure (synhashBuiltinDecl builtin)
-          ReferenceDerived ref ->
-            case sequence (lcaDeclToConstructors Map.! name) of
-              -- If we don't have a name for every constructor, that's okay, just use a dummy syntactic hash here.
-              -- This is safe; Alice/Bob can't have such a decl (it violates a merge precondition), so there's no risk
-              -- that we accidentally get an equal hash and classify a real update as unchanged.
-              Nothing -> pure (Hash mempty)
-              Just names -> do
-                decl <- loadDeclWithGoodConstructorNames names ref
-                pure (synhashDerivedDecl ppe name decl)
-      )
-      defns.lca
-  hashes <- sequence (synhashDefns <$> declNameLookups <*> ThreeWay.forgetLca defns)
+nameBasedNamespaceDiff db declNameLookups lcaDeclNameLookup defns = do
+  lcaHashes <- synhashLcaDefns db ppe lcaDeclNameLookup defns.lca
+  hashes <- sequence (synhashDefns db ppe <$> declNameLookups <*> ThreeWay.forgetLca defns)
   pure (diffNamespaceDefns lcaHashes <$> hashes)
   where
-    synhashDefns ::
-      DeclNameLookup ->
-      Defns (BiMultimap Referent Name) (BiMultimap TypeReference Name) ->
-      Transaction (DefnsF2 (Map Name) Synhashed Referent TypeReference)
-    synhashDefns declNameLookup =
-      -- FIXME: use cache so we only synhash each thing once
-      synhashDefnsWith hashTerm hashType
-      where
-        hashType :: Name -> TypeReference -> Transaction Hash
-        hashType name = \case
-          ReferenceBuiltin builtin -> pure (synhashBuiltinDecl builtin)
-          ReferenceDerived ref -> do
-            decl <- loadDeclWithGoodConstructorNames (DeclNameLookup.expectConstructorNames declNameLookup name) ref
-            pure (synhashDerivedDecl ppe name decl)
-
-    loadDeclWithGoodConstructorNames :: [Name] -> TypeReferenceId -> Transaction (Decl Symbol Ann)
-    loadDeclWithGoodConstructorNames names =
-      fmap (DataDeclaration.setConstructorNames (map Name.toVar names)) . db.loadV1Decl
-
-    hashTerm :: Referent -> Transaction Hash
-    hashTerm =
-      synhashTerm db.loadV1Term ppe
-
     ppe :: PrettyPrintEnv
     ppe =
       -- The order between Alice and Bob isn't important here for syntactic hashing; not sure right now if it matters
@@ -101,6 +66,71 @@ nameBasedNamespaceDiff db declNameLookups lcaDeclToConstructors defns = do
       deepNamespaceDefinitionsToPpe defns.alice
         `Ppe.addFallback` deepNamespaceDefinitionsToPpe defns.bob
         `Ppe.addFallback` deepNamespaceDefinitionsToPpe defns.lca
+
+synhashLcaDefns ::
+  MergeDatabase ->
+  PrettyPrintEnv ->
+  PartialDeclNameLookup ->
+  Defns (BiMultimap Referent Name) (BiMultimap TypeReference Name) ->
+  Transaction (DefnsF2 (Map Name) Synhashed Referent TypeReference)
+synhashLcaDefns db ppe declNameLookup =
+  synhashDefnsWith hashReferent hashType
+  where
+    -- For the LCA only, if we don't have a name for every constructor, or we don't have a name for a decl, that's okay,
+    -- just use a dummy syntactic hash (e.g. where we return `Hash mempty` below in two places).
+    --
+    -- This is safe and correct; Alice/Bob can't have such a decl (it violates a merge precondition), so there's no risk
+    -- that we accidentally get an equal hash and classify a real update as unchanged.
+
+    hashReferent :: Name -> Referent -> Transaction Hash
+    hashReferent name = \case
+      Referent.Con (ConstructorReference ref _) _ ->
+        case Map.lookup name declNameLookup.constructorToDecl of
+          Nothing -> pure (Hash mempty) -- see note above
+          Just declName -> hashType declName ref
+      Referent.Ref ref -> synhashTerm db.loadV1Term ppe ref
+
+    hashType :: Name -> TypeReference -> Transaction Hash
+    hashType name = \case
+      ReferenceBuiltin builtin -> pure (synhashBuiltinDecl builtin)
+      ReferenceDerived ref ->
+        case sequence (declNameLookup.declToConstructors Map.! name) of
+          Nothing -> pure (Hash mempty) -- see note above
+          Just names -> do
+            decl <- loadDeclWithGoodConstructorNames db names ref
+            pure (synhashDerivedDecl ppe name decl)
+
+synhashDefns ::
+  MergeDatabase ->
+  PrettyPrintEnv ->
+  DeclNameLookup ->
+  Defns (BiMultimap Referent Name) (BiMultimap TypeReference Name) ->
+  Transaction (DefnsF2 (Map Name) Synhashed Referent TypeReference)
+synhashDefns db ppe declNameLookup =
+  -- FIXME: use cache so we only synhash each thing once
+  synhashDefnsWith hashReferent hashType
+  where
+    hashReferent :: Name -> Referent -> Transaction Hash
+    hashReferent name = \case
+      -- We say that a referent constructor *in the namespace* (distinct from a referent that is in a term body) has a
+      -- synhash that is simply equal to the synhash of its type declaration. This is because the type declaration and
+      -- constructors are changed in lock-step: it is not possible to change one, but not the other.
+      --
+      -- For example, if Alice updates `type Foo = Bar Nat` to `type Foo = Bar Nat Nat`, we want different synhashes on
+      -- both the type (Foo) and the constructor (Foo.Bar).
+      Referent.Con (ConstructorReference ref _) _ -> hashType (DeclNameLookup.expectDeclName declNameLookup name) ref
+      Referent.Ref ref -> synhashTerm db.loadV1Term ppe ref
+
+    hashType :: Name -> TypeReference -> Transaction Hash
+    hashType name = \case
+      ReferenceBuiltin builtin -> pure (synhashBuiltinDecl builtin)
+      ReferenceDerived ref -> do
+        decl <- loadDeclWithGoodConstructorNames db (DeclNameLookup.expectConstructorNames declNameLookup name) ref
+        pure (synhashDerivedDecl ppe name decl)
+
+loadDeclWithGoodConstructorNames :: MergeDatabase -> [Name] -> TypeReferenceId -> Transaction (Decl Symbol Ann)
+loadDeclWithGoodConstructorNames db names =
+  fmap (DataDeclaration.setConstructorNames (map Name.toVar names)) . db.loadV1Decl
 
 diffNamespaceDefns ::
   DefnsF2 (Map Name) Synhashed term typ ->
@@ -139,17 +169,17 @@ deepNamespaceDefinitionsToPpe Defns {terms, types} =
 
 synhashDefnsWith ::
   Monad m =>
-  (term -> m Hash) ->
+  (Name -> term -> m Hash) ->
   (Name -> typ -> m Hash) ->
   Defns (BiMultimap term Name) (BiMultimap typ Name) ->
   m (DefnsF2 (Map Name) Synhashed term typ)
 synhashDefnsWith hashTerm hashType = do
   bitraverse
-    (traverse hashTerm1 . BiMultimap.range)
+    (Map.traverseWithKey hashTerm1 . BiMultimap.range)
     (Map.traverseWithKey hashType1 . BiMultimap.range)
   where
-    hashTerm1 term = do
-      hash <- hashTerm term
+    hashTerm1 name term = do
+      hash <- hashTerm name term
       pure (Synhashed hash term)
 
     hashType1 name typ = do

--- a/unison-merge/src/Unison/Merge/PartialDeclNameLookup.hs
+++ b/unison-merge/src/Unison/Merge/PartialDeclNameLookup.hs
@@ -1,0 +1,15 @@
+module Unison.Merge.PartialDeclNameLookup
+  ( PartialDeclNameLookup (..),
+  )
+where
+
+import Unison.Name (Name)
+import Unison.Prelude
+
+-- | Like a @DeclNameLookup@, but "partial" / more lenient - because we don't require the LCA of a merge to have a full
+-- @DeclNameLookup@.
+data PartialDeclNameLookup = PartialDeclNameLookup
+  { constructorToDecl :: !(Map Name Name),
+    declToConstructors :: !(Map Name [Maybe Name])
+  }
+  deriving stock (Generic)

--- a/unison-merge/unison-merge.cabal
+++ b/unison-merge/unison-merge.cabal
@@ -26,6 +26,7 @@ library
       Unison.Merge.EitherWay
       Unison.Merge.EitherWayI
       Unison.Merge.Libdeps
+      Unison.Merge.PartialDeclNameLookup
       Unison.Merge.PartitionCombinedDiffs
       Unison.Merge.Synhash
       Unison.Merge.Synhashed

--- a/unison-src/transcripts/merge.md
+++ b/unison-src/transcripts/merge.md
@@ -14,7 +14,7 @@ contains both additions.
 ## Basic merge: two unconflicted adds
 
 ```ucm:hide
-project/main> builtins.mergeio
+project/main> builtins.mergeio lib.builtins
 ```
 
 ```ucm:hide
@@ -56,7 +56,7 @@ project/alice> view foo bar
 If Alice and Bob also happen to add the same definition, that's not a conflict.
 
 ```ucm:hide
-project/main> builtins.mergeio
+project/main> builtins.mergeio lib.builtins
 project/main> branch alice
 ```
 
@@ -97,7 +97,7 @@ project/alice> view foo bar
 Updates that occur in one branch are propagated to the other. In this example, Alice updates `foo`, while Bob adds a new dependent `bar` of the original `foo`. When Bob's branch is merged into Alice's, her update to `foo` is propagated to his `bar`.
 
 ```ucm:hide
-project/main> builtins.mergeio
+project/main> builtins.mergeio lib.builtins
 ```
 
 Original branch:
@@ -152,7 +152,7 @@ We classify something as an update if its "syntactic hash"—not its normal Unis
 Let's see an example. We have `foo`, which depends on `bar` and `baz`. Alice updates `bar` (propagating to `foo`), and Bob updates `baz` (propagating to `foo`). When we merge their updates, both updates will be reflected in the final `foo`.
 
 ```ucm:hide
-project/main> builtins.mergeio
+project/main> builtins.mergeio lib.builtins
 ```
 
 Original branch:
@@ -216,7 +216,7 @@ project/alice> display foo
 Of course, it's also possible for Alice's update to propagate to one of Bob's updates. In this example, `foo` depends on `bar` which depends on `baz`. Alice updates `baz`, propagating to `bar` and `foo`, while Bob updates `bar` (to something that still depends on `foo`), propagating to `baz`. The merged result will have Alice's update to `foo` incorporated into Bob's updated `bar`, and both updates will propagate to `baz`.
 
 ```ucm:hide
-project/main> builtins.mergeio
+project/main> builtins.mergeio lib.builtins
 ```
 
 Original branch:
@@ -286,7 +286,7 @@ project/alice> display foo
 We don't currently consider "update + delete" a conflict like Git does. In this situation, the delete is just ignored, allowing the update to proceed.
 
 ```ucm:hide
-project/main> builtins.mergeio
+project/main> builtins.mergeio lib.builtins
 ```
 
 Original branch:
@@ -333,7 +333,7 @@ In a future version, we'd like to give the user a warning at least.
 Library dependencies don't cause merge conflicts, the library dependencies are just unioned together. If two library dependencies have the same name but different namespace hashes, then the merge algorithm makes up two fresh names.
 
 ```ucm:hide
-project/main> builtins.mergeio
+project/main> builtins.mergeio lib.builtins
 ```
 
 Alice's adds:
@@ -387,7 +387,7 @@ project/alice> view foo bar baz
 If Bob is equals Alice, then merging Bob into Alice looks like this.
 
 ```ucm:hide
-project/main> builtins.mergeio
+project/main> builtins.mergeio lib.builtins
 ```
 
 ```ucm
@@ -405,7 +405,7 @@ project/alice> merge /bob
 If Bob is behind Alice, then merging Bob into Alice looks like this.
 
 ```ucm:hide
-project/main> builtins.mergeio
+project/main> builtins.mergeio lib.builtins
 ```
 
 ```ucm
@@ -433,7 +433,7 @@ project/alice> merge /bob
 If Bob is ahead of Alice, then merging Bob into Alice looks like this.
 
 ```ucm:hide
-project/main> builtins.mergeio
+project/main> builtins.mergeio lib.builtins
 ```
 
 ```ucm
@@ -465,7 +465,7 @@ This can cause merge failures due to out-of-scope identifiers, and the user may 
 In this example, Alice deletes `foo`, while Bob adds a new dependent of `foo`.
 
 ```ucm:hide
-project/main> builtins.mergeio
+project/main> builtins.mergeio lib.builtins
 ```
 
 Original branch:
@@ -508,7 +508,7 @@ It may be Alice's and Bob's changes merge together cleanly in the sense that the
 In this example, Alice updates a `Text` to a `Nat`, while Bob adds a new dependent of the `Text`. Upon merging, propagating Alice's update to Bob's dependent causes a typechecking failure.
 
 ```ucm:hide
-project/main> builtins.mergeio
+project/main> builtins.mergeio lib.builtins
 ```
 
 Original branch:
@@ -557,7 +557,7 @@ Alice and Bob may disagree about the definition of a term. In this case, the con
 are presented to the user to resolve.
 
 ```ucm:hide
-project/main> builtins.mergeio
+project/main> builtins.mergeio lib.builtins
 ```
 
 Original branch:
@@ -621,7 +621,7 @@ project/merge-bob-into-alice> view bar baz
 Ditto for types; if the hashes don't match, it's a conflict. In this example, Alice and Bob do different things to the same constructor. However, any explicit changes to the same type will result in a conflict, including changes that could concievably be merged (e.g. Alice and Bob both add a new constructor, or edit different constructors).
 
 ```ucm:hide
-project/main> builtins.mergeio
+project/main> builtins.mergeio lib.builtins
 ```
 
 Original branch:
@@ -664,7 +664,7 @@ project/alice> merge /bob
 We model the renaming of a type's constructor as an update, so if Alice updates a type and Bob renames one of its constructors (even without changing its structure), we consider it a conflict.
 
 ```ucm:hide
-project/main> builtins.mergeio
+project/main> builtins.mergeio lib.builtins
 ```
 
 Original branch:
@@ -707,7 +707,7 @@ project/alice> merge /bob
 Here is another example demonstrating that constructor renames are modeled as updates.
 
 ```ucm:hide
-project/main> builtins.mergeio
+project/main> builtins.mergeio lib.builtins
 ```
 
 Original branch:
@@ -745,7 +745,7 @@ project/alice> merge bob
 A constructor on one side can conflict with a regular term definition on the other.
 
 ```ucm:hide
-project/main> builtins.mergeio
+project/main> builtins.mergeio lib.builtins
 ```
 
 ```ucm:hide
@@ -786,7 +786,7 @@ project/alice> merge bob
 Here's a subtle situation where a new type is added on each side of the merge, and an existing term is replaced with a constructor of one of the types.
 
 ```ucm:hide
-project/main> builtins.mergeio
+project/main> builtins.mergeio lib.builtins
 ```
 
 Original branch:
@@ -835,7 +835,7 @@ project/alice> merge bob
 Here's a more involved example that demonstrates the same idea.
 
 ```ucm:hide
-project/main> builtins.mergeio
+project/main> builtins.mergeio lib.builtins
 ```
 
 In the LCA, we have a type with two constructors, and some term.
@@ -914,7 +914,7 @@ which is a parse error.
 We will resolve this situation automatically in a future version.
 
 ```ucm:hide
-project/main> builtins.mergeio
+project/main> builtins.mergeio lib.builtins
 ```
 
 ```ucm:hide
@@ -961,7 +961,7 @@ After merge conflicts are resolved, you can use `merge.commit` rather than `swit
 
 ```ucm:hide
 .> project.create-empty project
-project/main> builtins.mergeio
+project/main> builtins.mergeio lib.builtins
 ```
 
 Original branch:
@@ -1026,7 +1026,7 @@ project/alice> branches
 
 ```ucm:hide
 .> project.create-empty project
-project/main> builtins.mergeio
+project/main> builtins.mergeio lib.builtins
 ```
 
 ```ucm
@@ -1051,7 +1051,7 @@ There are a number of conditions under which we can't perform a merge, and the u
 If `foo` and `bar` are aliases in the nearest common ancestor, but not in Alice's branch, then we don't know whether to update Bob's dependents to Alice's `foo` or Alice's `bar` (and vice-versa).
 
 ```ucm:hide
-project/main> builtins.mergeio
+project/main> builtins.mergeio lib.builtins
 ```
 
 Original branch:
@@ -1108,7 +1108,7 @@ conflict involving a builtin, we can't perform a merge.
 One way to fix this in the future would be to introduce a syntax for defining aliases in the scratch file.
 
 ```ucm:hide
-project/main> builtins.mergeio
+project/main> builtins.mergeio lib.builtins
 ```
 
 ```ucm:hide
@@ -1117,7 +1117,7 @@ project/main> branch alice
 
 Alice's branch:
 ```ucm
-project/alice> alias.type builtin.Nat MyNat
+project/alice> alias.type lib.builtins.Nat MyNat
 ```
 
 Bob's branch:
@@ -1146,7 +1146,7 @@ project/alice> merge /bob
 Each naming of a decl may not have more than one name for each constructor, within the decl's namespace.
 
 ```ucm:hide
-project/main> builtins.mergeio
+project/main> builtins.mergeio lib.builtins
 ```
 
 ```ucm:hide
@@ -1192,7 +1192,7 @@ project/alice> merge /bob
 Each naming of a decl must have a name for each constructor, within the decl's namespace.
 
 ```ucm:hide
-project/main> builtins.mergeio
+project/main> builtins.mergeio lib.builtins
 ```
 
 Alice's branch:
@@ -1239,7 +1239,7 @@ project/alice> merge /bob
 A decl cannot be aliased within the namespace of another of its aliased.
 
 ```ucm:hide
-project/main> builtins.mergeio
+project/main> builtins.mergeio lib.builtins
 ```
 
 Alice's branch:
@@ -1287,7 +1287,7 @@ project/alice> merge /bob
 Constructors may only exist within the corresponding decl's namespace.
 
 ```ucm:hide
-project/main> builtins.mergeio
+project/main> builtins.mergeio lib.builtins
 ```
 
 Alice's branch:
@@ -1331,7 +1331,7 @@ project/alice> merge bob
 By convention, `lib` can only namespaces; each of these represents a library dependencies. Individual terms and types are not allowed at the top level of `lib`.
 
 ```ucm:hide
-project/main> builtins.mergeio
+project/main> builtins.mergeio lib.builtins
 ```
 
 Alice's branch:
@@ -1375,7 +1375,7 @@ Here's an example. We'll delete a constructor name from the LCA and still be abl
 together.
 
 ```ucm:hide
-project/main> builtins.mergeio
+project/main> builtins.mergeio lib.builtins
 ```
 
 LCA:
@@ -1439,7 +1439,7 @@ project/alice> merge /bob
 
 
 ```ucm:hide
-project/main> builtins.mergeio
+project/main> builtins.mergeio lib.builtins
 ```
 
 ```unison
@@ -1472,6 +1472,47 @@ project/bob> add
 
 ```ucm
 project/alice> merge /bob
+```
+
+```ucm:hide
+.> project.delete project
+```
+
+### Delete a constructor
+
+
+```ucm:hide
+project/main> builtins.mergeio lib.builtins
+```
+
+```unison
+type Foo = Bar | Baz
+```
+
+```ucm
+project/main> add
+project/main> branch topic
+```
+
+```unison
+boop = "boop"
+```
+
+```ucm
+project/topic> add
+```
+
+```unison
+type Foo = Bar
+```
+
+```ucm
+project/main> update
+```
+
+```ucm
+project/main> merge topic
+project/main> view Foo
 ```
 
 ```ucm:hide

--- a/unison-src/transcripts/merge.output.md
+++ b/unison-src/transcripts/merge.output.md
@@ -1255,7 +1255,7 @@ One way to fix this in the future would be to introduce a syntax for defining al
 
 Alice's branch:
 ```ucm
-project/alice> alias.type builtin.Nat MyNat
+project/alice> alias.type lib.builtins.Nat MyNat
 
   Done.
 
@@ -1694,5 +1694,102 @@ project/bob> add
 project/alice> merge /bob
 
   I merged project/bob into project/alice.
+
+```
+### Delete a constructor
+
+
+```unison
+type Foo = Bar | Baz
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      type Foo
+
+```
+```ucm
+project/main> add
+
+  ⍟ I've added these definitions:
+  
+    type Foo
+
+project/main> branch topic
+
+  Done. I've created the topic branch based off of main.
+  
+  Tip: To merge your work back into the main branch, first
+       `switch /main` then `merge /topic`.
+
+```
+```unison
+boop = "boop"
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      boop : Text
+
+```
+```ucm
+project/topic> add
+
+  ⍟ I've added these definitions:
+  
+    boop : Text
+
+```
+```unison
+type Foo = Bar
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      type Foo
+
+```
+```ucm
+project/main> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+
+```
+```ucm
+project/main> merge topic
+
+  I merged project/topic into project/main.
+
+project/main> view Foo
+
+  type Foo = Bar
 
 ```


### PR DESCRIPTION
## Overview

This PR attempts to fix a bug in merge reported at #5092.

The syntactic hashing of constructor referents was wrong, at least in the context of how the rest of the algorithm used the diff computed by syntactic hashes.

Prior to this PR, we computed the syntactic hash of a constructor as equivalent to the term that represents calling that constructor.

For example, if the namespace contains the name

```
Just = #Maybe#1
```

then the syntactic hash of that referent was computed as the syntactic hash of the _term_ whose body is just `#Maybe#1`.

Thus, when updating

```
type Foo = Bar | Baz
```

to

```
type Foo = Bar
```

the diff would show an update on the type `Foo` but not the constructor `Bar`.

There may be a design in which that works out ok, but not in ours: we take the adds, updates, and deletes from the diff and lay them over the LCA. In this example, we'd end up with an updated `Foo` without a name for its new constructor `Bar`.

So, the fix I implemented is to change how we compute syntactic hashes of constructors. Now, it's simply equivalent to the syntactic hash of its type declaration (which itself would change if any constructors change in shape or name). Therefore, the constructors of a type that undergoes an update would appear in the diff as updates as well.

Additionally, I noticed while reading the syntactic hashing code that we computed the hash _tokens_ of a constructor reference differently than a normal term reference. That seemed like a mistake, unrelated to this bug, which could cause unnecessary conflicts. So, I fixed that too. 

## Test coverage

I've added a regression test to the main `merge.md` transcript. You can see its results flip from incorrect to correct [right here](https://github.com/unisonweb/unison/commit/a021eb414154217df9800c4e2dbe5a0ecc15933c#diff-9fa53b0e0205444487371ae6e56a87fece3e8b0e76d39181825cbb56716ebc54): prior to this PR, merge erroneously dropped the name for a constructor, and now it doesn't.

## Loose ends

Link to related issues that address things you didn't get to. Stuff you encountered on the way and decided not to include in this PR.
