### PR TITLE
drop branch filter for CI runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,16 +5,10 @@ defaults:
     shell: bash
 
 on:
-  # Build on every pull request (and new PR commit)
+  # Run on the post-merge result of every PR commit
   pull_request:
-  # Build on new pushes to trunk (E.g. Merge commits)
-  # Without the branch filter, each commit on a branch with a PR is triggered twice.
-  # See: https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662
+  # Build on the pre-merge result of every branch commit
   push:
-    branches:
-      - trunk
-    tags:
-      - release/*
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
We had previously tried to avoid what we saw as duplicate runs of CI on each PR commit. We didn't realize (or didn't document) that the two runs represent the actual branch (`on: push`) vs a hypothetical merge (`on: pull_request`).

Only running `on: pull_request` however, meant that CI would not run unless the branch could cleanly merge with `trunk`, which is not a great requirement for running CI.

With this change, we can try out running on both. It will mean we have a lot of checks, and it will mean that we maybe need to adjust `.mergify.yml` to be sure that it doesn't auto-merge a PR that can't merge. (Well, I suppose it wouldn't do that; but we don't want it to try, and fail, either.)