### PR TITLE
Prefer `foo()` to `!foo`

### DIFF
--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -490,7 +490,7 @@ pretty0
               (App' x (Constructor' (ConstructorReference DD.UnitRef 0)), _) | isLeaf x -> do
                 px <- pretty0 (ac (if isBlock x then 0 else 9) Normal im doc) x
                 pure . paren (p >= 11 || isBlock x && p >= 3) $
-                  fmt S.DelayForceChar (l "!") <> PP.indentNAfterNewline 1 px
+                  px <> fmt S.DelayForceChar (l "()")
               (Apps' f (unsnoc -> Just (args, lastArg)), _)
                 | isSoftHangable lastArg -> do
                     fun <- goNormal 9 f

--- a/unison-src/transcripts-manual/rewrites.output.md
+++ b/unison-src/transcripts-manual/rewrites.output.md
@@ -183,7 +183,7 @@ woot1to2 x =
 
 wootEx : Nat ->{Woot2} Nat
 wootEx a =
-  _ = !Woot2.woot2
+  _ = Woot2.woot2()
   blah2
 
 blah = 123
@@ -198,7 +198,7 @@ After adding the rewritten form to the codebase, here's the rewritten `Woot1` to
 
   wootEx : Nat ->{Woot2} Nat
   wootEx a =
-    _ = !woot2
+    _ = woot2()
     blah2
 
 ```

--- a/unison-src/transcripts-round-trip/main.output.md
+++ b/unison-src/transcripts-round-trip/main.output.md
@@ -24,7 +24,7 @@ So we can see the pretty-printed output:
 
   ☝️
   
-  I added 105 definitions to the top of scratch.u
+  I added 106 definitions to the top of scratch.u
   
   You can edit them there, then run `update` to replace the
   definitions currently in this namespace.
@@ -73,13 +73,13 @@ structural ability Zoink where
 Abort.toDefault! : a -> '{g, Abort} a ->{g} a
 Abort.toDefault! default thunk =
   h x = Abort.toDefault! (handler_1778 default x) thunk
-  handle !thunk with h
+  handle thunk() with h
 
 Abort.toOptional : '{g, Abort} a -> '{g} Optional a
 Abort.toOptional thunk = do toOptional! thunk
 
 Abort.toOptional! : '{g, Abort} a ->{g} Optional a
-Abort.toOptional! thunk = toDefault! None do Some !thunk
+Abort.toOptional! thunk = toDefault! None do Some thunk()
 
 catchAll : x -> Nat
 catchAll x = 99
@@ -87,7 +87,7 @@ catchAll x = 99
 Decode.remainder : '{Ask (Optional Bytes)} Bytes
 Decode.remainder = do match ask with
   None   -> Bytes.empty
-  Some b -> b Bytes.++ !Decode.remainder
+  Some b -> b Bytes.++ Decode.remainder()
 
 ex1 : Nat
 ex1 =
@@ -194,7 +194,7 @@ fix_2650 =
     use Nat +
     y = 12
     13 + y
-  !addNumbers
+  addNumbers()
 
 fix_2650a : tvar -> fun -> ()
 fix_2650a tvar fun = ()
@@ -341,6 +341,16 @@ fix_525_exampleTerm quaffle =
 
 fix_525_exampleType : Id qualifiedName -> Id Fully.qualifiedName
 fix_525_exampleType z = Id (Dontcare () 19)
+
+fnApplicationSyntax : Nat
+fnApplicationSyntax =
+  use Nat +
+  Environment.default = do 1 + 1
+  oog = do 2 + 2
+  blah : Nat -> Float -> Nat
+  blah x y = x + 1
+  _ = blah Environment.default() 1.0
+  blah oog() (max 1.0 2.0)
 
 Foo.bar.qux1 : Nat
 Foo.bar.qux1 = 42
@@ -672,7 +682,7 @@ UUID.random = do UUID 0 (0, 0)
 
 UUID.randomUUIDBytes : 'Bytes
 UUID.randomUUIDBytes = do
-  (UUID a (b, _)) = !random
+  (UUID a (b, _)) = random()
   encodeNat64be a Bytes.++ encodeNat64be b
 
 (|>) : a -> (a ->{e} b) ->{e} b

--- a/unison-src/transcripts-round-trip/reparses-with-same-hash.u
+++ b/unison-src/transcripts-round-trip/reparses-with-same-hash.u
@@ -550,4 +550,4 @@ fnApplicationSyntax =
   blah : Nat -> Float -> Nat
   blah x y = x + 1 
   _ = blah Environment.default() 1.0 
-  blah oog() Float.max(1.0, 2.0)
+  blah oog() (Float.max 1.0 2.0)

--- a/unison-src/transcripts-round-trip/reparses-with-same-hash.u
+++ b/unison-src/transcripts-round-trip/reparses-with-same-hash.u
@@ -543,3 +543,11 @@ fix_4384e =
   id : x -> x
   id x = x
   {{ {{ docExampleBlock 0 (id id id id id id id id id id id id id id id id id id id id id (x -> 0) }} }}
+
+fnApplicationSyntax = 
+  Environment.default = do 1 + 1
+  oog = do 2 + 2
+  blah : Nat -> Float -> Nat
+  blah x y = x + 1 
+  _ = blah Environment.default() 1.0 
+  blah oog() Float.max(1.0, 2.0)

--- a/unison-src/transcripts/cycle-update-1.output.md
+++ b/unison-src/transcripts/cycle-update-1.output.md
@@ -67,11 +67,11 @@ ping _ = !pong + 3
   ping : 'Nat
   ping _ =
     use Nat +
-    !pong + 3
+    pong() + 3
   
   pong : 'Nat
   pong _ =
     use Nat +
-    !ping + 2
+    ping() + 2
 
 ```

--- a/unison-src/transcripts/cycle-update-2.output.md
+++ b/unison-src/transcripts/cycle-update-2.output.md
@@ -70,6 +70,6 @@ ping _ = 3
   pong : 'Nat
   pong _ =
     use Nat +
-    !ping + 2
+    ping() + 2
 
 ```

--- a/unison-src/transcripts/cycle-update-3.output.md
+++ b/unison-src/transcripts/cycle-update-3.output.md
@@ -65,6 +65,6 @@ ping = 3
   pong : 'Nat
   pong _ =
     use Nat +
-    !#4t465jk908.1 + 2
+    #4t465jk908.1() + 2
 
 ```

--- a/unison-src/transcripts/cycle-update-4.output.md
+++ b/unison-src/transcripts/cycle-update-4.output.md
@@ -74,16 +74,16 @@ clang _ = !pong + 3
   clang : 'Nat
   clang _ =
     use Nat +
-    !pong + 3
+    pong() + 3
   
   ping : 'Nat
   ping _ =
     use Nat +
-    !clang + 1
+    clang() + 1
   
   pong : 'Nat
   pong _ =
     use Nat +
-    !ping + 2
+    ping() + 2
 
 ```

--- a/unison-src/transcripts/cycle-update-5.output.md
+++ b/unison-src/transcripts/cycle-update-5.output.md
@@ -65,7 +65,7 @@ inner.ping _ = !pong + 3
   inner.ping : 'Nat
   inner.ping _ =
     use Nat +
-    !pong + 1
+    pong() + 1
 
 ```
 The bug here is that `inner.ping` still refers to `pong` by name. But if we properly identified the nameless (in the

--- a/unison-src/transcripts/delete.output.md
+++ b/unison-src/transcripts/delete.output.md
@@ -486,6 +486,6 @@ pong _ = 4 Nat.+ !ping
   pong : 'Nat
   pong _ =
     use Nat +
-    4 + !#l9uq1dpl5v.1
+    4 + #l9uq1dpl5v.1()
 
 ```

--- a/unison-src/transcripts/formatter.output.md
+++ b/unison-src/transcripts/formatter.output.md
@@ -142,7 +142,7 @@ provide a action =
   h = cases
     { ask -> resume } -> handle resume a with h
     { r }             -> r
-  handle !action with h
+  handle action() with h
 
 Optional.doc = {{ A Doc before a type }}
 structural type Optional a = More Text | Some | Other a | None Nat 

--- a/unison-syntax/src/Unison/Syntax/Parser.hs
+++ b/unison-syntax/src/Unison/Syntax/Parser.hs
@@ -39,6 +39,7 @@ module Unison.Syntax.Parser
     run,
     semi,
     Unison.Syntax.Parser.seq,
+    Unison.Syntax.Parser.seq',
     sepBy,
     sepBy1,
     string,


### PR DESCRIPTION
From recent discussions, there's a feeling that `!` isn't really paying its way as special syntax. It...

* looks weird...
* isn't suggestive of what it is (passing `()` to a function), and...
* it's in the "wrong" spot, needing to go before the symbol being forced - by time I think to write `!` I've already generally typed the symbol and have to backtrack in the buffer.
* adding confusion, identifiers can end with a `!`, a loose convention used for a variant of a function that runs its effects rather than returning a thunk, so you sometimes have expressions like `object.at! !qux (quaffle 1 2)` and it makes me sad to think about trying to explain why the `!` appears at the end of `object.at` but at the start of `!qux`...

This PR changes things. Before, you'd write `!foo` to mean `foo ()` with high precedence. Now you can just use `foo()` with no spaces after the `foo` to get the same precedence and meaning as `foo ()`. The pretty-printer uses this syntax as well. The old `!foo` syntax is still supported in the parser but is now unused by the pretty-printer.

Here's a few examples (which parse and pretty-print like this):

```haskell
deployHttp Environment.default() hello.logic

forkAt pool() do 1 + 1
```

The lack of any space after `Environment.default` and `pool` makes this bind tighter than the normal function application syntax. If you put any spaces, the parenthesized thing is treated like a tuple, just like now.

---

(possibly controversial, ended up being removed from this PR, but including for posterity) It was easy to generalize this syntax to have it work for higher-precedence function application, just like in C, Java, etc:

* `foo sqrt(2.0)` parses as `foo (sqrt 2.0)`
* `foo max(x, y)` parses as `foo (max x y)`

**The pretty-printer still prefers the `foo (max x y)` syntax** in these cases though, so consider this more of a "I'm typing and don't feel like going backwards to add parens" or "I forgot that I'm not programming in Java, but this still parses the way Java would".

## Implementation notes

A simple, surgical change to the term parser and pretty-printer.

## Interesting/controversial decisions

Possibly this whole thing is controversial. :)

Some possibilities I considered:

* We could disallow `foo(x, y, z)` for function application, instead just supporting `foo()` for forcing. I didn't see the harm in including the more general syntax. I'll probably use it myself when I'm feeling lazy about going back and adding parens, and it might make folks coming from other languages more comfortable. (I have seen people accidentally using `foo(x,y,z)` for function application many times.)
* Don't use `blah foo() arg2` in the pretty-printer - print this as `blah (foo ()) arg2`. So basically - this PR, but don't use the syntax in the pretty-printer. I don't like this as much. I feel like `forkAt pool() do ...` is pretty easy to parse even if you don't know Unison. You tend to assume that `pool()`
* Remove `!` syntax entirely. I'd rather keep it around for a while. We can remove it after people have adjusted and we're confident in the change.

This is also easy to back out anytime later.

## Test coverage

Existing transcripts provide pretty good coverage, and I added a round trip test. I think coverage is good.

## Loose ends

None