### PR TITLE
bugfix: don't emit virtual semis inside { or [

### DIFF
--- a/unison-syntax/src/Unison/Syntax/Lexer.hs
+++ b/unison-syntax/src/Unison/Syntax/Lexer.hs
@@ -224,7 +224,7 @@ token'' tok p = do
     pops p = do
       env <- S.get
       let l = layout env
-      if top l == column p && topBlockName l /= Just "(" -- don't emit virtual semis inside parens
+      if top l == column p && topContainsVirtualSemis l
         then pure [Token (Semi True) p p]
         else
           if column p > top l || topHasClosePair l
@@ -233,6 +233,12 @@ token'' tok p = do
               if column p < top l
                 then S.put (env {layout = pop l}) >> ((Token Close p p :) <$> pops p)
                 else error "impossible"
+
+    -- don't emit virtual semis in (, {, or [ blocks
+    topContainsVirtualSemis :: Layout -> Bool
+    topContainsVirtualSemis = \case
+      [] -> False
+      ((name, _) : _) -> name /= "(" && name /= "{" && name /= "["
 
     topHasClosePair :: Layout -> Bool
     topHasClosePair [] = False

--- a/unison-syntax/test/Main.hs
+++ b/unison-syntax/test/Main.hs
@@ -210,7 +210,13 @@ test =
         [Textual "test escaped quotes \"in quotes\""],
       t "\"\\n \\t \\b \\a\"" [Textual "\n \t \b \a"],
       -- Delayed string
-      t "'\"\"" [Reserved "'", Textual ""]
+      t "'\"\"" [Reserved "'", Textual ""],
+      -- https://github.com/unisonweb/unison/issues/4683
+      -- don't emit virtual semis in ability lists or normal lists
+      t "{foo\n,bar}" [Open "{", simpleWordyId "foo", Reserved ",", simpleWordyId "bar", Close],
+      t "{foo\n ,bar}" [Open "{", simpleWordyId "foo", Reserved ",", simpleWordyId "bar", Close],
+      t "[foo\n,bar]" [Open "[", simpleWordyId "foo", Reserved ",", simpleWordyId "bar", Close],
+      t "[foo\n ,bar]" [Open "[", simpleWordyId "foo", Reserved ",", simpleWordyId "bar", Close]
     ]
 
 t :: String -> [Lexeme] -> Test ()


### PR DESCRIPTION
## Overview

Fixes #4683

This PR adjusts the lexer to not emit virtual semicolons in ability sets (`{` blocks) nor regular lists (`[` blocks), just like it already did for `(` blocks.

## Test coverage

I added lexer tests to cover this change.