### PR TITLE
feat: add `alias.term.force`

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -474,7 +474,7 @@ loop e = do
               branch <- liftIO $ Codebase.getBranchAtPath codebase absPath
               _evalErrs <- liftIO $ (Backend.docsInBranchToHtmlFiles sandboxedRuntime codebase branch sourceDirectory)
               pure ()
-            AliasTermI src' dest' -> do
+            AliasTermI force src' dest' -> do
               Cli.Env {codebase} <- ask
               src <- traverseOf _Right Cli.resolveSplit' src'
               srcTerms <-
@@ -493,7 +493,7 @@ loop e = do
                       pure (DeleteNameAmbiguous hqLength name srcTerms Set.empty)
               dest <- Cli.resolveSplit' dest'
               destTerms <- Cli.getTermsAt (HQ'.NameOnly <$> dest)
-              when (not (Set.null destTerms)) do
+              when (not force && not (Set.null destTerms)) do
                 Cli.returnEarly (TermAlreadyExists dest' destTerms)
               description <- inputDescription input
               Cli.stepAt description (BranchUtil.makeAddTermName (first Path.unabsolute dest) srcTerm)
@@ -998,10 +998,10 @@ inputDescription input =
     ResetRootI src0 -> do
       src <- hp' src0
       pure ("reset-root " <> src)
-    AliasTermI src0 dest0 -> do
+    AliasTermI force src0 dest0 -> do
       src <- hhqs' src0
       dest <- ps' dest0
-      pure ("alias.term " <> src <> " " <> dest)
+      pure ((if force then "alias.term.force " else "alias.term ") <> src <> " " <> dest)
     AliasTypeI src0 dest0 -> do
       src <- hhqs' src0
       dest <- ps' dest0

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -132,7 +132,7 @@ data Input
     -- > names .foo.bar#asdflkjsdf
     -- > names #sdflkjsdfhsdf
     NamesI IsGlobal (HQ.HashQualified Name)
-  | AliasTermI HashOrHQSplit' Path.Split'
+  | AliasTermI !Bool HashOrHQSplit' Path.Split' -- bool = force?
   | AliasTypeI HashOrHQSplit' Path.Split'
   | AliasManyI [Path.HQSplit] Path'
   | MoveAllI Path.Path' Path.Path'

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -1397,14 +1397,28 @@ deleteBranch =
 aliasTerm :: InputPattern
 aliasTerm =
   InputPattern
-    "alias.term"
-    []
-    I.Visible
-    [("term to alias", Required, exactDefinitionTermQueryArg), ("alias name", Required, newNameArg)]
-    "`alias.term foo bar` introduces `bar` with the same definition as `foo`."
-    $ \case
-      [oldName, newName] -> Input.AliasTermI <$> handleShortHashOrHQSplit'Arg oldName <*> handleSplit'Arg newName
-      _ -> Left . warn $ P.wrap "`alias.term` takes two arguments, like `alias.term oldname newname`."
+    { patternName = "alias.term",
+      aliases = [],
+      visibility = I.Visible,
+      args = [("term to alias", Required, exactDefinitionTermQueryArg), ("alias name", Required, newNameArg)],
+      help = "`alias.term foo bar` introduces `bar` with the same definition as `foo`.",
+      parse = \case
+        [oldName, newName] -> Input.AliasTermI False <$> handleShortHashOrHQSplit'Arg oldName <*> handleSplit'Arg newName
+        _ -> Left . warn $ P.wrap "`alias.term` takes two arguments, like `alias.term oldname newname`."
+    }
+
+aliasTermForce :: InputPattern
+aliasTermForce =
+  InputPattern
+    { patternName = "alias.term.force",
+      aliases = [],
+      visibility = I.Hidden,
+      args = [("term to alias", Required, exactDefinitionTermQueryArg), ("alias name", Required, newNameArg)],
+      help = "`alias.term.force foo bar` introduces `bar` with the same definition as `foo`.",
+      parse = \case
+        [oldName, newName] -> Input.AliasTermI True <$> handleShortHashOrHQSplit'Arg oldName <*> handleSplit'Arg newName
+        _ -> Left . warn $ P.wrap "`alias.term.force` takes two arguments, like `alias.term.force oldname newname`."
+    }
 
 aliasType :: InputPattern
 aliasType =
@@ -3296,6 +3310,7 @@ validInputs =
     [ add,
       aliasMany,
       aliasTerm,
+      aliasTermForce,
       aliasType,
       api,
       authLogin,

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -1410,14 +1410,16 @@ aliasTerm =
 aliasTermForce :: InputPattern
 aliasTermForce =
   InputPattern
-    { patternName = "alias.term.force",
+    { patternName = "debug.alias.term.force",
       aliases = [],
       visibility = I.Hidden,
       args = [("term to alias", Required, exactDefinitionTermQueryArg), ("alias name", Required, newNameArg)],
-      help = "`alias.term.force foo bar` introduces `bar` with the same definition as `foo`.",
+      help = "`debug.alias.term.force foo bar` introduces `bar` with the same definition as `foo`.",
       parse = \case
         [oldName, newName] -> Input.AliasTermI True <$> handleShortHashOrHQSplit'Arg oldName <*> handleSplit'Arg newName
-        _ -> Left . warn $ P.wrap "`alias.term.force` takes two arguments, like `alias.term.force oldname newname`."
+        _ ->
+          Left . warn $
+            P.wrap "`debug.alias.term.force` takes two arguments, like `debug.alias.term.force oldname newname`."
     }
 
 aliasType :: InputPattern

--- a/unison-src/transcripts/alias-term.md
+++ b/unison-src/transcripts/alias-term.md
@@ -1,0 +1,30 @@
+`alias.term` makes a new name for a term.
+
+```ucm:hide
+project/main> builtins.mergeio lib.builtins
+```
+
+```ucm
+project/main> alias.term lib.builtins.bug foo
+project/main> ls
+project/main> reflog
+```
+
+It won't create a conflicted name, though.
+
+```ucm:error
+project/main> alias.term lib.builtins.todo foo
+```
+
+```ucm
+project/main> ls
+project/main> reflog
+```
+
+You can use `alias.term.force` for that.
+
+```ucm
+project/main> alias.term.force lib.builtins.todo foo
+project/main> ls
+project/main> reflog
+```

--- a/unison-src/transcripts/alias-term.md
+++ b/unison-src/transcripts/alias-term.md
@@ -19,9 +19,9 @@ project/main> alias.term lib.builtins.todo foo
 project/main> ls
 ```
 
-You can use `alias.term.force` for that.
+You can use `debug.alias.term.force` for that.
 
 ```ucm
-project/main> alias.term.force lib.builtins.todo foo
+project/main> debug.alias.term.force lib.builtins.todo foo
 project/main> ls
 ```

--- a/unison-src/transcripts/alias-term.md
+++ b/unison-src/transcripts/alias-term.md
@@ -7,7 +7,6 @@ project/main> builtins.mergeio lib.builtins
 ```ucm
 project/main> alias.term lib.builtins.bug foo
 project/main> ls
-project/main> reflog
 ```
 
 It won't create a conflicted name, though.
@@ -18,7 +17,6 @@ project/main> alias.term lib.builtins.todo foo
 
 ```ucm
 project/main> ls
-project/main> reflog
 ```
 
 You can use `alias.term.force` for that.
@@ -26,5 +24,4 @@ You can use `alias.term.force` for that.
 ```ucm
 project/main> alias.term.force lib.builtins.todo foo
 project/main> ls
-project/main> reflog
 ```

--- a/unison-src/transcripts/alias-term.output.md
+++ b/unison-src/transcripts/alias-term.output.md
@@ -10,27 +10,6 @@ project/main> ls
   1. foo  (a -> b)
   2. lib/ (643 terms, 92 types)
 
-project/main> reflog
-
-  Here is a log of the root namespace hashes, starting with the
-  most recent, along with the command that got us there. Try:
-  
-    `fork 2 .old`             
-    `fork #akvmucsmam .old`   to make an old namespace
-                              accessible again,
-                              
-    `reset-root #akvmucsmam`  to reset the root namespace and
-                              its history to that of the
-                              specified namespace.
-  
-       When   Root Hash     Action
-  1.   now    #94cs49dp5a   alias.term .__projects._f3c06c2f_7513_4da4_87a2_5b7860d8895f...
-  2.   now    #akvmucsmam   builtins.mergeio .__projects._f3c06c2f_7513_4da4_87a2_5b7860...
-  3.          #sg60bvjo91   history starts here
-  
-  Tip: Use `diff.namespace 1 7` to compare namespaces between
-       two points in history.
-
 ```
 It won't create a conflicted name, though.
 
@@ -48,27 +27,6 @@ project/main> ls
   1. foo  (a -> b)
   2. lib/ (643 terms, 92 types)
 
-project/main> reflog
-
-  Here is a log of the root namespace hashes, starting with the
-  most recent, along with the command that got us there. Try:
-  
-    `fork 2 .old`             
-    `fork #akvmucsmam .old`   to make an old namespace
-                              accessible again,
-                              
-    `reset-root #akvmucsmam`  to reset the root namespace and
-                              its history to that of the
-                              specified namespace.
-  
-       When   Root Hash     Action
-  1.   now    #94cs49dp5a   alias.term .__projects._f3c06c2f_7513_4da4_87a2_5b7860d8895f...
-  2.   now    #akvmucsmam   builtins.mergeio .__projects._f3c06c2f_7513_4da4_87a2_5b7860...
-  3.          #sg60bvjo91   history starts here
-  
-  Tip: Use `diff.namespace 1 7` to compare namespaces between
-       two points in history.
-
 ```
 You can use `alias.term.force` for that.
 
@@ -82,27 +40,5 @@ project/main> ls
   1. foo  (a -> b)
   2. foo  (a -> b)
   3. lib/ (643 terms, 92 types)
-
-project/main> reflog
-
-  Here is a log of the root namespace hashes, starting with the
-  most recent, along with the command that got us there. Try:
-  
-    `fork 2 .old`             
-    `fork #94cs49dp5a .old`   to make an old namespace
-                              accessible again,
-                              
-    `reset-root #94cs49dp5a`  to reset the root namespace and
-                              its history to that of the
-                              specified namespace.
-  
-       When   Root Hash     Action
-  1.   now    #agpq4mvdbu   alias.term.force .__projects._f3c06c2f_7513_4da4_87a2_5b7860...
-  2.   now    #94cs49dp5a   alias.term .__projects._f3c06c2f_7513_4da4_87a2_5b7860d8895f...
-  3.   now    #akvmucsmam   builtins.mergeio .__projects._f3c06c2f_7513_4da4_87a2_5b7860...
-  4.          #sg60bvjo91   history starts here
-  
-  Tip: Use `diff.namespace 1 7` to compare namespaces between
-       two points in history.
 
 ```

--- a/unison-src/transcripts/alias-term.output.md
+++ b/unison-src/transcripts/alias-term.output.md
@@ -28,10 +28,10 @@ project/main> ls
   2. lib/ (643 terms, 92 types)
 
 ```
-You can use `alias.term.force` for that.
+You can use `debug.alias.term.force` for that.
 
 ```ucm
-project/main> alias.term.force lib.builtins.todo foo
+project/main> debug.alias.term.force lib.builtins.todo foo
 
   Done.
 

--- a/unison-src/transcripts/alias-term.output.md
+++ b/unison-src/transcripts/alias-term.output.md
@@ -1,0 +1,108 @@
+`alias.term` makes a new name for a term.
+
+```ucm
+project/main> alias.term lib.builtins.bug foo
+
+  Done.
+
+project/main> ls
+
+  1. foo  (a -> b)
+  2. lib/ (643 terms, 92 types)
+
+project/main> reflog
+
+  Here is a log of the root namespace hashes, starting with the
+  most recent, along with the command that got us there. Try:
+  
+    `fork 2 .old`             
+    `fork #akvmucsmam .old`   to make an old namespace
+                              accessible again,
+                              
+    `reset-root #akvmucsmam`  to reset the root namespace and
+                              its history to that of the
+                              specified namespace.
+  
+       When   Root Hash     Action
+  1.   now    #94cs49dp5a   alias.term .__projects._f3c06c2f_7513_4da4_87a2_5b7860d8895f...
+  2.   now    #akvmucsmam   builtins.mergeio .__projects._f3c06c2f_7513_4da4_87a2_5b7860...
+  3.          #sg60bvjo91   history starts here
+  
+  Tip: Use `diff.namespace 1 7` to compare namespaces between
+       two points in history.
+
+```
+It won't create a conflicted name, though.
+
+```ucm
+project/main> alias.term lib.builtins.todo foo
+
+  ⚠️
+  
+  A term by that name already exists.
+
+```
+```ucm
+project/main> ls
+
+  1. foo  (a -> b)
+  2. lib/ (643 terms, 92 types)
+
+project/main> reflog
+
+  Here is a log of the root namespace hashes, starting with the
+  most recent, along with the command that got us there. Try:
+  
+    `fork 2 .old`             
+    `fork #akvmucsmam .old`   to make an old namespace
+                              accessible again,
+                              
+    `reset-root #akvmucsmam`  to reset the root namespace and
+                              its history to that of the
+                              specified namespace.
+  
+       When   Root Hash     Action
+  1.   now    #94cs49dp5a   alias.term .__projects._f3c06c2f_7513_4da4_87a2_5b7860d8895f...
+  2.   now    #akvmucsmam   builtins.mergeio .__projects._f3c06c2f_7513_4da4_87a2_5b7860...
+  3.          #sg60bvjo91   history starts here
+  
+  Tip: Use `diff.namespace 1 7` to compare namespaces between
+       two points in history.
+
+```
+You can use `alias.term.force` for that.
+
+```ucm
+project/main> alias.term.force lib.builtins.todo foo
+
+  Done.
+
+project/main> ls
+
+  1. foo  (a -> b)
+  2. foo  (a -> b)
+  3. lib/ (643 terms, 92 types)
+
+project/main> reflog
+
+  Here is a log of the root namespace hashes, starting with the
+  most recent, along with the command that got us there. Try:
+  
+    `fork 2 .old`             
+    `fork #94cs49dp5a .old`   to make an old namespace
+                              accessible again,
+                              
+    `reset-root #94cs49dp5a`  to reset the root namespace and
+                              its history to that of the
+                              specified namespace.
+  
+       When   Root Hash     Action
+  1.   now    #agpq4mvdbu   alias.term.force .__projects._f3c06c2f_7513_4da4_87a2_5b7860...
+  2.   now    #94cs49dp5a   alias.term .__projects._f3c06c2f_7513_4da4_87a2_5b7860d8895f...
+  3.   now    #akvmucsmam   builtins.mergeio .__projects._f3c06c2f_7513_4da4_87a2_5b7860...
+  4.          #sg60bvjo91   history starts here
+  
+  Tip: Use `diff.namespace 1 7` to compare namespaces between
+       two points in history.
+
+```


### PR DESCRIPTION
## Overview

This PR adds `alias.term.force`, which is exactly like `alias.term`, except:

- It's hidden from `help` output
- It won't complain if you ask it to make a conflicted name

## Test coverage

I've added a transcript.

## Loose ends

`alias.type.force` isn't implemented yet