### PR TITLE
Fix roundtrip bug when sub-docs contain headings

### DIFF
--- a/unison-src/transcripts-round-trip/main.output.md
+++ b/unison-src/transcripts-round-trip/main.output.md
@@ -24,7 +24,7 @@ So we can see the pretty-printed output:
 
   ☝️
   
-  I added 105 definitions to the top of scratch.u
+  I added 107 definitions to the top of scratch.u
   
   You can edit them there, then run `update` to replace the
   definitions currently in this namespace.
@@ -329,6 +329,59 @@ fix_4384e =
   docExampleBlock
     0 (id id id id id id id id id id id id id id id id id id id id id (x -> 0))
   }}
+  }}
+
+fix_4729a : Doc2
+fix_4729a =
+  {{
+  # H1A
+  
+    ## H2A
+    
+       ```
+       {{
+       # H1B
+       
+         ## B2B
+         
+            
+       }}
+       ```
+    
+    ## H2A
+    
+       
+  }}
+
+fix_4729b : Doc2
+fix_4729b =
+  {{
+  # H1A
+  
+    ## H2A
+    
+       {{ docTable
+         [[{{
+             # HA
+             
+               
+             }}, {{
+             # HB
+             
+               
+             }}], [{{
+             # a
+             
+               
+             }}, {{
+             # b
+             
+               
+             }}]] }}
+    
+    ## H2A
+    
+       
   }}
 
 Fix_525.bar.quaffle : Nat

--- a/unison-src/transcripts-round-trip/main.output.md
+++ b/unison-src/transcripts-round-trip/main.output.md
@@ -24,7 +24,7 @@ So we can see the pretty-printed output:
 
   ☝️
   
-  I added 107 definitions to the top of scratch.u
+  I added 108 definitions to the top of scratch.u
   
   You can edit them there, then run `update` to replace the
   definitions currently in this namespace.
@@ -382,6 +382,29 @@ fix_4729b =
     ## H2A
     
        
+  }}
+
+fix_4729c : Doc2
+fix_4729c =
+  {{
+  # Examples ``
+  docCallout
+    (Some
+      (syntax.docUntitledSection
+        [syntax.docSection (syntax.docParagraph [syntax.docWord "Title"]) []]))
+    (syntax.docUntitledSection
+      [ syntax.docParagraph
+          [ syntax.docWord "This"
+          , syntax.docWord "is"
+          , syntax.docWord "a"
+          , syntax.docWord "callout"
+          , syntax.docWord "with"
+          , syntax.docWord "a"
+          , syntax.docWord "title"
+          ]
+      ]) ``
+  
+    
   }}
 
 Fix_525.bar.quaffle : Nat

--- a/unison-src/transcripts-round-trip/reparses-with-same-hash.u
+++ b/unison-src/transcripts-round-trip/reparses-with-same-hash.u
@@ -543,3 +543,32 @@ fix_4384e =
   id : x -> x
   id x = x
   {{ {{ docExampleBlock 0 (id id id id id id id id id id id id id id id id id id id id id (x -> 0) }} }}
+
+fix_4729a = {{
+  # H1A
+
+  ## H2A
+
+  ```
+  {{
+    # H1B
+
+    ## B2B
+  }}
+  ```
+
+  ## H2A
+}}
+
+fix_4729b = {{
+  # H1A
+
+  ## H2A
+
+  {{ docTable [
+     [ {{ # HA }}, {{ # HB }} ],
+     [ {{ ## a }}, {{ ## b }} ]
+     ] }}
+
+  ## H2A
+}}

--- a/unison-src/transcripts-round-trip/reparses-with-same-hash.u
+++ b/unison-src/transcripts-round-trip/reparses-with-same-hash.u
@@ -572,3 +572,15 @@ fix_4729b = {{
 
   ## H2A
 }}
+
+fix_4729c = {{
+  # Examples
+  ```
+  docCallout
+    (Some
+      {{
+        # Title
+
+      }}) {{ This is a callout with a title }}
+  ```
+}}

--- a/unison-syntax/src/Unison/Syntax/Lexer.hs
+++ b/unison-syntax/src/Unison/Syntax/Lexer.hs
@@ -78,7 +78,7 @@ data ParsingEnv = ParsingEnv
     -- are we inside a construct that uses layout?
     inLayout :: Bool,
     -- Use a stack to remember the parent section and
-    -- allow docSections within docSessions.
+    -- allow docSections within docSections.
     -- 1 means we are inside a # Heading 1
     parentSections :: [Int],
     -- 4 means we are inside a list starting at the fourth column


### PR DESCRIPTION
Currently the parser errors out when we have headings inside sub-docs eg:

```
    x = {{ # Heading A
    
    ```
    {{ # Heading B }}
    ```
    }}
```

Fails with 

```
I got confused here:

      4 | {{ # Heading B }}


  I was surprised to find a #  here.
  I was expecting one of these instead:

  * white space
  * }}
```

I think this is because in `Lexer.hs` we have a single `parentSection :: Int` to keep track of the heading levels and to know how many `#` characters to expect.  However, when we enter a sub-doc, that number needs to be saved somehow and reset back to `0`. 

## Overview

Use a List (read: stack) to push a new `0` each time we enter a doc section.

Closes #4476
Closes #4729 

## Test coverage

I've added three tests in `reparses-with-same-hash.u` - not sure if they are really necessary but I figured it's better to err on the side of caution.

## Loose ends

N/A?