### PR TITLE
Fix roundtrip bug in Bytes.splitAt.doc

### DIFF
--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -459,7 +459,7 @@ pretty0
                     go tm = goNormal 10 tm
                 PP.hang kw <$> fmap PP.lines (traverse go rs)
               (Bytes' bs, _) ->
-                pure $ fmt S.BytesLiteral "0xs" <> PP.shown (Bytes.fromWord8s (map fromIntegral bs))
+                pure $ PP.group $ fmt S.BytesLiteral "0xs" <> PP.shown (Bytes.fromWord8s (map fromIntegral bs))
               BinaryAppsPred' apps lastArg -> do
                 prettyLast <- pretty0 (ac 3 Normal im doc) lastArg
                 prettyApps <- binaryApps apps prettyLast

--- a/unison-src/transcripts-round-trip/main.output.md
+++ b/unison-src/transcripts-round-trip/main.output.md
@@ -24,7 +24,7 @@ So we can see the pretty-printed output:
 
   ☝️
   
-  I added 105 definitions to the top of scratch.u
+  I added 106 definitions to the top of scratch.u
   
   You can edit them there, then run `update` to replace the
   definitions currently in this namespace.
@@ -330,6 +330,9 @@ fix_4384e =
     0 (id id id id id id id id id id id id id id id id id id id id id (x -> 0))
   }}
   }}
+
+fix_4727 : Doc2
+fix_4727 = {{ `` 0xs900dc0ffee `` }}
 
 Fix_525.bar.quaffle : Nat
 Fix_525.bar.quaffle = 32

--- a/unison-src/transcripts-round-trip/reparses-with-same-hash.u
+++ b/unison-src/transcripts-round-trip/reparses-with-same-hash.u
@@ -543,3 +543,5 @@ fix_4384e =
   id : x -> x
   id x = x
   {{ {{ docExampleBlock 0 (id id id id id id id id id id id id id id id id id id id id id (x -> 0) }} }}
+
+fix_4727 = {{ `` 0xs900dc0ffee `` }}


### PR DESCRIPTION
Closes https://github.com/unisonweb/unison/issues/4727

## Overview

Wraps the printing of `BytesLiteral` in a `F.Group` this removes the space between elements.

**NOTE** I am not 100% sure this is the right fix.  I haven't traced exactly how the `Pretty` datatype gets converted to a String.  I just noticed we use `group` in other cases where we don't want separation eg:

```
prettyRemoteBranchInfo :: (URI, ProjectName, ProjectBranchName) -> Pretty
prettyRemoteBranchInfo (host, remoteProject, remoteBranch) =
  -- Special-case Unison Share since we know its project branch URLs
  if URI.uriToString id host "" == "https://api.unison-lang.org"
    then
      P.group $
        "https://share.unison-lang.org/"
          <> prettyProjectName remoteProject
          <> "/code/"
          <> prettyProjectBranchName remoteBranch
  ...
```

Without the fix we would get this failure:

```
    The transcript failed due to an error in the stanza above. The error is:
    
    
      This looks like a function call, but with a Bytes where the function should be.  Are you missing an operator?
      
        302 | fix_4727 = {{ `` 0xs 900dc0ffee `` }}

```

## Loose ends

I added the test in `reparses-with-same-hash.u` mainly because there isn't a dedicated test for `TermPrinter.hs` (there is only one for `TypePrinter.hs`) I'm wondering if it would be better add it though?