### PR TITLE
Don't relax type when doing an instantiateL during subtyping

### DIFF
--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -2561,8 +2561,7 @@ subtype tx ty = scope (InSubtype tx ty) $ do
     go ctx (Type.Var' (TypeVar.Existential b v)) t -- `InstantiateL`
       | Set.member v (existentials ctx)
           && notMember v (Type.freeVars t) = do
-          e <- extendExistential Var.inferAbility
-          instantiateL b v (relax' False e t)
+          instantiateL b v t
     go ctx t (Type.Var' (TypeVar.Existential b v)) -- `InstantiateR`
       | Set.member v (existentials ctx)
           && notMember v (Type.freeVars t) = do

--- a/unison-src/transcripts-using-base/fix5129.md
+++ b/unison-src/transcripts-using-base/fix5129.md
@@ -1,0 +1,45 @@
+```ucm:hide
+.> builtins.mergeio
+```
+
+Checks for some bad type checking behavior. Some ability subtyping was
+too lenient when higher-order functions were involved.
+
+```unison:error
+foreach : (a ->{g} ()) -> [a] ->{g} ()
+foreach f = cases
+  [] -> ()
+  x +: xs ->
+    f x
+    foreach f xs
+
+forkIt : '{IO} () ->{IO} ()
+forkIt e =
+  _ = IO.forkComp e
+  ()
+
+thunk : '{IO,Exception} ()
+thunk = do
+  raise (Failure (typeLink MiscFailure) "thunk" (Any ()))
+
+go = do
+  foreach forkIt [thunk]
+```
+
+This comes from issue #3513
+
+```unison:error
+(<<) : (b ->{e} c) -> (a ->{e} b) -> a ->{e} c
+(<<) f g x = f (g x)
+
+catchAll.impl : '{IO, Exception} a ->{IO} Either Failure a
+catchAll.impl thunk =
+  handle tryEval do catch thunk
+  with
+    cases
+      { x }                    -> x
+      {Exception.raise f -> _} -> Left f
+
+fancyTryEval : '{g, IO, Exception} a ->{g, IO, Exception} a
+fancyTryEval = reraise << catchAll.impl
+```

--- a/unison-src/transcripts-using-base/fix5129.output.md
+++ b/unison-src/transcripts-using-base/fix5129.output.md
@@ -1,0 +1,73 @@
+Checks for some bad type checking behavior. Some ability subtyping was
+too lenient when higher-order functions were involved.
+
+```unison
+foreach : (a ->{g} ()) -> [a] ->{g} ()
+foreach f = cases
+  [] -> ()
+  x +: xs ->
+    f x
+    foreach f xs
+
+forkIt : '{IO} () ->{IO} ()
+forkIt e =
+  _ = IO.forkComp e
+  ()
+
+thunk : '{IO,Exception} ()
+thunk = do
+  raise (Failure (typeLink MiscFailure) "thunk" (Any ()))
+
+go = do
+  foreach forkIt [thunk]
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I found an ability mismatch when checking the application
+  
+     18 |   foreach forkIt [thunk]
+  
+  
+  When trying to match [Unit ->{𝕖75, IO, Exception} Unit] with
+  [Unit ->{IO} Unit] the left hand side contained extra
+  abilities: {𝕖75, Exception}
+  
+  
+
+```
+This comes from issue #3513
+
+```unison
+(<<) : (b ->{e} c) -> (a ->{e} b) -> a ->{e} c
+(<<) f g x = f (g x)
+
+catchAll.impl : '{IO, Exception} a ->{IO} Either Failure a
+catchAll.impl thunk =
+  handle tryEval do catch thunk
+  with
+    cases
+      { x }                    -> x
+      {Exception.raise f -> _} -> Left f
+
+fancyTryEval : '{g, IO, Exception} a ->{g, IO, Exception} a
+fancyTryEval = reraise << catchAll.impl
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  The expression in red
+  
+                needs the abilities: {g76}
+    but was assumed to only require: {IO, Exception}
+  
+  This is likely a result of using an un-annotated function as an argument with concrete abilities. Try adding an annotation to the function definition whose body is red.
+  
+     13 | fancyTryEval = reraise << catchAll.impl
+  
+
+```

--- a/unison-src/transcripts/fix2355.output.md
+++ b/unison-src/transcripts/fix2355.output.md
@@ -28,7 +28,7 @@ example = 'let
   
   The expression in red was inferred to require the ability: 
   
-      {A t25 {𝕖39, 𝕖18}}
+      {A t25 {𝕖36, 𝕖18}}
   
   where `𝕖18` is its overall abilities.
   


### PR DESCRIPTION
This is the case of `a < T` for some structured `T`. By relaxing, we are actually allowing `a` to be a _supertype_ of `T` as far as abilities go, which is not correct. Seems like it was just erroneously mirrored from the opposite case, where `T < a` means that `a` _could_ be more general than `T`.

Fixes #5129 and #3513.