### PR TITLE
fix: fix the textual representation of an ordinal number

### DIFF
--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -75,6 +75,7 @@ import Unison.Util.Monoid (intercalateMap)
 import Unison.Util.Pretty (ColorText, Pretty)
 import Unison.Util.Pretty qualified as Pr
 import Unison.Util.Range (Range (..), startingLine)
+import Unison.Util.Text (ordinal)
 import Unison.Var (Var)
 import Unison.Var qualified as Var
 
@@ -831,14 +832,6 @@ renderTypeError e env src = case e of
       let sz = length wrongs
           pl a b = if sz == 1 then a else b
        in mconcat [txt pl, intercalateMap "\n" (renderSuggestion env) wrongs]
-    ordinal :: (IsString s) => Int -> s
-    ordinal n =
-      fromString $
-        show n ++ case last (show n) of
-          '1' -> "st"
-          '2' -> "nd"
-          '3' -> "rd"
-          _ -> "th"
     debugNoteLoc a = if Settings.debugNoteLoc then a else mempty
     debugSummary :: C.ErrorNote v loc -> Pretty ColorText
     debugSummary note =

--- a/parser-typechecker/src/Unison/Util/Text.hs
+++ b/parser-typechecker/src/Unison/Util/Text.hs
@@ -6,6 +6,7 @@ module Unison.Util.Text where
 
 import Data.Foldable (toList)
 import Data.List (foldl', unfoldr)
+import Data.List qualified as L
 import Data.String (IsString (..))
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as T
@@ -130,6 +131,25 @@ indexOf needle haystack =
   where
     needle' = toLazyText needle
     haystack' = toLazyText haystack
+
+-- | Return the ordinal representation of a number in English.
+--   A number ending with '1' must finish with 'st'
+--   A number ending with '2' must finish with 'nd'
+--   A number ending with '3' must finish with 'rd'
+--   _except_ for 11, 12, and 13 which must finish with 'th'
+ordinal :: (IsString s) => Int -> s
+ordinal n = do
+  let s = show n
+  fromString $ s ++
+    case L.drop (L.length s - 2) s of
+      ['1', '1'] -> "th"
+      ['1', '2'] -> "th"
+      ['1', '3'] -> "th"
+      _ -> case last s of
+        '1' -> "st"
+        '2' -> "nd"
+        '3' -> "rd"
+        _ -> "th"
 
 -- Drop with both a maximum size and a predicate. Yields actual number of
 -- dropped characters.

--- a/parser-typechecker/tests/Unison/Test/Util/Text.hs
+++ b/parser-typechecker/tests/Unison/Test/Util/Text.hs
@@ -178,7 +178,28 @@ test =
                   )
                   (P.Join [P.Capture (P.Literal "zzzaaa"), P.Capture (P.Literal "!")])
            in P.run p "zzzaaa!!!"
-        ok
+        ok,
+      scope "ordinal" do
+        expectEqual (Text.ordinal 1) ("1st" :: String)
+        expectEqual (Text.ordinal 2) ("2nd" :: String)
+        expectEqual (Text.ordinal 3) ("3rd" :: String)
+        expectEqual (Text.ordinal 4) ("4th" :: String)
+        expectEqual (Text.ordinal 5) ("5th" :: String)
+        expectEqual (Text.ordinal 10) ("10th" :: String)
+        expectEqual (Text.ordinal 11) ("11th" :: String)
+        expectEqual (Text.ordinal 12) ("12th" :: String)
+        expectEqual (Text.ordinal 13) ("13th" :: String)
+        expectEqual (Text.ordinal 14) ("14th" :: String)
+        expectEqual (Text.ordinal 21) ("21st" :: String)
+        expectEqual (Text.ordinal 22) ("22nd" :: String)
+        expectEqual (Text.ordinal 23) ("23rd" :: String)
+        expectEqual (Text.ordinal 24) ("24th" :: String)
+        expectEqual (Text.ordinal 111) ("111th" :: String)
+        expectEqual (Text.ordinal 112) ("112th" :: String)
+        expectEqual (Text.ordinal 113) ("113th" :: String)
+        expectEqual (Text.ordinal 121) ("121st" :: String)
+        expectEqual (Text.ordinal 122) ("122nd" :: String)
+        expectEqual (Text.ordinal 123) ("123rd" :: String)
     ]
   where
     log2 :: Int -> Int


### PR DESCRIPTION
This PR fixes #5134. 

## Overview

The fix consists in making sure that any number ending with `11`, `12`, or `13` gets a `th` suffix.

## Implementation notes

I have moved that function to the `Unison.Util.Text` module in order to unit test it alongside other functions operating on `Text`.

## Test coverage

I'm not sure if this warrants a full transcript but I will add one if necessary.
