### PR TITLE
Group test results by definition

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Tests.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Tests.hs
@@ -14,7 +14,6 @@ import Data.Map qualified as Map
 import Data.Set qualified as Set
 import Data.Set.NonEmpty (NESet)
 import Data.Set.NonEmpty qualified as NESet
-import Data.Tuple qualified as Tuple
 import Unison.ABT qualified as ABT
 import Unison.Builtin.Decls qualified as DD
 import Unison.Cli.Monad (Cli)
@@ -69,21 +68,24 @@ handleTest TestInput {includeLibNamespace, path, showFailures, showSuccesses} = 
     Map.fromList <$> Cli.runTransaction do
       Set.toList testRefs & wither \case
         rid -> fmap (rid,) <$> Codebase.getWatch codebase WK.TestWatch rid
-  let (oks, fails) = passFails cachedTests
-      passFails :: (Ord r) => Map r (Term v a) -> ([(r, Text)], [(r, Text)])
-      passFails = Tuple.swap . partitionEithers . concat . map p . Map.toList
+  let (fails, oks) = passFails cachedTests
+      passFails :: (Ord r) => Map r (Term v a) -> (Map r [Text], Map r [Text])
+      passFails =
+        Map.foldrWithKey
+          (\r v (f, o) -> bimap (\ts -> if null ts then f else Map.insert r ts f) (\ts -> if null ts then o else Map.insert r ts o) . partitionEithers $ p v)
+          (Map.empty, Map.empty)
         where
-          p :: (r, Term v a) -> [Either (r, Text) (r, Text)]
-          p (r, tm) = case tm of
-            Term.List' ts -> mapMaybe (q r) (toList ts)
+          p :: Term v a -> [Either Text Text]
+          p = \case
+            Term.List' ts -> mapMaybe q $ toList ts
             _ -> []
-          q r = \case
+          q = \case
             Term.App' (Term.Constructor' (ConstructorReference ref cid)) (Term.Text' msg) ->
               if
                   | ref == DD.testResultRef ->
                       if
-                          | cid == DD.okConstructorId -> Just (Right (r, msg))
-                          | cid == DD.failConstructorId -> Just (Left (r, msg))
+                          | cid == DD.okConstructorId -> Just (Right msg)
+                          | cid == DD.failConstructorId -> Just (Left msg)
                           | otherwise -> Nothing
                   | otherwise -> Nothing
             _ -> Nothing
@@ -123,7 +125,7 @@ handleTest TestInput {includeLibNamespace, path, showFailures, showSuccesses} = 
               pure [(r, tm')]
 
     let m = Map.fromList computedTests
-        (mOks, mFails) = passFails m
+        (mFails, mOks) = passFails m
     Cli.respondNumbered $ TestResults Output.NewlyComputed fqnPPE showSuccesses showFailures mOks mFails
 
 handleIOTest :: HQ.HashQualified Name -> Cli ()
@@ -135,10 +137,14 @@ handleIOTest main = do
   let isIOTest typ = Foldable.any (Typechecker.isSubtype typ) $ Runtime.ioTestTypes runtime
   refs <- resolveHQNames names (Set.singleton main)
   (fails, oks) <-
-    refs & foldMapM \(ref, typ) -> do
-      when (not $ isIOTest typ) do
-        Cli.returnEarly (BadMainFunction "io.test" main typ suffixifiedPPE (Foldable.toList $ Runtime.ioTestTypes runtime))
-      runIOTest suffixifiedPPE ref
+    Foldable.foldrM
+      ( \(ref, typ) (f, o) -> do
+          when (not $ isIOTest typ) $
+            Cli.returnEarly (BadMainFunction "io.test" main typ suffixifiedPPE (Foldable.toList $ Runtime.ioTestTypes runtime))
+          bimap (\ts -> if null ts then f else Map.insert ref ts f) (\ts -> if null ts then o else Map.insert ref ts o) <$> runIOTest suffixifiedPPE ref
+      )
+      (Map.empty, Map.empty)
+      refs
   Cli.respondNumbered $ TestResults Output.NewlyComputed suffixifiedPPE True True oks fails
 
 findTermsOfTypes :: Codebase.Codebase m Symbol Ann -> Bool -> Path -> NESet (Type.Type Symbol Ann) -> Cli (Set TermReferenceId)
@@ -163,15 +169,20 @@ handleAllIOTests = do
   let suffixifiedPPE = PPED.suffixifiedPPE pped
   ioTestRefs <- findTermsOfTypes codebase False Path.empty (Runtime.ioTestTypes runtime)
   case NESet.nonEmptySet ioTestRefs of
-    Nothing -> Cli.respondNumbered $ TestResults Output.NewlyComputed suffixifiedPPE True True [] []
+    Nothing -> Cli.respondNumbered $ TestResults Output.NewlyComputed suffixifiedPPE True True Map.empty Map.empty
     Just neTestRefs -> do
       let total = NESet.size neTestRefs
       (fails, oks) <-
-        toList neTestRefs & zip [1 :: Int ..] & foldMapM \(n, r) -> do
-          Cli.respond $ TestIncrementalOutputStart suffixifiedPPE (n, total) r
-          (fails, oks) <- runIOTest suffixifiedPPE r
-          Cli.respond $ TestIncrementalOutputEnd suffixifiedPPE (n, total) r (null fails)
-          pure (fails, oks)
+        toList neTestRefs
+          & zip [1 :: Int ..]
+          & Foldable.foldrM
+            ( \(n, r) (f, o) -> do
+                Cli.respond $ TestIncrementalOutputStart suffixifiedPPE (n, total) r
+                (fails, oks) <- runIOTest suffixifiedPPE r
+                Cli.respond $ TestIncrementalOutputEnd suffixifiedPPE (n, total) r (null fails)
+                pure (if null fails then f else Map.insert r fails f, if null oks then o else Map.insert r oks o)
+            )
+            (Map.empty, Map.empty)
       Cli.respondNumbered $ TestResults Output.NewlyComputed suffixifiedPPE True True oks fails
 
 resolveHQNames :: Names -> Set (HQ.HashQualified Name) -> Cli (Set (Reference.Id, Type.Type Symbol Ann))
@@ -197,19 +208,16 @@ resolveHQNames parseNames hqNames =
           typ <- MaybeT (Codebase.getTypeOfReferent codebase (Referent.fromTermReferenceId ref))
           pure (ref, typ)
 
-runIOTest :: PPE.PrettyPrintEnv -> Reference.Id -> Cli ([(Reference.Id, Text)], [(Reference.Id, Text)])
+runIOTest :: PPE.PrettyPrintEnv -> Reference.Id -> Cli ([Text], [Text])
 runIOTest ppe ref = do
   let a = ABT.annotation tm
       tm = DD.forceTerm a a (Term.refId a ref)
   -- Don't cache IO tests
   tm' <- RuntimeUtils.evalUnisonTerm False ppe False tm
-  pure $ partitionTestResults [(ref, tm')]
+  pure $ partitionTestResults tm'
 
-partitionTestResults ::
-  [(Reference.Id, Term Symbol Ann)] ->
-  ([(Reference.Id, Text {- fails -})], [(Reference.Id, Text {- oks -})])
-partitionTestResults results = fold $ do
-  (ref, tm) <- results
+partitionTestResults :: Term Symbol Ann -> ([Text {- fails -}], [Text {- oks -}])
+partitionTestResults tm = fold $ do
   element <- case tm of
     Term.List' ts -> toList ts
     _ -> empty
@@ -217,8 +225,8 @@ partitionTestResults results = fold $ do
     Term.App' (Term.Constructor' (ConstructorReference conRef cid)) (Term.Text' msg) -> do
       guard (conRef == DD.testResultRef)
       if
-          | cid == DD.okConstructorId -> pure (mempty, [(ref, msg)])
-          | cid == DD.failConstructorId -> pure ([(ref, msg)], mempty)
+          | cid == DD.okConstructorId -> pure (mempty, [msg])
+          | cid == DD.failConstructorId -> pure ([msg], mempty)
           | otherwise -> empty
     _ -> empty
 

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -124,8 +124,8 @@ data NumberedOutput
       PPE.PrettyPrintEnv
       ShowSuccesses
       ShowFailures
-      [(TermReferenceId, Text)] -- oks
-      [(TermReferenceId, Text)] -- fails
+      (Map TermReferenceId [Text]) -- oks
+      (Map TermReferenceId [Text]) -- fails
   | Output'Todo !TodoOutput
   | -- | CantDeleteDefinitions ppe couldntDelete becauseTheseStillReferenceThem
     CantDeleteDefinitions PPE.PrettyPrintEnvDecl (Map LabeledDependency (NESet LabeledDependency))

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -308,8 +308,8 @@ notifyNumbered = \case
       )
       (showDiffNamespace ShowNumbers ppe (absPathToBranchId bAbs) (absPathToBranchId bAbs) diff)
   TestResults stats ppe _showSuccess _showFailures oksUnsorted failsUnsorted ->
-    let oks = Name.sortByText (HQ.toText . fst) [(name r, msg) | (r, msg) <- oksUnsorted]
-        fails = Name.sortByText (HQ.toText . fst) [(name r, msg) | (r, msg) <- failsUnsorted]
+    let oks = Name.sortByText (HQ.toText . fst) [(name r, msgs) | (r, msgs) <- Map.toList oksUnsorted]
+        fails = Name.sortByText (HQ.toText . fst) [(name r, msgs) | (r, msgs) <- Map.toList failsUnsorted]
         name r = PPE.termName ppe (Referent.fromTermReferenceId r)
      in ( case stats of
             CachedTests 0 _ -> P.callout "😶" $ "No tests to run."
@@ -2535,8 +2535,8 @@ displayRendered outputLoc pp =
 
 displayTestResults ::
   Bool -> -- whether to show the tip
-  [(HQ.HashQualified Name, Text)] ->
-  [(HQ.HashQualified Name, Text)] ->
+  [(HQ.HashQualified Name, [Text])] ->
+  [(HQ.HashQualified Name, [Text])] ->
   Pretty
 displayTestResults showTip oks fails =
   let name = P.text . HQ.toText
@@ -2545,11 +2545,11 @@ displayTestResults showTip oks fails =
           then mempty
           else
             P.indentN 2 $
-              P.numberedColumn2ListFrom 0 [(P.green "◉ " <> name r, "  " <> P.green (P.text msg)) | (r, msg) <- oks]
+              P.numberedColumn2ListFrom 0 [(name r, P.lines $ P.green . ("  ◉ " <>) . P.text <$> msgs) | (r, msgs) <- oks]
       okSummary =
         if null oks
           then mempty
-          else "✅ " <> P.bold (P.num (length oks)) <> P.green " test(s) passing"
+          else "✅ " <> P.bold (P.num (sum $ fmap (length . snd) oks)) <> P.green " test(s) passing"
       failMsg =
         if null fails
           then mempty
@@ -2557,11 +2557,11 @@ displayTestResults showTip oks fails =
             P.indentN 2 $
               P.numberedColumn2ListFrom
                 (length oks)
-                [(P.red "✗ " <> name r, "  " <> P.red (P.text msg)) | (r, msg) <- fails]
+                [(name r, P.lines $ P.red . ("  ✗ " <>) . P.text <$> msgs) | (r, msgs) <- fails]
       failSummary =
         if null fails
           then mempty
-          else "🚫 " <> P.bold (P.num (length fails)) <> P.red " test(s) failing"
+          else "🚫 " <> P.bold (P.num (sum $ fmap (length . snd) fails)) <> P.red " test(s) failing"
       tipMsg =
         if not showTip || (null oks && null fails)
           then mempty

--- a/unison-src/transcripts-manual/docs.to-html.output.md
+++ b/unison-src/transcripts-manual/docs.to-html.output.md
@@ -6,7 +6,7 @@
   I'll now fetch the latest version of the base Unison
   library...
 
-  Downloaded 14053 entities.
+  Downloaded 14067 entities.
 
   🎨 Type `ui` to explore this project's code in your browser.
   🔭 Discover libraries at https://share.unison-lang.org

--- a/unison-src/transcripts-using-base/_base.output.md
+++ b/unison-src/transcripts-using-base/_base.output.md
@@ -63,8 +63,8 @@ testAutoClean _ =
 
     New test results:
   
-    1. ◉ testAutoClean   our temporary directory should exist
-    2. ◉ testAutoClean   our temporary directory should no longer exist
+    1. testAutoClean   ◉ our temporary directory should exist
+                       ◉ our temporary directory should no longer exist
   
   ✅ 2 test(s) passing
   

--- a/unison-src/transcripts-using-base/binary-encoding-nats.output.md
+++ b/unison-src/transcripts-using-base/binary-encoding-nats.output.md
@@ -95,74 +95,74 @@ testABunchOfNats _ =
 
     New test results:
   
-    1.  ◉ testABunchOfNats   successfully decoded 4294967295 using 64 bit Big Endian
-    2.  ◉ testABunchOfNats   consumed all input
-    3.  ◉ testABunchOfNats   successfully decoded 4294967295 using 64 bit Little Endian
-    4.  ◉ testABunchOfNats   consumed all input
-    5.  ◉ testABunchOfNats   successfully decoded 4294967295 using 32 bit Big Endian
-    6.  ◉ testABunchOfNats   consumed all input
-    7.  ◉ testABunchOfNats   successfully decoded 4294967295 using 32 bit Little Endian
-    8.  ◉ testABunchOfNats   consumed all input
-    9.  ◉ testABunchOfNats   successfully decoded 1090519040 using 64 bit Big Endian
-    10. ◉ testABunchOfNats   consumed all input
-    11. ◉ testABunchOfNats   successfully decoded 1090519040 using 64 bit Little Endian
-    12. ◉ testABunchOfNats   consumed all input
-    13. ◉ testABunchOfNats   successfully decoded 1090519040 using 32 bit Big Endian
-    14. ◉ testABunchOfNats   consumed all input
-    15. ◉ testABunchOfNats   successfully decoded 1090519040 using 32 bit Little Endian
-    16. ◉ testABunchOfNats   consumed all input
-    17. ◉ testABunchOfNats   successfully decoded 4259840 using 64 bit Big Endian
-    18. ◉ testABunchOfNats   consumed all input
-    19. ◉ testABunchOfNats   successfully decoded 4259840 using 64 bit Little Endian
-    20. ◉ testABunchOfNats   consumed all input
-    21. ◉ testABunchOfNats   successfully decoded 4259840 using 32 bit Big Endian
-    22. ◉ testABunchOfNats   consumed all input
-    23. ◉ testABunchOfNats   successfully decoded 4259840 using 32 bit Little Endian
-    24. ◉ testABunchOfNats   consumed all input
-    25. ◉ testABunchOfNats   successfully decoded 16640 using 64 bit Big Endian
-    26. ◉ testABunchOfNats   consumed all input
-    27. ◉ testABunchOfNats   successfully decoded 16640 using 64 bit Little Endian
-    28. ◉ testABunchOfNats   consumed all input
-    29. ◉ testABunchOfNats   successfully decoded 16640 using 32 bit Big Endian
-    30. ◉ testABunchOfNats   consumed all input
-    31. ◉ testABunchOfNats   successfully decoded 16640 using 32 bit Little Endian
-    32. ◉ testABunchOfNats   consumed all input
-    33. ◉ testABunchOfNats   successfully decoded 16640 using 16 bit Big Endian
-    34. ◉ testABunchOfNats   consumed all input
-    35. ◉ testABunchOfNats   successfully decoded 16640 using 16 bit Little Endian
-    36. ◉ testABunchOfNats   consumed all input
-    37. ◉ testABunchOfNats   successfully decoded 2255827097 using 64 bit Big Endian
-    38. ◉ testABunchOfNats   consumed all input
-    39. ◉ testABunchOfNats   successfully decoded 2255827097 using 64 bit Little Endian
-    40. ◉ testABunchOfNats   consumed all input
-    41. ◉ testABunchOfNats   successfully decoded 2255827097 using 32 bit Big Endian
-    42. ◉ testABunchOfNats   consumed all input
-    43. ◉ testABunchOfNats   successfully decoded 2255827097 using 32 bit Little Endian
-    44. ◉ testABunchOfNats   consumed all input
-    45. ◉ testABunchOfNats   successfully decoded 65 using 64 bit Big Endian
-    46. ◉ testABunchOfNats   consumed all input
-    47. ◉ testABunchOfNats   successfully decoded 65 using 64 bit Little Endian
-    48. ◉ testABunchOfNats   consumed all input
-    49. ◉ testABunchOfNats   successfully decoded 65 using 32 bit Big Endian
-    50. ◉ testABunchOfNats   consumed all input
-    51. ◉ testABunchOfNats   successfully decoded 65 using 32 bit Little Endian
-    52. ◉ testABunchOfNats   consumed all input
-    53. ◉ testABunchOfNats   successfully decoded 65 using 16 bit Big Endian
-    54. ◉ testABunchOfNats   consumed all input
-    55. ◉ testABunchOfNats   successfully decoded 65 using 16 bit Little Endian
-    56. ◉ testABunchOfNats   consumed all input
-    57. ◉ testABunchOfNats   successfully decoded 0 using 64 bit Big Endian
-    58. ◉ testABunchOfNats   consumed all input
-    59. ◉ testABunchOfNats   successfully decoded 0 using 64 bit Little Endian
-    60. ◉ testABunchOfNats   consumed all input
-    61. ◉ testABunchOfNats   successfully decoded 0 using 32 bit Big Endian
-    62. ◉ testABunchOfNats   consumed all input
-    63. ◉ testABunchOfNats   successfully decoded 0 using 32 bit Little Endian
-    64. ◉ testABunchOfNats   consumed all input
-    65. ◉ testABunchOfNats   successfully decoded 0 using 16 bit Big Endian
-    66. ◉ testABunchOfNats   consumed all input
-    67. ◉ testABunchOfNats   successfully decoded 0 using 16 bit Little Endian
-    68. ◉ testABunchOfNats   consumed all input
+    1. testABunchOfNats   ◉ successfully decoded 4294967295 using 64 bit Big Endian
+                          ◉ consumed all input
+                          ◉ successfully decoded 4294967295 using 64 bit Little Endian
+                          ◉ consumed all input
+                          ◉ successfully decoded 4294967295 using 32 bit Big Endian
+                          ◉ consumed all input
+                          ◉ successfully decoded 4294967295 using 32 bit Little Endian
+                          ◉ consumed all input
+                          ◉ successfully decoded 1090519040 using 64 bit Big Endian
+                          ◉ consumed all input
+                          ◉ successfully decoded 1090519040 using 64 bit Little Endian
+                          ◉ consumed all input
+                          ◉ successfully decoded 1090519040 using 32 bit Big Endian
+                          ◉ consumed all input
+                          ◉ successfully decoded 1090519040 using 32 bit Little Endian
+                          ◉ consumed all input
+                          ◉ successfully decoded 4259840 using 64 bit Big Endian
+                          ◉ consumed all input
+                          ◉ successfully decoded 4259840 using 64 bit Little Endian
+                          ◉ consumed all input
+                          ◉ successfully decoded 4259840 using 32 bit Big Endian
+                          ◉ consumed all input
+                          ◉ successfully decoded 4259840 using 32 bit Little Endian
+                          ◉ consumed all input
+                          ◉ successfully decoded 16640 using 64 bit Big Endian
+                          ◉ consumed all input
+                          ◉ successfully decoded 16640 using 64 bit Little Endian
+                          ◉ consumed all input
+                          ◉ successfully decoded 16640 using 32 bit Big Endian
+                          ◉ consumed all input
+                          ◉ successfully decoded 16640 using 32 bit Little Endian
+                          ◉ consumed all input
+                          ◉ successfully decoded 16640 using 16 bit Big Endian
+                          ◉ consumed all input
+                          ◉ successfully decoded 16640 using 16 bit Little Endian
+                          ◉ consumed all input
+                          ◉ successfully decoded 2255827097 using 64 bit Big Endian
+                          ◉ consumed all input
+                          ◉ successfully decoded 2255827097 using 64 bit Little Endian
+                          ◉ consumed all input
+                          ◉ successfully decoded 2255827097 using 32 bit Big Endian
+                          ◉ consumed all input
+                          ◉ successfully decoded 2255827097 using 32 bit Little Endian
+                          ◉ consumed all input
+                          ◉ successfully decoded 65 using 64 bit Big Endian
+                          ◉ consumed all input
+                          ◉ successfully decoded 65 using 64 bit Little Endian
+                          ◉ consumed all input
+                          ◉ successfully decoded 65 using 32 bit Big Endian
+                          ◉ consumed all input
+                          ◉ successfully decoded 65 using 32 bit Little Endian
+                          ◉ consumed all input
+                          ◉ successfully decoded 65 using 16 bit Big Endian
+                          ◉ consumed all input
+                          ◉ successfully decoded 65 using 16 bit Little Endian
+                          ◉ consumed all input
+                          ◉ successfully decoded 0 using 64 bit Big Endian
+                          ◉ consumed all input
+                          ◉ successfully decoded 0 using 64 bit Little Endian
+                          ◉ consumed all input
+                          ◉ successfully decoded 0 using 32 bit Big Endian
+                          ◉ consumed all input
+                          ◉ successfully decoded 0 using 32 bit Little Endian
+                          ◉ consumed all input
+                          ◉ successfully decoded 0 using 16 bit Big Endian
+                          ◉ consumed all input
+                          ◉ successfully decoded 0 using 16 bit Little Endian
+                          ◉ consumed all input
   
   ✅ 68 test(s) passing
   

--- a/unison-src/transcripts-using-base/codeops.output.md
+++ b/unison-src/transcripts-using-base/codeops.output.md
@@ -364,19 +364,19 @@ to actual show that the serialization works.
 
     New test results:
   
-    1.  ◉ tests   (ext f) passed
-    2.  ◉ tests   (ext h) passed
-    3.  ◉ tests   (ident compound) passed
-    4.  ◉ tests   (ident fib10) passed
-    5.  ◉ tests   (ident effect) passed
-    6.  ◉ tests   (ident zero) passed
-    7.  ◉ tests   (ident h) passed
-    8.  ◉ tests   (ident text) passed
-    9.  ◉ tests   (ident int) passed
-    10. ◉ tests   (ident float) passed
-    11. ◉ tests   (ident termlink) passed
-    12. ◉ tests   (ident bool) passed
-    13. ◉ tests   (ident bytes) passed
+    1. tests   ◉ (ext f) passed
+               ◉ (ext h) passed
+               ◉ (ident compound) passed
+               ◉ (ident fib10) passed
+               ◉ (ident effect) passed
+               ◉ (ident zero) passed
+               ◉ (ident h) passed
+               ◉ (ident text) passed
+               ◉ (ident int) passed
+               ◉ (ident float) passed
+               ◉ (ident termlink) passed
+               ◉ (ident bool) passed
+               ◉ (ident bytes) passed
   
   ✅ 13 test(s) passing
   
@@ -386,7 +386,7 @@ to actual show that the serialization works.
 
     New test results:
   
-    1. ◉ badLoad   serialized77
+    1. badLoad   ◉ serialized77
   
   ✅ 1 test(s) passing
   
@@ -453,36 +453,36 @@ codeTests =
 
     New test results:
   
-    1.  ◉ codeTests   (idem f) passed
-    2.  ◉ codeTests   (idem h) passed
-    3.  ◉ codeTests   (idem rotate) passed
-    4.  ◉ codeTests   (idem zapper) passed
-    5.  ◉ codeTests   (idem showThree) passed
-    6.  ◉ codeTests   (idem concatMap) passed
-    7.  ◉ codeTests   (idem big) passed
-    8.  ◉ codeTests   (idem extensionality) passed
-    9.  ◉ codeTests   (idem identicality) passed
-    10. ◉ codeTests   (verified f) passed
-    11. ◉ codeTests   (verified h) passed
-    12. ◉ codeTests   (verified rotate) passed
-    13. ◉ codeTests   (verified zapper) passed
-    14. ◉ codeTests   (verified showThree) passed
-    15. ◉ codeTests   (verified concatMap) passed
-    16. ◉ codeTests   (verified big) passed
-    17. ◉ codeTests   (verified extensionality) passed
-    18. ◉ codeTests   (verified identicality) passed
-    19. ◉ codeTests   (verified mutual0) passed
-    20. ◉ codeTests   (verified mutual1) passed
-    21. ◉ codeTests   (verified mutual2) passed
-    22. ◉ codeTests   (rejected missing mutual0) passed
-    23. ◉ codeTests   (rejected missing mutual1) passed
-    24. ◉ codeTests   (rejected missing mutual2) passed
-    25. ◉ codeTests   (rejected swapped zapper) passed
-    26. ◉ codeTests   (rejected swapped extensionality) passed
-    27. ◉ codeTests   (rejected swapped identicality) passed
-    28. ◉ codeTests   (rejected swapped mututal0) passed
-    29. ◉ codeTests   (rejected swapped mututal1) passed
-    30. ◉ codeTests   (rejected swapped mututal2) passed
+    1. codeTests   ◉ (idem f) passed
+                   ◉ (idem h) passed
+                   ◉ (idem rotate) passed
+                   ◉ (idem zapper) passed
+                   ◉ (idem showThree) passed
+                   ◉ (idem concatMap) passed
+                   ◉ (idem big) passed
+                   ◉ (idem extensionality) passed
+                   ◉ (idem identicality) passed
+                   ◉ (verified f) passed
+                   ◉ (verified h) passed
+                   ◉ (verified rotate) passed
+                   ◉ (verified zapper) passed
+                   ◉ (verified showThree) passed
+                   ◉ (verified concatMap) passed
+                   ◉ (verified big) passed
+                   ◉ (verified extensionality) passed
+                   ◉ (verified identicality) passed
+                   ◉ (verified mutual0) passed
+                   ◉ (verified mutual1) passed
+                   ◉ (verified mutual2) passed
+                   ◉ (rejected missing mutual0) passed
+                   ◉ (rejected missing mutual1) passed
+                   ◉ (rejected missing mutual2) passed
+                   ◉ (rejected swapped zapper) passed
+                   ◉ (rejected swapped extensionality) passed
+                   ◉ (rejected swapped identicality) passed
+                   ◉ (rejected swapped mututal0) passed
+                   ◉ (rejected swapped mututal1) passed
+                   ◉ (rejected swapped mututal2) passed
   
   ✅ 30 test(s) passing
   
@@ -541,14 +541,14 @@ vtests _ =
 
     New test results:
   
-    1. ◉ vtests   validated
-    2. ◉ vtests   validated
-    3. ◉ vtests   validated
-    4. ◉ vtests   validated
-    5. ◉ vtests   validated
-    6. ◉ vtests   validated
-    7. ◉ vtests   validated
-    8. ◉ vtests   validated
+    1. vtests   ◉ validated
+                ◉ validated
+                ◉ validated
+                ◉ validated
+                ◉ validated
+                ◉ validated
+                ◉ validated
+                ◉ validated
   
   ✅ 8 test(s) passing
   

--- a/unison-src/transcripts-using-base/hashing.output.md
+++ b/unison-src/transcripts-using-base/hashing.output.md
@@ -316,31 +316,31 @@ test> crypto.hash.numTests =
 
   Cached test results (`help testcache` to learn more)
   
-    1.  ◉ blake2b_512.tests.ex1   Passed
-    2.  ◉ blake2b_512.tests.ex2   Passed
-    3.  ◉ blake2b_512.tests.ex3   Passed
-    4.  ◉ blake2s_256.tests.ex1   Passed
-    5.  ◉ crypto.hash.numTests    Passed
-    6.  ◉ sha1.tests.ex1          Passed
-    7.  ◉ sha1.tests.ex2          Passed
-    8.  ◉ sha1.tests.ex3          Passed
-    9.  ◉ sha1.tests.ex4          Passed
-    10. ◉ sha2_256.tests.ex1      Passed
-    11. ◉ sha2_256.tests.ex2      Passed
-    12. ◉ sha2_256.tests.ex3      Passed
-    13. ◉ sha2_256.tests.ex4      Passed
-    14. ◉ sha2_512.tests.ex1      Passed
-    15. ◉ sha2_512.tests.ex2      Passed
-    16. ◉ sha2_512.tests.ex3      Passed
-    17. ◉ sha2_512.tests.ex4      Passed
-    18. ◉ sha3_256.tests.ex1      Passed
-    19. ◉ sha3_256.tests.ex2      Passed
-    20. ◉ sha3_256.tests.ex3      Passed
-    21. ◉ sha3_256.tests.ex4      Passed
-    22. ◉ sha3_512.tests.ex1      Passed
-    23. ◉ sha3_512.tests.ex2      Passed
-    24. ◉ sha3_512.tests.ex3      Passed
-    25. ◉ sha3_512.tests.ex4      Passed
+    1.  blake2b_512.tests.ex1   ◉ Passed
+    2.  blake2b_512.tests.ex2   ◉ Passed
+    3.  blake2b_512.tests.ex3   ◉ Passed
+    4.  blake2s_256.tests.ex1   ◉ Passed
+    5.  crypto.hash.numTests    ◉ Passed
+    6.  sha1.tests.ex1          ◉ Passed
+    7.  sha1.tests.ex2          ◉ Passed
+    8.  sha1.tests.ex3          ◉ Passed
+    9.  sha1.tests.ex4          ◉ Passed
+    10. sha2_256.tests.ex1      ◉ Passed
+    11. sha2_256.tests.ex2      ◉ Passed
+    12. sha2_256.tests.ex3      ◉ Passed
+    13. sha2_256.tests.ex4      ◉ Passed
+    14. sha2_512.tests.ex1      ◉ Passed
+    15. sha2_512.tests.ex2      ◉ Passed
+    16. sha2_512.tests.ex3      ◉ Passed
+    17. sha2_512.tests.ex4      ◉ Passed
+    18. sha3_256.tests.ex1      ◉ Passed
+    19. sha3_256.tests.ex2      ◉ Passed
+    20. sha3_256.tests.ex3      ◉ Passed
+    21. sha3_256.tests.ex4      ◉ Passed
+    22. sha3_512.tests.ex1      ◉ Passed
+    23. sha3_512.tests.ex2      ◉ Passed
+    24. sha3_512.tests.ex3      ◉ Passed
+    25. sha3_512.tests.ex4      ◉ Passed
   
   ✅ 25 test(s) passing
   
@@ -478,34 +478,34 @@ test> md5.tests.ex3 =
 
   Cached test results (`help testcache` to learn more)
   
-    1.  ◉ blake2b_512.tests.ex1   Passed
-    2.  ◉ blake2b_512.tests.ex2   Passed
-    3.  ◉ blake2b_512.tests.ex3   Passed
-    4.  ◉ blake2s_256.tests.ex1   Passed
-    5.  ◉ crypto.hash.numTests    Passed
-    6.  ◉ md5.tests.ex1           Passed
-    7.  ◉ md5.tests.ex2           Passed
-    8.  ◉ md5.tests.ex3           Passed
-    9.  ◉ sha1.tests.ex1          Passed
-    10. ◉ sha1.tests.ex2          Passed
-    11. ◉ sha1.tests.ex3          Passed
-    12. ◉ sha1.tests.ex4          Passed
-    13. ◉ sha2_256.tests.ex1      Passed
-    14. ◉ sha2_256.tests.ex2      Passed
-    15. ◉ sha2_256.tests.ex3      Passed
-    16. ◉ sha2_256.tests.ex4      Passed
-    17. ◉ sha2_512.tests.ex1      Passed
-    18. ◉ sha2_512.tests.ex2      Passed
-    19. ◉ sha2_512.tests.ex3      Passed
-    20. ◉ sha2_512.tests.ex4      Passed
-    21. ◉ sha3_256.tests.ex1      Passed
-    22. ◉ sha3_256.tests.ex2      Passed
-    23. ◉ sha3_256.tests.ex3      Passed
-    24. ◉ sha3_256.tests.ex4      Passed
-    25. ◉ sha3_512.tests.ex1      Passed
-    26. ◉ sha3_512.tests.ex2      Passed
-    27. ◉ sha3_512.tests.ex3      Passed
-    28. ◉ sha3_512.tests.ex4      Passed
+    1.  blake2b_512.tests.ex1   ◉ Passed
+    2.  blake2b_512.tests.ex2   ◉ Passed
+    3.  blake2b_512.tests.ex3   ◉ Passed
+    4.  blake2s_256.tests.ex1   ◉ Passed
+    5.  crypto.hash.numTests    ◉ Passed
+    6.  md5.tests.ex1           ◉ Passed
+    7.  md5.tests.ex2           ◉ Passed
+    8.  md5.tests.ex3           ◉ Passed
+    9.  sha1.tests.ex1          ◉ Passed
+    10. sha1.tests.ex2          ◉ Passed
+    11. sha1.tests.ex3          ◉ Passed
+    12. sha1.tests.ex4          ◉ Passed
+    13. sha2_256.tests.ex1      ◉ Passed
+    14. sha2_256.tests.ex2      ◉ Passed
+    15. sha2_256.tests.ex3      ◉ Passed
+    16. sha2_256.tests.ex4      ◉ Passed
+    17. sha2_512.tests.ex1      ◉ Passed
+    18. sha2_512.tests.ex2      ◉ Passed
+    19. sha2_512.tests.ex3      ◉ Passed
+    20. sha2_512.tests.ex4      ◉ Passed
+    21. sha3_256.tests.ex1      ◉ Passed
+    22. sha3_256.tests.ex2      ◉ Passed
+    23. sha3_256.tests.ex3      ◉ Passed
+    24. sha3_256.tests.ex4      ◉ Passed
+    25. sha3_512.tests.ex1      ◉ Passed
+    26. sha3_512.tests.ex2      ◉ Passed
+    27. sha3_512.tests.ex3      ◉ Passed
+    28. sha3_512.tests.ex4      ◉ Passed
   
   ✅ 28 test(s) passing
   

--- a/unison-src/transcripts-using-base/mvar.output.md
+++ b/unison-src/transcripts-using-base/mvar.output.md
@@ -77,19 +77,19 @@ testMvars _ =
 
     New test results:
   
-    1.  ◉ testMvars   ma should not be empty
-    2.  ◉ testMvars   should read what you sow
-    3.  ◉ testMvars   should reap what you sow
-    4.  ◉ testMvars   ma should be empty
-    5.  ◉ testMvars   swap returns old contents
-    6.  ◉ testMvars   swap returns old contents
-    7.  ◉ testMvars   tryRead should succeed when not empty
-    8.  ◉ testMvars   tryPut should fail when not empty
-    9.  ◉ testMvars   tryTake should succeed when not empty
-    10. ◉ testMvars   tryTake should not succeed when empty
-    11. ◉ testMvars   ma2 should be empty
-    12. ◉ testMvars   tryTake should fail when empty
-    13. ◉ testMvars   tryRead should fail when empty
+    1. testMvars   ◉ ma should not be empty
+                   ◉ should read what you sow
+                   ◉ should reap what you sow
+                   ◉ ma should be empty
+                   ◉ swap returns old contents
+                   ◉ swap returns old contents
+                   ◉ tryRead should succeed when not empty
+                   ◉ tryPut should fail when not empty
+                   ◉ tryTake should succeed when not empty
+                   ◉ tryTake should not succeed when empty
+                   ◉ ma2 should be empty
+                   ◉ tryTake should fail when empty
+                   ◉ tryRead should fail when empty
   
   ✅ 13 test(s) passing
   

--- a/unison-src/transcripts-using-base/nat-coersion.output.md
+++ b/unison-src/transcripts-using-base/nat-coersion.output.md
@@ -63,20 +63,20 @@ test = 'let
 
     New test results:
   
-    1.  ◉ test   expected 0.0 got 0.0
-    2.  ◉ test   round trip though float, expected 0 got 0
-    3.  ◉ test   expected 0 got 0
-    4.  ◉ test   round trip though Int, expected 0 got 0
-    5.  ◉ test   skipped
-    6.  ◉ test   expected 1 got 1
-    7.  ◉ test   round trip though Int, expected 1 got 1
-    8.  ◉ test   skipped
-    9.  ◉ test   expected -1 got -1
-    10. ◉ test   round trip though Int, expected 18446744073709551615 got 18446744073709551615
-    11. ◉ test   expected 1.0000000000000002 got 1.0000000000000002
-    12. ◉ test   round trip though float, expected 4607182418800017409 got 4607182418800017409
-    13. ◉ test   expected 4607182418800017409 got 4607182418800017409
-    14. ◉ test   round trip though Int, expected 4607182418800017409 got 4607182418800017409
+    1. test   ◉ expected 0.0 got 0.0
+              ◉ round trip though float, expected 0 got 0
+              ◉ expected 0 got 0
+              ◉ round trip though Int, expected 0 got 0
+              ◉ skipped
+              ◉ expected 1 got 1
+              ◉ round trip though Int, expected 1 got 1
+              ◉ skipped
+              ◉ expected -1 got -1
+              ◉ round trip though Int, expected 18446744073709551615 got 18446744073709551615
+              ◉ expected 1.0000000000000002 got 1.0000000000000002
+              ◉ round trip though float, expected 4607182418800017409 got 4607182418800017409
+              ◉ expected 4607182418800017409 got 4607182418800017409
+              ◉ round trip though Int, expected 4607182418800017409 got 4607182418800017409
   
   ✅ 14 test(s) passing
   

--- a/unison-src/transcripts-using-base/net.output.md
+++ b/unison-src/transcripts-using-base/net.output.md
@@ -119,9 +119,9 @@ testDefaultPort _ =
 
     New test results:
   
-    1. ◉ testDefaultPort   successfully created socket
-    2. ◉ testDefaultPort   port should be > 1024
-    3. ◉ testDefaultPort   port should be < 65536
+    1. testDefaultPort   ◉ successfully created socket
+                         ◉ port should be > 1024
+                         ◉ port should be < 65536
   
   ✅ 3 test(s) passing
   
@@ -206,7 +206,7 @@ testTcpConnect = 'let
 
     New test results:
   
-    1. ◉ testTcpConnect   should have reaped what we've sown
+    1. testTcpConnect   ◉ should have reaped what we've sown
   
   ✅ 1 test(s) passing
   

--- a/unison-src/transcripts-using-base/random-deserial.output.md
+++ b/unison-src/transcripts-using-base/random-deserial.output.md
@@ -89,11 +89,11 @@ serialTests = do
 
     New test results:
   
-    1. ◉ serialTests   case-00
-    2. ◉ serialTests   case-01
-    3. ◉ serialTests   case-02
-    4. ◉ serialTests   case-03
-    5. ◉ serialTests   case-04
+    1. serialTests   ◉ case-00
+                     ◉ case-01
+                     ◉ case-02
+                     ◉ case-03
+                     ◉ case-04
   
   ✅ 5 test(s) passing
   

--- a/unison-src/transcripts-using-base/ref-promise.output.md
+++ b/unison-src/transcripts-using-base/ref-promise.output.md
@@ -42,8 +42,8 @@ casTest = do
 
     New test results:
   
-    1. ◉ casTest   CAS is successful is there were no conflicting writes
-    2. ◉ casTest   CAS fails when there was an intervening write
+    1. casTest   ◉ CAS is successful is there were no conflicting writes
+                 ◉ CAS fails when there was an intervening write
   
   ✅ 2 test(s) passing
   
@@ -106,8 +106,8 @@ promiseConcurrentTest = do
 
     New test results:
   
-    1. ◉ promiseSequentialTest   Should read a value that's been written
-    2. ◉ promiseSequentialTest   Promise can only be written to once
+    1. promiseSequentialTest   ◉ Should read a value that's been written
+                               ◉ Promise can only be written to once
   
   ✅ 2 test(s) passing
   
@@ -117,7 +117,7 @@ promiseConcurrentTest = do
 
     New test results:
   
-    1. ◉ promiseConcurrentTest   Reads awaits for completion of the Promise
+    1. promiseConcurrentTest   ◉ Reads awaits for completion of the Promise
   
   ✅ 1 test(s) passing
   
@@ -246,7 +246,7 @@ fullTest = do
 
     New test results:
   
-    1. ◉ fullTest   The state of the counter is consistent 
+    1. fullTest   ◉ The state of the counter is consistent 
   
   ✅ 1 test(s) passing
   

--- a/unison-src/transcripts-using-base/stm.output.md
+++ b/unison-src/transcripts-using-base/stm.output.md
@@ -119,16 +119,16 @@ tests = '(map spawn nats)
 
     New test results:
   
-    1.  ◉ tests   verified
-    2.  ◉ tests   verified
-    3.  ◉ tests   verified
-    4.  ◉ tests   verified
-    5.  ◉ tests   verified
-    6.  ◉ tests   verified
-    7.  ◉ tests   verified
-    8.  ◉ tests   verified
-    9.  ◉ tests   verified
-    10. ◉ tests   verified
+    1. tests   ◉ verified
+               ◉ verified
+               ◉ verified
+               ◉ verified
+               ◉ verified
+               ◉ verified
+               ◉ verified
+               ◉ verified
+               ◉ verified
+               ◉ verified
   
   ✅ 10 test(s) passing
   

--- a/unison-src/transcripts-using-base/thread.output.md
+++ b/unison-src/transcripts-using-base/thread.output.md
@@ -82,7 +82,7 @@ testBasicMultiThreadMVar = 'let
 
     New test results:
   
-    1. ◉ testBasicMultiThreadMVar   other thread should have incremented
+    1. testBasicMultiThreadMVar   ◉ other thread should have incremented
   
   ✅ 1 test(s) passing
   
@@ -157,7 +157,7 @@ testTwoThreads = 'let
 
     New test results:
   
-    1. ◉ testTwoThreads   
+    1. testTwoThreads   ◉ 
   
   ✅ 1 test(s) passing
   

--- a/unison-src/transcripts-using-base/tls.output.md
+++ b/unison-src/transcripts-using-base/tls.output.md
@@ -55,8 +55,8 @@ what_should_work _ = this_should_work ++ this_should_not_work
 
     New test results:
   
-    1. ◉ what_should_work   succesfully decoded self_signed_pem
-    2. ◉ what_should_work   failed
+    1. what_should_work   ◉ succesfully decoded self_signed_pem
+                          ◉ failed
   
   ✅ 2 test(s) passing
   
@@ -255,7 +255,7 @@ testCNReject _ =
 
     New test results:
   
-    1. ◉ testConnectSelfSigned   should have reaped what we've sown
+    1. testConnectSelfSigned   ◉ should have reaped what we've sown
   
   ✅ 1 test(s) passing
   
@@ -265,7 +265,7 @@ testCNReject _ =
 
     New test results:
   
-    1. ◉ testCAReject   correctly rejected self-signed cert
+    1. testCAReject   ◉ correctly rejected self-signed cert
   
   ✅ 1 test(s) passing
   
@@ -275,7 +275,7 @@ testCNReject _ =
 
     New test results:
   
-    1. ◉ testCNReject   correctly rejected self-signed cert
+    1. testCNReject   ◉ correctly rejected self-signed cert
   
   ✅ 1 test(s) passing
   

--- a/unison-src/transcripts/builtins.output.md
+++ b/unison-src/transcripts/builtins.output.md
@@ -490,7 +490,7 @@ openFilesIO = do
 
     New test results:
   
-    1. ◉ openFilesIO   Passed
+    1. openFilesIO   ◉ Passed
   
   ✅ 1 test(s) passing
   
@@ -539,33 +539,33 @@ Now that all the tests have been added to the codebase, let's view the test repo
 
   Cached test results (`help testcache` to learn more)
   
-    1.  ◉ Any.test1                           Passed
-    2.  ◉ Any.test2                           Passed
-    3.  ◉ Boolean.tests.andTable              Passed
-    4.  ◉ Boolean.tests.notTable              Passed
-    5.  ◉ Boolean.tests.orTable               Passed
-    6.  ◉ Bytes.tests.at                      Passed
-    7.  ◉ Bytes.tests.compression             Passed
-    8.  ◉ Bytes.tests.fromBase64UrlUnpadded   Passed
-    9.  ◉ Bytes.tests.indexOf                 Passed
-    10. ◉ Int.tests.arithmetic                Passed
-    11. ◉ Int.tests.bitTwiddling              Passed
-    12. ◉ Int.tests.conversions               Passed
-    13. ◉ Nat.tests.arithmetic                Passed
-    14. ◉ Nat.tests.bitTwiddling              Passed
-    15. ◉ Nat.tests.conversions               Passed
-    16. ◉ Sandbox.test1                       Passed
-    17. ◉ Sandbox.test2                       Passed
-    18. ◉ Sandbox.test3                       Passed
-    19. ◉ test.rtjqan7bcs                     Passed
-    20. ◉ Text.tests.alignment                Passed
-    21. ◉ Text.tests.indexOf                  Passed
-    22. ◉ Text.tests.indexOfEmoji             Passed
-    23. ◉ Text.tests.literalsEq               Passed
-    24. ◉ Text.tests.patterns                 Passed
-    25. ◉ Text.tests.repeat                   Passed
-    26. ◉ Text.tests.takeDropAppend           Passed
-    27. ◉ Universal.murmurHash.tests          Passed
+    1.  Any.test1                           ◉ Passed
+    2.  Any.test2                           ◉ Passed
+    3.  Boolean.tests.andTable              ◉ Passed
+    4.  Boolean.tests.notTable              ◉ Passed
+    5.  Boolean.tests.orTable               ◉ Passed
+    6.  Bytes.tests.at                      ◉ Passed
+    7.  Bytes.tests.compression             ◉ Passed
+    8.  Bytes.tests.fromBase64UrlUnpadded   ◉ Passed
+    9.  Bytes.tests.indexOf                 ◉ Passed
+    10. Int.tests.arithmetic                ◉ Passed
+    11. Int.tests.bitTwiddling              ◉ Passed
+    12. Int.tests.conversions               ◉ Passed
+    13. Nat.tests.arithmetic                ◉ Passed
+    14. Nat.tests.bitTwiddling              ◉ Passed
+    15. Nat.tests.conversions               ◉ Passed
+    16. Sandbox.test1                       ◉ Passed
+    17. Sandbox.test2                       ◉ Passed
+    18. Sandbox.test3                       ◉ Passed
+    19. test.rtjqan7bcs                     ◉ Passed
+    20. Text.tests.alignment                ◉ Passed
+    21. Text.tests.indexOf                  ◉ Passed
+    22. Text.tests.indexOfEmoji             ◉ Passed
+    23. Text.tests.literalsEq               ◉ Passed
+    24. Text.tests.patterns                 ◉ Passed
+    25. Text.tests.repeat                   ◉ Passed
+    26. Text.tests.takeDropAppend           ◉ Passed
+    27. Universal.murmurHash.tests          ◉ Passed
   
   ✅ 27 test(s) passing
   

--- a/unison-src/transcripts/fix2049.output.md
+++ b/unison-src/transcripts/fix2049.output.md
@@ -132,9 +132,9 @@ tests _ =
 
     New test results:
   
-    1. ◉ tests   caught
-    2. ◉ tests   caught
-    3. ◉ tests   got the right answer
+    1. tests   ◉ caught
+               ◉ caught
+               ◉ got the right answer
   
   ✅ 3 test(s) passing
   

--- a/unison-src/transcripts/fix4172.output.md
+++ b/unison-src/transcripts/fix4172.output.md
@@ -49,7 +49,7 @@ allowDebug = debug [1,2,3]
 
   Cached test results (`help testcache` to learn more)
   
-    1. ◉ t1   Yay
+    1. t1   ◉ Yay
   
   ✅ 1 test(s) passing
   
@@ -91,7 +91,7 @@ bool = false
 
     New test results:
   
-    1. ✗ t1   [1, 2, 3]
+    1. t1   ✗ [1, 2, 3]
   
   🚫 1 test(s) failing
   

--- a/unison-src/transcripts/fix5080.output.md
+++ b/unison-src/transcripts/fix5080.output.md
@@ -6,7 +6,7 @@
   I'll now fetch the latest version of the base Unison
   library...
 
-  Downloaded 14053 entities.
+  Downloaded 14067 entities.
 
   🎨 Type `ui` to explore this project's code in your browser.
   🔭 Discover libraries at https://share.unison-lang.org
@@ -63,9 +63,9 @@ test-5080/main> test
 
   Cached test results (`help testcache` to learn more)
   
-    1. ◉ fix5080.tests.success   Passed
+    1. fix5080.tests.success   ◉ Passed
   
-    2. ✗ fix5080.tests.failure   Failed
+    2. fix5080.tests.failure   ✗ Failed
   
   🚫 1 test(s) failing, ✅ 1 test(s) passing
   
@@ -81,7 +81,7 @@ test-5080/main> test
 
   Cached test results (`help testcache` to learn more)
   
-    1. ◉ fix5080.tests.success   Passed
+    1. fix5080.tests.success   ◉ Passed
   
   ✅ 1 test(s) passing
   

--- a/unison-src/transcripts/fix942.output.md
+++ b/unison-src/transcripts/fix942.output.md
@@ -116,7 +116,7 @@ test> t1 = if z == 3 then [Fail "nooo!!!"] else [Ok "great"]
 
   Cached test results (`help testcache` to learn more)
   
-    1. ◉ t1   great
+    1. t1   ◉ great
   
   ✅ 1 test(s) passing
   

--- a/unison-src/transcripts/io-test-command.output.md
+++ b/unison-src/transcripts/io-test-command.output.md
@@ -22,7 +22,7 @@ Run a IO tests one by one
 
     New test results:
   
-    1. ◉ ioAndExceptionTest   Success
+    1. ioAndExceptionTest   ◉ Success
   
   ✅ 1 test(s) passing
   
@@ -32,7 +32,7 @@ Run a IO tests one by one
 
     New test results:
   
-    1. ◉ ioTest   Success
+    1. ioTest   ◉ Success
   
   ✅ 1 test(s) passing
   
@@ -46,7 +46,7 @@ Run a IO tests one by one
 
     New test results:
   
-    1. ◉ ioAndExceptionTest   Success
+    1. ioAndExceptionTest   ◉ Success
   
   ✅ 1 test(s) passing
   
@@ -68,8 +68,8 @@ Run a IO tests one by one
 
     New test results:
   
-    1. ◉ ioAndExceptionTest   Success
-    2. ◉ ioTest               Success
+    1. ioAndExceptionTest   ◉ Success
+    2. ioTest               ◉ Success
   
   ✅ 2 test(s) passing
   

--- a/unison-src/transcripts/io.output.md
+++ b/unison-src/transcripts/io.output.md
@@ -69,13 +69,13 @@ testCreateRename _ =
 
     New test results:
   
-    1. ◉ testCreateRename   create a foo directory
-    2. ◉ testCreateRename   directory should exist
-    3. ◉ testCreateRename   foo should no longer exist
-    4. ◉ testCreateRename   directory should no longer exist
-    5. ◉ testCreateRename   bar should now exist
-    6. ◉ testCreateRename   removeDirectory works recursively
-    7. ◉ testCreateRename   removeDirectory works recursively
+    1. testCreateRename   ◉ create a foo directory
+                          ◉ directory should exist
+                          ◉ foo should no longer exist
+                          ◉ directory should no longer exist
+                          ◉ bar should now exist
+                          ◉ removeDirectory works recursively
+                          ◉ removeDirectory works recursively
   
   ✅ 7 test(s) passing
   
@@ -151,12 +151,12 @@ testOpenClose _ =
 
     New test results:
   
-    1. ◉ testOpenClose   file should be open
-    2. ◉ testOpenClose   file handle buffering should match what we just set.
-    3. ◉ testOpenClose   file should be closed
-    4. ◉ testOpenClose   bytes have been written
-    5. ◉ testOpenClose   bytes have been written
-    6. ◉ testOpenClose   file should be closed
+    1. testOpenClose   ◉ file should be open
+                       ◉ file handle buffering should match what we just set.
+                       ◉ file should be closed
+                       ◉ bytes have been written
+                       ◉ bytes have been written
+                       ◉ file should be closed
   
   ✅ 6 test(s) passing
   
@@ -241,14 +241,14 @@ testGetSomeBytes _ =
 
     New test results:
   
-    1. ◉ testGetSomeBytes   chunk size splits data into 2 uneven sides
-    2. ◉ testGetSomeBytes   file should be closed
-    3. ◉ testGetSomeBytes   first chunk matches first part of testData
-    4. ◉ testGetSomeBytes   second chunk matches rest of testData
-    5. ◉ testGetSomeBytes   should be at end of file
-    6. ◉ testGetSomeBytes   reading at end of file results in Bytes.empty
-    7. ◉ testGetSomeBytes   requesting many bytes results in what's available
-    8. ◉ testGetSomeBytes   file should be closed
+    1. testGetSomeBytes   ◉ chunk size splits data into 2 uneven sides
+                          ◉ file should be closed
+                          ◉ first chunk matches first part of testData
+                          ◉ second chunk matches rest of testData
+                          ◉ should be at end of file
+                          ◉ reading at end of file results in Bytes.empty
+                          ◉ requesting many bytes results in what's available
+                          ◉ file should be closed
   
   ✅ 8 test(s) passing
   
@@ -350,13 +350,13 @@ testAppend _ =
 
     New test results:
   
-    1. ◉ testSeek   seeked
-    2. ◉ testSeek   readable file should be seekable
-    3. ◉ testSeek   shouldn't be the EOF
-    4. ◉ testSeek   we should be at position 0
-    5. ◉ testSeek   we should be at position 1
-    6. ◉ testSeek   should be able to read our temporary file after seeking
-    7. ◉ testSeek   getLine should get a line
+    1. testSeek   ◉ seeked
+                  ◉ readable file should be seekable
+                  ◉ shouldn't be the EOF
+                  ◉ we should be at position 0
+                  ◉ we should be at position 1
+                  ◉ should be able to read our temporary file after seeking
+                  ◉ getLine should get a line
   
   ✅ 7 test(s) passing
   
@@ -366,7 +366,7 @@ testAppend _ =
 
     New test results:
   
-    1. ◉ testAppend   should be able to read our temporary file
+    1. testAppend   ◉ should be able to read our temporary file
   
   ✅ 1 test(s) passing
   
@@ -408,7 +408,7 @@ testSystemTime _ =
 
     New test results:
   
-    1. ◉ testSystemTime   systemTime should be sane
+    1. testSystemTime   ◉ systemTime should be sane
   
   ✅ 1 test(s) passing
   
@@ -438,8 +438,8 @@ testGetTempDirectory _ =
 
     New test results:
   
-    1. ◉ testGetTempDirectory   Temp directory is directory
-    2. ◉ testGetTempDirectory   Temp directory should exist
+    1. testGetTempDirectory   ◉ Temp directory is directory
+                              ◉ Temp directory should exist
   
   ✅ 2 test(s) passing
   
@@ -469,8 +469,8 @@ testGetCurrentDirectory _ =
 
     New test results:
   
-    1. ◉ testGetCurrentDirectory   Current directory is directory
-    2. ◉ testGetCurrentDirectory   Current directory should exist
+    1. testGetCurrentDirectory   ◉ Current directory is directory
+                                 ◉ Current directory should exist
   
   ✅ 2 test(s) passing
   
@@ -502,8 +502,8 @@ testDirContents _ =
 
     New test results:
   
-    1. ◉ testDirContents   directory size should be
-    2. ◉ testDirContents   directory contents should have current directory and parent
+    1. testDirContents   ◉ directory size should be
+                         ◉ directory contents should have current directory and parent
   
   ✅ 2 test(s) passing
   
@@ -535,8 +535,8 @@ testGetEnv _ =
 
     New test results:
   
-    1. ◉ testGetEnv   PATH environent variable should be set
-    2. ◉ testGetEnv   DOESNTEXIST didn't exist
+    1. testGetEnv   ◉ PATH environent variable should be set
+                    ◉ DOESNTEXIST didn't exist
   
   ✅ 2 test(s) passing
   
@@ -699,8 +699,8 @@ testRandom = do
 
     New test results:
   
-    1. ◉ testGetEnv   PATH environent variable should be set
-    2. ◉ testGetEnv   DOESNTEXIST didn't exist
+    1. testGetEnv   ◉ PATH environent variable should be set
+                    ◉ DOESNTEXIST didn't exist
   
   ✅ 2 test(s) passing
   

--- a/unison-src/transcripts/test-command.output.md
+++ b/unison-src/transcripts/test-command.output.md
@@ -39,8 +39,8 @@ foo.test2 = [Ok "test2"]
 
     New test results:
   
-    1. ◉ foo.test2   test2
-    2. ◉ test1       test1
+    1. foo.test2   ◉ test2
+    2. test1       ◉ test1
   
   ✅ 2 test(s) passing
   
@@ -54,8 +54,8 @@ Tests should be cached if unchanged.
 
   Cached test results (`help testcache` to learn more)
   
-    1. ◉ foo.test2   test2
-    2. ◉ test1       test1
+    1. foo.test2   ◉ test2
+    2. test1       ◉ test1
   
   ✅ 2 test(s) passing
   
@@ -87,8 +87,8 @@ testInLib = [Ok "testInLib"]
 
   Cached test results (`help testcache` to learn more)
   
-    1. ◉ foo.test2   test2
-    2. ◉ test1       test1
+    1. foo.test2   ◉ test2
+    2. test1       ◉ test1
   
   ✅ 2 test(s) passing
   
@@ -99,8 +99,8 @@ testInLib = [Ok "testInLib"]
     
     Cached test results (`help testcache` to learn more)
     
-      1. ◉ foo.test2   test2
-      2. ◉ test1       test1
+      1. foo.test2   ◉ test2
+      2. test1       ◉ test1
     
     ✅ 2 test(s) passing
     
@@ -112,7 +112,7 @@ testInLib = [Ok "testInLib"]
 
     New test results:
   
-    1. ◉ lib.testInLib   testInLib
+    1. lib.testInLib   ◉ testInLib
   
   ✅ 1 test(s) passing
   
@@ -126,7 +126,7 @@ testInLib = [Ok "testInLib"]
 
   Cached test results (`help testcache` to learn more)
   
-    1. ◉ testInLib   testInLib
+    1. testInLib   ◉ testInLib
   
   ✅ 1 test(s) passing
   
@@ -140,7 +140,7 @@ testInLib = [Ok "testInLib"]
 
   Cached test results (`help testcache` to learn more)
   
-    1. ◉ foo.test2   test2
+    1. foo.test2   ◉ test2
   
   ✅ 1 test(s) passing
   

--- a/unison-src/transcripts/top-level-exceptions.output.md
+++ b/unison-src/transcripts/top-level-exceptions.output.md
@@ -55,7 +55,7 @@ mytest _ = [Ok "Great"]
 
     New test results:
   
-    1. ◉ mytest   Great
+    1. mytest   ◉ Great
   
   ✅ 1 test(s) passing
   

--- a/unison-src/transcripts/unsafe-coerce.output.md
+++ b/unison-src/transcripts/unsafe-coerce.output.md
@@ -45,7 +45,7 @@ main _ =
 
     New test results:
   
-    1. ◉ main   
+    1. main   ◉ 
   
   ✅ 1 test(s) passing
   

--- a/unison-src/transcripts/watch-expressions.output.md
+++ b/unison-src/transcripts/watch-expressions.output.md
@@ -64,7 +64,7 @@ test> pass = [Ok "Passed"]
 
   Cached test results (`help testcache` to learn more)
   
-    1. ◉ pass   Passed
+    1. pass   ◉ Passed
   
   ✅ 1 test(s) passing
   


### PR DESCRIPTION
## Overview

Avoids duplication in the output.

Follow-up to #5140.

## Interesting/controversial decisions

With this new display, I’m wondering if it makes sense to _not_ split the failures from the successes, so all the terns for a definition are together rather than having the definition duplicated in each list.

## Test coverage

This is reflected in a number of transcripts.