### PR TITLE
Update lsp version and add cabal fixes

### DIFF
--- a/contrib/cabal.project
+++ b/contrib/cabal.project
@@ -29,7 +29,9 @@ packages:
   parser-typechecker
   unison-core
   unison-cli
+  unison-cli-main
   unison-hashing-v2
+  unison-merge
   unison-share-api
   unison-share-projects-api
   unison-syntax
@@ -47,10 +49,11 @@ source-repository-package
 
 constraints:
   lsp == 2.3.0.0,
-  fsnotify < 0.4,
-  crypton-x509-store <= 1.6.8,
-  servant <= 0.19.1,
-  optparse-applicative <= 0.17.1.0
+  fsnotify == 0.4.1.0,
+  crypton-x509-store == 1.6.9,
+  servant == 0.20.1,
+  optparse-applicative == 0.18.1.0,
+  tls == 1.8.0
 
 -- For now there is no way to apply ghc-options for all local packages
 -- See https://cabal.readthedocs.io/en/latest/cabal-project.html#package-configuration-options
@@ -127,6 +130,9 @@ package unison-core
   ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
 
 package unison-hashing-v2
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
+
+package unison-merge
   ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
 
 package unison-share-api

--- a/contrib/cabal.project
+++ b/contrib/cabal.project
@@ -46,6 +46,7 @@ source-repository-package
   tag: 9275eea7982dabbf47be2ba078ced669ae7ef3d5
 
 constraints:
+  lsp == 2.3.0.0,
   fsnotify < 0.4,
   crypton-x509-store <= 1.6.8,
   servant <= 0.19.1,

--- a/parser-typechecker/package.yaml
+++ b/parser-typechecker/package.yaml
@@ -80,7 +80,7 @@ dependencies:
   - nonempty-containers
   - open-browser
   - openapi3
-  - optparse-applicative >= 0.16.1.0
+  - optparse-applicative
   - pem
   - pretty-simple
   - primitive

--- a/parser-typechecker/src/Unison/Runtime/ANF/Serialize.hs
+++ b/parser-typechecker/src/Unison/Runtime/ANF/Serialize.hs
@@ -20,10 +20,10 @@ import Data.Serialize.Put (runPutLazy)
 import Data.Text (Text)
 import Data.Word (Word16, Word32, Word64)
 import GHC.Stack
+import GHC.IsList qualified (fromList)
 import Unison.ABT.Normalized (Term (..))
 import Unison.Reference (Reference, Reference' (Builtin), pattern Derived)
 import Unison.Runtime.ANF as ANF hiding (Tag)
-import Unison.Runtime.Array qualified as PA
 import Unison.Runtime.Exception
 import Unison.Runtime.Serialize
 import Unison.Util.EnumContainers qualified as EC
@@ -682,7 +682,7 @@ getBLit v =
     NegT -> Neg <$> getPositive
     CharT -> Char <$> getChar
     FloatT -> Float <$> getFloat
-    ArrT -> Arr . PA.fromList <$> getList (getValue v)
+    ArrT -> Arr . GHC.IsList.fromList <$> getList (getValue v)
 
 putRefs :: (MonadPut m) => [Reference] -> m ()
 putRefs rs = putFoldable putReference rs

--- a/parser-typechecker/src/Unison/Runtime/Array.hs
+++ b/parser-typechecker/src/Unison/Runtime/Array.hs
@@ -56,7 +56,7 @@ import Data.Primitive.PrimArray as EPA hiding
 import Data.Primitive.PrimArray qualified as PA
 import Data.Primitive.Types
 import Data.Word (Word8)
-import GHC.Exts (toList)
+import GHC.IsList (toList )
 
 #ifdef ARRAY_CHECK
 import GHC.Stack

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -286,7 +286,7 @@ library
     , nonempty-containers
     , open-browser
     , openapi3
-    , optparse-applicative >=0.16.1.0
+    , optparse-applicative
     , pem
     , pretty-simple
     , primitive
@@ -485,7 +485,7 @@ test-suite parser-typechecker-tests
     , nonempty-containers
     , open-browser
     , openapi3
-    , optparse-applicative >=0.16.1.0
+    , optparse-applicative
     , pem
     , pretty-simple
     , primitive

--- a/unison-cli/src/Unison/LSP.hs
+++ b/unison-cli/src/Unison/LSP.hs
@@ -80,8 +80,8 @@ spawnLsp lspFormattingConfig codebase runtime latestRootHash latestPath =
 
           -- currently we have an independent VFS for each LSP client since each client might have
           -- different un-saved state for the same file.
-          initVFS $ \vfs -> do
-            vfsVar <- newMVar vfs
+          do
+            vfsVar <- newMVar emptyVFS
             void $ runServerWith lspServerLogger lspClientLogger clientInput clientOutput (serverDefinition lspFormattingConfig vfsVar codebase runtime scope latestRootHash latestPath)
   where
     handleFailure :: String -> IOException -> IO ()

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -217,7 +217,7 @@ library
     , ki
     , lens
     , lock-file
-    , lsp >=2.2.0.0
+    , lsp
     , lsp-types >=2.0.2.0
     , megaparsec
     , memory
@@ -359,7 +359,7 @@ executable transcripts
     , ki
     , lens
     , lock-file
-    , lsp >=2.2.0.0
+    , lsp
     , lsp-types >=2.0.2.0
     , megaparsec
     , memory
@@ -508,7 +508,7 @@ test-suite cli-tests
     , ki
     , lens
     , lock-file
-    , lsp >=2.2.0.0
+    , lsp
     , lsp-types >=2.0.2.0
     , megaparsec
     , memory


### PR DESCRIPTION
Hey @ChrisPenner I noticed your PR https://github.com/unisonweb/unison/pull/5142 wasn't compiling because of LSP so I re-added a change I made a while back.  Hopefully this would now all pass 🤞 (edit: seems to pass on Ubuntu and Mac but not windows 🤔 ) Feel free to use this as you wish either fully or in part!

The main change is:
```
          do
            vfsVar <- newMVar emptyVFS
```

I've also added changes to get cabal to compile.  But feel free to not include them.



## Test coverage

Only local testing with `cabal-install version 3.10.3.0` and `ghc-9.6.5`

## Loose ends

N/A?
