### PR TITLE
Include trailing '!' in identifier names for hover

### DIFF
--- a/unison-cli/src/Unison/LSP/VFS.hs
+++ b/unison-cli/src/Unison/LSP/VFS.hs
@@ -81,7 +81,9 @@ identifierSplitAtPosition uri pos = do
   vf <- getVirtualFile uri
   PosPrefixInfo {fullLine, cursorPos} <- MaybeT (VFS.getCompletionPrefix pos vf)
   let (before, after) = Text.splitAt (cursorPos ^. character . to fromIntegral) fullLine
-  pure (Text.takeWhileEnd isIdentifierChar before, Text.takeWhile isIdentifierChar after)
+  pure (Text.takeWhileEnd isIdentifierChar before,
+        -- names can end with '!', and it's not a force, so we include it in the identifier if it's at the end.
+        Text.takeWhile (\c -> isIdentifierChar c || c == '!') after)
   where
     isIdentifierChar c =
       -- Manually exclude '!' and apostrophe, since those are usually just forces and

--- a/unison-cli/src/Unison/LSP/VFS.hs
+++ b/unison-cli/src/Unison/LSP/VFS.hs
@@ -81,9 +81,11 @@ identifierSplitAtPosition uri pos = do
   vf <- getVirtualFile uri
   PosPrefixInfo {fullLine, cursorPos} <- MaybeT (VFS.getCompletionPrefix pos vf)
   let (before, after) = Text.splitAt (cursorPos ^. character . to fromIntegral) fullLine
-  pure (Text.takeWhileEnd isIdentifierChar before,
-        -- names can end with '!', and it's not a force, so we include it in the identifier if it's at the end.
-        Text.takeWhile (\c -> isIdentifierChar c || c == '!') after)
+  pure
+    ( Text.takeWhileEnd isIdentifierChar before,
+      -- names can end with '!', and it's not a force, so we include it in the identifier if it's at the end.
+      Text.takeWhile (\c -> isIdentifierChar c || c == '!') after
+    )
   where
     isIdentifierChar c =
       -- Manually exclude '!' and apostrophe, since those are usually just forces and


### PR DESCRIPTION
## Overview

Closes #5097 

cc @ceedubs 

## Implementation notes

Allow a trailing `!` on identifiers, but not in identifier prefixes.

## Test coverage

I tested it in Vim, would be good to add a more comprehensive Hover test suite eventually, but not worth the effort at the moment as there are more important things to do.
