### PR TITLE
move pretty-print helpers out of CommandLine.hs

### DIFF
--- a/unison-cli/src/Unison/CommandLine.hs
+++ b/unison-cli/src/Unison/CommandLine.hs
@@ -3,21 +3,7 @@
 {-# LANGUAGE ViewPatterns #-}
 
 module Unison.CommandLine
-  ( -- * Pretty Printing
-    allow,
-    backtick,
-    aside,
-    bigproblem,
-    note,
-    nothingTodo,
-    plural,
-    plural',
-    problem,
-    tip,
-    warn,
-    warnNote,
-
-    -- * Other
+  ( allow,
     parseInput,
     prompt,
     watchConfig,
@@ -32,7 +18,6 @@ import Data.Configurator (autoConfig, autoReload)
 import Data.Configurator qualified as Config
 import Data.Configurator.Types (Config, Worth (..))
 import Data.List (isPrefixOf, isSuffixOf)
-import Data.ListLike (ListLike)
 import Data.Map qualified as Map
 import Data.Semialign qualified as Align
 import Data.Text qualified as Text
@@ -51,6 +36,7 @@ import Unison.Codebase.Path qualified as Path
 import Unison.Codebase.Watch qualified as Watch
 import Unison.CommandLine.FZFResolvers qualified as FZFResolvers
 import Unison.CommandLine.FuzzySelect qualified as Fuzzy
+import Unison.CommandLine.Helpers (warn)
 import Unison.CommandLine.InputPattern (InputPattern (..))
 import Unison.CommandLine.InputPattern qualified as InputPattern
 import Unison.Parser.Ann (Ann)
@@ -88,36 +74,6 @@ watchFileSystem q dir = do
     (filePath, text) <- watcher
     atomically . Q.enqueue q $ UnisonFileChanged (Text.pack filePath) text
   pure (cancel >> killThread t)
-
-warnNote :: String -> String
-warnNote s = "⚠️  " <> s
-
-backtick :: (IsString s) => P.Pretty s -> P.Pretty s
-backtick s = P.group ("`" <> s <> "`")
-
-tip :: (ListLike s Char, IsString s) => P.Pretty s -> P.Pretty s
-tip s = P.column2 [("Tip:", P.wrap s)]
-
-note :: (ListLike s Char, IsString s) => P.Pretty s -> P.Pretty s
-note s = P.column2 [("Note:", P.wrap s)]
-
-aside :: (ListLike s Char, IsString s) => P.Pretty s -> P.Pretty s -> P.Pretty s
-aside a b = P.column2 [(a <> ":", b)]
-
-warn :: (ListLike s Char, IsString s) => P.Pretty s -> P.Pretty s
-warn = emojiNote "⚠️"
-
-problem :: (ListLike s Char, IsString s) => P.Pretty s -> P.Pretty s
-problem = emojiNote "❗️"
-
-bigproblem :: (ListLike s Char, IsString s) => P.Pretty s -> P.Pretty s
-bigproblem = emojiNote "‼️"
-
-emojiNote :: (ListLike s Char, IsString s) => String -> P.Pretty s -> P.Pretty s
-emojiNote lead s = P.group (fromString lead) <> "\n" <> P.wrap s
-
-nothingTodo :: (ListLike s Char, IsString s) => P.Pretty s -> P.Pretty s
-nothingTodo = emojiNote "😶"
 
 parseInput ::
   Codebase IO Symbol Ann ->
@@ -235,15 +191,3 @@ fzfResolve codebase projCtx getCurrentBranch pat args = runExceptT do
 
 prompt :: String
 prompt = "> "
-
--- `plural [] "cat" "cats" = "cats"`
--- `plural ["meow"] "cat" "cats" = "cat"`
--- `plural ["meow", "meow"] "cat" "cats" = "cats"`
-plural :: (Foldable f) => f a -> b -> b -> b
-plural items one other = case toList items of
-  [_] -> one
-  _ -> other
-
-plural' :: (Integral a) => a -> b -> b -> b
-plural' 1 one _other = one
-plural' _ _one other = other

--- a/unison-cli/src/Unison/CommandLine/Helpers.hs
+++ b/unison-cli/src/Unison/CommandLine/Helpers.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Unison.CommandLine.Helpers
+  ( -- * Pretty Printing
+    backtick,
+    aside,
+    bigproblem,
+    note,
+    nothingTodo,
+    plural,
+    plural',
+    problem,
+    tip,
+    warn,
+    warnNote,
+  )
+where
+
+import Data.ListLike (ListLike)
+import Unison.Prelude
+import Unison.Util.Pretty qualified as P
+import Prelude hiding (readFile, writeFile)
+
+warnNote :: String -> String
+warnNote s = "⚠️  " <> s
+
+backtick :: (IsString s) => P.Pretty s -> P.Pretty s
+backtick s = P.group ("`" <> s <> "`")
+
+tip :: (ListLike s Char, IsString s) => P.Pretty s -> P.Pretty s
+tip s = P.column2 [("Tip:", P.wrap s)]
+
+note :: (ListLike s Char, IsString s) => P.Pretty s -> P.Pretty s
+note s = P.column2 [("Note:", P.wrap s)]
+
+aside :: (ListLike s Char, IsString s) => P.Pretty s -> P.Pretty s -> P.Pretty s
+aside a b = P.column2 [(a <> ":", b)]
+
+warn :: (ListLike s Char, IsString s) => P.Pretty s -> P.Pretty s
+warn = emojiNote "⚠️"
+
+problem :: (ListLike s Char, IsString s) => P.Pretty s -> P.Pretty s
+problem = emojiNote "❗️"
+
+bigproblem :: (ListLike s Char, IsString s) => P.Pretty s -> P.Pretty s
+bigproblem = emojiNote "‼️"
+
+emojiNote :: (ListLike s Char, IsString s) => String -> P.Pretty s -> P.Pretty s
+emojiNote lead s = P.group (fromString lead) <> "\n" <> P.wrap s
+
+nothingTodo :: (ListLike s Char, IsString s) => P.Pretty s -> P.Pretty s
+nothingTodo = emojiNote "😶"
+
+-- `plural [] "cat" "cats" = "cats"`
+-- `plural ["meow"] "cat" "cats" = "cat"`
+-- `plural ["meow", "meow"] "cat" "cats" = "cats"`
+plural :: (Foldable f) => f a -> b -> b -> b
+plural items one other = case toList items of
+  [_] -> one
+  _ -> other
+
+plural' :: (Integral a) => a -> b -> b -> b
+plural' 1 one _other = one
+plural' _ _one other = other

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -188,11 +188,11 @@ import Unison.Codebase.Path.Parse qualified as Path
 import Unison.Codebase.PushBehavior qualified as PushBehavior
 import Unison.Codebase.ShortCausalHash (ShortCausalHash)
 import Unison.Codebase.ShortCausalHash qualified as SCH
-import Unison.CommandLine
 import Unison.CommandLine.BranchRelativePath (BranchRelativePath (..), parseBranchRelativePath, parseIncrementalBranchRelativePath)
 import Unison.CommandLine.BranchRelativePath qualified as BranchRelativePath
 import Unison.CommandLine.Completion
 import Unison.CommandLine.FZFResolvers qualified as Resolvers
+import Unison.CommandLine.Helpers (aside, backtick, tip, warn)
 import Unison.CommandLine.InputPattern (ArgumentType (..), InputPattern (InputPattern), IsOptional (..), unionSuggestions)
 import Unison.CommandLine.InputPattern qualified as I
 import Unison.Core.Project (ProjectBranchName (..))

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -73,8 +73,8 @@ import Unison.Codebase.Runtime qualified as Runtime
 import Unison.Codebase.ShortCausalHash (ShortCausalHash)
 import Unison.Codebase.ShortCausalHash qualified as SCH
 import Unison.Codebase.SqliteCodebase.Conversions qualified as Cv
-import Unison.CommandLine (bigproblem, note, tip)
 import Unison.CommandLine.FZFResolvers qualified as FZFResolvers
+import Unison.CommandLine.Helpers (bigproblem, note, tip)
 import Unison.CommandLine.InputPattern (InputPattern)
 import Unison.CommandLine.InputPatterns (makeExample')
 import Unison.CommandLine.InputPatterns qualified as IP

--- a/unison-cli/src/Unison/Main.hs
+++ b/unison-cli/src/Unison/Main.hs
@@ -74,7 +74,8 @@ import Unison.Codebase.Runtime qualified as Rt
 import Unison.Codebase.SqliteCodebase qualified as SC
 import Unison.Codebase.TranscriptParser qualified as TR
 import Unison.Codebase.Verbosity qualified as Verbosity
-import Unison.CommandLine (plural', watchConfig)
+import Unison.CommandLine (watchConfig)
+import Unison.CommandLine.Helpers (plural')
 import Unison.CommandLine.Main qualified as CommandLine
 import Unison.CommandLine.Types qualified as CommandLine
 import Unison.CommandLine.Welcome (CodebaseInitStatus (..))

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -112,6 +112,7 @@ library
       Unison.CommandLine.DisplayValues
       Unison.CommandLine.FuzzySelect
       Unison.CommandLine.FZFResolvers
+      Unison.CommandLine.Helpers
       Unison.CommandLine.InputPattern
       Unison.CommandLine.InputPatterns
       Unison.CommandLine.Main


### PR DESCRIPTION
to avoid a potential cycle between CommandLine.hs and InputPatterns.hs that otherwise came up on another branch.

InputPatterns.hs also has formatting helpers that could be used in CommandLine.hs. Maybe they should be moved too, but I haven't thought about it.
