### PR TITLE
Improve LSP completion sorting

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -65,6 +65,7 @@ import Unison.Codebase.Editor.HandleInput.EditNamespace (handleEditNamespace)
 import Unison.Codebase.Editor.HandleInput.FindAndReplace (handleStructuredFindI, handleStructuredFindReplaceI)
 import Unison.Codebase.Editor.HandleInput.FormatFile qualified as Format
 import Unison.Codebase.Editor.HandleInput.InstallLib (handleInstallLib)
+import Unison.Codebase.Editor.HandleInput.LSPDebug qualified as LSPDebug
 import Unison.Codebase.Editor.HandleInput.Load (EvalMode (Sandboxed), evalUnisonFile, handleLoad, loadUnisonFile)
 import Unison.Codebase.Editor.HandleInput.Ls (handleLs)
 import Unison.Codebase.Editor.HandleInput.Merge2 (handleMerge)
@@ -809,6 +810,8 @@ loop e = do
               let completionFunc = Completion.haskelineTabComplete IP.patternMap codebase authHTTPClient currentPath
               (_, completions) <- liftIO $ completionFunc (reverse (unwords inputs), "")
               Cli.respond (DisplayDebugCompletions completions)
+            DebugLSPNameCompletionI prefix -> do
+              LSPDebug.debugLspNameCompletion prefix
             DebugFuzzyOptionsI command args -> do
               Cli.Env {codebase} <- ask
               currentPath <- Cli.getCurrentPath
@@ -1077,6 +1080,7 @@ inputDescription input =
     DebugNameDiffI {} -> wat
     DebugNumberedArgsI {} -> wat
     DebugTabCompletionI _input -> wat
+    DebugLSPNameCompletionI _prefix -> wat
     DebugFuzzyOptionsI cmd input -> pure . Text.pack $ "debug.fuzzy-completions " <> unwords (cmd : toList input)
     DebugFormatI -> pure "debug.format"
     DebugTypecheckedUnisonFileI {} -> wat

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/LSPDebug.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/LSPDebug.hs
@@ -1,0 +1,15 @@
+module Unison.Codebase.Editor.HandleInput.LSPDebug (debugLspNameCompletion) where
+
+import Unison.Cli.Monad (Cli)
+import Unison.Cli.Monad qualified as Cli
+import Unison.Cli.NamesUtils qualified as Cli
+import Unison.Codebase.Editor.Output (Output (DisplayDebugLSPNameCompletions))
+import Unison.LSP.Completion qualified as Completion
+import Unison.Prelude
+
+debugLspNameCompletion :: Text -> Cli ()
+debugLspNameCompletion prefix = do
+  names <- Cli.currentNames
+  let ct = Completion.namesToCompletionTree names
+  let (_, matches) = Completion.completionsForQuery ct prefix
+  Cli.respond $ DisplayDebugLSPNameCompletions matches

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -192,6 +192,7 @@ data Input
     -- no path is provided.
     NamespaceDependenciesI (Maybe Path')
   | DebugTabCompletionI [String] -- The raw arguments provided
+  | DebugLSPNameCompletionI Text -- The raw arguments provided
   | DebugFuzzyOptionsI String [String] -- cmd and arguments
   | DebugFormatI
   | DebugNumberedArgsI

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -31,6 +31,7 @@ module Unison.CommandLine.InputPatterns
     debugNameDiff,
     debugNumberedArgs,
     debugTabCompletion,
+    debugLspNameCompletion,
     debugTerm,
     debugTermVerbose,
     debugType,
@@ -1821,6 +1822,21 @@ debugTabCompletion =
     )
     (fmap Input.DebugTabCompletionI . traverse (unsupportedStructuredArgument "text"))
 
+debugLspNameCompletion :: InputPattern
+debugLspNameCompletion =
+  InputPattern
+    "debug.lsp-name-completion"
+    []
+    I.Hidden
+    [("Completion prefix", OnePlus, noCompletionsArg)]
+    ( P.lines
+        [ P.wrap $ "This command can be used to test and debug ucm's LSP name-completion within transcripts."
+        ]
+    )
+    \case
+      [prefix] -> Input.DebugLSPNameCompletionI . Text.pack <$> unsupportedStructuredArgument "text" prefix
+      _ -> Left (I.help debugLspNameCompletion)
+
 debugFuzzyOptions :: InputPattern
 debugFuzzyOptions =
   InputPattern
@@ -3341,6 +3357,7 @@ validInputs =
       debugNameDiff,
       debugNumberedArgs,
       debugTabCompletion,
+      debugLspNameCompletion,
       debugFuzzyOptions,
       debugFormat,
       delete,

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1646,6 +1646,16 @@ notifyUser dir = \case
                     else ""
              in (isCompleteTxt, P.string (Completion.replacement comp))
         )
+  DisplayDebugLSPNameCompletions completions ->
+    pure $
+      P.columnNHeader
+        ["Matching Path", "Name", "Hash"]
+        ( completions <&> \(pathText, fqn, ld) ->
+            let ldRef = case ld of
+                  LD.TermReferent ref -> prettyReferent 10 ref
+                  LD.TypeReference ref -> prettyReference 10 ref
+             in [P.text pathText, prettyName fqn, P.syntaxToColor ldRef]
+        )
   DebugDisplayFuzzyOptions argDesc fuzzyOptions ->
     pure $
       P.lines

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -67,6 +67,7 @@ library
       Unison.Codebase.Editor.HandleInput.InstallLib
       Unison.Codebase.Editor.HandleInput.Load
       Unison.Codebase.Editor.HandleInput.Ls
+      Unison.Codebase.Editor.HandleInput.LSPDebug
       Unison.Codebase.Editor.HandleInput.Merge2
       Unison.Codebase.Editor.HandleInput.MoveAll
       Unison.Codebase.Editor.HandleInput.MoveBranch

--- a/unison-src/transcripts/lsp-name-completion.md
+++ b/unison-src/transcripts/lsp-name-completion.md
@@ -1,0 +1,35 @@
+```ucm:hide
+scratch/main> builtins.merge lib.builtins
+```
+
+```unison:hide
+foldMap = "top-level"
+nested.deeply.foldMap = "nested"
+lib.base.foldMap = "lib"
+lib.dep.lib.transitive.foldMap = "transitive-lib"
+-- A deeply nested definition with the same hash as the top level one.
+-- This should not be included in the completion results if a better name with the same hash IS included.
+lib.dep.lib.transitive_same_hash.foldMap = "top-level"
+foldMapWith = "partial match"
+
+other = "other"
+```
+
+```ucm:hide
+scratch/main> add
+```
+
+Completion should find all the `foldMap` definitions in the codebase,
+sorted by number of name segments, shortest first.
+
+Individual LSP clients may still handle sorting differently, e.g. doing a fuzzy match over returned results, or
+prioritizing exact matches over partial matches. We don't have any control over that.
+
+```ucm
+scratch/main> debug.lsp-name-completion foldMap
+```
+
+Should still find the term which has a matching hash to a better name if the better name doesn't match.
+```ucm
+scratch/main> debug.lsp-name-completion transitive_same_hash.foldMap
+```

--- a/unison-src/transcripts/lsp-name-completion.output.md
+++ b/unison-src/transcripts/lsp-name-completion.output.md
@@ -1,0 +1,38 @@
+```unison
+foldMap = "top-level"
+nested.deeply.foldMap = "nested"
+lib.base.foldMap = "lib"
+lib.dep.lib.transitive.foldMap = "transitive-lib"
+-- A deeply nested definition with the same hash as the top level one.
+-- This should not be included in the completion results if a better name with the same hash IS included.
+lib.dep.lib.transitive_same_hash.foldMap = "top-level"
+foldMapWith = "partial match"
+
+other = "other"
+```
+
+Completion should find all the `foldMap` definitions in the codebase,
+sorted by number of name segments, shortest first.
+
+Individual LSP clients may still handle sorting differently, e.g. doing a fuzzy match over returned results, or
+prioritizing exact matches over partial matches. We don't have any control over that.
+
+```ucm
+scratch/main> debug.lsp-name-completion foldMap
+
+  Matching Path   Name                             Hash
+  foldMap         foldMap                          #o38ps8p4q6
+  foldMapWith     foldMapWith                      #r9rs4mcb0m
+  foldMap         nested.deeply.foldMap            #snrjegr5dk
+  foldMap         lib.base.foldMap                 #jf4buul17k
+  foldMap         lib.dep.lib.transitive.foldMap   #0o01gvr3fi
+
+```
+Should still find the term which has a matching hash to a better name if the better name doesn't match.
+```ucm
+scratch/main> debug.lsp-name-completion transitive_same_hash.foldMap
+
+  Matching Path                  Name                                       Hash
+  transitive_same_hash.foldMap   lib.dep.lib.transitive_same_hash.foldMap   #o38ps8p4q6
+
+```


### PR DESCRIPTION
## Overview

@pchiusano  noticed some pretty poor results from completion; deep transitive results were eclipsing his actual `base` dependency. This change uses a few heuristics to provide some info the LSP client to hopefully improve prioritization of results.
https://discord.com/channels/862108724948500490/1200119435931942994/1258414967363735673

Before; not pictured but the first results are all from a transitive `jwt` library with an old `base` lib.
<img width="689" alt="image" src="https://github.com/unisonweb/unison/assets/6439644/d8f6bf42-f910-43ac-9c81-de8edfb57626">


After; all the top results are from the top-level base lib. If we had a local 'foldMap' it appears at the very top.
<img width="699" alt="image" src="https://github.com/unisonweb/unison/assets/6439644/d5b2cf2f-d59e-4663-a2f6-37e69e3c605e">

## Implementation

* Add a debug command and transcripts to see results more easily
* Sort results by: number of lib segments, number of total segments, name
* Construct a lexicographically sorted composite of the above as text to provide to the LSP client.

## Test coverage

Added some transcript tests which show how we sort results; which is the same order we 'hint' for the client to prefer things.

## Loose ends

The completions in VS Code don't necessary provide the most information (we only show the suffixified name, which doesn't always show which lib it's in). The user can expand more info with `ctrl-space` if they want, but we may want experiment with other renderings later on.