### PR TITLE
Adds unused binding warnings to the LSP

### DIFF
--- a/unison-cli/src/Unison/LSP/Conversions.hs
+++ b/unison-cli/src/Unison/LSP/Conversions.hs
@@ -49,3 +49,10 @@ annToRange = \case
   Ann.External -> Nothing
   Ann.GeneratedFrom a -> annToRange a
   Ann.Ann start end -> Just $ Range (uToLspPos start) (uToLspPos end)
+
+annToURange :: Ann.Ann -> Maybe Range.Range
+annToURange = \case
+  Ann.Intrinsic -> Nothing
+  Ann.External -> Nothing
+  Ann.GeneratedFrom a -> annToURange a
+  Ann.Ann start end -> Just $ Range.Range start end

--- a/unison-cli/src/Unison/LSP/FileAnalysis.hs
+++ b/unison-cli/src/Unison/LSP/FileAnalysis.hs
@@ -35,6 +35,7 @@ import Unison.KindInference.Error qualified as KindInference
 import Unison.LSP.Conversions
 import Unison.LSP.Conversions qualified as Cv
 import Unison.LSP.Diagnostics (DiagnosticSeverity (..), mkDiagnostic, reportDiagnostics)
+import Unison.LSP.FileAnalysis.UnusedBindings qualified as UnusedBindings
 import Unison.LSP.Orphans ()
 import Unison.LSP.Types
 import Unison.LSP.VFS qualified as VFS
@@ -111,12 +112,14 @@ checkFile doc = runMaybeT do
           & toRangeMap
   let typeSignatureHints = fromMaybe mempty (mkTypeSignatureHints <$> parsedFile <*> typecheckedFile)
   let fileSummary = FileSummary.mkFileSummary parsedFile typecheckedFile
+  let unusedBindingDiagnostics = fileSummary ^.. _Just . to termsBySymbol . folded . _3 . folding (UnusedBindings.analyseTerm fileUri)
+  Debug.debugM Debug.Temp "Unused binding diagnostics" unusedBindingDiagnostics
   let tokenMap = getTokenMap tokens
   conflictWarningDiagnostics <-
     fold <$> for fileSummary \fs ->
       lift $ computeConflictWarningDiagnostics fileUri fs
   let diagnosticRanges =
-        (errDiagnostics <> conflictWarningDiagnostics)
+        (errDiagnostics <> conflictWarningDiagnostics <> unusedBindingDiagnostics)
           & fmap (\d -> (d ^. range, d))
           & toRangeMap
   let fileAnalysis = FileAnalysis {diagnostics = diagnosticRanges, codeActions = codeActionRanges, fileSummary, typeSignatureHints, ..}

--- a/unison-cli/src/Unison/LSP/FileAnalysis.hs
+++ b/unison-cli/src/Unison/LSP/FileAnalysis.hs
@@ -112,8 +112,7 @@ checkFile doc = runMaybeT do
           & toRangeMap
   let typeSignatureHints = fromMaybe mempty (mkTypeSignatureHints <$> parsedFile <*> typecheckedFile)
   let fileSummary = FileSummary.mkFileSummary parsedFile typecheckedFile
-  let unusedBindingDiagnostics = fileSummary ^.. _Just . to termsBySymbol . folded . _3 . folding (UnusedBindings.analyseTerm fileUri)
-  Debug.debugM Debug.Temp "Unused binding diagnostics" unusedBindingDiagnostics
+  let unusedBindingDiagnostics = fileSummary ^.. _Just . to termsBySymbol . folded . folding (\(topLevelAnn, _refId, trm, _type) -> UnusedBindings.analyseTerm fileUri topLevelAnn trm)
   let tokenMap = getTokenMap tokens
   conflictWarningDiagnostics <-
     fold <$> for fileSummary \fs ->

--- a/unison-cli/src/Unison/LSP/FileAnalysis/UnusedBindings.hs
+++ b/unison-cli/src/Unison/LSP/FileAnalysis/UnusedBindings.hs
@@ -1,0 +1,32 @@
+module Unison.LSP.FileAnalysis.UnusedBindings (analyseTerm) where
+
+import Data.Foldable qualified as Foldable
+import Data.Map qualified as Map
+import Data.Set qualified as Set
+import Language.LSP.Protocol.Types (Diagnostic)
+import Language.LSP.Protocol.Types qualified as Lsp
+import U.Core.ABT (ABT (..))
+import U.Core.ABT qualified as ABT
+import Unison.LSP.Conversions qualified as Cv
+import Unison.LSP.Diagnostics qualified as Diagnostic
+import Unison.Parser.Ann (Ann)
+import Unison.Prelude
+import Unison.Symbol (Symbol)
+import Unison.Term (Term)
+
+analyseTerm :: Lsp.Uri -> Term Symbol Ann -> [Diagnostic]
+analyseTerm fileUri tm =
+  let (unusedVars, _) = ABT.cata alg tm
+   in Map.toList unusedVars & mapMaybe \(v, ann) -> do
+        range <- Cv.annToRange ann
+        pure $ Diagnostic.mkDiagnostic fileUri range Diagnostic.DiagnosticSeverity_Warning ("Unused binding " <> tShow v) []
+  where
+    alg :: (Foldable f, Ord v) => Ann -> ABT f v (Map v Ann, Set v) -> (Map v Ann, Set v)
+    alg ann abt = case abt of
+      Var v -> (mempty, Set.singleton v)
+      Cycle x -> x
+      Abs v (unusedBindings, usedVars) ->
+        if v `Set.member` usedVars
+          then (unusedBindings, Set.delete v usedVars)
+          else (Map.insert v ann unusedBindings, usedVars)
+      Tm fx -> Foldable.fold fx

--- a/unison-cli/src/Unison/LSP/FileAnalysis/UnusedBindings.hs
+++ b/unison-cli/src/Unison/LSP/FileAnalysis/UnusedBindings.hs
@@ -10,13 +10,13 @@ import U.Core.ABT (ABT (..))
 import U.Core.ABT qualified as ABT
 import Unison.LSP.Conversions qualified as Cv
 import Unison.LSP.Diagnostics qualified as Diagnostic
+import Unison.Lexer.Pos qualified as Pos
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
 import Unison.Symbol (Symbol (..))
 import Unison.Term (Term)
 import Unison.Util.Range qualified as Range
 import Unison.Var qualified as Var
-import Unison.Lexer.Pos qualified as Pos
 
 analyseTerm :: Lsp.Uri -> Ann -> Term Symbol Ann -> [Diagnostic]
 analyseTerm fileUri topLevelTermAnn tm =

--- a/unison-cli/src/Unison/LSP/FileAnalysis/UnusedBindings.hs
+++ b/unison-cli/src/Unison/LSP/FileAnalysis/UnusedBindings.hs
@@ -1,8 +1,8 @@
 module Unison.LSP.FileAnalysis.UnusedBindings (analyseTerm) where
 
-import Data.Foldable qualified as Foldable
-import Data.Map qualified as Map
+import Control.Lens
 import Data.Set qualified as Set
+
 import Language.LSP.Protocol.Types (Diagnostic)
 import Language.LSP.Protocol.Types qualified as Lsp
 import U.Core.ABT (ABT (..))
@@ -13,20 +13,24 @@ import Unison.Parser.Ann (Ann)
 import Unison.Prelude
 import Unison.Symbol (Symbol)
 import Unison.Term (Term)
+import Unison.Term qualified as Term
 
 analyseTerm :: Lsp.Uri -> Term Symbol Ann -> [Diagnostic]
 analyseTerm fileUri tm =
-  let (unusedVars, _) = ABT.cata alg tm
-   in Map.toList unusedVars & mapMaybe \(v, ann) -> do
+  let (unusedVars, _) = ABT.para alg tm
+   in unusedVars & mapMaybe \(v, ann) -> do
         range <- Cv.annToRange ann
         pure $ Diagnostic.mkDiagnostic fileUri range Diagnostic.DiagnosticSeverity_Warning ("Unused binding " <> tShow v) []
   where
-    alg :: (Foldable f, Ord v) => Ann -> ABT f v (Map v Ann, Set v) -> (Map v Ann, Set v)
+    alg :: (Ord v) => Ann -> ABT (Term.F v a a) v (Term v Ann, ([(v, Ann)], Set v)) -> ([(v, Ann)], Set v)
     alg ann abt = case abt of
       Var v -> (mempty, Set.singleton v)
-      Cycle x -> x
-      Abs v (unusedBindings, usedVars) ->
+      Cycle (_t, x) -> x
+      Abs v (_, (unusedBindings, usedVars)) ->
         if v `Set.member` usedVars
           then (unusedBindings, Set.delete v usedVars)
-          else (Map.insert v ann unusedBindings, usedVars)
-      Tm fx -> Foldable.fold fx
+          else ((v, ann) : unusedBindings, usedVars)
+      Tm fx -> case fx of
+        Term.Let _isTop (lhsTerm, lx) (_rhsTerm, rx) ->
+          set (_1 . _head . _2) (ABT.annotation lhsTerm) lx <> rx
+        _ -> foldOf (folded . _2) fx

--- a/unison-cli/src/Unison/LSP/FileAnalysis/UnusedBindings.hs
+++ b/unison-cli/src/Unison/LSP/FileAnalysis/UnusedBindings.hs
@@ -3,6 +3,7 @@ module Unison.LSP.FileAnalysis.UnusedBindings where
 import Data.Foldable qualified as Foldable
 import Data.Map qualified as Map
 import Data.Set qualified as Set
+import Data.Text qualified as Text
 import Language.LSP.Protocol.Types (Diagnostic)
 import Language.LSP.Protocol.Types qualified as Lsp
 import U.Core.ABT (ABT (..))
@@ -11,22 +12,36 @@ import Unison.LSP.Conversions qualified as Cv
 import Unison.LSP.Diagnostics qualified as Diagnostic
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
-import Unison.Symbol (Symbol)
+import Unison.Symbol (Symbol (..))
 import Unison.Term (Term)
+import Unison.Util.Range qualified as Range
+import Unison.Var qualified as Var
+import Unison.Lexer.Pos qualified as Pos
 
-analyseTerm :: Lsp.Uri -> Term Symbol Ann -> [Diagnostic]
-analyseTerm fileUri tm =
+analyseTerm :: Lsp.Uri -> Ann -> Term Symbol Ann -> [Diagnostic]
+analyseTerm fileUri topLevelTermAnn tm =
   let (unusedVars, _) = ABT.cata alg tm
-   in Map.toList unusedVars & mapMaybe \(v, ann) -> do
-        range <- Cv.annToRange ann
-        pure $ Diagnostic.mkDiagnostic fileUri range Diagnostic.DiagnosticSeverity_Warning ("Unused binding " <> tShow v) []
+   in Map.toList unusedVars & mapMaybe \(v, _ann) -> do
+        name <- getRelevantVarName v
+        -- Unfortunately we don't capture the annotation of the actual binding when parsing :'(, for now the least
+        -- annoying thing to do is just highlight the top of the binding.
+        urange <- Cv.annToURange topLevelTermAnn <&> (\(Range.Range start@(Pos.Pos line _col) _end) -> Range.Range start (Pos.Pos line 9999))
+        let lspRange = Cv.uToLspRange urange
+        pure $ Diagnostic.mkDiagnostic fileUri lspRange Diagnostic.DiagnosticSeverity_Warning ("Unused binding " <> tShow name <> " inside this term.\nUse the binding, or prefix it with an _ to dismiss this warning.") []
   where
+    getRelevantVarName :: Symbol -> Maybe Text
+    getRelevantVarName = \case
+      -- We only care about user bindings which don't start with an underscore
+      Symbol _ (Var.User n) -> do
+        guard (not (Text.isPrefixOf "_" n))
+        pure n
+      _ -> Nothing
     alg :: (Foldable f, Ord v) => Ann -> ABT f v (Map v Ann, Set v) -> (Map v Ann, Set v)
     alg ann abt = case abt of
       Var v -> (mempty, Set.singleton v)
       Cycle x -> x
       Abs v (unusedBindings, usedVars) ->
         if v `Set.member` usedVars
-          then (mempty, Set.delete v usedVars)
+          then (unusedBindings, Set.delete v usedVars)
           else (Map.insert v ann unusedBindings, usedVars)
       Tm fx -> Foldable.fold fx

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -128,6 +128,7 @@ library
       Unison.LSP.Conversions
       Unison.LSP.Diagnostics
       Unison.LSP.FileAnalysis
+      Unison.LSP.FileAnalysis.UnusedBindings
       Unison.LSP.FoldingRange
       Unison.LSP.Formatting
       Unison.LSP.HandlerUtils


### PR DESCRIPTION
## Overview

Adds unused binding warnings to the LSP;

It can detect unused function arguments and unused bindings in lets.
Does not detect unused cycles.

<img width="714" alt="image" src="https://github.com/unisonweb/unison/assets/6439644/7ac3c00f-8431-416e-9ff5-e1876a06b369">

Unfortunately, the parser literally doesn't capture the location of binding names, so I can't put the warning on the appropriate binding :'(
We could fix this, but I think it would require either editing Unison.Term, the ABT, or changing UnisonFile to have a map of included binding locations.

## Implementation notes

The implementation is quite simple, we just use a `cata` to fold up a term bottom-up, every time we see a `Var` we mark that `v` as being used. Ever time we see an `Abs` we check if its `v` is actually used in the body, and if not, generate a warning.

## Interesting/controversial decisions

This will generate warnings for code which previously didn't have warnings, but it's just an LSP warning, it doesn't prevent or alter compilation.

## Test coverage

Tested it in VS Code

## Loose ends

It would be really great to actually be able to attach the diagnostics to the terms which are unused 😢 