### PR TITLE
Unused binding detection cleanup

### DIFF
--- a/lib/unison-prelude/src/Unison/Debug.hs
+++ b/lib/unison-prelude/src/Unison/Debug.hs
@@ -147,7 +147,7 @@ debugPatternCoverageConstraintSolver = PatternCoverageConstraintSolver `Set.memb
 debug :: (Show a) => DebugFlag -> String -> a -> a
 debug flag msg a =
   if shouldDebug flag
-    then (pTrace (msg <> ":\n" <> into @String (pShow a)) a)
+    then (trace (msg <> ":\n" <> into @String (pShow a)) a)
     else a
 
 -- | Use for selective debug logging in monadic contexts.


### PR DESCRIPTION
Sorry this was meant to be part of the [original PR](https://github.com/unisonweb/unison/pull/5186), but I didn't notice my push got blocked because CI ran a formatting pass 🙈 ;

Trunk is still in a good state I think, but this makes it just a little nicer.

Just combines the results into a single nice message rather than a separate diagnostic for each one.