### PR TITLE
avoid numeric vs textual clash in args length error

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -64,8 +64,13 @@ extra-deps:
   - recover-rtti-0.4.2@sha256:c179a303921126d8d782264e14f386c96e54a270df74be002e4c4ec3c8c7aebd,4529
   - lsp-2.2.0.0@sha256:82fbf4b69d94d8d22543be71f89986b3e90050032d671fb3de3f8253ea1e5b6f,3550
   - lsp-types-2.0.2.0@sha256:a9a51c3cea0726d91fe63fa0670935ee720f7b31bc3f3b33b2483fc538152677,29421
+  - numerals-0.4.1@sha256:f138b4a0efbde3b3c6cbccb788eff683cb8a5d046f449729712fd174c5ee8a78,11430
   - row-types-1.0.1.2@sha256:4d4c7cb95d06a32b28ba977852d52a26b4c1f695ef083a6fd874ab6d79933b64,3071
   - network-udp-0.0.0
+
+allow-newer: true
+allow-newer-deps:
+  - numerals
 
 ghc-options:
   # All packages

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -76,6 +76,13 @@ packages:
   original:
     hackage: lsp-types-2.0.2.0@sha256:a9a51c3cea0726d91fe63fa0670935ee720f7b31bc3f3b33b2483fc538152677,29421
 - completed:
+    hackage: numerals-0.4.1@sha256:f138b4a0efbde3b3c6cbccb788eff683cb8a5d046f449729712fd174c5ee8a78,11430
+    pantry-tree:
+      sha256: c616791b08f1792fd1d4ca03c6d2c773dedb25b24b66454c97864aefd85a5d0a
+      size: 13751
+  original:
+    hackage: numerals-0.4.1@sha256:f138b4a0efbde3b3c6cbccb788eff683cb8a5d046f449729712fd174c5ee8a78,11430
+- completed:
     hackage: row-types-1.0.1.2@sha256:4d4c7cb95d06a32b28ba977852d52a26b4c1f695ef083a6fd874ab6d79933b64,3071
     pantry-tree:
       sha256: 6a3617038d3970095100d14d026c396002a115700500cf3004ffb67ae5a75611

--- a/unison-cli/package.yaml
+++ b/unison-cli/package.yaml
@@ -54,6 +54,7 @@ dependencies:
   - network-udp
   - network-uri
   - nonempty-containers
+  - numerals
   - open-browser
   - optparse-applicative >= 0.16.1.0
   - pretty-simple

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -152,6 +152,8 @@ import System.Console.Haskeline.Completion (Completion (Completion))
 import System.Console.Haskeline.Completion qualified as Haskeline
 import System.Console.Haskeline.Completion qualified as Line
 import Text.Megaparsec qualified as Megaparsec
+import Text.Numeral (defaultInflection)
+import Text.Numeral.Language.ENG qualified as Numeral
 import U.Codebase.HashTags (CausalHash (..))
 import U.Codebase.Sqlite.DbId (ProjectBranchId)
 import U.Codebase.Sqlite.Project qualified as Sqlite
@@ -342,7 +344,11 @@ wrongStructuredArgument expected actual =
 
 wrongArgsLength :: Text -> [a] -> Either (P.Pretty CT.ColorText) b
 wrongArgsLength expected args =
-  Left . P.text $ "I expected " <> expected <> ", but received " <> Text.pack (show $ length args) <> "."
+  let foundCount =
+        if null args
+          then "none"
+          else fromMaybe (tShow $ length args) $ Numeral.us_cardinal defaultInflection (length args)
+   in Left . P.text $ "I expected " <> expected <> ", but received " <> foundCount <> "."
 
 patternName :: InputPattern -> P.Pretty P.ColorText
 patternName = fromString . I.patternName

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -345,9 +345,9 @@ wrongStructuredArgument expected actual =
 wrongArgsLength :: Text -> [a] -> Either (P.Pretty CT.ColorText) b
 wrongArgsLength expected args =
   let foundCount =
-        if null args
-          then "none"
-          else fromMaybe (tShow $ length args) $ Numeral.us_cardinal defaultInflection (length args)
+        case length args of
+          0 -> "none"
+          n -> fromMaybe (tShow n) $ Numeral.us_cardinal defaultInflection n
    in Left . P.text $ "I expected " <> expected <> ", but received " <> foundCount <> "."
 
 patternName :: InputPattern -> P.Pretty P.ColorText

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -230,6 +230,7 @@ library
     , network-udp
     , network-uri
     , nonempty-containers
+    , numerals
     , open-browser
     , optparse-applicative >=0.16.1.0
     , pretty-simple
@@ -371,6 +372,7 @@ executable transcripts
     , network-udp
     , network-uri
     , nonempty-containers
+    , numerals
     , open-browser
     , optparse-applicative >=0.16.1.0
     , pretty-simple
@@ -519,6 +521,7 @@ test-suite cli-tests
     , network-udp
     , network-uri
     , nonempty-containers
+    , numerals
     , open-browser
     , optparse-applicative >=0.16.1.0
     , pretty-simple

--- a/unison-src/transcripts/input-parse-errors.output.md
+++ b/unison-src/transcripts/input-parse-errors.output.md
@@ -68,7 +68,7 @@ scratch/main> update arg
 
 Sorry, I wasn’t sure how to process your request:
 
-  I expected no arguments, but received 1.
+  I expected no arguments, but received one.
 
 You can run `help update` for more information on using
 `update`.


### PR DESCRIPTION
## Overview

<img width="536" alt="image" src="https://github.com/unisonweb/unison/assets/538571/bb4bd4ed-9fda-4a74-a2ae-ada704ff3dc9">

## Implementation notes

Just calls `Numerals.us_cardinal` instead of `show` on the number of arguments to be mentioned in the error message.

## Interesting/controversial decisions

* `numerals` doesn't seem to be maintained anymore, but maybe that doesn't matter

* "zero" (the default) vs special-casing "none"

## Test coverage

I attempted to add additional transcript tests to cover the under-saturated case, but couldn't due to #5190. I would create them as soon as it's possible.

## Loose ends
