### PR TITLE
Use `SyntaxText.Unit` as style for `foo()`

### DIFF
--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -490,7 +490,7 @@ pretty0
               (App' x (Constructor' (ConstructorReference DD.UnitRef 0)), _) | isLeaf x -> do
                 px <- pretty0 (ac (if isBlock x then 0 else 9) Normal im doc) x
                 pure . paren (p >= 11 || isBlock x && p >= 3) $
-                  px <> fmt S.DelayForceChar (l "()")
+                  px <> fmt S.Unit (l "()")
               (Apps' f (unsnoc -> Just (args, lastArg)), _)
                 | isSoftHangable lastArg -> do
                     fun <- goNormal 9 f


### PR DESCRIPTION
Before:

![image](https://github.com/unisonweb/unison/assets/11074/eed5389a-4d8c-419a-a1fe-e6d58d4e86c6)

Right now the parens are styled using the `SyntaxText.DelayForceChar`. This PR switches to the `SyntaxText.Unit` style, which by default will render like the `()` here:

<img width="273" alt="CleanShot 2024-07-09 at 15 23 10@2x" src="https://github.com/unisonweb/unison/assets/11074/09f2e395-6d03-4652-8e3a-4fb87528dcfc">

The `'` in type signatures will still be styled the same.

No unit tests added for this. We actually don't have any unit tests for syntax highlighting. Maybe we should one day, though it doesn't seem very important.