### PR TITLE
Use pretty text in MsgTrace case of debug toText

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/Machine.hs
+++ b/parser-typechecker/src/Unison/Runtime/Machine.hs
@@ -384,7 +384,7 @@ exec !env !denv !_activeThreads !ustk !bstk !k _ (BPrim1 DBTX i)
       ustk <- bump ustk
       bstk <- case tracer env False clo of
         NoTrace -> bstk <$ poke ustk 0
-        MsgTrace _ tx _ -> do
+        MsgTrace _ _ tx -> do
           poke ustk 1
           bstk <- bump bstk
           bstk <$ pokeBi bstk (Util.Text.pack tx)


### PR DESCRIPTION
This changes the behavior of the `DBTX` instruction to use the provided 'pretty' text in cases where decompilation isn't complete. I think when this was first written it wouldn't provide much output, but since we have made it so that decompilation always produces something relatively useful, even if there are parts of the value that cannot be decompiled into any term.

This should improve e.g. cases that @ceedubs was seeing where looking at debug text for a value with a promise in it would produce massively more verbose `show` output rather than somewhat more comprehensible 'pretty' output.