### PR TITLE
Use builtin reference names in foreign decompiling

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/Decompile.hs
+++ b/parser-typechecker/src/Unison/Runtime/Decompile.hs
@@ -230,7 +230,11 @@ decompileForeign backref topTerms f
   | Just s <- unwrapSeq f =
       list' () <$> traverse (decompile backref topTerms) s
 decompileForeign _ _ (Wrap r _) =
-  err (BadForeign r) $ bug "<Foreign>"
+  err (BadForeign r) $ bug text
+  where
+    text
+      | Builtin name <- r = "<" <> name <> ">"
+      | otherwise = "<Foreign>"
 
 decompileBytes :: (Var v) => By.Bytes -> Term v ()
 decompileBytes =


### PR DESCRIPTION
This change makes e.g. a printed promise look like `bug "<Promise>"` instead of `bug "<Foreign>"`. I don't think there are any foreign values that have hash based references, but if there are, they'll fall back to just printing `<Foreign>`.