### PR TITLE
Fix unused binding annotations

### DIFF
--- a/parser-typechecker/src/Unison/Builtin/Decls.hs
+++ b/parser-typechecker/src/Unison/Builtin/Decls.hs
@@ -776,8 +776,8 @@ tupleTerm = foldr tupleConsTerm (unitTerm mempty)
 forceTerm :: (Var v) => a -> a -> Term v a -> Term v a
 forceTerm a au e = Term.app a e (unitTerm au)
 
-delayTerm :: (Var v) => a -> Term v a -> Term v a
-delayTerm a = Term.lam a $ Var.typed Var.Delay
+delayTerm :: (Var v) => a -> a -> Term v a -> Term v a
+delayTerm spanAnn argAnn = Term.lam spanAnn (argAnn, Var.typed Var.Delay)
 
 unTupleTerm ::
   Term.Term2 vt at ap v a ->

--- a/parser-typechecker/src/Unison/Syntax/TermParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermParser.hs
@@ -38,8 +38,8 @@ import Unison.NameSegment qualified as NameSegment
 import Unison.Names (Names)
 import Unison.Names qualified as Names
 import Unison.NamesWithHistory qualified as Names
-import Unison.Parser.Ann qualified as Ann
 import Unison.Parser.Ann (Ann)
+import Unison.Parser.Ann qualified as Ann
 import Unison.Pattern (Pattern)
 import Unison.Pattern qualified as Pattern
 import Unison.Prelude
@@ -412,7 +412,7 @@ hashQualifiedPrefixTerm = resolveHashQualified =<< hqPrefixId
 hashQualifiedInfixTerm :: (Monad m, Var v) => TermP v m
 hashQualifiedInfixTerm = resolveHashQualified =<< hqInfixId
 
-quasikeyword :: Ord v => Text -> P v m (L.Token ())
+quasikeyword :: (Ord v) => Text -> P v m (L.Token ())
 quasikeyword kw = queryToken \case
   L.WordyId (HQ'.NameOnly n) | nameIsKeyword n kw -> Just ()
   _ -> Nothing
@@ -993,10 +993,10 @@ bang = P.label "bang" do
   e <- termLeaf
   pure $ DD.forceTerm (ann start <> ann e) (ann start) e
 
-force :: forall m v . (Monad m, Var v) => TermP v m
+force :: forall m v. (Monad m, Var v) => TermP v m
 force = P.label "force" $ P.try do
   -- `forkAt pool() blah` parses as `forkAt (pool ()) blah`
-  -- That is, empty parens immediately (no space) following a symbol 
+  -- That is, empty parens immediately (no space) following a symbol
   -- is treated as high precedence function application of `Unit`
   fn <- hashQualifiedPrefixTerm
   tok <- ann <$> openBlockWith "("
@@ -1008,10 +1008,10 @@ seqOp :: (Ord v) => P v m Pattern.SeqOp
 seqOp =
   Pattern.Snoc
     <$ matchToken (L.SymbolyId (HQ'.fromName (Name.fromSegment NameSegment.snocSegment)))
-    <|> Pattern.Cons
-      <$ matchToken (L.SymbolyId (HQ'.fromName (Name.fromSegment NameSegment.consSegment)))
-    <|> Pattern.Concat
-      <$ matchToken (L.SymbolyId (HQ'.fromName (Name.fromSegment NameSegment.concatSegment)))
+      <|> Pattern.Cons
+    <$ matchToken (L.SymbolyId (HQ'.fromName (Name.fromSegment NameSegment.consSegment)))
+      <|> Pattern.Concat
+    <$ matchToken (L.SymbolyId (HQ'.fromName (Name.fromSegment NameSegment.concatSegment)))
 
 term4 :: (Monad m, Var v) => TermP v m
 term4 = f <$> some termLeaf

--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -1958,7 +1958,7 @@ toDocExample' suffix ppe (Apps' (Ref' r) [Nat' n, l@(LamsNamed' vs tm)])
   | nameEndsWith ppe suffix r,
     ABT.freeVars l == mempty,
     ok tm =
-      Just (lam' (ABT.annotation l) (drop (fromIntegral n + 1) vs) tm)
+      Just (lamWithoutBindingAnns (ABT.annotation l) (drop (fromIntegral n + 1) vs) tm)
   where
     ok (Apps' f _) = ABT.freeVars f == mempty
     ok tm = ABT.freeVars tm == mempty

--- a/parser-typechecker/src/Unison/Typechecker/Components.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Components.hs
@@ -78,7 +78,7 @@ minimize (Term.LetRecNamedAnnotatedTop' isTop blockAnn bs e) =
                       blockAnn
                       [(annotatedVar hdv, hdb)]
                       e
-                | otherwise = Term.singleLet isTop blockAnn (hdv, hdb) e
+                | otherwise = Term.singleLet isTop blockAnn (annotationFor hdv) (hdv, hdb) e
               mklet cycle@((_, _) : _) e =
                 Term.letRec
                   isTop
@@ -86,10 +86,7 @@ minimize (Term.LetRecNamedAnnotatedTop' isTop blockAnn bs e) =
                   (first annotatedVar <$> cycle)
                   e
               mklet [] e = e
-           in -- The outer annotation is going to be meaningful, so we make
-              -- sure to preserve it, whereas the annotations at intermediate Abs
-              -- nodes aren't necessarily meaningful
-              Right . Just . ABT.annotate blockAnn . foldr mklet e $ cs
+           in Right . Just . foldr mklet e $ cs
 minimize _ = Right Nothing
 
 minimize' ::

--- a/parser-typechecker/tests/Unison/Test/Term.hs
+++ b/parser-typechecker/tests/Unison/Test/Term.hs
@@ -57,7 +57,7 @@ test =
               ref = R.Id h 0
               v1 = Var.unnamedRef @Symbol ref
               -- input component: `ref = \v1 -> ref`
-              component = Map.singleton ref (Term.lam () v1 (Term.refId () ref))
+              component = Map.singleton ref (Term.lam () ((), v1) (Term.refId () ref))
               component' = Term.unhashComponent component
               -- expected unhashed component: `v2 = \v1 -> v2`, where `v2 /= v1`,
               -- i.e. `v2` cannot be just `ref` converted to a ref-named variable,

--- a/unison-cli/src/Unison/CommandLine/DisplayValues.hs
+++ b/unison-cli/src/Unison/CommandLine/DisplayValues.hs
@@ -178,12 +178,12 @@ displayPretty pped terms typeOf eval types tm = go tm
       DD.Doc2SpecialFormExample n (DD.Doc2Example vs body) ->
         P.backticked <$> displayTerm pped terms typeOf eval types ex
         where
-          ex = Term.lam' (ABT.annotation body) (drop (fromIntegral n) vs) body
+          ex = Term.lamWithoutBindingAnns (ABT.annotation body) (drop (fromIntegral n) vs) body
       DD.Doc2SpecialFormExampleBlock n (DD.Doc2Example vs body) ->
         -- todo: maybe do something with `vs` to indicate the variables are free
         P.indentN 4 <$> displayTerm' True pped terms typeOf eval types ex
         where
-          ex = Term.lam' (ABT.annotation body) (drop (fromIntegral n) vs) body
+          ex = Term.lamWithoutBindingAnns (ABT.annotation body) (drop (fromIntegral n) vs) body
 
       -- Link (Either Link.Type Doc2.Term)
       DD.Doc2SpecialFormLink e ->

--- a/unison-cli/src/Unison/LSP/FileAnalysis/UnusedBindings.hs
+++ b/unison-cli/src/Unison/LSP/FileAnalysis/UnusedBindings.hs
@@ -10,32 +10,23 @@ import U.Core.ABT (ABT (..))
 import U.Core.ABT qualified as ABT
 import Unison.LSP.Conversions qualified as Cv
 import Unison.LSP.Diagnostics qualified as Diagnostic
-import Unison.Lexer.Pos qualified as Pos
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
 import Unison.Symbol (Symbol (..))
 import Unison.Term (Term)
-import Unison.Util.Monoid qualified as Monoid
-import Unison.Util.Range qualified as Range
 import Unison.Var qualified as Var
 
-analyseTerm :: Lsp.Uri -> Ann -> Term Symbol Ann -> [Diagnostic]
-analyseTerm fileUri topLevelTermAnn tm =
+analyseTerm :: Lsp.Uri -> Term Symbol Ann -> [Diagnostic]
+analyseTerm fileUri tm =
   let (unusedVars, _) = ABT.cata alg tm
-      -- Unfortunately we don't capture the annotation of the actual binding when parsing :'(, for now the least
-      -- annoying thing to do is just highlight the top of the binding.
-      mayRange =
-        Cv.annToURange topLevelTermAnn
-          <&> (\(Range.Range start@(Pos.Pos line _col) _end) -> Range.Range start (Pos.Pos line 9999))
-          <&> Cv.uToLspRange
       vars =
-        Map.toList unusedVars & mapMaybe \(v, _ann) -> do
-          getRelevantVarName v
-   in case mayRange of
-        Nothing -> []
-        Just lspRange ->
-          let bindings = Text.intercalate ", " (tShow <$> vars)
-           in Monoid.whenM (not $ null vars) [Diagnostic.mkDiagnostic fileUri lspRange Diagnostic.DiagnosticSeverity_Warning ("Unused binding(s) " <> bindings <> " inside this term.\nUse the binding(s), or prefix them with an _ to dismiss this warning.") []]
+        Map.toList unusedVars & mapMaybe \(v, ann) -> do
+          (,ann) <$> getRelevantVarName v
+      diagnostics =
+        vars & mapMaybe \(varName, ann) -> do
+          lspRange <- Cv.annToRange ann
+          pure $ Diagnostic.mkDiagnostic fileUri lspRange Diagnostic.DiagnosticSeverity_Warning ("Unused binding " <> varName <> ". Use the binding, or prefix it with an _ to dismiss this warning.") []
+   in diagnostics
   where
     getRelevantVarName :: Symbol -> Maybe Text
     getRelevantVarName = \case

--- a/unison-cli/tests/Unison/Test/LSP.hs
+++ b/unison-cli/tests/Unison/Test/LSP.hs
@@ -10,6 +10,8 @@ import Data.String.Here.Uninterpolated (here)
 import Data.Text
 import Data.Text qualified as Text
 import EasyTest
+import Language.LSP.Protocol.Lens qualified as LSP
+import Language.LSP.Protocol.Types qualified as LSP
 import System.IO.Temp qualified as Temp
 import Unison.ABT qualified as ABT
 import Unison.Builtin.Decls (unitRef)
@@ -20,6 +22,8 @@ import Unison.Codebase.Init qualified as Codebase.Init
 import Unison.Codebase.SqliteCodebase qualified as SC
 import Unison.ConstructorReference (GConstructorReference (..))
 import Unison.FileParsers qualified as FileParsers
+import Unison.LSP.Conversions qualified as Cv
+import Unison.LSP.FileAnalysis.UnusedBindings qualified as UnusedBindings
 import Unison.LSP.Queries qualified as LSPQ
 import Unison.Lexer.Pos qualified as Lexer
 import Unison.Parser.Ann (Ann (..))
@@ -42,6 +46,10 @@ test = do
     tests
       [ refFinding,
         annotationNesting
+      ]
+  scope "diagnostics" $
+    tests
+      [ unusedBindingLocations
       ]
 
 trm :: Term.F Symbol () () (ABT.Term (Term.F Symbol () ()) Symbol ()) -> LSPQ.SourceNode ()
@@ -239,15 +247,39 @@ term = let
       )
     ]
 
--- | Test helper which lets you specify a cursor position inline with source text as a '|'.
+-- | Test helper which lets you specify a cursor position inline with source text as a '^'.
 extractCursor :: Text -> Test (Lexer.Pos, Text)
 extractCursor txt =
-  case Text.splitOn "^" txt of
+  case splitOnDelimiter '^' txt of
+    Nothing -> crash "expected exactly one cursor"
+    Just (before, pos, after) -> pure (pos, before <> after)
+
+-- | Splits a text on a delimiter, returning the text before and after the delimiter, along with the position of the delimiter.
+--
+-- >>> splitOnDelimiter '^' "foo b^ar baz"
+-- Just ("foo b",Pos {line = 0, column = 5},"ar baz")
+splitOnDelimiter :: Char -> Text -> Maybe (Text, Lexer.Pos, Text)
+splitOnDelimiter sym txt =
+  case Text.splitOn (Text.singleton sym) txt of
     [before, after] ->
-      let col = Text.length $ Text.takeWhileEnd (/= '\n') before
-          line = Prelude.length $ Text.lines before
-       in pure $ (Lexer.Pos line col, before <> after)
-    _ -> crash "expected exactly one cursor"
+      let col = (Text.length $ Text.takeWhileEnd (/= '\n') before) + 1
+          line = Text.count "\n" before + 1
+       in Just $ (before, Lexer.Pos line col, after)
+    _ -> Nothing
+
+-- | Test helper which lets you specify a cursor position inline with source text as a '^'.
+--
+-- >>> extractDelimitedBlock ('{', '}') "foo {bar} baz"
+-- Just (Ann {start = Pos {line = 1, column = 4}, end = Pos {line = 1, column = 7}},"bar","foo bar baz")
+--
+-- >>> extractDelimitedBlock ('{', '}') "term =\n  {foo} = 12345"
+-- Just (Ann {start = Pos {line = 2, column = 2}, end = Pos {line = 2, column = 5}},"foo","term =\n  foo = 12345")
+extractDelimitedBlock :: (Char, Char) -> Text -> Maybe (Ann {- ann spanning the inside of the delimiters -}, Text {- Text within the delimiters -}, Text {- entire source text with the delimiters stripped -})
+extractDelimitedBlock (startDelim, endDelim) txt = do
+  (beforeStart, startPos, afterStart) <- splitOnDelimiter startDelim txt
+  (beforeEnd, endPos, afterEnd) <- splitOnDelimiter endDelim (beforeStart <> afterStart)
+  let ann = Ann startPos endPos
+  pure (ann, Text.takeWhile (/= endDelim) afterStart, beforeEnd <> afterEnd)
 
 makeNodeSelectionTest :: (String, Text, Bool, LSPQ.SourceNode ()) -> Test ()
 makeNodeSelectionTest (name, testSrc, testTypechecked, expected) = scope name $ do
@@ -308,7 +340,7 @@ annotationNestingTest (name, src) = scope name do
     & traverse_ \(_fileAnn, _refId, _wk, trm, _typ) ->
       assertAnnotationsAreNested trm
 
--- | Asserts that for all nodes in the provided ABT, the annotations of all child nodes are
+-- | Asserts that for all nodes in the provided ABT EXCEPT Abs nodes, the annotations of all child nodes are
 -- within the span of the parent node.
 assertAnnotationsAreNested :: forall f. (Foldable f, Functor f, Show (f (Either String Ann))) => ABT.Term f Symbol Ann -> Test ()
 assertAnnotationsAreNested term = do
@@ -319,12 +351,19 @@ assertAnnotationsAreNested term = do
     alg :: Ann -> ABT.ABT f Symbol (Either String Ann) -> Either String Ann
     alg ann abt = do
       childSpan <- abt & foldMapM id
-      case ann `Ann.encompasses` childSpan of
-        -- one of the annotations isn't in the file, don't bother checking.
-        Nothing -> pure (ann <> childSpan)
-        Just isInFile
-          | isInFile -> pure ann
-          | otherwise -> Left $ "Containment breach: children aren't contained with the parent:" <> show (ann, abt)
+      case abt of
+        -- Abs nodes are the only nodes whose annotations are allowed to not contain their children,
+        -- they represet the location of the variable being bound instead. Ideally we'd have a separate child
+        -- node for that, but we can't add it without editing the ABT or Term types.
+        ABT.Abs _ _ ->
+          pure (ann <> childSpan)
+        _ -> do
+          case ann `Ann.encompasses` childSpan of
+            -- one of the annotations isn't in the file, don't bother checking.
+            Nothing -> pure (ann <> childSpan)
+            Just isInFile
+              | isInFile -> pure ann
+              | otherwise -> Left $ "Containment breach: children aren't contained with the parent:" <> show (ann, abt)
 
 typecheckSrc ::
   String ->
@@ -374,3 +413,38 @@ withTestCodebase action = do
     tmpDir <- Temp.createTempDirectory tmp "lsp-test"
     Codebase.Init.withCreatedCodebase SC.init "lsp-test" tmpDir SC.DontLock action
   either (crash . show) pure r
+
+makeDiagnosticRangeTest :: (String, Text) -> Test ()
+makeDiagnosticRangeTest (testName, testSrc) = scope testName $ do
+  (ann, _block, cleanSrc) <- case extractDelimitedBlock ('«', '»') testSrc of
+    Nothing -> crash "expected exactly one delimited block"
+    Just r -> pure r
+  (pf, _mayTypecheckedFile) <- typecheckSrc testName cleanSrc
+  UF.terms pf
+    & Map.elems
+    & \case
+      [(_a, trm)] -> do
+        case UnusedBindings.analyseTerm (LSP.Uri "test") trm of
+          [diag] -> do
+            let expectedRange = Cv.annToRange ann
+            let actualRange = Just (diag ^. LSP.range)
+            when (expectedRange /= actualRange) do
+              crash $ "Expected diagnostic at range: " <> show expectedRange <> ", got: " <> show actualRange
+          _ -> crash "Expected exactly one diagnostic"
+      _ -> crash "Expected exactly one term"
+
+unusedBindingLocations :: Test ()
+unusedBindingLocations =
+  scope "unused bindings" . tests . fmap makeDiagnosticRangeTest $
+    [ ( "Unused binding in let block",
+        [here|term =
+  usedOne = true
+  «unused = "unused"»
+  usedTwo = false
+  usedOne && usedTwo
+        |]
+      ),
+      ( "Unused argument",
+        [here|term «unused» = 1|]
+      )
+    ]

--- a/unison-core/src/Unison/DataDeclaration/Records.hs
+++ b/unison-core/src/Unison/DataDeclaration/Records.hs
@@ -41,7 +41,7 @@ generateRecordAccessors namespaced generatedAnn fields typename typ =
 
         -- point -> case point of Point _ y _ -> y
         get =
-          Term.lam ann argname $
+          Term.lam ann (ann, argname) $
             Term.match
               ann
               (Term.var ann argname)
@@ -57,7 +57,7 @@ generateRecordAccessors namespaced generatedAnn fields typename typ =
 
         -- y' point -> case point of Point x _ z -> Point x y' z
         set =
-          Term.lam' ann [fname', argname] $
+          Term.lam' ann [(ann, fname'), (ann, argname)] $
             Term.match
               ann
               (Term.var ann argname)
@@ -86,7 +86,7 @@ generateRecordAccessors namespaced generatedAnn fields typename typ =
 
         -- example: `f point -> case point of Point x y z -> Point x (f y) z`
         modify =
-          Term.lam' ann [fname', argname] $
+          Term.lam' ann [(ann, fname'), (ann, argname)] $
             Term.match
               ann
               (Term.var ann argname)

--- a/unison-core/src/Unison/Term.hs
+++ b/unison-core/src/Unison/Term.hs
@@ -947,7 +947,7 @@ letRec isTop blockAnn bindings e =
     (foldr addAbs body bindings)
   where
     addAbs :: ((a, v), b) -> ABT.Term f v a -> ABT.Term f v a
-    addAbs ((_a, v), _b) t = ABT.abs' blockAnn v t
+    addAbs ((a, v), _b) t = ABT.abs' a v t
     body :: Term' vt v a
     body = ABT.tm' blockAnn (LetRec isTop (map snd bindings) e)
 

--- a/unison-share-api/src/Unison/Server/Doc.hs
+++ b/unison-share-api/src/Unison/Server/Doc.hs
@@ -333,11 +333,13 @@ evalDoc terms typeOf eval types tm =
       DD.Doc2SpecialFormExample n (DD.Doc2Example vs body) ->
         pure $ EExample ex
         where
-          ex = Term.lam' (ABT.annotation body) (drop (fromIntegral n) vs) body
+          annotatedVs = ((),) <$> vs
+          ex = Term.lam' (ABT.annotation body) (drop (fromIntegral n) annotatedVs) body
       DD.Doc2SpecialFormExampleBlock n (DD.Doc2Example vs body) ->
         pure $ EExampleBlock ex
         where
-          ex = Term.lam' (ABT.annotation body) (drop (fromIntegral n) vs) body
+          annotatedVs = ((),) <$> vs
+          ex = Term.lam' (ABT.annotation body) (drop (fromIntegral n) annotatedVs) body
 
       -- Link (Either Link.Type Doc2.Term)
       DD.Doc2SpecialFormLink e ->

--- a/unison-syntax/src/Unison/Lexer/Pos.hs
+++ b/unison-syntax/src/Unison/Lexer/Pos.hs
@@ -4,21 +4,13 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ViewPatterns #-}
 
-module Unison.Lexer.Pos (Pos (..), Line, Column, line, column) where
+module Unison.Lexer.Pos (Pos (..), Line, Column) where
 
 type Line = Int
 
 type Column = Int
 
-data Pos = Pos {-# UNPACK #-} !Line {-# UNPACK #-} !Column deriving (Eq, Ord)
-
-line :: Pos -> Line
-line (Pos line _) = line
-
-column :: Pos -> Column
-column (Pos _ column) = column
-
-instance Show Pos where show (Pos line col) = "line " <> show line <> ", column " <> show col
+data Pos = Pos { line :: {-# UNPACK #-} !Line, column :: {-# UNPACK #-} !Column} deriving (Show, Eq, Ord)
 
 instance Semigroup Pos where
   Pos line col <> Pos line2 col2 =

--- a/unison-syntax/src/Unison/Syntax/Lexer.hs
+++ b/unison-syntax/src/Unison/Syntax/Lexer.hs
@@ -8,8 +8,6 @@ module Unison.Syntax.Lexer
     Pos (..),
     Lexeme (..),
     lexer,
-    line,
-    column,
     escapeChars,
     debugFileLex,
     debugLex',


### PR DESCRIPTION
## Overview

Previously I thought we wouldn't be able to get the correct locations of bindings for printing errors, but found we were actually stripping them during component minimization. This propagates the annotations so we can improve the location of unused bindings errors (and any other diagnostics which reference bindings in the future).

Old:
<img width="768" alt="image" src="https://github.com/user-attachments/assets/2e8a836e-ec59-448e-90b9-0287efadb042">


New:

<img width="815" alt="image" src="https://github.com/user-attachments/assets/435862af-2def-405d-a503-363e6c07b3fe">


## Implementation notes

* Changes the annotations we have on `Abs` nodes to be the annotation of the actual variable
* Use the ann from the Abs node instead of the top-level-term
* Split to have a separate diagnostic for each var
* Set the diagnostics as "unnecessary" so they render as greyed-out in editors (just like HLS does it)


## Interesting/controversial decisions

This does remove the invariant I had previously held where every node's annotations contains everything inside, but I think it's worth it to gain this functionality. I just special-cased the other commands to know to ignore the Abs annotation when looking things up.

Ideally I'd just have a spot to put a distinct annotation for variable bindings, but I can't do that without changing either the Term or the ABT which is a ton of work and would maybe affect hashing. Maybe we can address this when we do the next re-hash migration.

## Test coverage

Added some clever tests where you can mark the expected diagnostic location for a given error.

## Loose ends

The let-binding error still spans the entire binding rather than just the name. I think I can fix this by threading another annotation through the Unison File, but that's a bigger change for a pretty small value-add, so I'll leave that for later.