### PR TITLE
Keep most recent path and branches through migration to version 17

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -289,6 +289,7 @@ module U.Codebase.Sqlite.Queries
     -- * Types
     NamespaceText,
     TextPathSegments,
+    JsonParseFailure(..),
   )
 where
 

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations/MigrateSchema16To17.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations/MigrateSchema16To17.hs
@@ -263,7 +263,7 @@ getMostRecentProjectBranchIds :: Sqlite.Transaction (Maybe (ProjectId, ProjectBr
 getMostRecentProjectBranchIds = do
   nameSegments <- expectMostRecentNamespace
   case nameSegments of
-    [proj, UUIDNameSegment projectId, branches, UUIDNameSegment branchId]
+    (proj : UUIDNameSegment projectId : branches : UUIDNameSegment branchId : _)
       | proj == projectsNameSegment && branches == branchesNameSegment ->
           pure . Just $ (ProjectId projectId, ProjectBranchId branchId)
     _ -> pure Nothing


### PR DESCRIPTION
## Overview

Put the user back onto the same branch they were on before the migration; also keep the most_recent_branches table intact through the migration.

If the user was in loose code, they'll be put on `scratch/main`.

## Implementation notes

Get the current path before the migration, convert it into a project-branch path, and set that as the new 'current path' after.

# Testing

I tested it on my codebase both from a project and from loose code and it keeps both recent_branches and the current path.