### PR TITLE
Don't evaluate the unison file if there are no watch expressions.

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Load.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Load.hs
@@ -40,7 +40,9 @@ import Unison.Syntax.Parser qualified as Parser
 import Unison.Term (Term)
 import Unison.Term qualified as Term
 import Unison.UnisonFile (TypecheckedUnisonFile)
+import Unison.UnisonFile qualified as UF
 import Unison.UnisonFile.Names qualified as UF
+import Unison.Util.Timing qualified as Timing
 import Unison.WatchKind qualified as WK
 
 handleLoad :: Maybe FilePath -> Cli ()
@@ -65,11 +67,14 @@ loadUnisonFile sourceName text = do
   pped <- Cli.prettyPrintEnvDeclFromNames names
   let ppe = PPE.suffixifiedPPE pped
   Cli.respond $ Output.Typechecked sourceName ppe sr unisonFile
-  (bindings, e) <- evalUnisonFile Permissive ppe unisonFile []
-  let e' = Map.map go e
-      go (ann, kind, _hash, _uneval, eval, isHit) = (ann, kind, eval, isHit)
-  when (not (null e')) do
-    Cli.respond $ Output.Evaluated text ppe bindings e'
+
+  when (not . null $ UF.watchComponents unisonFile) do
+    Timing.time "evaluating watches" do
+      (bindings, e) <- evalUnisonFile Permissive ppe unisonFile []
+      let e' = Map.map go e
+          go (ann, kind, _hash, _uneval, eval, isHit) = (ann, kind, eval, isHit)
+      when (not (null e')) do
+        Cli.respond $ Output.Evaluated text ppe bindings e'
   #latestTypecheckedFile .= Just (Right unisonFile)
   where
     withFile ::
@@ -81,8 +86,8 @@ loadUnisonFile sourceName text = do
       pp <- Cli.getCurrentProjectPath
       State.modify' \loopState ->
         loopState
-          & #latestFile .~ Just (Text.unpack sourceName, False)
-          & #latestTypecheckedFile .~ Nothing
+          & (#latestFile .~ Just (Text.unpack sourceName, False))
+          & (#latestTypecheckedFile .~ Nothing)
       Cli.Env {codebase, generateUniqueName} <- ask
       uniqueName <- liftIO generateUniqueName
       let parsingEnv =


### PR DESCRIPTION
## Overview

For some reason unison file evaluation is pretty slow even when there are no watches to evaluate.
I'll look into that next, but it's a clear win to just skip the whole process if we have no watches to care about.

## Implementation notes

Skip unison file evaluation if we have no watch expressions.

## Test coverage

I tested manually that it still evaluates with watch expressions, but is fast without them.

## Loose ends

Figure out why evaluating a file with nothing to do is so slow; it's likely we can speed up watch expressions too if we can figure that out.