### PR TITLE
Pin Haskell tool versions for VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "haskell.toolchain": {
+    "cabal": "3.10.3.0",
+    "hls": "2.8.0.0",
+    "stack": "2.15.7"
+  }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -26,11 +26,15 @@
       "aarch64-darwin"
     ]
     (system: let
-      versions = {
-        ormolu = "0.7.2.0";
-        hls = "2.8.0.0";
-        stack = "2.15.7";
+      ## It’s much easier to read from a JSON file than to have JSON import from some other file, so we extract some
+      ## configuration from the VS Code settings to avoid duplication.
+      vscodeSettings = nixpkgs-release.lib.importJSON ./.vscode/settings.json;
+      versions =
+        vscodeSettings."haskell.toolchain"
+        ## There are some things we want to pin that the VS Code Haskell extension doesn’t let us control.
+        // {
         hpack = "0.35.2";
+        ormolu = "0.7.2.0";
       };
       pkgs = import nixpkgs-haskellNix {
         inherit system;

--- a/nix/haskell-nix-flake.nix
+++ b/nix/haskell-nix-flake.nix
@@ -28,7 +28,7 @@
       tools =
         (args.tools or {})
         // {
-          cabal = {};
+          cabal = {version = versions.cabal;};
           ormolu = {version = versions.ormolu;};
           haskell-language-server = {
             version = versions.hls;


### PR DESCRIPTION
This should help VS Code users get the same versions of various tools as Nix users do when working on Unison.

This also has the flake get its version pins from the VS Code settings. And we pin Cabal now, too.