### PR TITLE
Silence some Stack complaints

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,6 @@
+## We pin a specific Stack version when possible. We shouldn’t then tell contributors to upgrade from there.
+recommend-stack-upgrade: false
+
 flags:
   haskeline:
     terminfo: false

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,5 @@
+## We intentionally disable Nix integration when running in a Nix shell.
+notify-if-nix-on-path: false
 ## We pin a specific Stack version when possible. We shouldn’t then tell contributors to upgrade from there.
 recommend-stack-upgrade: false
 


### PR DESCRIPTION
## Overview

By default, Stack will complain if you’re not using Nix integration when `nix` is on the `PATH` and it will complain when you’re not using the latest version of Stack.

We have reasons for not doing either of these things, and so we tell Stack to stop complaining.

## Interesting/controversial decisions

Ideally, we could tell Stack to not complain about Nix only when we’re running from the Nix shell, but Stack doesn’t accept `--no-notify-if-nix-on-path` as a CLI flag, so we silence it more broadly.

## Test coverage

CI ensures that Stack runs as intended, but not whether these particular warnings are printed out or not. It’s simply a contributor convenience, and “it works for me.”