### PR TITLE
Refactor transcript parser

### DIFF
--- a/unison-cli/src/Unison/Codebase/Transcript.hs
+++ b/unison-cli/src/Unison/Codebase/Transcript.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE PatternSynonyms #-}
+
+-- | The data model for Unison transcripts.
+module Unison.Codebase.Transcript
+  ( ExpectingError,
+    ScratchFileName,
+    Hidden (..),
+    UcmLine (..),
+    UcmContext (..),
+    APIRequest (..),
+    pattern CMarkCodeBlock,
+    Stanza,
+    ProcessedBlock (..),
+  )
+where
+
+import CMark qualified
+import Unison.Core.Project (ProjectBranchName, ProjectName)
+import Unison.Prelude
+import Unison.Project (ProjectAndBranch)
+
+type ExpectingError = Bool
+
+type ScratchFileName = Text
+
+data Hidden = Shown | HideOutput | HideAll
+  deriving (Eq, Show)
+
+data UcmLine
+  = UcmCommand UcmContext Text
+  | -- | Text does not include the '--' prefix.
+    UcmComment Text
+
+-- | Where a command is run: a project branch (myproject/mybranch>).
+data UcmContext
+  = UcmContextProject (ProjectAndBranch ProjectName ProjectBranchName)
+
+data APIRequest
+  = GetRequest Text
+  | APIComment Text
+
+pattern CMarkCodeBlock :: (Maybe CMark.PosInfo) -> Text -> Text -> CMark.Node
+pattern CMarkCodeBlock pos info body = CMark.Node pos (CMark.CODE_BLOCK info body) []
+
+type Stanza = Either CMark.Node ProcessedBlock
+
+data ProcessedBlock
+  = Ucm Hidden ExpectingError [UcmLine]
+  | Unison Hidden ExpectingError (Maybe ScratchFileName) Text
+  | API [APIRequest]

--- a/unison-cli/src/Unison/Codebase/Transcript/Parser.hs
+++ b/unison-cli/src/Unison/Codebase/Transcript/Parser.hs
@@ -1,0 +1,166 @@
+-- | Parse and print CommonMark (like Github-flavored Markdown) transcripts.
+module Unison.Codebase.Transcript.Parser
+  ( -- * printing
+    formatAPIRequest,
+    formatUcmLine,
+    formatStanza,
+    formatNode,
+    formatProcessedBlock,
+
+    -- * conversion
+    processedBlockToNode,
+
+    -- * parsing
+    stanzas,
+    ucmLine,
+    apiRequest,
+    fenced,
+    hidden,
+    expectingError,
+    language,
+  )
+where
+
+import CMark qualified
+import Data.Char qualified as Char
+import Data.Text qualified as Text
+import Data.These (These (..))
+import Text.Megaparsec qualified as P
+import Unison.Codebase.Transcript
+import Unison.Prelude
+import Unison.Project (ProjectAndBranch (ProjectAndBranch))
+
+formatAPIRequest :: APIRequest -> Text
+formatAPIRequest = \case
+  GetRequest txt -> "GET " <> txt
+  APIComment txt -> "-- " <> txt
+
+formatUcmLine :: UcmLine -> Text
+formatUcmLine = \case
+  UcmCommand context txt -> formatContext context <> "> " <> txt
+  UcmComment txt -> "--" <> txt
+  where
+    formatContext (UcmContextProject projectAndBranch) = into @Text projectAndBranch
+
+formatStanza :: Stanza -> Text
+formatStanza = either formatNode formatProcessedBlock
+
+formatNode :: CMark.Node -> Text
+formatNode = (<> "\n") . CMark.nodeToCommonmark [] Nothing
+
+formatProcessedBlock :: ProcessedBlock -> Text
+formatProcessedBlock = formatNode . processedBlockToNode
+
+processedBlockToNode :: ProcessedBlock -> CMark.Node
+processedBlockToNode = \case
+  Ucm _ _ cmds -> CMarkCodeBlock Nothing "ucm" $ foldr ((<>) . formatUcmLine) "" cmds
+  Unison _hide _ fname txt ->
+    CMarkCodeBlock Nothing "unison" $ maybe txt (\fname -> Text.unlines ["---", "title: " <> fname, "---", txt]) fname
+  API apiRequests -> CMarkCodeBlock Nothing "api" $ Text.unlines $ formatAPIRequest <$> apiRequests
+
+type P = P.Parsec Void Text
+
+stanzas :: FilePath -> Text -> Either (P.ParseErrorBundle Text Void) [Stanza]
+stanzas srcName = (\(CMark.Node _ _DOCUMENT blocks) -> traverse stanzaFromNode blocks) . CMark.commonmarkToNode []
+  where
+    stanzaFromNode :: CMark.Node -> Either (P.ParseErrorBundle Text Void) Stanza
+    stanzaFromNode node = case node of
+      CMarkCodeBlock _ info body -> maybe (Left node) pure <$> P.parse (fenced info) srcName body
+      _ -> pure $ Left node
+
+ucmLine :: P UcmLine
+ucmLine = ucmCommand <|> ucmComment
+  where
+    ucmCommand :: P UcmLine
+    ucmCommand = do
+      context <-
+        P.try do
+          contextString <- P.takeWhile1P Nothing (/= '>')
+          context <-
+            case (tryFrom @Text contextString) of
+              (Right (These project branch)) -> pure (UcmContextProject (ProjectAndBranch project branch))
+              _ -> fail "expected project/branch or absolute path"
+          void $ lineToken $ word ">"
+          pure context
+      line <- P.takeWhileP Nothing (/= '\n') <* spaces
+      pure $ UcmCommand context line
+
+    ucmComment :: P UcmLine
+    ucmComment = do
+      word "--"
+      line <- P.takeWhileP Nothing (/= '\n') <* spaces
+      pure $ UcmComment line
+
+apiRequest :: P APIRequest
+apiRequest = do
+  apiComment <|> getRequest
+  where
+    getRequest = do
+      word "GET"
+      spaces
+      path <- P.takeWhile1P Nothing (/= '\n')
+      spaces
+      pure (GetRequest path)
+    apiComment = do
+      word "--"
+      comment <- P.takeWhileP Nothing (/= '\n')
+      spaces
+      pure (APIComment comment)
+
+-- | Produce the correct parser for the code block based on the provided info string.
+fenced :: Text -> P (Maybe ProcessedBlock)
+fenced info = do
+  body <- P.getInput
+  P.setInput info
+  fenceType <- lineToken (word "ucm" <|> word "unison" <|> word "api" <|> language)
+  case fenceType of
+    "ucm" -> do
+      hide <- hidden
+      err <- expectingError
+      P.setInput body
+      pure . Ucm hide err <$> (spaces *> many ucmLine)
+    "unison" ->
+      do
+        -- todo: this has to be more interesting
+        -- ```unison:hide
+        -- ```unison
+        -- ```unison:hide:all scratch.u
+        hide <- lineToken hidden
+        err <- lineToken expectingError
+        fileName <- optional untilSpace1
+        P.setInput body
+        pure . Unison hide err fileName <$> (spaces *> P.getInput)
+    "api" -> do
+      P.setInput body
+      pure . API <$> (spaces *> many apiRequest)
+    _ -> pure Nothing
+
+word :: Text -> P Text
+word txt = P.try $ do
+  chs <- P.takeP (Just $ show txt) (Text.length txt)
+  guard (chs == txt)
+  pure txt
+
+lineToken :: P a -> P a
+lineToken p = p <* nonNewlineSpaces
+
+nonNewlineSpaces :: P ()
+nonNewlineSpaces = void $ P.takeWhileP Nothing (\ch -> ch == ' ' || ch == '\t')
+
+hidden :: P Hidden
+hidden =
+  (HideAll <$ word ":hide:all")
+    <|> (HideOutput <$ word ":hide")
+    <|> pure Shown
+
+expectingError :: P ExpectingError
+expectingError = isJust <$> optional (word ":error")
+
+untilSpace1 :: P Text
+untilSpace1 = P.takeWhile1P Nothing (not . Char.isSpace)
+
+language :: P Text
+language = P.takeWhileP Nothing (\ch -> Char.isDigit ch || Char.isLower ch || ch == '_')
+
+spaces :: P ()
+spaces = void $ P.takeWhileP (Just "spaces") Char.isSpace

--- a/unison-cli/src/Unison/Main.hs
+++ b/unison-cli/src/Unison/Main.hs
@@ -74,7 +74,7 @@ import Unison.Codebase.Path qualified as Path
 import Unison.Codebase.ProjectPath qualified as PP
 import Unison.Codebase.Runtime qualified as Rt
 import Unison.Codebase.SqliteCodebase qualified as SC
-import Unison.Codebase.TranscriptParser qualified as Transcript
+import Unison.Codebase.Transcript.Runner qualified as Transcript
 import Unison.Codebase.Verbosity qualified as Verbosity
 import Unison.CommandLine (watchConfig)
 import Unison.CommandLine.Helpers (plural')

--- a/unison-cli/src/Unison/Main.hs
+++ b/unison-cli/src/Unison/Main.hs
@@ -60,6 +60,7 @@ import System.IO.CodePage (withCP65001)
 import System.IO.Error (catchIOError)
 import System.IO.Temp qualified as Temp
 import System.Path qualified as Path
+import Text.Megaparsec qualified as MP
 import U.Codebase.Sqlite.Queries qualified as Queries
 import Unison.Cli.ProjectUtils qualified as ProjectUtils
 import Unison.Codebase (Codebase, CodebasePath)
@@ -73,7 +74,7 @@ import Unison.Codebase.Path qualified as Path
 import Unison.Codebase.ProjectPath qualified as PP
 import Unison.Codebase.Runtime qualified as Rt
 import Unison.Codebase.SqliteCodebase qualified as SC
-import Unison.Codebase.TranscriptParser qualified as TR
+import Unison.Codebase.TranscriptParser qualified as Transcript
 import Unison.Codebase.Verbosity qualified as Verbosity
 import Unison.CommandLine (watchConfig)
 import Unison.CommandLine.Helpers (plural')
@@ -424,49 +425,55 @@ runTranscripts' version progName mcodepath nativeRtp transcriptDir markdownFiles
   currentDir <- getCurrentDirectory
   configFilePath <- getConfigFilePath mcodepath
   -- We don't need to create a codebase through `getCodebaseOrExit` as we've already done so previously.
-  and <$> getCodebaseOrExit (Just (DontCreateCodebaseWhenMissing transcriptDir)) (SC.MigrateAutomatically SC.Backup SC.Vacuum) \(_, codebasePath, theCodebase) -> do
-    let isTest = False
-    TR.withTranscriptRunner isTest Verbosity.Verbose (Version.gitDescribeWithDate version) nativeRtp (Just configFilePath) $ \runTranscript -> do
-      for markdownFiles $ \(MarkdownFile fileName) -> do
-        transcriptSrc <- readUtf8 fileName
-        result <- runTranscript fileName transcriptSrc (codebasePath, theCodebase)
-        let outputFile = replaceExtension (currentDir </> fileName) ".output.md"
-        (output, succeeded) <- case result of
-          Left err -> case err of
-            TR.TranscriptParseError err -> do
-              PT.putPrettyLn $
-                P.callout
-                  "❓"
-                  ( P.lines
-                      [ P.indentN 2 "An error occurred while parsing the following file: " <> P.string fileName,
-                        "",
-                        P.indentN 2 $ P.text err
-                      ]
+  and
+    <$> getCodebaseOrExit
+      (Just (DontCreateCodebaseWhenMissing transcriptDir))
+      (SC.MigrateAutomatically SC.Backup SC.Vacuum)
+      \(_, codebasePath, theCodebase) -> do
+        let isTest = False
+        Transcript.withRunner
+          isTest
+          Verbosity.Verbose
+          (Version.gitDescribeWithDate version)
+          nativeRtp
+          (Just configFilePath)
+          \runTranscript -> do
+            for markdownFiles $ \(MarkdownFile fileName) -> do
+              transcriptSrc <- readUtf8 fileName
+              result <- runTranscript fileName transcriptSrc (codebasePath, theCodebase)
+              let outputFile = replaceExtension (currentDir </> fileName) ".output.md"
+              output <-
+                either
+                  ( uncurry ($>) . first (PT.putPrettyLn . P.callout "❓" . P.lines) . \case
+                      Transcript.ParseError err ->
+                        let msg = MP.errorBundlePretty err
+                         in ( [ P.indentN 2 $
+                                  "An error occurred while parsing the following file: " <> P.string fileName,
+                                "",
+                                P.indentN 2 $ P.string msg
+                              ],
+                              Text.pack msg
+                            )
+                      Transcript.RunFailure msg ->
+                        ( [ P.indentN 2 $ "An error occurred while running the following file: " <> P.string fileName,
+                            "",
+                            P.indentN 2 (P.text msg),
+                            P.string $
+                              "Run `"
+                                <> progName
+                                <> " --codebase "
+                                <> codebasePath
+                                <> "` "
+                                <> "to do more work with it."
+                          ],
+                          msg
+                        )
                   )
-              pure (err, False)
-            TR.TranscriptRunFailure err -> do
-              PT.putPrettyLn $
-                P.callout
-                  "❓"
-                  ( P.lines
-                      [ P.indentN 2 "An error occurred while running the following file: " <> P.string fileName,
-                        "",
-                        P.indentN 2 $ P.text err,
-                        P.text $
-                          "Run `"
-                            <> Text.pack progName
-                            <> " --codebase "
-                            <> Text.pack codebasePath
-                            <> "` "
-                            <> "to do more work with it."
-                      ]
-                  )
-              pure (err, False)
-          Right mdOut -> do
-            pure (mdOut, True)
-        writeUtf8 outputFile output
-        putStrLn $ "💾  Wrote " <> outputFile
-        pure succeeded
+                  pure
+                  result
+              writeUtf8 outputFile output
+              putStrLn $ "💾  Wrote " <> outputFile
+              pure $ isRight result
 
 runTranscripts ::
   Version ->

--- a/unison-cli/tests/Unison/Test/Ucm.hs
+++ b/unison-cli/tests/Unison/Test/Ucm.hs
@@ -24,7 +24,7 @@ import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Init qualified as Codebase.Init
 import Unison.Codebase.Init.CreateCodebaseError (CreateCodebaseError (..))
 import Unison.Codebase.SqliteCodebase qualified as SC
-import Unison.Codebase.TranscriptParser qualified as Transcript
+import Unison.Codebase.Transcript.Runner qualified as Transcript
 import Unison.Codebase.Verbosity qualified as Verbosity
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude (traceM)

--- a/unison-cli/tests/Unison/Test/Ucm.hs
+++ b/unison-cli/tests/Unison/Test/Ucm.hs
@@ -24,7 +24,7 @@ import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Init qualified as Codebase.Init
 import Unison.Codebase.Init.CreateCodebaseError (CreateCodebaseError (..))
 import Unison.Codebase.SqliteCodebase qualified as SC
-import Unison.Codebase.TranscriptParser qualified as TR
+import Unison.Codebase.TranscriptParser qualified as Transcript
 import Unison.Codebase.Verbosity qualified as Verbosity
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude (traceM)
@@ -66,17 +66,16 @@ runTranscript :: Codebase -> Transcript -> IO TranscriptOutput
 runTranscript (Codebase codebasePath fmt) transcript = do
   let err e = fail $ "Parse error: \n" <> show e
       cbInit = case fmt of CodebaseFormat2 -> SC.init
-  let isTest = True
-  TR.withTranscriptRunner isTest Verbosity.Silent "Unison.Test.Ucm.runTranscript Invalid Version String" rtp configFile $ \runner -> do
-    result <- Codebase.Init.withOpenCodebase cbInit "transcript" codebasePath SC.DoLock SC.DontMigrate \codebase -> do
-      Codebase.runTransaction codebase (Codebase.installUcmDependencies codebase)
-      let transcriptSrc = stripMargin . Text.pack $ unTranscript transcript
-      output <- either err Text.unpack <$> runner "transcript" transcriptSrc (codebasePath, codebase)
-      when debugTranscriptOutput $ traceM output
-      pure output
-    case result of
-      Left e -> fail $ P.toANSI 80 (P.shown e)
-      Right x -> pure x
+      isTest = True
+  Transcript.withRunner isTest Verbosity.Silent "Unison.Test.Ucm.runTranscript Invalid Version String" rtp configFile $
+    \runner -> do
+      result <- Codebase.Init.withOpenCodebase cbInit "transcript" codebasePath SC.DoLock SC.DontMigrate \codebase -> do
+        Codebase.runTransaction codebase (Codebase.installUcmDependencies codebase)
+        let transcriptSrc = stripMargin . Text.pack $ unTranscript transcript
+        output <- either err Text.unpack <$> runner "transcript" transcriptSrc (codebasePath, codebase)
+        when debugTranscriptOutput $ traceM output
+        pure output
+      either (fail . P.toANSI 80 . P.shown) pure result
   where
     configFile = Nothing
     -- Note: this needs to be properly configured if these tests ever

--- a/unison-cli/transcripts/Transcripts.hs
+++ b/unison-cli/transcripts/Transcripts.hs
@@ -25,7 +25,7 @@ import System.IO.Silently (silence)
 import Text.Megaparsec qualified as MP
 import Unison.Codebase.Init (withTemporaryUcmCodebase)
 import Unison.Codebase.SqliteCodebase qualified as SC
-import Unison.Codebase.TranscriptParser as Transcript
+import Unison.Codebase.Transcript.Runner as Transcript
 import Unison.Codebase.Verbosity qualified as Verbosity
 import Unison.Prelude
 import UnliftIO.STM qualified as STM

--- a/unison-cli/transcripts/Transcripts.hs
+++ b/unison-cli/transcripts/Transcripts.hs
@@ -22,9 +22,10 @@ import System.FilePath
   )
 import System.IO.CodePage (withCP65001)
 import System.IO.Silently (silence)
+import Text.Megaparsec qualified as MP
 import Unison.Codebase.Init (withTemporaryUcmCodebase)
 import Unison.Codebase.SqliteCodebase qualified as SC
-import Unison.Codebase.TranscriptParser (TranscriptError (..), withTranscriptRunner)
+import Unison.Codebase.TranscriptParser as Transcript
 import Unison.Codebase.Verbosity qualified as Verbosity
 import Unison.Prelude
 import UnliftIO.STM qualified as STM
@@ -48,7 +49,7 @@ testBuilder ::
 testBuilder expectFailure recordFailure runtimePath dir prelude transcript = scope transcript $ do
   outputs <- io . withTemporaryUcmCodebase SC.init Verbosity.Silent "transcript" SC.DoLock $ \(codebasePath, codebase) -> do
     let isTest = True
-    withTranscriptRunner isTest Verbosity.Silent "TODO: pass version here" runtimePath Nothing \runTranscript -> do
+    Transcript.withRunner isTest Verbosity.Silent "TODO: pass version here" runtimePath Nothing \runTranscript -> do
       for files \filePath -> do
         transcriptSrc <- readUtf8 filePath
         out <- silence $ runTranscript filePath transcriptSrc (codebasePath, codebase)
@@ -57,12 +58,12 @@ testBuilder expectFailure recordFailure runtimePath dir prelude transcript = sco
     (filePath, Left err) -> do
       let outputFile = outputFileForTranscript filePath
       case err of
-        TranscriptParseError msg -> do
+        Transcript.ParseError errors -> do
           when (not expectFailure) $ do
-            let errMsg = "Error parsing " <> filePath <> ": " <> Text.unpack msg
+            let errMsg = "Error parsing " <> filePath <> ": " <> MP.errorBundlePretty errors
             io $ recordFailure (filePath, Text.pack errMsg)
             crash errMsg
-        TranscriptRunFailure errOutput -> do
+        Transcript.RunFailure errOutput -> do
           io $ writeUtf8 outputFile errOutput
           when (not expectFailure) $ do
             io $ Text.putStrLn errOutput

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -106,7 +106,9 @@ library
       Unison.Codebase.Editor.StructuredArgument
       Unison.Codebase.Editor.UCMVersion
       Unison.Codebase.Editor.UriParser
-      Unison.Codebase.TranscriptParser
+      Unison.Codebase.Transcript
+      Unison.Codebase.Transcript.Parser
+      Unison.Codebase.Transcript.Runner
       Unison.Codebase.Watch
       Unison.CommandLine
       Unison.CommandLine.BranchRelativePath

--- a/unison-src/transcripts/error-messages.output.md
+++ b/unison-src/transcripts/error-messages.output.md
@@ -211,8 +211,7 @@ foo = match 1 with
 
   I got confused here:
   
-      2 |   2 -- no right-hand-side
-  
+      3 | 
   
   I was surprised to find an end of section here.
   I was expecting one of these instead:
@@ -258,8 +257,7 @@ x = match Some a with
 
   I got confused here:
   
-      6 |         2
-  
+      7 | 
   
   I was surprised to find an end of section here.
   I was expecting one of these instead:

--- a/unison-src/transcripts/generic-parse-errors.output.md
+++ b/unison-src/transcripts/generic-parse-errors.output.md
@@ -96,8 +96,7 @@ x = "hi
 
   I got confused here:
   
-      1 | x = "hi
-  
+      2 | 
   
   I was surprised to find an end of input here.
   I was expecting one of these instead:
@@ -117,8 +116,7 @@ y : a
 
   I got confused here:
   
-      1 | y : a 
-  
+      2 | 
   
   I was surprised to find an end of section here.
   I was expecting one of these instead:


### PR DESCRIPTION
## Overview

This cleans up and reorganizes some of the transcript parsing/running code after #5204.

It is mostly a refactor, except that it does fix one issue I had in #5204, which was the need to use `Text.init` when parsing some fenced blocks. I managed to remove that here, and that resulted in a minor (but correct, I think) change to a couple transcript outputs, where an parsing EOF error was reported on the wrong line.

## Test coverage

Every transcript tests this.

## Loose ends

There is still some complexity and coupling in here, but I don’t think it’s worth spending time on at the moment.