### PR TITLE
[do not merge] JIT CI better cache invalidation

### DIFF
--- a/.github/workflows/ci-test-jit.yaml
+++ b/.github/workflows/ci-test-jit.yaml
@@ -74,7 +74,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{env.jit_test_results}}
-          key: jit-test-results.dist-exe_${{ hashFiles(env.jit_dist_rel_exe) }}.tests_${{ env.runtime_tests_causalhash }}.yaml_${{ hashFiles('**/ci-test-jit.yaml') }}
+          key: jit-test-results.dist-exe_${{ hashFiles(env.jit_dist_rel_exe) }}.tests_${{ env.runtime_tests_causalhash }}.yaml_${{ hashFiles('**/ci-test-jit.yaml') }}_$({ hashFiles(env.ucm) })
 
       - name: install libb2 (linux)
         uses: awalsh128/cache-apt-pkgs-action@latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -381,7 +381,7 @@ jobs:
           write-mode: overwrite
           contents: |
             ```ucm
-            .> project.create-empty jit-setup
+            scratch/main> project.create-empty jit-setup
             jit-setup/main> lib.install ${{ env.jit_version }}
             ```
             ```unison

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -372,7 +372,7 @@ jobs:
         id: cache-generated-source
         with:
           path: ${{ env.jit_generated_src_scheme }}
-          key: jit_generated_src_scheme-jit_${{env.jit_version}}-${{env.jit_causalhash}}
+          key: jit_generated_src_scheme-jit_${{env.jit_version}}-${{env.jit_causalhash}}-${{ hashFiles('**/ci.yaml') }}
       - name: create transcript
         if: steps.cache-generated-source.outputs.cache-hit != 'true'
         uses: DamianReeves/write-file-action@v1.3

--- a/unison-src/builtin-tests/jit-tests.output.md
+++ b/unison-src/builtin-tests/jit-tests.output.md
@@ -34,9 +34,9 @@ foo = do
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
-
+  
     ⍟ These new definitions are ok to `add`:
-
+    
       foo : '{Exception} ()
 
 ```
@@ -58,10 +58,10 @@ an exception.
 runtime-tests/selected> run.native testBug
 
   💔💥
-
+  
   I've encountered a call to builtin.bug with the following
   value:
-
+  
     "testing"
 
 ```


### PR DESCRIPTION
## Overview

From the following discussion: https://github.com/unisonweb/unison/pull/5224#issuecomment-2229409852

Currently the CI cache for the JIT tests misses a few things which might change (and hence break the tests).  At the very least they are:

* the template in `ci.yaml` that's used to generate the JIT sources
* the actual UCM binary for when running the tests (I think?)

As such, we use `hashFiles(..)` to ensure that when those dependencies change the source generation & tests are re-run.

## Interesting/controversial decisions

I'm not super familiar with what triggers a rebuild.  Is it just the hashes?  If so, it seems like we would always want to hash the `ucm` binary since we would always want to rerun the tests if our main binary changes?

Also currently because we have the JIT source generation template in `ci.yaml`, any (unrelated) change in that file would cause a regeneration of the JIT sources.  As such, ideally, we should move the JIT source generation into its own `.yaml` file.  I haven't looked into that since it would take a bit more time to get familiar with github actions.

We could also remove caching all-together to be on the safe side, but I'm guessing caching was added for a reason.  I'm thinking it would mean pulling from `@unison/internal` each time which might mean extra bandwidth costs?

## Test coverage
n/a - relying on CI

## Loose ends
n/a see "interesting/controversial decisions" above