### PR TITLE
Support native compilation on non-GNU Unix systems

### DIFF
--- a/scheme-libs/racket/unison/crypto.rkt
+++ b/scheme-libs/racket/unison/crypto.rkt
@@ -96,6 +96,7 @@
                     (error 'blake2 "~a failed with return value ~a" fn r))))))
 
 (define blake2b-raw (libb2-raw "blake2b"))
+(define blake2s-raw (libb2-raw "blake2s"))
 
 (define HashAlgorithm.Md5 (lc-algo "EVP_md5" 128))
 (define HashAlgorithm.Sha1 (lc-algo "EVP_sha1" 160))
@@ -103,8 +104,6 @@
 (define HashAlgorithm.Sha2_512 (lc-algo "EVP_sha512" 512))
 (define HashAlgorithm.Sha3_256 (lc-algo "EVP_sha3_256" 256))
 (define HashAlgorithm.Sha3_512 (lc-algo "EVP_sha3_512" 512))
-(define HashAlgorithm.Blake2s_256 (lc-algo "EVP_blake2s256" 256))
-(define HashAlgorithm.Blake2b_512 (lc-algo "EVP_blake2b512" 512))
 
 (define _EVP_PKEY-pointer (_cpointer 'EVP_PKEY))
 (define _EVP_MD_CTX-pointer (_cpointer 'EVP_MD_CTX))
@@ -234,6 +233,8 @@
         (chunked-bytes->bytes input)
         (chunked-bytes->bytes signature)))
 
+(define (HashAlgorithm.Blake2s_256) (cons 'blake2s 256))
+(define (HashAlgorithm.Blake2b_512) (cons 'blake2b 512))
 ; This one isn't provided by libcrypto, for some reason
 (define (HashAlgorithm.Blake2b_256) (cons 'blake2b 256))
 
@@ -252,6 +253,7 @@
          [algo (car kind)])
     (case algo
       ['blake2b (blake2b-raw output input #f bytes (bytes-length input) 0)]
+      ['blake2s (blake2s-raw output input #f bytes (bytes-length input) 0)]
       [else (EVP_Digest input (bytes-length input) output #f algo #f)])
 
     output))
@@ -294,6 +296,7 @@
 (define (hmacBytes-raw kind key input)
   (case (car kind)
     ['blake2b (hmacBlake kind key input)]
+    ['blake2s (hmacBlake kind key input)]
     [else
      (let* ([bytes (/ (cdr kind) 8)]
             [output (make-bytes bytes)]

--- a/unison-src/builtin-tests/jit-tests.output.md
+++ b/unison-src/builtin-tests/jit-tests.output.md
@@ -34,9 +34,9 @@ foo = do
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
-
+  
     ⍟ These new definitions are ok to `add`:
-
+    
       foo : '{Exception} ()
 
 ```
@@ -58,10 +58,10 @@ an exception.
 runtime-tests/selected> run.native testBug
 
   💔💥
-
+  
   I've encountered a call to builtin.bug with the following
   value:
-
+  
     "testing"
 
 ```

--- a/unison-src/builtin-tests/jit-tests.sh
+++ b/unison-src/builtin-tests/jit-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 set -ex
 
 # the first arg is the path to the unison executable
@@ -7,9 +7,6 @@ if [ -z "$1" ]; then
   echo "Example: $0 ./unison --runtime-path ./runtime/bin/unison-runtime"
   exit 1
 fi
-
-# call unison with all its args quoted
-ucm=("$@")
 
 runtime_tests_version="@unison/runtime-tests/main"
 echo $runtime_tests_version
@@ -27,4 +24,5 @@ runtime_tests_version="$runtime_tests_version" \
     < unison-src/builtin-tests/jit-tests.tpl.md \
     > unison-src/builtin-tests/jit-tests.md
 
-time "${ucm[@]}" transcript.fork -C $codebase -S $codebase unison-src/builtin-tests/jit-tests.md
+# call unison with all its args quoted
+time "$@" transcript.fork -C $codebase -S $codebase unison-src/builtin-tests/jit-tests.md


### PR DESCRIPTION
## Overview

Currently only tested on OpenBSD, but the hope is to more easily support non-GNU systems.  Two main changes:

1. Use `libb2` for all blake2 related functions.  This is because blake2 is not supported [at the moment](https://github.com/libressl/portable/issues/199) by LibreSSL
2. Use the more portable `sh` in `jit-tests.sh`.  This ensures it can run on systems where bash isn't installed by default.

(cc @dolio as I think you've been quite involved in the native compilation?  Curious to hear your thoughts on this!)

## Interesting/controversial decisions

One could argue that the vast majority of users will be on Windows/Linux/Mac.  However, I think it's important in general to strive for portable software.  The more systems software can run on, the less chances of system/implementation-specific issues cropping up.

## Test coverage

Relying mostly on CI .  Manually ran `jit-tests.sh` locally on Mac.

## Loose ends

I've also updated the README for the scheme-libs here #5238

Tests are currently failing because of outdated scripts.  That is fixed in #5236