### PR TITLE
Update JIT generation template in ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -388,7 +388,7 @@ jobs:
           write-mode: overwrite
           contents: |
             ```ucm
-            .> project.create-empty jit-setup
+            scratch/main> project.create-empty jit-setup
             jit-setup/main> lib.install ${{ env.jit_version }}
             ```
             ```unison


### PR DESCRIPTION
Split form #5236 - fix CI failures while we work on a better / more correct way of doing caching.

CC @sellout - hey, was wondering if you'd like to cherry-pick this commit on your dev branch and see if it fixes the [issues](https://github.com/sellout/unison/actions) you've been seeing?