### PR TITLE
Don't limit max line length on .u scratch files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ indent_style = space
 insert_final_newline = true
 max_line_length = 120
 trim_trailing_whitespace = true
+
+[*.u]
+max_line_length = off


### PR DESCRIPTION
The recently added `.editorconfig` sets a max line length of 120 characters for all file types. I found this to be
pretty frustrating when writing Unison scratch files. While writing Unison code my editor would seemingly randomly
create a new line, generating invalid Unison code. This came up more often when writing `Doc` values, since I tend to
write longer lines in prose than in code.

The formatting in scratch files is ephemeral, so I don't think that there is any good reason to force a max line length
on it.
