### PR TITLE
Remove reset-root, fix docs for reset

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -262,17 +262,6 @@ loop e = do
               description <- inputDescription input
               _ <- Cli.updateAt description target (const newRoot)
               Cli.respond Success
-            ResetRootI src0 ->
-              Cli.time "reset-root" do
-                newRoot <-
-                  case src0 of
-                    BranchAtSCH hash -> Cli.resolveShortCausalHash hash
-                    BranchAtPath path' -> Cli.expectBranchAtPath' path'
-                    BranchAtProjectPath pp -> Cli.getBranchFromProjectPath pp
-                description <- inputDescription input
-                pb <- getCurrentProjectBranch
-                void $ Cli.updateProjectBranchRoot_ pb description (const newRoot)
-                Cli.respond Success
             ForkLocalBranchI src0 dest0 -> do
               (srcb, branchEmpty) <-
                 case src0 of
@@ -908,9 +897,6 @@ inputDescription input =
           let tgtText = into @Text tgt
           pure (" " <> tgtText)
       pure ("reset " <> hashTxt <> tgt)
-    ResetRootI src0 -> do
-      let src = into @Text src0
-      pure ("reset-root " <> src)
     AliasTermI force src0 dest0 -> do
       src <- hhqs' src0
       dest <- ps' dest0

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -125,11 +125,10 @@ data Input
   | DiffNamespaceI BranchId2 BranchId2 -- old new
   | PullI !PullSourceTarget !PullMode
   | PushRemoteBranchI PushRemoteBranchInput
-  | ResetRootI BranchId
   | ResetI (BranchId2 {- namespace to reset it to -}) (Maybe UnresolvedProjectBranch {- ProjectBranch to reset -})
-  | -- todo: Q: Does it make sense to publish to not-the-root of a Github repo?
-    --          Does it make sense to fork from not-the-root of a Github repo?
-    -- used in Welcome module to give directions to user
+  -- todo: Q: Does it make sense to publish to not-the-root of a Github repo?
+  --          Does it make sense to fork from not-the-root of a Github repo?
+  | -- used in Welcome module to give directions to user
     CreateMessage (P.Pretty P.ColorText)
   | -- Change directory.
     SwitchBranchI Path'

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -100,7 +100,6 @@ module Unison.CommandLine.InputPatterns
     renameTerm,
     renameType,
     reset,
-    resetRoot,
     runScheme,
     saveExecuteResult,
     sfind,
@@ -1661,11 +1660,14 @@ reset =
     [ ("namespace, hash, or branch to reset to", Required, namespaceOrProjectBranchArg config),
       ("namespace to be reset", Optional, namespaceOrProjectBranchArg config)
     ]
-    ( P.wrapColumn2
-        [ ("`reset #pvfd222s8n`", "reset the current namespace to the causal `#pvfd222s8n`"),
-          ("`reset foo`", "reset the current namespace to that of the `foo` namespace."),
-          ("`reset foo bar`", "reset the namespace `bar` to that of the `foo` namespace."),
-          ("`reset #pvfd222s8n /topic`", "reset the branch `topic` of the current project to the causal `#pvfd222s8n`.")
+    ( P.lines
+        [ P.wrapColumn2
+            [ ("`reset #pvfd222s8n`", "reset the current namespace to the hash `#pvfd222s8n`"),
+              ("`reset foo`", "reset the current namespace to the state of the `foo` namespace."),
+              ("`reset #pvfd222s8n /topic`", "reset the branch `topic` of the current project to the causal `#pvfd222s8n`.")
+            ],
+          "",
+          P.wrap $ "If you make a mistake using reset, consult the " <> makeExample' branchReflog <> " command and use another " <> makeExample' reset <> " command to return to a previous state."
         ]
     )
     \case
@@ -1679,31 +1681,6 @@ reset =
           projectInclusion = AllProjects,
           branchInclusion = AllBranches
         }
-
--- asBranch = tryInto @(ProjectAndBranch (Maybe ProjectName) ProjectBranchName) (Text.pack inputString)
-
-resetRoot :: InputPattern
-resetRoot =
-  InputPattern
-    "reset-root"
-    []
-    I.Hidden
-    [("namespace or hash to reset to", Required, namespaceArg)]
-    ( P.lines
-        [ "Deprecated because it's incompatible with projects. ⚠️ Warning, this command can cause codebase corruption.",
-          P.wrapColumn2
-            [ ( makeExample resetRoot [".foo"],
-                "Reset the root namespace (along with its history) to that of the `.foo` namespace. Deprecated"
-              ),
-              ( makeExample resetRoot ["#9dndk3kbsk13nbpeu"],
-                "Reset the root namespace (along with its history) to that of the namespace with hash `#9dndk3kbsk13nbpeu`."
-              )
-            ]
-        ]
-    )
-    $ \case
-      [src] -> Input.ResetRootI <$> handleBranchIdArg src
-      args -> wrongArgsLength "exactly one argument" args
 
 pull :: InputPattern
 pull =
@@ -3502,7 +3479,6 @@ validInputs =
       renameType,
       moveAll,
       reset,
-      resetRoot,
       runScheme,
       saveExecuteResult,
       test,

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -997,7 +997,6 @@ notifyUser dir = \case
       --       defs in the codebase.  In some cases it's fine for bindings to
       --       shadow codebase names, but you don't want it to capture them in
       --       the decompiled output.
-
         let prettyBindings =
               P.bracket . P.lines $
                 P.wrap "The watch expression(s) reference these definitions:"
@@ -1290,8 +1289,8 @@ notifyUser dir = \case
                         "to make an old namespace accessible again,"
                       ),
                       (mempty, mempty),
-                      ( IP.makeExample IP.resetRoot [prettySCH prevSCH],
-                        "to reset the root namespace and its history to that of the specified"
+                      ( IP.makeExample IP.reset [prettySCH prevSCH],
+                        "to reset the current namespace and its history to that of the specified"
                           <> "namespace."
                       )
                     ]

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -997,6 +997,7 @@ notifyUser dir = \case
       --       defs in the codebase.  In some cases it's fine for bindings to
       --       shadow codebase names, but you don't want it to capture them in
       --       the decompiled output.
+
         let prettyBindings =
               P.bracket . P.lines $
                 P.wrap "The watch expression(s) reference these definitions:"

--- a/unison-src/transcripts/help.output.md
+++ b/unison-src/transcripts/help.output.md
@@ -683,14 +683,16 @@ scratch/main> help
   
   reset
   `reset #pvfd222s8n`         reset the current namespace to the
-                              causal `#pvfd222s8n`
-  `reset foo`                 reset the current namespace to
-                              that of the `foo` namespace.
-  `reset foo bar`             reset the namespace `bar` to that
-                              of the `foo` namespace.
+                              hash `#pvfd222s8n`
+  `reset foo`                 reset the current namespace to the
+                              state of the `foo` namespace.
   `reset #pvfd222s8n /topic`  reset the branch `topic` of the
                               current project to the causal
                               `#pvfd222s8n`.
+  
+  If you make a mistake using reset, consult the `branch.reflog`
+  command and use another `reset` command to return to a
+  previous state.
   
   rewrite (or sfind.replace)
   `rewrite rule1` rewrites definitions in the latest scratch file.


### PR DESCRIPTION
## Overview

`reset-root` doesn't make sense anymore, so that's gone.

`reset` only resets branches now, so I updated the examples to reflect that.

# Tests

See transcripts