### PR TITLE
feat/bugfix: on failed update, put dependents below definitions that were in file before running update

### DIFF
--- a/lib/unison-util-relation/src/Unison/Util/BiMultimap.hs
+++ b/lib/unison-util-relation/src/Unison/Util/BiMultimap.hs
@@ -3,6 +3,9 @@ module Unison.Util.BiMultimap
   ( BiMultimap,
     Unison.Util.BiMultimap.empty,
 
+    -- ** Basic queries
+    isEmpty,
+
     -- ** Lookup
     memberDom,
     lookupDom,
@@ -32,6 +35,9 @@ module Unison.Util.BiMultimap
     dom,
     ran,
 
+    -- ** Relations
+    toRelation,
+
     -- ** Insert
     insert,
     unsafeInsert,
@@ -48,6 +54,8 @@ import Data.Set.NonEmpty qualified as Set.NonEmpty
 import Unison.Prelude
 import Unison.Util.Map qualified as Map
 import Prelude hiding (filter)
+import Unison.Util.Relation (Relation)
+import qualified Unison.Util.Relation as Relation
 
 -- | A left-unique relation.
 --
@@ -61,6 +69,11 @@ data BiMultimap a b = BiMultimap
 -- | An empty left-unique relation.
 empty :: (Ord a, Ord b) => BiMultimap a b
 empty = BiMultimap mempty mempty
+
+-- | Is a left-unique relation empty?
+isEmpty :: BiMultimap a b -> Bool
+isEmpty =
+  Map.null . domain
 
 memberDom :: Ord a => a -> BiMultimap a b -> Bool
 memberDom x =
@@ -199,6 +212,11 @@ dom =
 ran :: BiMultimap a b -> Set b
 ran =
   Map.keysSet . toMapR
+
+-- | Convert a left-unique relation to a relation (forgetting its left-uniqueness).
+toRelation :: (Ord a, Ord b) => BiMultimap a b -> Relation a b
+toRelation =
+  Relation.fromMultimap . Map.map Set.NonEmpty.toSet . domain
 
 -- | Insert a pair into a left-unique relation, maintaining left-uniqueness, preferring the latest inserted element.
 --

--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -86,6 +86,7 @@ module Unison.Codebase.Branch
     -- ** Term/type queries
     deepTerms,
     deepTypes,
+    deepDefns,
     deepEdits,
     deepPaths,
     deepReferents,
@@ -112,6 +113,7 @@ import Unison.Codebase.Branch.Type
     UnwrappedBranch,
     branch0,
     children,
+    deepDefns,
     deepEdits,
     deepPaths,
     deepTerms,
@@ -318,7 +320,7 @@ cons = step . const
 -- | Construct a two-parent merge node.
 mergeNode ::
   forall m.
-  Applicative m =>
+  (Applicative m) =>
   Branch0 m ->
   (CausalHash, m (Branch m)) ->
   (CausalHash, m (Branch m)) ->

--- a/parser-typechecker/src/Unison/Codebase/Branch/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch/Type.hs
@@ -10,8 +10,8 @@ module Unison.Codebase.Branch.Type
     Branch (..),
     Branch0,
     branch0,
-    terms,
-    types,
+    Unison.Codebase.Branch.Type.terms,
+    Unison.Codebase.Branch.Type.types,
     children,
     nonEmptyChildren,
     history,
@@ -19,6 +19,7 @@ module Unison.Codebase.Branch.Type
     isEmpty0,
     deepTerms,
     deepTypes,
+    deepDefns,
     deepPaths,
     deepEdits,
     Star,
@@ -47,9 +48,11 @@ import Unison.NameSegment qualified as NameSegment
 import Unison.Prelude hiding (empty)
 import Unison.Reference (Reference, TypeReference)
 import Unison.Referent (Referent)
+import Unison.Util.Defns (Defns (..), DefnsF)
 import Unison.Util.Monoid qualified as Monoid
 import Unison.Util.Relation (Relation)
 import Unison.Util.Relation qualified as R
+import Unison.Util.Relation qualified as Relation
 import Unison.Util.Star2 qualified as Star2
 import Prelude hiding (head, read, subtract)
 
@@ -147,6 +150,13 @@ deepTerms = _deepTerms
 
 deepTypes :: Branch0 m -> Relation TypeReference Name
 deepTypes = _deepTypes
+
+deepDefns :: Branch0 m -> DefnsF (Relation Name) Referent TypeReference
+deepDefns branch =
+  Defns
+    { terms = Relation.swap (deepTerms branch),
+      types = Relation.swap (deepTypes branch)
+    }
 
 deepPaths :: Branch0 m -> Set Path
 deepPaths = _deepPaths

--- a/parser-typechecker/src/Unison/PrettyPrintEnvDecl/Names.hs
+++ b/parser-typechecker/src/Unison/PrettyPrintEnvDecl/Names.hs
@@ -1,8 +1,11 @@
 module Unison.PrettyPrintEnvDecl.Names
   ( makePPED,
+    makeFilePPED,
+    makeCodebasePPED,
   )
 where
 
+import Unison.Names (Names)
 import Unison.PrettyPrintEnv.Names qualified as PPE
 import Unison.PrettyPrintEnvDecl (PrettyPrintEnvDecl (PrettyPrintEnvDecl))
 
@@ -11,3 +14,23 @@ makePPED namer suffixifier =
   PrettyPrintEnvDecl
     (PPE.makePPE namer PPE.dontSuffixify)
     (PPE.makePPE namer suffixifier)
+
+-- | Make a PPED suitable for names in a Unison file.
+--
+-- Such names have special suffixification rules: aliases may *not* be referred to by a common suffix. For example, if
+-- a file contains
+--
+--   one.foo = 6
+--   two.foo = 6
+--
+-- then the suffix `foo` will *not* be accepted (currently). So, this PPE uses the "suffixify by name" strategy.
+makeFilePPED :: Names -> PrettyPrintEnvDecl
+makeFilePPED names =
+  makePPED (PPE.namer names) (PPE.suffixifyByName names)
+
+-- | Make a PPED suitable for names in the codebase. These names are hash qualified and suffixified by hash.
+makeCodebasePPED :: Names -> PrettyPrintEnvDecl
+makeCodebasePPED names =
+  makePPED
+    (PPE.hqNamer 10 names)
+    (PPE.suffixifyByHash names)

--- a/unison-cli/src/Unison/Cli/UpdateUtils.hs
+++ b/unison-cli/src/Unison/Cli/UpdateUtils.hs
@@ -1,0 +1,245 @@
+-- | This module contains functionality that is common to the general idea of "updating" a term in Unison, which is when
+-- we reassign a name from one hash to another and then see if all dependents still typecheck.
+--
+-- This occurs in the `pull`, `merge`, `update`, and `upgrade` commands.
+module Unison.Cli.UpdateUtils
+  ( -- * Narrowing definitions
+    narrowDefns,
+
+    -- * Hydrating definitions
+    hydrateDefns,
+    hydrateDefnsRel,
+
+    -- * Rendering definitions
+    renderDefnsForUnisonFile,
+  )
+where
+
+import Control.Lens (mapped, _1, _2)
+import Control.Monad.Writer (Writer)
+import Control.Monad.Writer qualified as Writer
+import Data.Bitraversable (bitraverse)
+import Data.Foldable qualified as Foldable
+import Data.List qualified as List
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
+import U.Codebase.Reference (TermReferenceId, TypeReferenceId)
+import Unison.Builtin.Decls qualified as Builtin.Decls
+import Unison.ConstructorReference (ConstructorReference, GConstructorReference (..))
+import Unison.DataDeclaration (Decl)
+import Unison.Hash (Hash)
+import Unison.HashQualified qualified as HQ
+import Unison.HashQualifiedPrime qualified as HQ'
+import Unison.Merge.DeclNameLookup (DeclNameLookup (..), expectConstructorNames)
+import Unison.Name (Name)
+import Unison.Prelude
+import Unison.PrettyPrintEnvDecl (PrettyPrintEnvDecl (..))
+import Unison.Reference qualified as Reference
+import Unison.Referent (Referent)
+import Unison.Referent qualified as Referent
+import Unison.Syntax.DeclPrinter (AccessorName)
+import Unison.Syntax.DeclPrinter qualified as DeclPrinter
+import Unison.Syntax.TermPrinter qualified as TermPrinter
+import Unison.Term (Term)
+import Unison.Type (Type)
+import Unison.Typechecker qualified as Typechecker
+import Unison.Util.BiMultimap (BiMultimap)
+import Unison.Util.BiMultimap qualified as BiMultimap
+import Unison.Util.Defn (Defn (..))
+import Unison.Util.Defns (Defns (..), DefnsF)
+import Unison.Util.Monoid qualified as Monoid
+import Unison.Util.Pretty (ColorText, Pretty)
+import Unison.Util.Pretty qualified as Pretty
+import Unison.Util.Relation (Relation)
+import Unison.Util.Relation qualified as Relation
+import Unison.Util.Set qualified as Set
+import Unison.Var (Var)
+import Prelude hiding (unzip, zip, zipWith)
+
+------------------------------------------------------------------------------------------------------------------------
+-- Narrowing definitions
+
+-- | "Narrow" a namespace that may contain conflicted names, resulting in either a failure (if we find a conflicted
+-- name), or the narrowed left-unique relation namespace without conflicted names.
+narrowDefns ::
+  (Ord term, Ord typ) =>
+  DefnsF (Relation Name) term typ ->
+  Either (Defn Name Name) (Defns (BiMultimap term Name) (BiMultimap typ Name))
+narrowDefns =
+  bitraverse (mapLeft TermDefn . go) (mapLeft TypeDefn . go)
+  where
+    go :: (Ord ref) => Relation Name ref -> Either Name (BiMultimap ref Name)
+    go =
+      fmap BiMultimap.fromRange . Map.traverseWithKey unconflicted . Relation.domain
+      where
+        unconflicted :: Name -> Set ref -> Either Name ref
+        unconflicted name refs =
+          case Set.asSingleton refs of
+            Nothing -> Left name
+            Just ref -> Right ref
+
+------------------------------------------------------------------------------------------------------------------------
+-- Hydrating definitions
+
+-- | Hydrate term/type references to actual terms/types.
+hydrateDefns ::
+  forall m name term typ.
+  (Monad m, Ord name) =>
+  (Hash -> m [term]) ->
+  (Hash -> m [typ]) ->
+  DefnsF (Map name) TermReferenceId TypeReferenceId ->
+  m (DefnsF (Map name) term (TypeReferenceId, typ))
+hydrateDefns getTermComponent getTypeComponent = do
+  bitraverse hydrateTerms hydrateTypes
+  where
+    hydrateTerms :: Map name TermReferenceId -> m (Map name term)
+    hydrateTerms terms =
+      hydrateDefns_ getTermComponent terms \_ _ -> id
+
+    hydrateTypes :: Map name TypeReferenceId -> m (Map name (TypeReferenceId, typ))
+    hydrateTypes types =
+      hydrateDefns_ getTypeComponent types \_ -> (,)
+
+hydrateDefns_ ::
+  forall a b name m.
+  (Monad m, Ord name) =>
+  (Hash -> m [a]) ->
+  Map name Reference.Id ->
+  (name -> Reference.Id -> a -> b) ->
+  m (Map name b)
+hydrateDefns_ getComponent defns modify =
+  Foldable.foldlM f Map.empty (foldMap (Set.singleton . Reference.idToHash) defns)
+  where
+    f :: Map name b -> Hash -> m (Map name b)
+    f acc hash =
+      List.foldl' g acc . Reference.componentFor hash <$> getComponent hash
+
+    g :: Map name b -> (Reference.Id, a) -> Map name b
+    g acc (ref, thing) =
+      Set.foldl' (h ref thing) acc (BiMultimap.lookupDom ref defns2)
+
+    h :: Reference.Id -> a -> Map name b -> name -> Map name b
+    h ref thing acc name =
+      Map.insert name (modify name ref thing) acc
+
+    defns2 :: BiMultimap Reference.Id name
+    defns2 =
+      BiMultimap.fromRange defns
+
+-- | Like 'hydrateDefns', but when you have a relation (i.e. names can be conflicted). Maybe this code should be deleted
+-- in favor of just asserting that names can't be conflicted before doing something (since it's easy to resolve: just
+-- rename one). But, for now, this exists.
+hydrateDefnsRel ::
+  forall m name term typ.
+  (Monad m, Ord name, Ord term, Ord typ) =>
+  (Hash -> m [term]) ->
+  (Hash -> m [typ]) ->
+  DefnsF (Relation name) TermReferenceId TypeReferenceId ->
+  m (DefnsF (Relation name) term (TypeReferenceId, typ))
+hydrateDefnsRel getTermComponent getTypeComponent = do
+  bitraverse hydrateTerms hydrateTypes
+  where
+    hydrateTerms :: Relation name TermReferenceId -> m (Relation name term)
+    hydrateTerms terms =
+      hydrateDefnsRel_ getTermComponent terms \_ _ -> id
+
+    hydrateTypes :: Relation name TypeReferenceId -> m (Relation name (TypeReferenceId, typ))
+    hydrateTypes types =
+      hydrateDefnsRel_ getTypeComponent types \_ -> (,)
+
+hydrateDefnsRel_ ::
+  forall a b name m.
+  (Ord b, Monad m, Ord name) =>
+  (Hash -> m [a]) ->
+  Relation name Reference.Id ->
+  (name -> Reference.Id -> a -> b) ->
+  m (Relation name b)
+hydrateDefnsRel_ getComponent defns modify =
+  let hashes :: [Hash]
+      hashes =
+        defns
+          & Relation.toList
+          & List.foldl' (\acc (_, ref) -> Set.insert (Reference.idToHash ref) acc) Set.empty
+          & Set.toList
+   in hashes & Monoid.foldMapM \hash -> do
+        component <- getComponent hash
+        pure
+          ( List.foldl'
+              f
+              Relation.empty
+              (Reference.componentFor hash component)
+          )
+  where
+    f :: Relation name b -> (Reference.Id, a) -> Relation name b
+    f acc (ref, x) =
+      List.foldl' (g ref x) acc (Set.toList (Relation.lookupRan ref defns))
+
+    g :: Reference.Id -> a -> Relation name b -> name -> Relation name b
+    g ref x acc2 name =
+      Relation.insert name (modify name ref x) acc2
+
+------------------------------------------------------------------------------------------------------------------------
+-- Rendering definitions
+
+-- | Render definitions destined for a Unison file.
+--
+-- This first renders the types (discovering which record accessors will be generated upon parsing), then renders the
+-- terms (being careful not to render any record accessors, since those would cause duplicate binding errors upon
+-- parsing).
+renderDefnsForUnisonFile ::
+  forall a v.
+  (Var v, Monoid a) =>
+  DeclNameLookup ->
+  PrettyPrintEnvDecl ->
+  DefnsF (Map Name) (Term v a, Type v a) (TypeReferenceId, Decl v a) ->
+  DefnsF (Map Name) (Pretty ColorText) (Pretty ColorText)
+renderDefnsForUnisonFile declNameLookup ppe defns =
+  let (types, accessorNames) = Writer.runWriter (Map.traverseWithKey renderType defns.types)
+   in Defns
+        { terms = Map.mapMaybeWithKey (renderTerm accessorNames) defns.terms,
+          types
+        }
+  where
+    renderType :: Name -> (TypeReferenceId, Decl v a) -> Writer (Set AccessorName) (Pretty ColorText)
+    renderType name (ref, typ) =
+      fmap Pretty.syntaxToColor $
+        DeclPrinter.prettyDeclW
+          -- Sort of a hack; since the decl printer looks in the PPE for names of constructors,
+          -- we just delete all term names out and add back the constructors...
+          -- probably no need to wipe out the suffixified side but we do it anyway
+          (setPpedToConstructorNames declNameLookup name ref ppe)
+          (Reference.fromId ref)
+          (HQ.NameOnly name)
+          typ
+
+    renderTerm :: Set Name -> Name -> (Term v a, Type v a) -> Maybe (Pretty ColorText)
+    renderTerm accessorNames name (term, typ) = do
+      guard (not (Set.member name accessorNames))
+      let hqName = HQ.NameOnly name
+      let rendered
+            | Typechecker.isEqual (Builtin.Decls.testResultListType mempty) typ =
+                "test> " <> TermPrinter.prettyBindingWithoutTypeSignature ppe.suffixifiedPPE hqName term
+            | otherwise = TermPrinter.prettyBinding ppe.suffixifiedPPE hqName term
+      Just (Pretty.syntaxToColor rendered)
+
+setPpedToConstructorNames :: DeclNameLookup -> Name -> TypeReferenceId -> PrettyPrintEnvDecl -> PrettyPrintEnvDecl
+setPpedToConstructorNames declNameLookup name ref =
+  set (#unsuffixifiedPPE . #termNames) referentNames
+    . set (#suffixifiedPPE . #termNames) referentNames
+  where
+    constructorNameMap :: Map ConstructorReference Name
+    constructorNameMap =
+      Map.fromList
+        ( name
+            & expectConstructorNames declNameLookup
+            & List.zip [0 ..]
+            & over (mapped . _1) (ConstructorReference (Reference.fromId ref))
+        )
+
+    referentNames :: Referent -> [(HQ'.HashQualified Name, HQ'.HashQualified Name)]
+    referentNames = \case
+      Referent.Con conRef _ ->
+        case Map.lookup conRef constructorNameMap of
+          Nothing -> []
+          Just conName -> let hqConName = HQ'.NameOnly conName in [(hqConName, hqConName)]
+      Referent.Ref _ -> []

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Merge2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Merge2.hs
@@ -250,13 +250,7 @@ doMerge info = do
               Just (who, branch) -> do
                 defns <- loadDefns branch
                 declNameLookup <-
-                  Cli.runTransaction
-                    ( checkDeclCoherency
-                        db.loadDeclNumConstructors
-                        Referent.toConstructorReferenceId
-                        Reference.toId
-                        defns
-                    )
+                  Cli.runTransaction (checkDeclCoherency db.loadDeclNumConstructors defns)
                     & onLeftM (done . Output.IncoherentDeclDuringMerge who)
                 pure (defns, declNameLookup)
 

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Todo.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Todo.hs
@@ -27,8 +27,6 @@ import Unison.Reference (TermReference)
 import Unison.Syntax.Name qualified as Name
 import Unison.Util.Defns (Defns (..))
 import Unison.Util.Set qualified as Set
-import qualified Unison.Referent as Referent
-import qualified Unison.Reference as Reference
 
 handleTodo :: Cli ()
 handleTodo = do
@@ -74,8 +72,6 @@ handleTodo = do
         fmap (Either.fromLeft (IncoherentDeclReasons [] [] [] [])) $
           checkAllDeclCoherency
             Operations.expectDeclNumConstructors
-            Referent.toConstructorReferenceId
-            Reference.toId
             (Names.lenientToNametree (Branch.toNames currentNamespaceWithoutLibdeps))
 
       pure (defnsInLib, dependentsOfTodo.terms, directDependencies, hashLen, incoherentDeclReasons)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Todo.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Todo.hs
@@ -27,6 +27,8 @@ import Unison.Reference (TermReference)
 import Unison.Syntax.Name qualified as Name
 import Unison.Util.Defns (Defns (..))
 import Unison.Util.Set qualified as Set
+import qualified Unison.Referent as Referent
+import qualified Unison.Reference as Reference
 
 handleTodo :: Cli ()
 handleTodo = do
@@ -72,6 +74,8 @@ handleTodo = do
         fmap (Either.fromLeft (IncoherentDeclReasons [] [] [] [])) $
           checkAllDeclCoherency
             Operations.expectDeclNumConstructors
+            Referent.toConstructorReferenceId
+            Reference.toId
             (Names.lenientToNametree (Branch.toNames currentNamespaceWithoutLibdeps))
 
       pure (defnsInLib, dependentsOfTodo.terms, directDependencies, hashLen, incoherentDeclReasons)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
@@ -85,13 +85,7 @@ handleUpdate2 = do
 
   -- Assert that the namespace doesn't have any incoherent decls
   declNameLookup <-
-    Cli.runTransaction
-      ( checkDeclCoherency
-          Operations.expectDeclNumConstructors
-          Referent.toConstructorReferenceId
-          Reference.toId
-          defns
-      )
+    Cli.runTransaction (checkDeclCoherency Operations.expectDeclNumConstructors defns)
       & onLeftM (Cli.returnEarly . Output.IncoherentDeclDuringUpdate)
 
   Cli.respond Output.UpdateLookingForDependents

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
@@ -156,9 +156,9 @@ makePrettyUnisonFile originalFile dependents =
   originalFile
     <> Pretty.newline
     <> Pretty.newline
-    <> "-- The definitions below are not compatible with the updated definitions above."
+    <> "-- The definitions below no longer typecheck with the changes above."
     <> Pretty.newline
-    <> "-- Please fix the errors and run `update` again."
+    <> "-- Please fix the errors and try `update` again."
     <> Pretty.newline
     <> Pretty.newline
     <> ( dependents

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
@@ -3,45 +3,30 @@ module Unison.Codebase.Editor.HandleInput.Update2
   ( handleUpdate2,
 
     -- * Misc helpers to be organized later
-    addDefinitionsToUnisonFile,
-    findCtorNames,
-    findCtorNamesMaybe,
-    forwardCtorNames,
-    makeParsingEnv,
-    prettyParseTypecheck,
-    prettyParseTypecheck2,
     typecheckedUnisonFileToBranchUpdates,
-    typecheckedUnisonFileToBranchAdds,
-    getNamespaceDependentsOf,
-    getNamespaceDependentsOf2,
   )
 where
 
-import Control.Lens qualified as Lens
 import Control.Monad.RWS (ask)
 import Data.Bifoldable (bifoldMap)
-import Data.Foldable qualified as Foldable
 import Data.List qualified as List
-import Data.List.NonEmpty qualified as NonEmpty
-import Data.List.NonEmpty.Extra ((|>))
 import Data.Map qualified as Map
-import Data.Maybe (fromJust)
 import Data.Set qualified as Set
 import Data.Text qualified as Text
-import Data.Text.Lazy qualified as Lazy.Text
-import Text.Pretty.Simple (pShow)
 import U.Codebase.Reference (Reference, TermReferenceId)
 import U.Codebase.Reference qualified as Reference
 import U.Codebase.Sqlite.Operations qualified as Operations
-import U.Codebase.Sqlite.Operations qualified as Ops
-import Unison.Builtin.Decls qualified as Decls
 import Unison.Cli.Monad (Cli, Env (..))
 import Unison.Cli.Monad qualified as Cli
 import Unison.Cli.MonadUtils qualified as Cli
 import Unison.Cli.Pretty qualified as Pretty
-import Unison.Cli.TypeCheck (computeTypecheckingEnvironment)
-import Unison.Cli.UniqueTypeGuidLookup qualified as Cli
-import Unison.Cli.UpdateUtils (hydrateDefns, narrowDefns, renderDefnsForUnisonFile)
+import Unison.Cli.UpdateUtils
+  ( getNamespaceDependentsOf2,
+    hydrateDefns,
+    narrowDefns,
+    parseAndTypecheck,
+    renderDefnsForUnisonFile,
+  )
 import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Branch (Branch0)
 import Unison.Codebase.Branch qualified as Branch
@@ -51,29 +36,15 @@ import Unison.Codebase.Editor.Output (Output)
 import Unison.Codebase.Editor.Output qualified as Output
 import Unison.Codebase.Path (Path)
 import Unison.Codebase.Path qualified as Path
-import Unison.Codebase.ProjectPath (ProjectPath)
 import Unison.Codebase.SqliteCodebase.Operations qualified as Operations
-import Unison.Codebase.Type (Codebase)
-import Unison.ConstructorReference (GConstructorReference (ConstructorReference))
-import Unison.DataDeclaration (DataDeclaration, Decl)
-import Unison.DataDeclaration qualified as DataDeclaration
+import Unison.DataDeclaration (Decl)
 import Unison.DataDeclaration qualified as Decl
-import Unison.DataDeclaration.ConstructorId (ConstructorId)
-import Unison.Debug qualified as Debug
-import Unison.FileParsers qualified as FileParsers
-import Unison.Hash (Hash)
 import Unison.Merge.DeclCoherencyCheck (checkDeclCoherency)
 import Unison.Merge.DeclNameLookup (DeclNameLookup (..))
 import Unison.Name (Name)
-import Unison.Name qualified as Name
-import Unison.Name.Forward (ForwardName (..))
-import Unison.Name.Forward qualified as ForwardName
-import Unison.NameSegment.Internal (NameSegment (NameSegment))
 import Unison.Names (Names)
 import Unison.Names qualified as Names
 import Unison.Parser.Ann (Ann)
-import Unison.Parser.Ann qualified as Ann
-import Unison.Parsers qualified as Parsers
 import Unison.Prelude
 import Unison.PrettyPrintEnv.Names qualified as PPE
 import Unison.PrettyPrintEnvDecl (PrettyPrintEnvDecl)
@@ -81,30 +52,19 @@ import Unison.PrettyPrintEnvDecl qualified as PPED
 import Unison.PrettyPrintEnvDecl.Names qualified as PPED
 import Unison.Reference (TypeReference, TypeReferenceId)
 import Unison.Reference qualified as Reference (fromId)
-import Unison.Referent (Referent)
 import Unison.Referent qualified as Referent
-import Unison.Result qualified as Result
 import Unison.Sqlite (Transaction)
 import Unison.Symbol (Symbol)
 import Unison.Syntax.Name qualified as Name
-import Unison.Syntax.Parser qualified as Parser
-import Unison.Term (Term)
-import Unison.Type (Type)
-import Unison.Typechecker qualified as Typechecker
-import Unison.UnisonFile (UnisonFile)
 import Unison.UnisonFile qualified as UF
 import Unison.UnisonFile.Names qualified as UF
 import Unison.UnisonFile.Type (TypecheckedUnisonFile)
-import Unison.Util.BiMultimap (BiMultimap)
-import Unison.Util.BiMultimap qualified as BiMultimap
 import Unison.Util.Defns (Defns (..), DefnsF, defnsAreEmpty)
 import Unison.Util.Monoid qualified as Monoid
 import Unison.Util.Nametree (flattenNametrees)
 import Unison.Util.Pretty (ColorText, Pretty)
 import Unison.Util.Pretty qualified as Pretty
-import Unison.Util.Relation (Relation)
 import Unison.Util.Relation qualified as Relation
-import Unison.Util.Set qualified as Set
 import Unison.Var (Var)
 import Unison.WatchKind qualified as WK
 
@@ -117,7 +77,6 @@ handleUpdate2 = do
   currentBranch0 <- Cli.getCurrentBranch0
   let currentBranch0ExcludingLibdeps = Branch.deleteLibdeps currentBranch0
   let namesIncludingLibdeps = Branch.toNames currentBranch0
-  let namesExcludingLibdeps = Branch.toNames currentBranch0ExcludingLibdeps
 
   -- Assert that the namespace doesn't have any conflicted names
   defns <-
@@ -143,7 +102,7 @@ handleUpdate2 = do
       dependents0 <-
         getNamespaceDependentsOf2
           (flattenNametrees defns)
-          (getExistingReferencesNamed termAndDeclNames namesExcludingLibdeps)
+          (getExistingReferencesNamed termAndDeclNames (Branch.toNames currentBranch0ExcludingLibdeps))
 
       -- Throw away the dependents that are shadowed by the file itself
       let dependents1 :: DefnsF (Map Name) TermReferenceId TypeReferenceId
@@ -175,19 +134,18 @@ handleUpdate2 = do
                     (Pretty.prettyUnisonFile ppe (UF.discardTypes tuf))
                     (renderDefnsForUnisonFile declNameLookup ppe hydratedDependents)
 
-        parsingEnv <- makeParsingEnv pp namesIncludingLibdeps
+        parsingEnv <- Cli.makeParsingEnv pp namesIncludingLibdeps
 
         secondTuf <-
-          prettyParseTypecheck2 prettyUnisonFile parsingEnv & onLeftM \prettyUf -> do
+          parseAndTypecheck prettyUnisonFile parsingEnv & onNothingM do
             scratchFilePath <- fst <$> Cli.expectLatestFile
-            liftIO $ env.writeSource (Text.pack scratchFilePath) (Text.pack $ Pretty.toPlain 80 prettyUf)
+            liftIO $ env.writeSource (Text.pack scratchFilePath) (Text.pack $ Pretty.toPlain 80 prettyUnisonFile)
             Cli.returnEarly Output.UpdateTypecheckingFailure
 
         Cli.respond Output.UpdateTypecheckingSuccess
 
         pure secondTuf
 
-  env <- ask
   path <- Cli.getCurrentProjectPath
   branchUpdates <-
     Cli.runTransactionWithRollback \abort -> do
@@ -220,49 +178,6 @@ makePrettyUnisonFile originalFile dependents =
       bimap f f
       where
         f = map snd . List.sortOn (Name.toText . fst) . Map.toList
-
--- TODO: find a better module for this function, as it's used in a couple places
-prettyParseTypecheck ::
-  UnisonFile Symbol Ann ->
-  PrettyPrintEnvDecl ->
-  Parser.ParsingEnv Transaction ->
-  Cli (Either (Pretty Pretty.ColorText) (TypecheckedUnisonFile Symbol Ann))
-prettyParseTypecheck bigUf pped =
-  prettyParseTypecheck2 (Pretty.prettyUnisonFile pped bigUf)
-
--- TODO: find a better module for this function, as it's used in a couple places
-prettyParseTypecheck2 ::
-  Pretty Pretty.ColorText ->
-  Parser.ParsingEnv Transaction ->
-  Cli (Either (Pretty Pretty.ColorText) (TypecheckedUnisonFile Symbol Ann))
-prettyParseTypecheck2 prettyUf parsingEnv = do
-  Cli.Env {codebase} <- ask
-  let stringUf = Pretty.toPlain 80 prettyUf
-  Debug.whenDebug Debug.Update do
-    liftIO do
-      putStrLn "--- Scratch ---"
-      putStrLn stringUf
-  Cli.runTransaction do
-    Parsers.parseFile "<update>" stringUf parsingEnv >>= \case
-      Left {} -> pure $ Left prettyUf
-      Right reparsedUf -> do
-        typecheckingEnv <-
-          computeTypecheckingEnvironment (FileParsers.ShouldUseTndr'Yes parsingEnv) codebase [] reparsedUf
-        pure case FileParsers.synthesizeFile typecheckingEnv reparsedUf of
-          Result.Result _notes (Just reparsedTuf) -> Right reparsedTuf
-          Result.Result _notes Nothing -> Left prettyUf
-
--- @makeParsingEnv path names@ makes a parsing environment with @names@ in scope, which are all relative to @path@.
-makeParsingEnv :: ProjectPath -> Names -> Cli (Parser.ParsingEnv Transaction)
-makeParsingEnv path names = do
-  Cli.Env {generateUniqueName} <- ask
-  uniqueName <- liftIO generateUniqueName
-  pure do
-    Parser.ParsingEnv
-      { uniqueNames = uniqueName,
-        uniqueTypeGuid = Cli.loadUniqueTypeGuid path,
-        names
-      }
 
 -- @typecheckedUnisonFileToBranchUpdates getConstructors file@ returns a list of branch updates (suitable for passing
 -- along to `batchUpdates` or some "step at" combinator) that corresponds to using all of the contents of @file@.
@@ -337,40 +252,6 @@ typecheckedUnisonFileToBranchUpdates abort getConstructors tuf = do
     splitVar :: Symbol -> Path.Split
     splitVar = Path.splitFromName . Name.unsafeParseVar
 
-typecheckedUnisonFileToBranchAdds :: TypecheckedUnisonFile Symbol Ann -> [(Path, Branch0 m -> Branch0 m)]
-typecheckedUnisonFileToBranchAdds tuf = do
-  declAdds ++ termAdds
-  where
-    declAdds :: [(Path, Branch0 m -> Branch0 m)]
-    declAdds = do
-      foldMap makeDataDeclAdds (Map.toList $ UF.dataDeclarationsId' tuf)
-        ++ foldMap makeEffectDeclUpdates (Map.toList $ UF.effectDeclarationsId' tuf)
-      where
-        makeDataDeclAdds (symbol, (typeRefId, dataDecl)) = makeDeclAdds (symbol, (typeRefId, Right dataDecl))
-        makeEffectDeclUpdates (symbol, (typeRefId, effectDecl)) = makeDeclAdds (symbol, (typeRefId, Left effectDecl))
-
-        makeDeclAdds :: (Symbol, (TypeReferenceId, Decl Symbol Ann)) -> [(Path, Branch0 m -> Branch0 m)]
-        makeDeclAdds (symbol, (typeRefId, decl)) =
-          let insertTypeAction = BranchUtil.makeAddTypeName (splitVar symbol) (Reference.fromId typeRefId)
-              insertTypeConstructorActions =
-                zipWith
-                  (\sym rid -> BranchUtil.makeAddTermName (splitVar sym) (Reference.fromId <$> rid))
-                  (Decl.constructorVars (Decl.asDataDecl decl))
-                  (Decl.declConstructorReferents typeRefId decl)
-           in insertTypeAction : insertTypeConstructorActions
-
-    termAdds :: [(Path, Branch0 m -> Branch0 m)]
-    termAdds =
-      tuf
-        & UF.hashTermsId
-        & Map.toList
-        & mapMaybe \(var, (_, ref, wk, _, _)) -> do
-          guard (WK.watchKindShouldBeStoredInDatabase wk)
-          Just (BranchUtil.makeAddTermName (splitVar var) (Referent.fromTermReferenceId ref))
-
-    splitVar :: Symbol -> Path.Split
-    splitVar = Path.splitFromName . Name.unsafeParseVar
-
 -- | get references from `names` that have the same names as in `defns`
 -- For constructors, we get the type reference.
 getExistingReferencesNamed :: DefnsF Set Name Name -> Names -> Set Reference
@@ -386,165 +267,6 @@ getExistingReferencesNamed defns names =
     fromTypes =
       foldMap \name ->
         Relation.lookupDom name (Names.types names)
-
-makeUnisonFile ::
-  (forall void. Output -> Transaction void) ->
-  Codebase IO Symbol Ann ->
-  (Maybe Int -> Name -> Either Output.Output [Name]) ->
-  DefnsF (Relation Name) TermReferenceId TypeReferenceId ->
-  Transaction (UnisonFile Symbol Ann)
-makeUnisonFile abort codebase doFindCtorNames defns = do
-  file <- foldM addTermComponent UF.emptyUnisonFile (Set.map Reference.idToHash (Relation.ran defns.terms))
-  foldM addDeclComponent file (Set.map Reference.idToHash (Relation.ran defns.types))
-  where
-    addTermComponent :: UnisonFile Symbol Ann -> Hash -> Transaction (UnisonFile Symbol Ann)
-    addTermComponent uf h = do
-      termComponent <- Codebase.unsafeGetTermComponent codebase h
-      pure $ foldl' addTermElement uf (zip termComponent [0 ..])
-      where
-        addTermElement :: UnisonFile Symbol Ann -> ((Term Symbol Ann, Type Symbol Ann), Reference.Pos) -> UnisonFile Symbol Ann
-        addTermElement uf ((tm, tp), i) = do
-          let termNames = Relation.lookupRan (Reference.Id h i) defns.terms
-          foldl' (addDefinition tm tp) uf termNames
-        addDefinition :: Term Symbol Ann -> Type Symbol Ann -> UnisonFile Symbol Ann -> Name -> UnisonFile Symbol Ann
-        addDefinition tm tp uf (Name.toVar -> v) =
-          let prependTerm to = (v, Ann.External, tm) : to
-           in if isTest tp
-                then uf & #watches . Lens.at WK.TestWatch . Lens.non [] Lens.%~ prependTerm
-                else uf & #terms Lens.%~ Map.insert v (Ann.External, tm)
-
-    isTest = Typechecker.isEqual (Decls.testResultListType mempty)
-
-    -- given a dependent hash, include that component in the scratch file
-    -- todo: wundefined: cut off constructor name prefixes
-    addDeclComponent :: UnisonFile Symbol Ann -> Hash -> Transaction (UnisonFile Symbol Ann)
-    addDeclComponent uf h = do
-      declComponent <- fromJust <$> Codebase.getDeclComponent h
-      foldM addDeclElement uf (zip declComponent [0 ..])
-      where
-        -- for each name a decl has, update its constructor names according to what exists in the namespace
-        addDeclElement :: UnisonFile Symbol Ann -> (Decl Symbol Ann, Reference.Pos) -> Transaction (UnisonFile Symbol Ann)
-        addDeclElement uf (decl, i) = do
-          let declNames = Relation.lookupRan (Reference.Id h i) defns.types
-          -- look up names for this decl's constructor based on the decl's name, and embed them in the decl definition.
-          foldM (addRebuiltDefinition decl) uf declNames
-          where
-            -- skip any definitions that already have names, we don't want to overwrite what the user has supplied
-            addRebuiltDefinition :: Decl Symbol Ann -> UnisonFile Symbol Ann -> Name -> Transaction (UnisonFile Symbol Ann)
-            addRebuiltDefinition decl uf name = case decl of
-              Left ed ->
-                overwriteConstructorNames name ed.toDataDecl <&> \ed' ->
-                  uf
-                    & #effectDeclarationsId
-                    %~ Map.insertWith (\_new old -> old) (Name.toVar name) (Reference.Id h i, Decl.EffectDeclaration ed')
-              Right dd ->
-                overwriteConstructorNames name dd <&> \dd' ->
-                  uf
-                    & #dataDeclarationsId
-                    %~ Map.insertWith (\_new old -> old) (Name.toVar name) (Reference.Id h i, dd')
-
-        -- Constructor names are bogus when pulled from the database, so we set them to what they should be here
-        overwriteConstructorNames :: Name -> DataDeclaration Symbol Ann -> Transaction (DataDeclaration Symbol Ann)
-        overwriteConstructorNames name dd =
-          let constructorNames :: Transaction [Symbol]
-              constructorNames =
-                case doFindCtorNames (Just $ Decl.constructorCount dd) name of
-                  Left err -> abort err
-                  Right array | all (isJust . Name.stripNamePrefix name) array -> pure (map Name.toVar array)
-                  Right array -> do
-                    traceM "I ran into a situation where a type's constructors didn't match its name,"
-                    traceM "in a spot where I didn't expect to be discovering that.\n\n"
-                    traceM "Type Name:"
-                    traceM . Lazy.Text.unpack $ pShow name
-                    traceM "Constructor Names:"
-                    traceM . Lazy.Text.unpack $ pShow array
-                    error "Sorry for crashing."
-
-              swapConstructorNames oldCtors =
-                let (annotations, _vars, types) = unzip3 oldCtors
-                 in zip3 annotations <$> constructorNames <*> pure types
-           in Lens.traverseOf Decl.constructors_ swapConstructorNames dd
-
--- | @addDefinitionsToUnisonFile abort codebase doFindCtorNames definitions file@ adds all @definitions@ to @file@,
--- avoiding overwriting anything already in @file@. Every definition is put into the file with every naming it has in
--- @names@ "on the left-hand-side of the equals" (but yes type decls don't really have a LHS).
---
--- TODO: find a better module for this function, as it's used in a couple places
-addDefinitionsToUnisonFile ::
-  (forall void. Output -> Transaction void) ->
-  Codebase IO Symbol Ann ->
-  (Maybe Int -> Name -> Either Output.Output [Name]) ->
-  DefnsF (Relation Name) TermReferenceId TypeReferenceId ->
-  UnisonFile Symbol Ann ->
-  Transaction (UnisonFile Symbol Ann)
-addDefinitionsToUnisonFile abort codebase doFindCtorNames newDefns oldUF = do
-  newUF <- makeUnisonFile abort codebase doFindCtorNames newDefns
-  pure (oldUF `UF.leftBiasedMerge` newUF)
-
--- | O(r + c * d) touches all the referents (r), and all the NameSegments (d) of all of the Con referents (c)
-forwardCtorNames :: Names -> Map ForwardName (Referent, Name)
-forwardCtorNames names =
-  Map.fromList $
-    [ (ForwardName.fromName name, (r, name))
-      | (r@Referent.Con {}, rNames) <- Map.toList $ Relation.range names.terms,
-        name <- Foldable.toList rNames
-    ]
-
--- | given a decl name, find names for all of its constructors, in order.
---
--- Precondition: 'n' is an element of 'names'
-findCtorNames :: Output.UpdateOrUpgrade -> Names -> Map ForwardName (Referent, Name) -> Maybe Int -> Name -> Either Output.Output [Name]
-findCtorNames operation names forwardCtorNames ctorCount n =
-  let declRef = case Set.lookupMin (Relation.lookupDom n names.types) of
-        Nothing -> error "[findCtorNames] precondition violation: n is not an element of names"
-        Just x -> x
-      f = ForwardName.fromName n
-      (_, centerRight) = Map.split f forwardCtorNames
-      (center, _) = Map.split (incrementLastSegmentChar f) centerRight
-
-      insertShortest :: Map ConstructorId Name -> (Referent, Name) -> Map ConstructorId Name
-      insertShortest m (Referent.Con (ConstructorReference r cid) _ct, newName) | r == declRef =
-        case Map.lookup cid m of
-          Just existingName
-            | length (Name.segments existingName) > length (Name.segments newName) ->
-                Map.insert cid newName m
-          Just {} -> m
-          Nothing -> Map.insert cid newName m
-      insertShortest m _ = m
-      m = foldl' insertShortest mempty (Foldable.toList center)
-      ctorCountGuess = fromMaybe (Map.size m) ctorCount
-   in if Map.size m == ctorCountGuess && all (isJust . flip Map.lookup m . fromIntegral) [0 .. ctorCountGuess - 1]
-        then Right $ Map.elems m
-        else Left $ Output.UpdateIncompleteConstructorSet operation n m ctorCount
-
-findCtorNamesMaybe ::
-  Output.UpdateOrUpgrade ->
-  Names ->
-  Map ForwardName (Referent, Name) ->
-  Maybe Int ->
-  Name ->
-  Either Output.Output (Maybe [Name])
-findCtorNamesMaybe operation names forwardCtorNames ctorCount name =
-  case Relation.memberDom name (Names.types names) of
-    True -> Just <$> findCtorNames operation names forwardCtorNames ctorCount name
-    False -> Right Nothing
-
--- Used by `findCtorNames` to filter `forwardCtorNames` to a narrow range which will be searched linearly.
--- >>> incrementLastSegmentChar $ ForwardName.fromName $ Name.unsafeFromText "foo.bar.quux"
--- ForwardName {toList = "foo" :| ["bar","quuy"]}
-incrementLastSegmentChar :: ForwardName -> ForwardName
-incrementLastSegmentChar (ForwardName segments) =
-  let (initSegments, lastSegment) = (NonEmpty.init segments, NonEmpty.last segments)
-      incrementedLastSegment = incrementLastCharInSegment lastSegment
-   in ForwardName $ maybe (NonEmpty.singleton incrementedLastSegment) (|> incrementedLastSegment) (NonEmpty.nonEmpty initSegments)
-  where
-    incrementLastCharInSegment :: NameSegment -> NameSegment
-    incrementLastCharInSegment (NameSegment text) =
-      let incrementedText =
-            if Text.null text
-              then text
-              else Text.init text `Text.append` Text.singleton (succ $ Text.last text)
-       in NameSegment incrementedText
 
 -- @getTermAndDeclNames file@ returns the names of the terms and decls defined in a typechecked Unison file.
 getTermAndDeclNames :: (Var v) => TypecheckedUnisonFile v a -> DefnsF Set Name Name
@@ -563,53 +285,6 @@ getTermAndDeclNames tuf =
     dataCtors = foldMap ctorsToNames $ fmap snd $ UF.dataDeclarationsId' tuf
     keysToNames = Set.map Name.unsafeParseVar . Map.keysSet
     ctorsToNames = Set.fromList . map Name.unsafeParseVar . Decl.constructorVars
-
--- | Given a namespace and a set of dependencies, return the subset of the namespace that consists of only the
--- (transitive) dependents of the dependencies.
-getNamespaceDependentsOf ::
-  Names ->
-  Set Reference ->
-  Transaction (DefnsF (Relation Name) TermReferenceId TypeReferenceId)
-getNamespaceDependentsOf names dependencies = do
-  dependents <- Ops.transitiveDependentsWithinScope (Names.referenceIds names) dependencies
-  pure (bimap (foldMap nameTerm) (foldMap nameType) dependents)
-  where
-    nameTerm :: TermReferenceId -> Relation Name TermReferenceId
-    nameTerm ref =
-      Relation.fromManyDom (Relation.lookupRan (Referent.fromTermReferenceId ref) (Names.terms names)) ref
-
-    nameType :: TypeReferenceId -> Relation Name TypeReferenceId
-    nameType ref =
-      Relation.fromManyDom (Relation.lookupRan (Reference.fromId ref) (Names.types names)) ref
-
--- | A better version of the above that operates on BiMultimaps rather than Relations.
-getNamespaceDependentsOf2 ::
-  Defns (BiMultimap Referent Name) (BiMultimap TypeReference Name) ->
-  Set Reference ->
-  Transaction (DefnsF (Map Name) TermReferenceId TypeReferenceId)
-getNamespaceDependentsOf2 defns dependencies = do
-  let toTermScope = Set.mapMaybe Referent.toReferenceId . BiMultimap.dom
-  let toTypeScope = Set.mapMaybe Reference.toId . BiMultimap.dom
-  let scope = bifoldMap toTermScope toTypeScope defns
-
-  dependents <-
-    Ops.transitiveDependentsWithinScope scope dependencies
-
-  pure
-    Defns
-      { terms = Set.foldl' addTerms Map.empty dependents.terms,
-        types = Set.foldl' addTypes Map.empty dependents.types
-      }
-  where
-    addTerms :: Map Name TermReferenceId -> TermReferenceId -> Map Name TermReferenceId
-    addTerms acc0 ref =
-      let names = BiMultimap.lookupDom (Referent.fromTermReferenceId ref) defns.terms
-       in Set.foldl' (\acc name -> Map.insert name ref acc) acc0 names
-
-    addTypes :: Map Name TypeReferenceId -> TypeReferenceId -> Map Name TypeReferenceId
-    addTypes acc0 ref =
-      let names = BiMultimap.lookupDom (Reference.fromId ref) defns.types
-       in Set.foldl' (\acc name -> Map.insert name ref acc) acc0 names
 
 -- The big picture behind PPE building, though there are many details:
 --

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
@@ -14,7 +14,6 @@ import Data.Map qualified as Map
 import Data.Set qualified as Set
 import Data.Text qualified as Text
 import U.Codebase.Reference (Reference, TermReferenceId)
-import U.Codebase.Reference qualified as Reference
 import U.Codebase.Sqlite.Operations qualified as Operations
 import Unison.Cli.Monad (Cli, Env (..))
 import Unison.Cli.Monad qualified as Cli

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Upgrade.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Upgrade.hs
@@ -4,43 +4,56 @@ module Unison.Codebase.Editor.HandleInput.Upgrade
   )
 where
 
+import Control.Lens qualified as Lens
 import Control.Monad.Reader (ask)
 import Data.Char qualified as Char
+import Data.Foldable qualified as Foldable
 import Data.List.NonEmpty (pattern (:|))
+import Data.List.NonEmpty qualified as List.NonEmpty
+import Data.List.NonEmpty.Extra ((|>))
 import Data.Map.Strict qualified as Map
+import Data.Maybe (fromJust)
 import Data.Set qualified as Set
 import Data.Text qualified as Text
+import Data.Text.Lazy qualified as Text.Lazy
 import Text.Builder qualified
+import Text.Pretty.Simple (pShow)
 import U.Codebase.Sqlite.DbId (ProjectId)
+import Unison.Builtin.Decls qualified as Decls
 import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
 import Unison.Cli.MonadUtils qualified as Cli
+import Unison.Cli.Pretty qualified as Pretty
 import Unison.Cli.ProjectUtils qualified as Cli
+import Unison.Cli.UpdateUtils (getNamespaceDependentsOf, parseAndTypecheck)
+import Unison.Codebase (Codebase)
 import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Branch qualified as Branch
 import Unison.Codebase.Branch.Names qualified as Branch
 import Unison.Codebase.Editor.HandleInput.Branch (CreateFrom (..))
 import Unison.Codebase.Editor.HandleInput.Branch qualified as HandleInput.Branch
-import Unison.Codebase.Editor.HandleInput.Update2
-  ( addDefinitionsToUnisonFile,
-    findCtorNames,
-    findCtorNamesMaybe,
-    forwardCtorNames,
-    getNamespaceDependentsOf,
-    makeParsingEnv,
-    prettyParseTypecheck,
-    typecheckedUnisonFileToBranchUpdates,
-  )
+import Unison.Codebase.Editor.HandleInput.Update2 (typecheckedUnisonFileToBranchUpdates)
+import Unison.Codebase.Editor.Output (Output)
 import Unison.Codebase.Editor.Output qualified as Output
 import Unison.Codebase.Path qualified as Path
 import Unison.Codebase.ProjectPath qualified as PP
+import Unison.ConstructorReference (GConstructorReference (..))
+import Unison.DataDeclaration (DataDeclaration, Decl)
+import Unison.DataDeclaration qualified as Decl
+import Unison.DataDeclaration.ConstructorId (ConstructorId)
+import Unison.Hash (Hash)
 import Unison.HashQualifiedPrime qualified as HQ'
 import Unison.Name (Name)
 import Unison.Name qualified as Name
+import Unison.Name.Forward (ForwardName (..))
+import Unison.Name.Forward qualified as ForwardName
 import Unison.NameSegment (NameSegment)
 import Unison.NameSegment qualified as NameSegment
+import Unison.NameSegment.Internal (NameSegment (NameSegment))
 import Unison.Names (Names (..))
 import Unison.Names qualified as Names
+import Unison.Parser.Ann (Ann)
+import Unison.Parser.Ann qualified as Ann
 import Unison.Prelude
 import Unison.PrettyPrintEnv qualified as PPE
 import Unison.PrettyPrintEnv.Names qualified as PPE
@@ -48,16 +61,25 @@ import Unison.PrettyPrintEnvDecl (PrettyPrintEnvDecl (..))
 import Unison.PrettyPrintEnvDecl qualified as PPED (addFallback)
 import Unison.PrettyPrintEnvDecl.Names qualified as PPED (makeCodebasePPED, makeFilePPED)
 import Unison.Project (ProjectBranchName)
-import Unison.Reference (TermReference, TypeReference)
+import Unison.Reference (TermReference, TermReferenceId, TypeReference, TypeReferenceId)
+import Unison.Reference qualified as Reference
 import Unison.Referent (Referent)
 import Unison.Referent qualified as Referent
 import Unison.Sqlite (Transaction)
+import Unison.Symbol (Symbol)
+import Unison.Syntax.Name qualified as Name
 import Unison.Syntax.NameSegment qualified as NameSegment (toEscapedText)
+import Unison.Term (Term)
+import Unison.Type (Type)
+import Unison.Typechecker qualified as Typechecker
+import Unison.UnisonFile (UnisonFile)
 import Unison.UnisonFile qualified as UnisonFile
+import Unison.Util.Defns (Defns (..), DefnsF)
 import Unison.Util.Pretty qualified as Pretty
 import Unison.Util.Relation (Relation)
 import Unison.Util.Relation qualified as Relation
 import Unison.Util.Set qualified as Set
+import Unison.WatchKind qualified as WK
 import Witch (unsafeFrom)
 
 handleUpgrade :: NameSegment -> NameSegment -> Cli ()
@@ -152,9 +174,10 @@ handleUpgrade oldName newName = do
         )
 
   pp@(PP.ProjectPath project projectBranch _path) <- Cli.getCurrentProjectPath
-  parsingEnv <- makeParsingEnv pp currentDeepNamesSansOld
-  typecheckedUnisonFile <-
-    prettyParseTypecheck unisonFile printPPE parsingEnv & onLeftM \prettyUnisonFile -> do
+  parsingEnv <- Cli.makeParsingEnv pp currentDeepNamesSansOld
+  typecheckedUnisonFile <- do
+    let prettyUnisonFile = Pretty.prettyUnisonFile printPPE unisonFile
+    parseAndTypecheck prettyUnisonFile parsingEnv & onNothingM do
       let getTemporaryBranchName = findTemporaryBranchName (project ^. #projectId) oldName newName
       (_temporaryBranchId, temporaryBranchName) <-
         HandleInput.Branch.createBranch
@@ -211,6 +234,100 @@ keepOldDeepTypesStillInUse :: Relation TypeReference Name -> Relation TypeRefere
 keepOldDeepTypesStillInUse oldDeepMinusLocalTypes currentDeepTypesSansOld =
   Relation.dom oldDeepMinusLocalTypes
     & Set.filter \typ -> not (Relation.memberDom typ currentDeepTypesSansOld)
+
+-- | @addDefinitionsToUnisonFile abort codebase doFindCtorNames definitions file@ adds all @definitions@ to @file@,
+-- avoiding overwriting anything already in @file@. Every definition is put into the file with every naming it has in
+-- @names@ "on the left-hand-side of the equals" (but yes type decls don't really have a LHS).
+--
+-- TODO: find a better module for this function, as it's used in a couple places
+addDefinitionsToUnisonFile ::
+  (forall void. Output -> Transaction void) ->
+  Codebase IO Symbol Ann ->
+  (Maybe Int -> Name -> Either Output.Output [Name]) ->
+  DefnsF (Relation Name) TermReferenceId TypeReferenceId ->
+  UnisonFile Symbol Ann ->
+  Transaction (UnisonFile Symbol Ann)
+addDefinitionsToUnisonFile abort codebase doFindCtorNames newDefns oldUF = do
+  newUF <- makeUnisonFile abort codebase doFindCtorNames newDefns
+  pure (oldUF `UnisonFile.leftBiasedMerge` newUF)
+
+makeUnisonFile ::
+  (forall void. Output -> Transaction void) ->
+  Codebase IO Symbol Ann ->
+  (Maybe Int -> Name -> Either Output.Output [Name]) ->
+  DefnsF (Relation Name) TermReferenceId TypeReferenceId ->
+  Transaction (UnisonFile Symbol Ann)
+makeUnisonFile abort codebase doFindCtorNames defns = do
+  file <- foldM addTermComponent UnisonFile.emptyUnisonFile (Set.map Reference.idToHash (Relation.ran defns.terms))
+  foldM addDeclComponent file (Set.map Reference.idToHash (Relation.ran defns.types))
+  where
+    addTermComponent :: UnisonFile Symbol Ann -> Hash -> Transaction (UnisonFile Symbol Ann)
+    addTermComponent uf h = do
+      termComponent <- Codebase.unsafeGetTermComponent codebase h
+      pure $ foldl' addTermElement uf (zip termComponent [0 ..])
+      where
+        addTermElement :: UnisonFile Symbol Ann -> ((Term Symbol Ann, Type Symbol Ann), Reference.Pos) -> UnisonFile Symbol Ann
+        addTermElement uf ((tm, tp), i) = do
+          let termNames = Relation.lookupRan (Reference.Id h i) defns.terms
+          foldl' (addDefinition tm tp) uf termNames
+        addDefinition :: Term Symbol Ann -> Type Symbol Ann -> UnisonFile Symbol Ann -> Name -> UnisonFile Symbol Ann
+        addDefinition tm tp uf (Name.toVar -> v) =
+          let prependTerm to = (v, Ann.External, tm) : to
+           in if isTest tp
+                then uf & #watches . Lens.at WK.TestWatch . Lens.non [] Lens.%~ prependTerm
+                else uf & #terms Lens.%~ Map.insert v (Ann.External, tm)
+
+    isTest = Typechecker.isEqual (Decls.testResultListType mempty)
+
+    -- given a dependent hash, include that component in the scratch file
+    -- todo: wundefined: cut off constructor name prefixes
+    addDeclComponent :: UnisonFile Symbol Ann -> Hash -> Transaction (UnisonFile Symbol Ann)
+    addDeclComponent uf h = do
+      declComponent <- fromJust <$> Codebase.getDeclComponent h
+      foldM addDeclElement uf (zip declComponent [0 ..])
+      where
+        -- for each name a decl has, update its constructor names according to what exists in the namespace
+        addDeclElement :: UnisonFile Symbol Ann -> (Decl Symbol Ann, Reference.Pos) -> Transaction (UnisonFile Symbol Ann)
+        addDeclElement uf (decl, i) = do
+          let declNames = Relation.lookupRan (Reference.Id h i) defns.types
+          -- look up names for this decl's constructor based on the decl's name, and embed them in the decl definition.
+          foldM (addRebuiltDefinition decl) uf declNames
+          where
+            -- skip any definitions that already have names, we don't want to overwrite what the user has supplied
+            addRebuiltDefinition :: Decl Symbol Ann -> UnisonFile Symbol Ann -> Name -> Transaction (UnisonFile Symbol Ann)
+            addRebuiltDefinition decl uf name = case decl of
+              Left ed ->
+                overwriteConstructorNames name ed.toDataDecl <&> \ed' ->
+                  uf
+                    & #effectDeclarationsId
+                    %~ Map.insertWith (\_new old -> old) (Name.toVar name) (Reference.Id h i, Decl.EffectDeclaration ed')
+              Right dd ->
+                overwriteConstructorNames name dd <&> \dd' ->
+                  uf
+                    & #dataDeclarationsId
+                    %~ Map.insertWith (\_new old -> old) (Name.toVar name) (Reference.Id h i, dd')
+
+        -- Constructor names are bogus when pulled from the database, so we set them to what they should be here
+        overwriteConstructorNames :: Name -> DataDeclaration Symbol Ann -> Transaction (DataDeclaration Symbol Ann)
+        overwriteConstructorNames name dd =
+          let constructorNames :: Transaction [Symbol]
+              constructorNames =
+                case doFindCtorNames (Just $ Decl.constructorCount dd) name of
+                  Left err -> abort err
+                  Right array | all (isJust . Name.stripNamePrefix name) array -> pure (map Name.toVar array)
+                  Right array -> do
+                    traceM "I ran into a situation where a type's constructors didn't match its name,"
+                    traceM "in a spot where I didn't expect to be discovering that.\n\n"
+                    traceM "Type Name:"
+                    traceM . Text.Lazy.unpack $ pShow name
+                    traceM "Constructor Names:"
+                    traceM . Text.Lazy.unpack $ pShow array
+                    error "Sorry for crashing."
+
+              swapConstructorNames oldCtors =
+                let (annotations, _vars, types) = unzip3 oldCtors
+                 in zip3 annotations <$> constructorNames <*> pure types
+           in Lens.traverseOf Decl.constructors_ swapConstructorNames dd
 
 makeOldDepPPE ::
   NameSegment ->
@@ -287,3 +404,72 @@ findTemporaryBranchName projectId oldDepName newDepName = do
 
     oldDepText = NameSegment.toEscapedText oldDepName
     newDepText = NameSegment.toEscapedText newDepName
+
+-- | O(r + c * d) touches all the referents (r), and all the NameSegments (d) of all of the Con referents (c)
+forwardCtorNames :: Names -> Map ForwardName (Referent, Name)
+forwardCtorNames names =
+  Map.fromList $
+    [ (ForwardName.fromName name, (r, name))
+      | (r@Referent.Con {}, rNames) <- Map.toList $ Relation.range names.terms,
+        name <- Foldable.toList rNames
+    ]
+
+-- | given a decl name, find names for all of its constructors, in order.
+--
+-- Precondition: 'n' is an element of 'names'
+findCtorNames :: Output.UpdateOrUpgrade -> Names -> Map ForwardName (Referent, Name) -> Maybe Int -> Name -> Either Output.Output [Name]
+findCtorNames operation names forwardCtorNames ctorCount n =
+  let declRef = case Set.lookupMin (Relation.lookupDom n names.types) of
+        Nothing -> error "[findCtorNames] precondition violation: n is not an element of names"
+        Just x -> x
+      f = ForwardName.fromName n
+      (_, centerRight) = Map.split f forwardCtorNames
+      (center, _) = Map.split (incrementLastSegmentChar f) centerRight
+
+      insertShortest :: Map ConstructorId Name -> (Referent, Name) -> Map ConstructorId Name
+      insertShortest m (Referent.Con (ConstructorReference r cid) _ct, newName) | r == declRef =
+        case Map.lookup cid m of
+          Just existingName
+            | length (Name.segments existingName) > length (Name.segments newName) ->
+                Map.insert cid newName m
+          Just {} -> m
+          Nothing -> Map.insert cid newName m
+      insertShortest m _ = m
+      m = foldl' insertShortest mempty (Foldable.toList center)
+      ctorCountGuess = fromMaybe (Map.size m) ctorCount
+   in if Map.size m == ctorCountGuess && all (isJust . flip Map.lookup m . fromIntegral) [0 .. ctorCountGuess - 1]
+        then Right $ Map.elems m
+        else Left $ Output.UpdateIncompleteConstructorSet operation n m ctorCount
+
+findCtorNamesMaybe ::
+  Output.UpdateOrUpgrade ->
+  Names ->
+  Map ForwardName (Referent, Name) ->
+  Maybe Int ->
+  Name ->
+  Either Output.Output (Maybe [Name])
+findCtorNamesMaybe operation names forwardCtorNames ctorCount name =
+  case Relation.memberDom name (Names.types names) of
+    True -> Just <$> findCtorNames operation names forwardCtorNames ctorCount name
+    False -> Right Nothing
+
+-- Used by `findCtorNames` to filter `forwardCtorNames` to a narrow range which will be searched linearly.
+-- >>> incrementLastSegmentChar $ ForwardName.fromName $ Name.unsafeFromText "foo.bar.quux"
+-- ForwardName {toList = "foo" :| ["bar","quuy"]}
+incrementLastSegmentChar :: ForwardName -> ForwardName
+incrementLastSegmentChar (ForwardName segments) =
+  let (initSegments, lastSegment) = (List.NonEmpty.init segments, List.NonEmpty.last segments)
+      incrementedLastSegment = incrementLastCharInSegment lastSegment
+   in ForwardName $
+        maybe
+          (List.NonEmpty.singleton incrementedLastSegment)
+          (|> incrementedLastSegment)
+          (List.NonEmpty.nonEmpty initSegments)
+  where
+    incrementLastCharInSegment :: NameSegment -> NameSegment
+    incrementLastCharInSegment (NameSegment text) =
+      let incrementedText =
+            if Text.null text
+              then text
+              else Text.init text `Text.append` Text.singleton (succ $ Text.last text)
+       in NameSegment incrementedText

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Upgrade.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Upgrade.hs
@@ -27,7 +27,6 @@ import Unison.Codebase.Editor.HandleInput.Update2
     findCtorNamesMaybe,
     forwardCtorNames,
     getNamespaceDependentsOf,
-    makeComplicatedPPE,
     makeParsingEnv,
     prettyParseTypecheck,
     typecheckedUnisonFileToBranchUpdates,
@@ -47,6 +46,7 @@ import Unison.PrettyPrintEnv qualified as PPE
 import Unison.PrettyPrintEnv.Names qualified as PPE
 import Unison.PrettyPrintEnvDecl (PrettyPrintEnvDecl (..))
 import Unison.PrettyPrintEnvDecl qualified as PPED (addFallback)
+import Unison.PrettyPrintEnvDecl.Names qualified as PPED (makeCodebasePPED, makeFilePPED)
 import Unison.Project (ProjectBranchName)
 import Unison.Reference (TermReference, TypeReference)
 import Unison.Referent (Referent)
@@ -138,7 +138,6 @@ handleUpgrade oldName newName = do
           (findCtorNames Output.UOUUpgrade currentLocalNames currentLocalConstructorNames)
           dependents
           UnisonFile.emptyUnisonFile
-      hashLength <- Codebase.hashLength
       pure
         ( unisonFile,
           makeOldDepPPE
@@ -148,7 +147,8 @@ handleUpgrade oldName newName = do
             (Branch.toNames oldNamespace)
             (Branch.toNames oldLocalNamespace)
             (Branch.toNames newLocalNamespace)
-            `PPED.addFallback` makeComplicatedPPE hashLength currentDeepNamesSansOld mempty dependents
+            `PPED.addFallback` PPED.makeFilePPED (Names.fromReferenceIds dependents)
+            `PPED.addFallback` PPED.makeCodebasePPED currentDeepNamesSansOld
         )
 
   pp@(PP.ProjectPath project projectBranch _path) <- Cli.getCurrentProjectPath

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -2773,7 +2773,7 @@ handleTodoOutput todo
           [] -> pure mempty
           constructors -> do
             nums <-
-              for constructors \constructor -> do
+              for constructors \(_typeRef, constructor) -> do
                 addNumberedArg (SA.Name constructor)
             -- Note [StrayConstructorMessage] If you change this, also change the other similar one
             pure $
@@ -2784,7 +2784,7 @@ handleTodoOutput todo
                   2
                   ( P.lines
                       ( zipWith
-                          (\n constructor -> formatNum n <> prettyName constructor)
+                          (\n (_typeRef, constructor) -> formatNum n <> prettyName constructor)
                           nums
                           constructors
                       )

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -85,7 +85,7 @@ import Unison.Hash32 (Hash32)
 import Unison.HashQualified qualified as HQ
 import Unison.HashQualifiedPrime qualified as HQ'
 import Unison.LabeledDependency as LD
-import Unison.Merge.DeclCoherencyCheck (IncoherentDeclReasons (..))
+import Unison.Merge.DeclCoherencyCheck (IncoherentDeclReason (..), IncoherentDeclReasons (..))
 import Unison.Name (Name)
 import Unison.Name qualified as Name
 import Unison.NameSegment qualified as NameSegment
@@ -141,6 +141,8 @@ import Unison.Term (Term)
 import Unison.Term qualified as Term
 import Unison.Type (Type)
 import Unison.UnisonFile qualified as UF
+import Unison.Util.Conflicted (Conflicted (..))
+import Unison.Util.Defn (Defn (..))
 import Unison.Util.Defns (Defns (..))
 import Unison.Util.List qualified as List
 import Unison.Util.Monoid (intercalateMap)
@@ -1384,12 +1386,6 @@ notifyUser dir = \case
         <> P.newline
         <> P.newline
         <> P.wrap "and then try merging again."
-  MergeConflictedTermName name _refs ->
-    pure . P.wrap $
-      "The term name" <> prettyName name <> "is ambiguous. Please resolve the ambiguity before merging."
-  MergeConflictedTypeName name _refs ->
-    pure . P.wrap $
-      "The type name" <> prettyName name <> "is ambiguous. Please resolve the ambiguity before merging."
   MergeConflictInvolvingBuiltin name ->
     pure . P.lines $
       [ P.wrap "Sorry, I wasn't able to perform the merge:",
@@ -1406,22 +1402,6 @@ notifyUser dir = \case
               <> "the same on both branches, or making neither of them a builtin, and then try the merge again."
           )
       ]
-  -- Note [ConstructorAliasMessage] If you change this, also change the other similar one
-  MergeConstructorAlias aliceOrBob typeName conName1 conName2 ->
-    pure . P.lines $
-      [ P.wrap "Sorry, I wasn't able to perform the merge:",
-        "",
-        P.wrap $
-          "On"
-            <> P.group (prettyMergeSourceOrTarget aliceOrBob <> ",")
-            <> "the type"
-            <> prettyName typeName
-            <> "has a constructor with multiple names, and I can't perform a merge in this situation:",
-        "",
-        P.indentN 2 (P.bulleted [prettyName conName1, prettyName conName2]),
-        "",
-        P.wrap "Please delete all but one name for each constructor, and then try merging again."
-      ]
   -- Note [DefnsInLibMessage] If you change this, also change the other similar one
   MergeDefnsInLib aliceOrBob ->
     pure . P.lines $
@@ -1434,54 +1414,6 @@ notifyUser dir = \case
             <> "subnamespaces representing library dependencies.",
         "",
         P.wrap "Please move or remove it and then try merging again."
-      ]
-  -- Note [MissingConstructorNameMessage] If you change this, also change the other similar one
-  MergeMissingConstructorName aliceOrBob name ->
-    pure . P.lines $
-      [ P.wrap "Sorry, I wasn't able to perform the merge:",
-        "",
-        P.wrap $
-          "On"
-            <> P.group (prettyMergeSourceOrTarget aliceOrBob <> ",")
-            <> "the type"
-            <> prettyName name
-            <> "has some constructors with missing names, and I can't perform a merge in this situation.",
-        "",
-        P.wrap $
-          "You can use"
-            <> IP.makeExample IP.view [prettyName name]
-            <> "and"
-            <> IP.makeExample IP.aliasTerm ["<hash>", prettyName name <> ".<ConstructorName>"]
-            <> "to give names to each unnamed constructor, and then try the merge again."
-      ]
-  -- Note [NestedDeclAliasMessage] If you change this, also change the other similar one
-  MergeNestedDeclAlias aliceOrBob shorterName longerName ->
-    pure . P.wrap $
-      "On"
-        <> P.group (prettyMergeSourceOrTarget aliceOrBob <> ",")
-        <> "the type"
-        <> prettyName longerName
-        <> "is an alias of"
-        <> P.group (prettyName shorterName <> ".")
-        <> "I'm not able to perform a merge when a type exists nested under an alias of itself. Please separate them or"
-        <> "delete one copy, and then try merging again."
-  -- Note [StrayConstructorMessage] If you change this, also change the other similar one
-  MergeStrayConstructor aliceOrBob name ->
-    pure . P.lines $
-      [ P.wrap $
-          "Sorry, I wasn't able to perform the merge, because I need all constructor names to be nested somewhere"
-            <> "beneath the corresponding type name.",
-        "",
-        P.wrap $
-          "On"
-            <> P.group (prettyMergeSourceOrTarget aliceOrBob <> ",")
-            <> "the constructor"
-            <> prettyName name
-            <> "is not nested beneath the corresponding type name. Please either use"
-            <> IP.makeExample' IP.moveAll
-            <> "to move it, or if it's an extra copy, you can simply"
-            <> IP.makeExample' IP.delete
-            <> "it. Then try the merge again."
       ]
   PreviewMergeAlreadyUpToDate src dest ->
     pure . P.callout "😶" $
@@ -2161,6 +2093,139 @@ notifyUser dir = \case
         <> P.newline
         <> "Synhash tokens: "
         <> P.text filename
+  ConflictedDefn operation defn ->
+    pure . P.wrap $
+      ( case defn of
+          TermDefn (Conflicted name _refs) -> "The term name" <> prettyName name <> "is ambiguous."
+          TypeDefn (Conflicted name _refs) -> "The type name" <> prettyName name <> "is ambiguous."
+      )
+        <> "Please resolve the ambiguity, then try to"
+        <> P.text operation
+        <> "again."
+  IncoherentDeclDuringMerge aliceOrBob reason ->
+    case reason of
+      -- Note [ConstructorAliasMessage] If you change this, also change the other similar ones
+      IncoherentDeclReason'ConstructorAlias typeName conName1 conName2 ->
+        pure . P.lines $
+          [ P.wrap "Sorry, I wasn't able to perform the merge:",
+            "",
+            P.wrap $
+              "On"
+                <> P.group (prettyMergeSourceOrTarget aliceOrBob <> ",")
+                <> "the type"
+                <> prettyName typeName
+                <> "has a constructor with multiple names, and I can't perform a merge in this situation:",
+            "",
+            P.indentN 2 (P.bulleted [prettyName conName1, prettyName conName2]),
+            "",
+            P.wrap "Please delete all but one name for each constructor, and then try merging again."
+          ]
+      -- Note [MissingConstructorNameMessage] If you change this, also change the other similar ones
+      IncoherentDeclReason'MissingConstructorName name ->
+        pure . P.lines $
+          [ P.wrap "Sorry, I wasn't able to perform the merge:",
+            "",
+            P.wrap $
+              "On"
+                <> P.group (prettyMergeSourceOrTarget aliceOrBob <> ",")
+                <> "the type"
+                <> prettyName name
+                <> "has some constructors with missing names, and I can't perform a merge in this situation.",
+            "",
+            P.wrap $
+              "You can use"
+                <> IP.makeExample IP.view [prettyName name]
+                <> "and"
+                <> IP.makeExample IP.aliasTerm ["<hash>", prettyName name <> ".<ConstructorName>"]
+                <> "to give names to each unnamed constructor, and then try the merge again."
+          ]
+      -- Note [NestedDeclAliasMessage] If you change this, also change the other similar ones
+      IncoherentDeclReason'NestedDeclAlias shorterName longerName ->
+        pure . P.wrap $
+          "On"
+            <> P.group (prettyMergeSourceOrTarget aliceOrBob <> ",")
+            <> "the type"
+            <> prettyName longerName
+            <> "is an alias of"
+            <> P.group (prettyName shorterName <> ".")
+            <> "I'm not able to perform a merge when a type exists nested under an alias of itself. Please separate them or"
+            <> "delete one copy, and then try merging again."
+      -- Note [StrayConstructorMessage] If you change this, also change the other similar ones
+      IncoherentDeclReason'StrayConstructor _typeRef name ->
+        pure . P.lines $
+          [ P.wrap $
+              "Sorry, I wasn't able to perform the merge, because I need all constructor names to be nested somewhere"
+                <> "beneath the corresponding type name.",
+            "",
+            P.wrap $
+              "On"
+                <> P.group (prettyMergeSourceOrTarget aliceOrBob <> ",")
+                <> "the constructor"
+                <> prettyName name
+                <> "is not nested beneath the corresponding type name. Please either use"
+                <> IP.makeExample' IP.moveAll
+                <> "to move it, or if it's an extra copy, you can simply"
+                <> IP.makeExample' IP.delete
+                <> "it. Then try the merge again."
+          ]
+  IncoherentDeclDuringUpdate reason ->
+    case reason of
+      -- Note [ConstructorAliasMessage] If you change this, also change the other similar ones
+      IncoherentDeclReason'ConstructorAlias typeName conName1 conName2 ->
+        pure . P.lines $
+          [ P.wrap "Sorry, I wasn't able to perform the update:",
+            "",
+            P.wrap $
+              "The type"
+                <> prettyName typeName
+                <> "has a constructor with multiple names, and I can't perform an update in this situation:",
+            "",
+            P.indentN 2 (P.bulleted [prettyName conName1, prettyName conName2]),
+            "",
+            P.wrap "Please delete all but one name for each constructor, and then try updating again."
+          ]
+      -- Note [MissingConstructorNameMessage] If you change this, also change the other similar ones
+      IncoherentDeclReason'MissingConstructorName name ->
+        pure . P.lines $
+          [ P.wrap "Sorry, I wasn't able to perform the update:",
+            "",
+            P.wrap $
+              "The type"
+                <> prettyName name
+                <> "has some constructors with missing names, and I can't perform an update in this situation.",
+            "",
+            P.wrap $
+              "You can use"
+                <> IP.makeExample IP.view [prettyName name]
+                <> "and"
+                <> IP.makeExample IP.aliasTerm ["<hash>", prettyName name <> ".<ConstructorName>"]
+                <> "to give names to each unnamed constructor, and then try the update again."
+          ]
+      -- Note [NestedDeclAliasMessage] If you change this, also change the other similar ones
+      IncoherentDeclReason'NestedDeclAlias shorterName longerName ->
+        pure . P.wrap $
+          "The type"
+            <> prettyName longerName
+            <> "is an alias of"
+            <> P.group (prettyName shorterName <> ".")
+            <> "I'm not able to perform an update when a type exists nested under an alias of itself. Please separate"
+            <> "them or delete one copy, and then try updating again."
+      -- Note [StrayConstructorMessage] If you change this, also change the other similar ones
+      IncoherentDeclReason'StrayConstructor _typeRef name ->
+        pure . P.lines $
+          [ P.wrap $
+              "Sorry, I wasn't able to perform the update, because I need all constructor names to be nested somewhere"
+                <> "beneath the corresponding type name.",
+            "",
+            P.wrap $
+              "The constructor"
+                <> prettyName name
+                <> "is not nested beneath the corresponding type name. Please either use"
+                <> IP.makeExample' IP.moveAll
+                <> "to move it, or if it's an extra copy, you can simply"
+                <> IP.makeExample' IP.delete
+                <> "it. Then try the update again."
+          ]
 
 prettyShareError :: ShareError -> Pretty
 prettyShareError =
@@ -2701,7 +2766,7 @@ handleTodoOutput todo
                   things
                     & map
                       ( \(typeName, prettyCon1, prettyCon2) ->
-                          -- Note [ConstructorAliasMessage] If you change this, also change the other similar one
+                          -- Note [ConstructorAliasMessage] If you change this, also change the other similar ones
                           P.wrap ("The type" <> prettyName typeName <> "has a constructor with multiple names.")
                             <> P.newline
                             <> P.newline
@@ -2720,7 +2785,7 @@ handleTodoOutput todo
               for types0 \typ -> do
                 n <- addNumberedArg (SA.Name typ)
                 pure (n, typ)
-            -- Note [MissingConstructorNameMessage] If you change this, also change the other similar one
+            -- Note [MissingConstructorNameMessage] If you change this, also change the other similar ones
             pure $
               P.wrap
                 "These types have some constructors with missing names."
@@ -2753,7 +2818,7 @@ handleTodoOutput todo
                 n1 <- addNumberedArg (SA.Name short)
                 n2 <- addNumberedArg (SA.Name long)
                 pure (formatNum n1 <> prettyName short, formatNum n2 <> prettyName long)
-            -- Note [NestedDeclAliasMessage] If you change this, also change the other similar one
+            -- Note [NestedDeclAliasMessage] If you change this, also change the other similar ones
             pure $
               aliases1
                 & map
@@ -2775,7 +2840,7 @@ handleTodoOutput todo
             nums <-
               for constructors \(_typeRef, constructor) -> do
                 addNumberedArg (SA.Name constructor)
-            -- Note [StrayConstructorMessage] If you change this, also change the other similar one
+            -- Note [StrayConstructorMessage] If you change this, also change the other similar ones
             pure $
               P.wrap "These constructors are not nested beneath their corresponding type names:"
                 <> P.newline

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -47,6 +47,7 @@ library
       Unison.Cli.Share.Projects.Types
       Unison.Cli.TypeCheck
       Unison.Cli.UniqueTypeGuidLookup
+      Unison.Cli.UpdateUtils
       Unison.Codebase.Editor.AuthorInfo
       Unison.Codebase.Editor.HandleInput
       Unison.Codebase.Editor.HandleInput.AddRun

--- a/unison-core/package.yaml
+++ b/unison-core/package.yaml
@@ -77,6 +77,7 @@ default-extensions:
   - LambdaCase
   - MultiParamTypeClasses
   - NamedFieldPuns
+  - OverloadedLabels
   - OverloadedStrings
   - OverloadedRecordDot
   - PatternSynonyms

--- a/unison-core/src/Unison/ConstructorReference.hs
+++ b/unison-core/src/Unison/ConstructorReference.hs
@@ -4,6 +4,7 @@ module Unison.ConstructorReference
     ConstructorReference,
     ConstructorReferenceId,
     reference_,
+    toId,
     toShortHash,
   )
 where
@@ -28,6 +29,10 @@ type ConstructorReferenceId = GConstructorReference TypeReferenceId
 reference_ :: Lens (GConstructorReference r) (GConstructorReference s) r s
 reference_ =
   lens (\(ConstructorReference r _) -> r) \(ConstructorReference _ i) r -> ConstructorReference r i
+
+toId :: ConstructorReference -> Maybe ConstructorReferenceId
+toId (ConstructorReference typeRef conId) =
+  ConstructorReference <$> Reference.toId typeRef <*> pure conId
 
 toShortHash :: ConstructorReference -> ShortHash
 toShortHash (ConstructorReference r i) =

--- a/unison-core/src/Unison/Names.hs
+++ b/unison-core/src/Unison/Names.hs
@@ -77,8 +77,6 @@ import Unison.Referent (Referent)
 import Unison.Referent qualified as Referent
 import Unison.ShortHash (ShortHash)
 import Unison.ShortHash qualified as SH
-import Unison.Util.BiMultimap (BiMultimap)
-import Unison.Util.BiMultimap qualified as BiMultimap
 import Unison.Util.Defns (Defns (..), DefnsF)
 import Unison.Util.Nametree (Nametree, unflattenNametree)
 import Unison.Util.Relation (Relation)

--- a/unison-core/src/Unison/Names.hs
+++ b/unison-core/src/Unison/Names.hs
@@ -544,10 +544,6 @@ lenientToNametree names =
   where
     lenientRelationToNametree :: Ord a => Relation Name a -> Nametree (Map NameSegment a)
     lenientRelationToNametree =
-      unflattenNametree . lenientRelationToLeftUniqueRelation
-
-    lenientRelationToLeftUniqueRelation :: (Ord a, Ord b) => Relation a b -> BiMultimap b a
-    lenientRelationToLeftUniqueRelation =
-      -- The partial `Set.findMin` are fine here because Relation.domain only has non-empty Set values. A NESet would be
+      -- The partial `Set.findMin` is fine here because Relation.domain only has non-empty Set values. A NESet would be
       -- better.
-      BiMultimap.fromRange . Map.map Set.findMin . Relation.domain
+      unflattenNametree . Map.map Set.findMin . Relation.domain

--- a/unison-core/src/Unison/Referent.hs
+++ b/unison-core/src/Unison/Referent.hs
@@ -12,6 +12,8 @@ module Unison.Referent
     toId,
     toReference,
     toReferenceId,
+    toConstructorReference,
+    toConstructorReferenceId,
     toTermReference,
     toTermReferenceId,
     fromId,
@@ -119,7 +121,16 @@ toReference = toReference'
 toReferenceId :: Referent -> Maybe Reference.Id
 toReferenceId = Reference.toId . toReference
 
-toTermReference :: Referent -> Maybe TermReference
+toConstructorReference :: Referent' r -> Maybe (GConstructorReference r)
+toConstructorReference = \case
+  Con' r _ -> Just r
+  Ref' _ -> Nothing
+
+toConstructorReferenceId :: Referent -> Maybe ConstructorReferenceId
+toConstructorReferenceId =
+  toConstructorReference >=> ConstructorReference.toId
+
+toTermReference :: Referent' r -> Maybe r
 toTermReference = \case
   Con' _ _ -> Nothing
   Ref' reference -> Just reference
@@ -129,7 +140,7 @@ toTermReferenceId r = toTermReference r >>= Reference.toId
 
 -- | Inject a Term Reference into a Referent
 fromTermReference :: TermReference -> Referent
-fromTermReference r = Ref r
+fromTermReference = Ref
 
 fromTermReferenceId :: TermReferenceId -> Referent
 fromTermReferenceId = fromTermReference . Reference.fromId

--- a/unison-core/src/Unison/Util/Conflicted.hs
+++ b/unison-core/src/Unison/Util/Conflicted.hs
@@ -1,0 +1,10 @@
+module Unison.Util.Conflicted
+  ( Conflicted (..),
+  )
+where
+
+import Data.Set.NonEmpty (NESet)
+
+-- | A conflicted thing.
+data Conflicted n a
+  = Conflicted !n !(NESet a)

--- a/unison-core/src/Unison/Util/Defn.hs
+++ b/unison-core/src/Unison/Util/Defn.hs
@@ -1,0 +1,9 @@
+module Unison.Util.Defn
+  ( Defn (..),
+  )
+where
+
+-- | A "definition" is either a term or a type.
+data Defn term typ
+  = TermDefn term
+  | TypeDefn typ

--- a/unison-core/src/Unison/Util/Nametree.hs
+++ b/unison-core/src/Unison/Util/Nametree.hs
@@ -120,9 +120,9 @@ flattenNametree f =
 -- >     "baz" = #baz
 -- >   }
 -- > }
-unflattenNametree :: Ord a => BiMultimap a Name -> Nametree (Map NameSegment a)
+unflattenNametree :: Ord a => Map Name a -> Nametree (Map NameSegment a)
 unflattenNametree =
-  unfoldNametree unflattenLevel . map (first Name.segments) . Map.toList . BiMultimap.range
+  unfoldNametree unflattenLevel . map (first Name.segments) . Map.toList
   where
     unflattenLevel :: [(NonEmpty NameSegment, a)] -> (Map NameSegment a, Map NameSegment [(NonEmpty NameSegment, a)])
     unflattenLevel =

--- a/unison-core/unison-core1.cabal
+++ b/unison-core/unison-core1.cabal
@@ -84,6 +84,7 @@ library
       LambdaCase
       MultiParamTypeClasses
       NamedFieldPuns
+      OverloadedLabels
       OverloadedStrings
       OverloadedRecordDot
       PatternSynonyms
@@ -153,6 +154,7 @@ test-suite tests
       LambdaCase
       MultiParamTypeClasses
       NamedFieldPuns
+      OverloadedLabels
       OverloadedStrings
       OverloadedRecordDot
       PatternSynonyms

--- a/unison-core/unison-core1.cabal
+++ b/unison-core/unison-core1.cabal
@@ -55,6 +55,7 @@ library
       Unison.Type
       Unison.Type.Names
       Unison.Util.Components
+      Unison.Util.Conflicted
       Unison.Util.Defn
       Unison.Util.Defns
       Unison.Util.Nametree

--- a/unison-core/unison-core1.cabal
+++ b/unison-core/unison-core1.cabal
@@ -55,6 +55,7 @@ library
       Unison.Type
       Unison.Type.Names
       Unison.Util.Components
+      Unison.Util.Defn
       Unison.Util.Defns
       Unison.Util.Nametree
       Unison.Var

--- a/unison-src/transcripts/diff-namespace.md
+++ b/unison-src/transcripts/diff-namespace.md
@@ -92,10 +92,14 @@ scratch/ns2> update
 scratch/main> diff.namespace /ns1: /ns2:
 scratch/ns2> alias.term d d'
 scratch/ns2> alias.type A A'
+scratch/ns2> alias.term A.A A'.A
 scratch/ns2> alias.type X X'
+scratch/ns2> alias.term X.x X'.x
 scratch/main> diff.namespace /ns1: /ns2:
 scratch/ns1> alias.type X X2
+scratch/ns1> alias.term X.x X2.x
 scratch/ns2> alias.type A' A''
+scratch/ns2> alias.term A'.A A''.A
 scratch/ns2> branch /ns3
 scratch/ns2> alias.term fromJust' yoohoo
 scratch/ns2> delete.term.verbose fromJust'

--- a/unison-src/transcripts/diff-namespace.output.md
+++ b/unison-src/transcripts/diff-namespace.output.md
@@ -199,7 +199,15 @@ scratch/ns2> alias.type A A'
 
   Done.
 
+scratch/ns2> alias.term A.A A'.A
+
+  Done.
+
 scratch/ns2> alias.type X X'
+
+  Done.
+
+scratch/ns2> alias.term X.x X'.x
 
   Done.
 
@@ -238,14 +246,26 @@ scratch/main> diff.namespace /ns1: /ns2:
     
     16. X                      17. X' (added)
     
-    18. fromJust'           ┐  19. fromJust#gjmq673r1v (removed)
-    20. fromJust#gjmq673r1v ┘  
+    18. A.A                    19. A'.A (added)
+    
+    20. fromJust'           ┐  21. fromJust#gjmq673r1v (removed)
+    22. fromJust#gjmq673r1v ┘  
+    
+    23. X.x                    24. X'.x (added)
 
 scratch/ns1> alias.type X X2
 
   Done.
 
+scratch/ns1> alias.term X.x X2.x
+
+  Done.
+
 scratch/ns2> alias.type A' A''
+
+  Done.
+
+scratch/ns2> alias.term A'.A A''.A
 
   Done.
 

--- a/unison-src/transcripts/update-on-conflict.md
+++ b/unison-src/transcripts/update-on-conflict.md
@@ -1,6 +1,6 @@
 # Update on conflict
 
-Updating conflicted definitions works fine.
+Conflicted definitions prevent `update` from succeeding.
 
 ```ucm:hide
 scratch/main> builtins.merge lib.builtins
@@ -21,7 +21,6 @@ scratch/main> delete.term temp
 x = 3
 ```
 
-```ucm
+```ucm:error
 scratch/main> update
-scratch/main> view x
 ```

--- a/unison-src/transcripts/update-on-conflict.output.md
+++ b/unison-src/transcripts/update-on-conflict.output.md
@@ -59,7 +59,8 @@ x = 3
 ``` ucm
 scratch/main> update
 
-  The term name x is ambiguous. Please resolve the ambiguity,
-  then try to update again.
+  This branch has more than one term with the name `x`. Please
+  delete or rename all but one of them, then try the update
+  again.
 
 ```

--- a/unison-src/transcripts/update-on-conflict.output.md
+++ b/unison-src/transcripts/update-on-conflict.output.md
@@ -1,6 +1,6 @@
 # Update on conflict
 
-Updating conflicted definitions works fine.
+Conflicted definitions prevent `update` from succeeding.
 
 ``` unison
 x = 1
@@ -59,14 +59,7 @@ x = 3
 ``` ucm
 scratch/main> update
 
-  Okay, I'm searching the branch for code that needs to be
-  updated...
-
-  Done.
-
-scratch/main> view x
-
-  x : Nat
-  x = 3
+  The term name x is ambiguous. Please resolve the ambiguity,
+  then try to update again.
 
 ```

--- a/unison-src/transcripts/update-suffixifies-properly.output.md
+++ b/unison-src/transcripts/update-suffixifies-properly.output.md
@@ -72,8 +72,8 @@ myproject/main> update
 ``` unison:added-by-ucm scratch.u
 foo = +30
 
--- The definitions below are not compatible with the updated definitions above.
--- Please fix the errors and run `update` again.
+-- The definitions below no longer typecheck with the changes above.
+-- Please fix the errors and try `update` again.
 
 bar : Nat
 bar =

--- a/unison-src/transcripts/update-suffixifies-properly.output.md
+++ b/unison-src/transcripts/update-suffixifies-properly.output.md
@@ -70,6 +70,11 @@ myproject/main> update
 
 ```
 ``` unison:added-by-ucm scratch.u
+foo = +30
+
+-- The definitions below are not compatible with the updated definitions above.
+-- Please fix the errors and run `update` again.
+
 bar : Nat
 bar =
   use Nat +
@@ -85,6 +90,5 @@ d.y.y.y.y =
   use Nat +
   foo + 10
 
-foo = +30
 ```
 

--- a/unison-src/transcripts/update-term-with-dependent-to-different-type.output.md
+++ b/unison-src/transcripts/update-term-with-dependent-to-different-type.output.md
@@ -71,8 +71,8 @@ scratch/main> update
 foo : Int
 foo = +5
 
--- The definitions below are not compatible with the updated definitions above.
--- Please fix the errors and run `update` again.
+-- The definitions below no longer typecheck with the changes above.
+-- Please fix the errors and try `update` again.
 
 bar : Nat
 bar =

--- a/unison-src/transcripts/update-term-with-dependent-to-different-type.output.md
+++ b/unison-src/transcripts/update-term-with-dependent-to-different-type.output.md
@@ -68,12 +68,16 @@ scratch/main> update
 
 ```
 ``` unison:added-by-ucm scratch.u
+foo : Int
+foo = +5
+
+-- The definitions below are not compatible with the updated definitions above.
+-- Please fix the errors and run `update` again.
+
 bar : Nat
 bar =
   use Nat +
   foo + 10
 
-foo : Int
-foo = +5
 ```
 

--- a/unison-src/transcripts/update-test-watch-roundtrip.output.md
+++ b/unison-src/transcripts/update-test-watch-roundtrip.output.md
@@ -53,8 +53,8 @@ scratch/main> update
 ``` unison:added-by-ucm scratch.u
 foo n = "hello, world!"
 
--- The definitions below are not compatible with the updated definitions above.
--- Please fix the errors and run `update` again.
+-- The definitions below no longer typecheck with the changes above.
+-- Please fix the errors and try `update` again.
 
 test> mynamespace.foo.test =
   n = 2

--- a/unison-src/transcripts/update-test-watch-roundtrip.output.md
+++ b/unison-src/transcripts/update-test-watch-roundtrip.output.md
@@ -51,10 +51,14 @@ scratch/main> update
 
 ```
 ``` unison:added-by-ucm scratch.u
+foo n = "hello, world!"
+
+-- The definitions below are not compatible with the updated definitions above.
+-- Please fix the errors and run `update` again.
+
 test> mynamespace.foo.test =
   n = 2
   if foo n == 2 then [Ok "passed"] else [Fail "wat"]
 
-foo n = "hello, world!"
 ```
 

--- a/unison-src/transcripts/update-type-constructor-alias.md
+++ b/unison-src/transcripts/update-type-constructor-alias.md
@@ -15,9 +15,6 @@ scratch/main> alias.term Foo.Bar Foo.BarAlias
 unique type Foo = Bar Nat Nat
 ```
 
-Bug: we leave `Foo.BarAlias` in the namespace with a nameless decl.
-
-```ucm
+```ucm:error
 scratch/main> update
-scratch/main> find.verbose
 ```

--- a/unison-src/transcripts/update-type-constructor-alias.output.md
+++ b/unison-src/transcripts/update-type-constructor-alias.output.md
@@ -45,27 +45,18 @@ unique type Foo = Bar Nat Nat
       type Foo
 
 ```
-Bug: we leave `Foo.BarAlias` in the namespace with a nameless decl.
-
 ``` ucm
 scratch/main> update
 
-  Okay, I'm searching the branch for code that needs to be
-  updated...
-
-  Done.
-
-scratch/main> find.verbose
-
-  1. -- #8fk6k0j208th1ia4vnjtoc5fomd6le540prec255svg71bcfga9dofrvoq1d7v6010d6b6em4q51p8st5c5juhrev72cnnel8ko3o1g
-     type Foo
-     
-  2. -- #8fk6k0j208th1ia4vnjtoc5fomd6le540prec255svg71bcfga9dofrvoq1d7v6010d6b6em4q51p8st5c5juhrev72cnnel8ko3o1g#0
-     Foo.Bar : Nat -> Nat -> Foo
-     
-  3. -- #b509v3eg4kehsg29g6pvrogeb71ue32nm2fj9284n4i7lprsr7u9a7g6s695d09du0fsfti6rrsk1s62q5thpr1jjkqb3us3s0lrd60#0
-     Foo.BarAlias : Nat -> #b509v3eg4k
-     
+  Sorry, I wasn't able to perform the update:
   
+  The type Foo has a constructor with multiple names, and I
+  can't perform an update in this situation:
+  
+    * Foo.Bar
+    * Foo.BarAlias
+  
+  Please delete all but one name for each constructor, and then
+  try updating again.
 
 ```

--- a/unison-src/transcripts/update-type-delete-constructor-with-dependent.output.md
+++ b/unison-src/transcripts/update-type-delete-constructor-with-dependent.output.md
@@ -65,11 +65,15 @@ scratch/main> update
 
 ```
 ``` unison:added-by-ucm scratch.u
+type Foo = Bar Nat
+
+-- The definitions below are not compatible with the updated definitions above.
+-- Please fix the errors and run `update` again.
+
 foo : Foo -> Nat
 foo = cases
   Bar n   -> n
   Baz n m -> n Nat.+ m
 
-type Foo = Bar Nat
 ```
 

--- a/unison-src/transcripts/update-type-delete-constructor-with-dependent.output.md
+++ b/unison-src/transcripts/update-type-delete-constructor-with-dependent.output.md
@@ -67,8 +67,8 @@ scratch/main> update
 ``` unison:added-by-ucm scratch.u
 type Foo = Bar Nat
 
--- The definitions below are not compatible with the updated definitions above.
--- Please fix the errors and run `update` again.
+-- The definitions below no longer typecheck with the changes above.
+-- Please fix the errors and try `update` again.
 
 foo : Foo -> Nat
 foo = cases

--- a/unison-src/transcripts/update-type-delete-record-field.output.md
+++ b/unison-src/transcripts/update-type-delete-record-field.output.md
@@ -104,6 +104,11 @@ scratch/main> find.verbose
 
 ```
 ``` unison:added-by-ucm scratch.u
+type Foo = { bar : Nat }
+
+-- The definitions below are not compatible with the updated definitions above.
+-- Please fix the errors and run `update` again.
+
 Foo.baz : Foo -> Int
 Foo.baz = cases Foo _ baz -> baz
 
@@ -113,6 +118,5 @@ Foo.baz.modify f = cases Foo bar baz -> Foo bar (f baz)
 Foo.baz.set : Int -> Foo -> Foo
 Foo.baz.set baz1 = cases Foo bar _ -> Foo bar baz1
 
-type Foo = { bar : Nat }
 ```
 

--- a/unison-src/transcripts/update-type-delete-record-field.output.md
+++ b/unison-src/transcripts/update-type-delete-record-field.output.md
@@ -106,8 +106,8 @@ scratch/main> find.verbose
 ``` unison:added-by-ucm scratch.u
 type Foo = { bar : Nat }
 
--- The definitions below are not compatible with the updated definitions above.
--- Please fix the errors and run `update` again.
+-- The definitions below no longer typecheck with the changes above.
+-- Please fix the errors and try `update` again.
 
 Foo.baz : Foo -> Int
 Foo.baz = cases Foo _ baz -> baz

--- a/unison-src/transcripts/update-type-missing-constructor.output.md
+++ b/unison-src/transcripts/update-type-missing-constructor.output.md
@@ -54,15 +54,13 @@ scratch/main> view Foo
 
 scratch/main> update
 
-  Okay, I'm searching the branch for code that needs to be
-  updated...
-
-  I couldn't complete the update because the type Foo has
-  unnamed constructors. (I currently need each constructor to
-  have a name somewhere under the type name.)
+  Sorry, I wasn't able to perform the update:
+  
+  The type Foo has some constructors with missing names, and I
+  can't perform an update in this situation.
   
   You can use `view Foo` and
   `alias.term <hash> Foo.<ConstructorName>` to give names to
-  each constructor, and then try the update again.
+  each unnamed constructor, and then try the update again.
 
 ```

--- a/unison-src/transcripts/update-type-nested-decl-aliases.md
+++ b/unison-src/transcripts/update-type-nested-decl-aliases.md
@@ -17,10 +17,6 @@ scratch/main> add
 unique type Foo = Bar Nat Nat
 ```
 
-Bug: we want this update to be rejected earlier, because it violates the "decl coherency" precondition that there's
-only one name for each constructor. We instead get too far in the update process, and are delivered a bogus scratch.u
-file to stare at.
-
 ```ucm:error
 scratch/main> update
 ```

--- a/unison-src/transcripts/update-type-nested-decl-aliases.output.md
+++ b/unison-src/transcripts/update-type-nested-decl-aliases.output.md
@@ -48,28 +48,12 @@ unique type Foo = Bar Nat Nat
       type Foo
 
 ```
-Bug: we want this update to be rejected earlier, because it violates the "decl coherency" precondition that there's
-only one name for each constructor. We instead get too far in the update process, and are delivered a bogus scratch.u
-file to stare at.
-
 ``` ucm
 scratch/main> update
 
-  Okay, I'm searching the branch for code that needs to be
-  updated...
-
-  That's done. Now I'm making sure everything typechecks...
-
-  Typechecking failed. I've updated your scratch file with the
-  definitions that need fixing. Once the file is compiling, try
-  `update` again.
+  The type A.B is an alias of A. I'm not able to perform an
+  update when a type exists nested under an alias of itself.
+  Please separate them or delete one copy, and then try updating
+  again.
 
 ```
-``` unison:added-by-ucm scratch.u
-structural type A = B.OneAlias Foo
-
-structural type A.B = OneAlias Foo
-
-type Foo = Bar Nat Nat
-```
-

--- a/unison-src/transcripts/update-type-stray-constructor-alias.md
+++ b/unison-src/transcripts/update-type-stray-constructor-alias.md
@@ -15,9 +15,6 @@ scratch/main> alias.term Foo.Bar Stray.BarAlias
 unique type Foo = Bar Nat Nat
 ```
 
-Bug: we leave `Stray.BarAlias` in the namespace with a nameless decl.
-
-```ucm
+```ucm:error
 scratch/main> update
-scratch/main> find.verbose
 ```

--- a/unison-src/transcripts/update-type-stray-constructor-alias.output.md
+++ b/unison-src/transcripts/update-type-stray-constructor-alias.output.md
@@ -45,27 +45,16 @@ unique type Foo = Bar Nat Nat
       type Foo
 
 ```
-Bug: we leave `Stray.BarAlias` in the namespace with a nameless decl.
-
 ``` ucm
 scratch/main> update
 
-  Okay, I'm searching the branch for code that needs to be
-  updated...
-
-  Done.
-
-scratch/main> find.verbose
-
-  1. -- #8fk6k0j208th1ia4vnjtoc5fomd6le540prec255svg71bcfga9dofrvoq1d7v6010d6b6em4q51p8st5c5juhrev72cnnel8ko3o1g
-     type Foo
-     
-  2. -- #8fk6k0j208th1ia4vnjtoc5fomd6le540prec255svg71bcfga9dofrvoq1d7v6010d6b6em4q51p8st5c5juhrev72cnnel8ko3o1g#0
-     Foo.Bar : Nat -> Nat -> Foo
-     
-  3. -- #b509v3eg4kehsg29g6pvrogeb71ue32nm2fj9284n4i7lprsr7u9a7g6s695d09du0fsfti6rrsk1s62q5thpr1jjkqb3us3s0lrd60#0
-     Stray.BarAlias : Nat -> #b509v3eg4k
-     
+  Sorry, I wasn't able to perform the update, because I need all
+  constructor names to be nested somewhere beneath the
+  corresponding type name.
   
+  The constructor Stray.BarAlias is not nested beneath the
+  corresponding type name. Please either use `move` to move it,
+  or if it's an extra copy, you can simply `delete` it. Then try
+  the update again.
 
 ```

--- a/unison-src/transcripts/update-type-stray-constructor.output.md
+++ b/unison-src/transcripts/update-type-stray-constructor.output.md
@@ -56,15 +56,13 @@ scratch/main> view Foo
 
 scratch/main> update
 
-  Okay, I'm searching the branch for code that needs to be
-  updated...
-
-  I couldn't complete the update because the type Foo has
-  unnamed constructors. (I currently need each constructor to
-  have a name somewhere under the type name.)
+  Sorry, I wasn't able to perform the update:
+  
+  The type Foo has some constructors with missing names, and I
+  can't perform an update in this situation.
   
   You can use `view Foo` and
   `alias.term <hash> Foo.<ConstructorName>` to give names to
-  each constructor, and then try the update again.
+  each unnamed constructor, and then try the update again.
 
 ```

--- a/unison-src/transcripts/update-type-with-dependent-term.output.md
+++ b/unison-src/transcripts/update-type-with-dependent-term.output.md
@@ -62,8 +62,8 @@ scratch/main> update
 ``` unison:added-by-ucm scratch.u
 type Foo = Bar Nat Nat
 
--- The definitions below are not compatible with the updated definitions above.
--- Please fix the errors and run `update` again.
+-- The definitions below no longer typecheck with the changes above.
+-- Please fix the errors and try `update` again.
 
 incrFoo : Foo -> Foo
 incrFoo = cases Bar n -> Bar (n Nat.+ 1)

--- a/unison-src/transcripts/update-type-with-dependent-term.output.md
+++ b/unison-src/transcripts/update-type-with-dependent-term.output.md
@@ -60,9 +60,13 @@ scratch/main> update
 
 ```
 ``` unison:added-by-ucm scratch.u
+type Foo = Bar Nat Nat
+
+-- The definitions below are not compatible with the updated definitions above.
+-- Please fix the errors and run `update` again.
+
 incrFoo : Foo -> Foo
 incrFoo = cases Bar n -> Bar (n Nat.+ 1)
 
-type Foo = Bar Nat Nat
 ```
 

--- a/unison-src/transcripts/update-type-with-dependent-type-to-different-kind.output.md
+++ b/unison-src/transcripts/update-type-with-dependent-type-to-different-kind.output.md
@@ -58,8 +58,12 @@ scratch/main> update
 
 ```
 ``` unison:added-by-ucm scratch.u
+type Foo a = Bar Nat a
+
+-- The definitions below are not compatible with the updated definitions above.
+-- Please fix the errors and run `update` again.
+
 type Baz = Qux Foo
 
-type Foo a = Bar Nat a
 ```
 

--- a/unison-src/transcripts/update-type-with-dependent-type-to-different-kind.output.md
+++ b/unison-src/transcripts/update-type-with-dependent-type-to-different-kind.output.md
@@ -60,8 +60,8 @@ scratch/main> update
 ``` unison:added-by-ucm scratch.u
 type Foo a = Bar Nat a
 
--- The definitions below are not compatible with the updated definitions above.
--- Please fix the errors and run `update` again.
+-- The definitions below no longer typecheck with the changes above.
+-- Please fix the errors and try `update` again.
 
 type Baz = Qux Foo
 

--- a/unison-syntax/src/Unison/Syntax/HashQualifiedPrime.hs
+++ b/unison-syntax/src/Unison/Syntax/HashQualifiedPrime.hs
@@ -48,7 +48,7 @@ toText =
 
 -- | A hash-qualified parser.
 hashQualifiedP ::
-  Monad m =>
+  (Monad m) =>
   ParsecT (Token Text) [Char] m name ->
   ParsecT (Token Text) [Char] m (HQ'.HashQualified name)
 hashQualifiedP nameP =


### PR DESCRIPTION
## Overview

Fixes #5150 

This PR beefs up the `update` implementation a bit to distinguish between the code the user had in their scratch file when they ran `update`, and the new (transitive) dependents pulled in for type checking with a comment that looks like:

```
-- The definitions below are not compatible with the updated definitions above.
-- Please fix the errors and run `update` again.
```

The current implementation just uses the rendered `TypecheckedUnisonFile` for the "above comment" definitions. So, those definitions could be arbitrarily permuted from their original order, and all comments are lost. Those improvements could be made in a subsequent PR.

This PR also makes `update` enforce many of the merge preconditions that were previously unchecked. `update` used to do the wrong thing here.

One perhaps notable change: you can no longer use `update` to resolve conflicted definitions. You just have to resolve them some other way, i.e. `rename` or `delete`. I had originally tried to preserve this feature of `update` but it ended up needing a lot of additional code, and it ultimately didn't seem like a very important feature to keep around. People shouldn't really have conflicted names anymore, and if they do, I don't see why it would be important for them to be able to `update` their way out of that situation, as opposed to `delete` or `rename`.

## Test coverage

No new tests, but existing transcripts have all been updated.
