### PR TITLE
Ensure transcript parser consumes entire stanzas

### DIFF
--- a/unison-src/transcripts/errors/invalid-api-requests.md
+++ b/unison-src/transcripts/errors/invalid-api-requests.md
@@ -1,0 +1,3 @@
+``` api:error
+DELETE /something/important
+```

--- a/unison-src/transcripts/errors/no-abspath-in-ucm.md
+++ b/unison-src/transcripts/errors/no-abspath-in-ucm.md
@@ -1,0 +1,5 @@
+``` ucm:error
+scratch/main> builtins.merge
+-- As of 0.5.25, we no longer allow loose code paths for UCM commands.
+.> ls
+```


### PR DESCRIPTION
## Overview

With the switch to `cmark`, the “second phase” parsing of individual stanzas omitted an EOF check to ensure that the entire stanza had been parsed. This resulted in parses where we end up with truncated sets of UCM commands or API requests, which could either result in premature success or failures occurring later in the transcript, where they’d complain about the wrong thing.

## Implementation notes

This additionally simplifies the `ucmLine` parser (using an existing project/branch parser directly, rather than indirecting via `tryFrom @Text`)

## Test coverage

There are two new transcripts in transcripts/errors to test the two changed cases.