### PR TITLE
Add FromJSON for Display Object for definition search

### DIFF
--- a/unison-share-api/src/Unison/Server/Orphans.hs
+++ b/unison-share-api/src/Unison/Server/Orphans.hs
@@ -155,6 +155,15 @@ instance (ToJSON b, ToJSON a) => ToJSON (DisplayObject b a) where
     MissingObject sh -> object ["tag" Aeson..= String "MissingObject", "contents" Aeson..= sh]
     UserObject a -> object ["tag" Aeson..= String "UserObject", "contents" Aeson..= a]
 
+instance (FromJSON a, FromJSON b) => FromJSON (DisplayObject b a) where
+  parseJSON = withObject "DisplayObject" \o -> do
+    tag <- o .: "tag"
+    case tag of
+      "BuiltinObject" -> BuiltinObject <$> o .: "contents"
+      "MissingObject" -> MissingObject <$> o .: "contents"
+      "UserObject" -> UserObject <$> o .: "contents"
+      _ -> fail $ "Invalid tag: " <> Text.unpack tag
+
 deriving instance (ToSchema b, ToSchema a) => ToSchema (DisplayObject b a)
 
 -- [21/10/07] Hello, this is Mitchell. Name refactor in progress. Changing internal representation from a flat text to a

--- a/unison-syntax/src/Unison/Syntax/HashQualifiedPrime.hs
+++ b/unison-syntax/src/Unison/Syntax/HashQualifiedPrime.hs
@@ -48,7 +48,7 @@ toText =
 
 -- | A hash-qualified parser.
 hashQualifiedP ::
-  Monad m =>
+  (Monad m) =>
   ParsecT (Token Text) [Char] m name ->
   ParsecT (Token Text) [Char] m (HQ'.HashQualified name)
 hashQualifiedP nameP =


### PR DESCRIPTION
## Overview

Adds a `FromJSON` to match the `ToJSON` for Display Object
I need it to hydrate definition summaries that I store in the global search index.

## Implementation notes

There's already a `ToJSON` for display objects, this just adds the inverse.

Needed for: https://github.com/unisoncomputing/share-api/pull/14

## Testing

Transcript tests in share-api