### PR TITLE
Add a transcript showing that #5178 is fixed

### DIFF
--- a/unison-src/transcripts-using-base/fix5178.md
+++ b/unison-src/transcripts-using-base/fix5178.md
@@ -1,0 +1,12 @@
+`Stream.emit` is an ability member, not a term, so the source needs to be handled differently.
+
+```unison
+foo = {{
+@source{Stream.emit}
+}}
+```
+
+```ucm
+scratch/main> add
+scratch/main> view foo
+```

--- a/unison-src/transcripts-using-base/fix5178.output.md
+++ b/unison-src/transcripts-using-base/fix5178.output.md
@@ -1,0 +1,34 @@
+`Stream.emit` is an ability member, not a term, so the source needs to be handled differently.
+
+``` unison
+foo = {{
+@source{Stream.emit}
+}}
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      foo : Doc2
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    foo : Doc2
+
+scratch/main> view foo
+
+  foo : Doc2
+  foo = {{     @source{emit} }}
+
+```


### PR DESCRIPTION
`@source{some ability member}` now shows the source of the ability.

Fixes #5178.