### PR TITLE
move /nix to /mnt/nix on Linux workflow

### DIFF
--- a/.github/workflows/nix-dev-cache.yaml
+++ b/.github/workflows/nix-dev-cache.yaml
@@ -29,7 +29,7 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         sudo mkdir /nix /mnt/nix
-        sudo mount -B /mnt/nix /nix
+        sudo mount --bind /mnt/nix /nix
     - uses: cachix/install-nix-action@v27
       if: runner.os == 'Linux'
       with:

--- a/.github/workflows/nix-dev-cache.yaml
+++ b/.github/workflows/nix-dev-cache.yaml
@@ -27,8 +27,8 @@ jobs:
     - name: set up mount points on Linux
       if: runner.os == 'Linux'
       run: |
-        mkdir /nix /mnt/nix
-        mount -B /mnt/nix /nix
+        sudo mkdir /nix /mnt/nix
+        sudo mount -B /mnt/nix /nix
     - uses: cachix/install-nix-action@v27
       if: runner.os == 'Linux'
       with:

--- a/.github/workflows/nix-dev-cache.yaml
+++ b/.github/workflows/nix-dev-cache.yaml
@@ -25,6 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: mount Nix store on larger partition
+      # on the Linux runner `/` doesn't have enough space, but there's a `/mnt` which does.
       if: runner.os == 'Linux'
       run: |
         sudo mkdir /nix /mnt/nix

--- a/.github/workflows/nix-dev-cache.yaml
+++ b/.github/workflows/nix-dev-cache.yaml
@@ -24,7 +24,7 @@ jobs:
           - macOS-14
     steps:
     - uses: actions/checkout@v4
-    - name: set up nix mount points on Linux
+    - name: mount Nix store on larger partition
       if: runner.os == 'Linux'
       run: |
         sudo mkdir /nix /mnt/nix

--- a/.github/workflows/nix-dev-cache.yaml
+++ b/.github/workflows/nix-dev-cache.yaml
@@ -24,6 +24,11 @@ jobs:
           - macOS-14
     steps:
     - uses: actions/checkout@v4
+    - name: set up mount points on Linux
+      if: runner.os == 'Linux'
+      run: |
+        mkdir /nix /mnt/nix
+        mount -B /mnt/nix /nix
     - uses: cachix/install-nix-action@v27
       if: runner.os == 'Linux'
       with:

--- a/.github/workflows/nix-dev-cache.yaml
+++ b/.github/workflows/nix-dev-cache.yaml
@@ -24,7 +24,7 @@ jobs:
           - macOS-14
     steps:
     - uses: actions/checkout@v4
-    - name: set up mount points on Linux
+    - name: set up nix mount points on Linux
       if: runner.os == 'Linux'
       run: |
         sudo mkdir /nix /mnt/nix
@@ -41,7 +41,7 @@ jobs:
       with:
         name: unison
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
     - name: build all packages and development shells
       run: nix -L build --accept-flake-config --no-link --keep-going '.#all'
+    - name: print disk free status
+      run: df -h

--- a/.github/workflows/nix-dev-cache.yaml
+++ b/.github/workflows/nix-dev-cache.yaml
@@ -36,5 +36,7 @@ jobs:
       with:
         name: unison
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
     - name: build all packages and development shells
       run: nix -L build --accept-flake-config --no-link --keep-going '.#all'


### PR DESCRIPTION
## Overview

nix is installed in /nix, which on the ubuntu-20.04 runner doesn't have enough space to build everything from scratch, resulting in CI failures on trunk and some PRs, eg #5265 

This PR causes the linux runner install nix onto a disk that's bigger than `/`

fixes https://github.com/unisonweb/unison/issues/5266

## Implementation notes

adds a step to `mount -o bind /mnt/nix /nix` before installing nix, and this seems to work.

## Interesting/controversial decisions

## Test coverage

the nix steps still pass

## Loose ends