### PR TITLE
Definition Diffs: Only emit annotation changes for hash changes

### DIFF
--- a/unison-share-api/src/Unison/Server/Backend/DefinitionDiff.hs
+++ b/unison-share-api/src/Unison/Server/Backend/DefinitionDiff.hs
@@ -59,5 +59,17 @@ diffSyntaxText (AnnotatedText fromST) (AnnotatedText toST) =
     detectSpecialCase fromSegment toSegment
       | fromSegment == toSegment = Left fromSegment
       | AT.annotation fromSegment == AT.annotation toSegment = Right (SegmentChange (AT.segment fromSegment, AT.segment toSegment) (AT.annotation fromSegment))
-      | AT.segment fromSegment == AT.segment toSegment = Right (AnnotationChange (AT.segment fromSegment) (AT.annotation fromSegment, AT.annotation toSegment))
+      -- We only emit an annotation change if it's a change in just the hash of the element (optionally the KIND of hash reference can change too).
+      | AT.segment fromSegment == AT.segment toSegment,
+        Just _fromHash <- AT.annotation fromSegment >>= elementHash,
+        Just _toHash <- AT.annotation toSegment >>= elementHash =
+          Right (AnnotationChange (AT.segment fromSegment) (AT.annotation fromSegment, AT.annotation toSegment))
       | otherwise = error "diffSyntaxText: found Syntax Elements in 'both' which have nothing in common."
+      where
+        elementHash :: Syntax.Element -> Maybe Syntax.UnisonHash
+        elementHash = \case
+          Syntax.TypeReference hash -> Just hash
+          Syntax.TermReference hash -> Just hash
+          Syntax.DataConstructorReference hash -> Just hash
+          Syntax.AbilityConstructorReference hash -> Just hash
+          _ -> Nothing

--- a/unison-src/transcripts/definition-diff-api.md
+++ b/unison-src/transcripts/definition-diff-api.md
@@ -1,5 +1,7 @@
 ```ucm
-diffs/main> builtins.merge
+diffs/main> builtins.mergeio lib.builtins
+diffs/main> alias.term lib.builtins.Nat.gt lib.builtins.Nat.>
+diffs/main> alias.term lib.builtins.Nat.drop lib.builtins.Nat.-
 ```
 
 ```unison
@@ -8,6 +10,20 @@ term =
   1 + 1
 
 type Type = Type Nat
+
+ability Stream a where
+  emit : a -> ()
+
+take n s =
+  use Nat > -
+  h n = cases
+    { emit a -> k } -> if n > 0
+                         then
+                           emit a
+                           handle k() with h (n - 1)
+                         else None
+    { r }  -> Some r
+  handle s() with h n
 ```
 
 ```ucm
@@ -21,6 +37,22 @@ term =
   1 + 2
 
 type Type a = Type a Text
+
+ability Stream a where
+  emit : a -> ()
+
+take n s =
+  use Nat > -
+  h n = cases
+    { emit a -> k } ->
+        emit a
+        if n > 0
+          then handle k() with h (n - 1)
+          else None
+    { r }  -> Some r
+  if n > 0
+    then handle s () with h (n - 1)
+    else None
 ```
 
 ```ucm
@@ -32,6 +64,13 @@ Diff terms
 ```api
 GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=term&newTerm=term
 ```
+
+More complex diff
+
+```api
+GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=take&newTerm=take
+```
+
 
 Diff types
 

--- a/unison-src/transcripts/definition-diff-api.output.md
+++ b/unison-src/transcripts/definition-diff-api.output.md
@@ -1,5 +1,13 @@
 ``` ucm
-diffs/main> builtins.merge
+diffs/main> builtins.mergeio lib.builtins
+
+  Done.
+
+diffs/main> alias.term lib.builtins.Nat.gt lib.builtins.Nat.>
+
+  Done.
+
+diffs/main> alias.term lib.builtins.Nat.drop lib.builtins.Nat.-
 
   Done.
 
@@ -10,6 +18,20 @@ term =
   1 + 1
 
 type Type = Type Nat
+
+ability Stream a where
+  emit : a -> ()
+
+take n s =
+  use Nat > -
+  h n = cases
+    { emit a -> k } -> if n > 0
+                         then
+                           emit a
+                           handle k() with h (n - 1)
+                         else None
+    { r }  -> Some r
+  handle s() with h n
 ```
 
 ``` ucm
@@ -22,7 +44,9 @@ type Type = Type Nat
   
     ⍟ These new definitions are ok to `add`:
     
+      ability Stream a
       type Type
+      take : Nat -> '{g} t ->{g, Stream a} Optional t
       term : Nat
 
 ```
@@ -31,7 +55,9 @@ diffs/main> add
 
   ⍟ I've added these definitions:
   
+    ability Stream a
     type Type
+    take : Nat -> '{g} t ->{g, Stream a} Optional t
     term : Nat
 
 diffs/main> branch.create new
@@ -48,6 +74,22 @@ term =
   1 + 2
 
 type Type a = Type a Text
+
+ability Stream a where
+  emit : a -> ()
+
+take n s =
+  use Nat > -
+  h n = cases
+    { emit a -> k } ->
+        emit a
+        if n > 0
+          then handle k() with h (n - 1)
+          else None
+    { r }  -> Some r
+  if n > 0
+    then handle s () with h (n - 1)
+    else None
 ```
 
 ``` ucm
@@ -58,10 +100,13 @@ type Type a = Type a Text
   do an `add` or `update`, here's how your codebase would
   change:
   
+    ⊡ Previously added definitions will be ignored: Stream
+    
     ⍟ These names already exist. You can `update` them to your
       new definition:
     
       type Type a
+      take : Nat -> '{g} t ->{g, Stream a} Optional t
       term : Nat
 
 ```
@@ -560,6 +605,2753 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=te
 }
 ```
 
+More complex diff
+
+``` api
+GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=take&newTerm=take
+{
+    "diff": {
+        "contents": [
+            {
+                "diffTag": "both",
+                "elements": [
+                    {
+                        "annotation": {
+                            "contents": "take",
+                            "tag": "HashQualifier"
+                        },
+                        "segment": "take"
+                    },
+                    {
+                        "annotation": {
+                            "tag": "TypeAscriptionColon"
+                        },
+                        "segment": " :"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "contents": "##Nat",
+                            "tag": "TypeReference"
+                        },
+                        "segment": "Nat"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "TypeOperator"
+                        },
+                        "segment": "->"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "DelayForceChar"
+                        },
+                        "segment": "'"
+                    },
+                    {
+                        "annotation": {
+                            "tag": "AbilityBraces"
+                        },
+                        "segment": "{"
+                    },
+                    {
+                        "annotation": {
+                            "tag": "Var"
+                        },
+                        "segment": "g"
+                    },
+                    {
+                        "annotation": {
+                            "tag": "AbilityBraces"
+                        },
+                        "segment": "}"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "Var"
+                        },
+                        "segment": "t"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "TypeOperator"
+                        },
+                        "segment": "->"
+                    },
+                    {
+                        "annotation": {
+                            "tag": "AbilityBraces"
+                        },
+                        "segment": "{"
+                    },
+                    {
+                        "annotation": {
+                            "tag": "Var"
+                        },
+                        "segment": "g"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": ","
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro",
+                            "tag": "TypeReference"
+                        },
+                        "segment": "Stream"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "Var"
+                        },
+                        "segment": "a"
+                    },
+                    {
+                        "annotation": {
+                            "tag": "AbilityBraces"
+                        },
+                        "segment": "}"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg",
+                            "tag": "TypeReference"
+                        },
+                        "segment": "Optional"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "Var"
+                        },
+                        "segment": "t"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "\n"
+                    },
+                    {
+                        "annotation": {
+                            "contents": "take",
+                            "tag": "HashQualifier"
+                        },
+                        "segment": "take"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "Var"
+                        },
+                        "segment": "n"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "Var"
+                        },
+                        "segment": "s"
+                    },
+                    {
+                        "annotation": {
+                            "tag": "BindingEquals"
+                        },
+                        "segment": " ="
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "\n"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "  "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "UseKeyword"
+                        },
+                        "segment": "use "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "UsePrefix"
+                        },
+                        "segment": "Nat"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "UseSuffix"
+                        },
+                        "segment": "-"
+                    },
+                    {
+                        "annotation": {
+                            "tag": "UseSuffix"
+                        },
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "UseSuffix"
+                        },
+                        "segment": ">"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "\n"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "  "
+                    },
+                    {
+                        "annotation": {
+                            "contents": "h",
+                            "tag": "HashQualifier"
+                        },
+                        "segment": "h"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "Var"
+                        },
+                        "segment": "n"
+                    },
+                    {
+                        "annotation": {
+                            "tag": "BindingEquals"
+                        },
+                        "segment": " ="
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "ControlKeyword"
+                        },
+                        "segment": "cases"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "\n"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "  "
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "  "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "DelimiterChar"
+                        },
+                        "segment": "{"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro#a0",
+                            "tag": "TermReference"
+                        },
+                        "segment": "emit"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "Var"
+                        },
+                        "segment": "a"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "ControlKeyword"
+                        },
+                        "segment": "->"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "Var"
+                        },
+                        "segment": "k"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "DelimiterChar"
+                        },
+                        "segment": "}"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "ControlKeyword"
+                        },
+                        "segment": "->"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "\n"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "  "
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "  "
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "  "
+                    }
+                ]
+            },
+            {
+                "diffTag": "old",
+                "elements": [
+                    {
+                        "annotation": {
+                            "tag": "ControlKeyword"
+                        },
+                        "segment": "if "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "Var"
+                        },
+                        "segment": "n"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "contents": "##Nat.>",
+                            "tag": "TermReference"
+                        },
+                        "segment": ">"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "NumericLiteral"
+                        },
+                        "segment": "0"
+                    },
+                    {
+                        "annotation": {
+                            "tag": "ControlKeyword"
+                        },
+                        "segment": " then"
+                    }
+                ]
+            },
+            {
+                "diffTag": "new",
+                "elements": [
+                    {
+                        "annotation": {
+                            "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro#a0",
+                            "tag": "TermReference"
+                        },
+                        "segment": "emit"
+                    }
+                ]
+            },
+            {
+                "annotation": null,
+                "diffTag": "segmentChange",
+                "fromSegment": "\n",
+                "toSegment": " "
+            },
+            {
+                "diffTag": "new",
+                "elements": [
+                    {
+                        "annotation": {
+                            "tag": "Var"
+                        },
+                        "segment": "a"
+                    }
+                ]
+            },
+            {
+                "annotation": null,
+                "diffTag": "segmentChange",
+                "fromSegment": "  ",
+                "toSegment": "\n"
+            },
+            {
+                "diffTag": "both",
+                "elements": [
+                    {
+                        "annotation": null,
+                        "segment": "  "
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "  "
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "  "
+                    }
+                ]
+            },
+            {
+                "diffTag": "old",
+                "elements": [
+                    {
+                        "annotation": {
+                            "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro#a0",
+                            "tag": "TermReference"
+                        },
+                        "segment": "emit"
+                    }
+                ]
+            },
+            {
+                "diffTag": "new",
+                "elements": [
+                    {
+                        "annotation": {
+                            "tag": "ControlKeyword"
+                        },
+                        "segment": "if"
+                    }
+                ]
+            },
+            {
+                "diffTag": "both",
+                "elements": [
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    }
+                ]
+            },
+            {
+                "annotation": {
+                    "tag": "Var"
+                },
+                "diffTag": "segmentChange",
+                "fromSegment": "a",
+                "toSegment": "n"
+            },
+            {
+                "annotation": null,
+                "diffTag": "segmentChange",
+                "fromSegment": "\n",
+                "toSegment": " "
+            },
+            {
+                "diffTag": "old",
+                "elements": [
+                    {
+                        "annotation": null,
+                        "segment": "  "
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "  "
+                    }
+                ]
+            },
+            {
+                "diffTag": "new",
+                "elements": [
+                    {
+                        "annotation": {
+                            "contents": "##Nat.>",
+                            "tag": "TermReference"
+                        },
+                        "segment": ">"
+                    }
+                ]
+            },
+            {
+                "annotation": null,
+                "diffTag": "segmentChange",
+                "fromSegment": "  ",
+                "toSegment": " "
+            },
+            {
+                "diffTag": "new",
+                "elements": [
+                    {
+                        "annotation": {
+                            "tag": "NumericLiteral"
+                        },
+                        "segment": "0"
+                    },
+                    {
+                        "annotation": {
+                            "tag": "ControlKeyword"
+                        },
+                        "segment": " then"
+                    }
+                ]
+            },
+            {
+                "annotation": null,
+                "diffTag": "segmentChange",
+                "fromSegment": "  ",
+                "toSegment": " "
+            },
+            {
+                "diffTag": "both",
+                "elements": [
+                    {
+                        "annotation": {
+                            "tag": "ControlKeyword"
+                        },
+                        "segment": "handle"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "Var"
+                        },
+                        "segment": "k"
+                    },
+                    {
+                        "annotation": {
+                            "tag": "Unit"
+                        },
+                        "segment": "()"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "ControlKeyword"
+                        },
+                        "segment": "with"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "Var"
+                        },
+                        "segment": "h"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "Parenthesis"
+                        },
+                        "segment": "("
+                    },
+                    {
+                        "annotation": {
+                            "tag": "Var"
+                        },
+                        "segment": "n"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "contents": "##Nat.drop",
+                            "tag": "TermReference"
+                        },
+                        "segment": "-"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "NumericLiteral"
+                        },
+                        "segment": "1"
+                    },
+                    {
+                        "annotation": {
+                            "tag": "Parenthesis"
+                        },
+                        "segment": ")"
+                    }
+                ]
+            },
+            {
+                "annotation": null,
+                "diffTag": "segmentChange",
+                "fromSegment": "\n",
+                "toSegment": " "
+            },
+            {
+                "diffTag": "old",
+                "elements": [
+                    {
+                        "annotation": null,
+                        "segment": "  "
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "  "
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "  "
+                    }
+                ]
+            },
+            {
+                "diffTag": "both",
+                "elements": [
+                    {
+                        "annotation": {
+                            "tag": "ControlKeyword"
+                        },
+                        "segment": "else"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d1",
+                            "tag": "TermReference"
+                        },
+                        "segment": "None"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "\n"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "  "
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "  "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "DelimiterChar"
+                        },
+                        "segment": "{"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "Var"
+                        },
+                        "segment": "r"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "DelimiterChar"
+                        },
+                        "segment": "}"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "           "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "ControlKeyword"
+                        },
+                        "segment": "->"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d0",
+                            "tag": "TermReference"
+                        },
+                        "segment": "Some"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "Var"
+                        },
+                        "segment": "r"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "\n"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "  "
+                    }
+                ]
+            },
+            {
+                "annotation": {
+                    "tag": "ControlKeyword"
+                },
+                "diffTag": "segmentChange",
+                "fromSegment": "handle",
+                "toSegment": "if"
+            },
+            {
+                "diffTag": "both",
+                "elements": [
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    }
+                ]
+            },
+            {
+                "annotation": {
+                    "tag": "Var"
+                },
+                "diffTag": "segmentChange",
+                "fromSegment": "s",
+                "toSegment": "n"
+            },
+            {
+                "diffTag": "new",
+                "elements": [
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "contents": "##Nat.>",
+                            "tag": "TermReference"
+                        },
+                        "segment": ">"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "NumericLiteral"
+                        },
+                        "segment": "0"
+                    },
+                    {
+                        "annotation": {
+                            "tag": "ControlKeyword"
+                        },
+                        "segment": " then"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "ControlKeyword"
+                        },
+                        "segment": "handle"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "Var"
+                        },
+                        "segment": "s"
+                    }
+                ]
+            },
+            {
+                "diffTag": "both",
+                "elements": [
+                    {
+                        "annotation": {
+                            "tag": "Unit"
+                        },
+                        "segment": "()"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "ControlKeyword"
+                        },
+                        "segment": "with"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "Var"
+                        },
+                        "segment": "h"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    }
+                ]
+            },
+            {
+                "diffTag": "new",
+                "elements": [
+                    {
+                        "annotation": {
+                            "tag": "Parenthesis"
+                        },
+                        "segment": "("
+                    }
+                ]
+            },
+            {
+                "diffTag": "both",
+                "elements": [
+                    {
+                        "annotation": {
+                            "tag": "Var"
+                        },
+                        "segment": "n"
+                    }
+                ]
+            },
+            {
+                "diffTag": "new",
+                "elements": [
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "contents": "##Nat.drop",
+                            "tag": "TermReference"
+                        },
+                        "segment": "-"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "NumericLiteral"
+                        },
+                        "segment": "1"
+                    },
+                    {
+                        "annotation": {
+                            "tag": "Parenthesis"
+                        },
+                        "segment": ")"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "ControlKeyword"
+                        },
+                        "segment": "else"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d1",
+                            "tag": "TermReference"
+                        },
+                        "segment": "None"
+                    }
+                ]
+            }
+        ],
+        "tag": "UserObject"
+    },
+    "diffKind": "diff",
+    "newBranchRef": "new",
+    "newTerm": {
+        "bestTermName": "take",
+        "defnTermTag": "Plain",
+        "signature": [
+            {
+                "annotation": {
+                    "contents": "##Nat",
+                    "tag": "TypeReference"
+                },
+                "segment": "Nat"
+            },
+            {
+                "annotation": null,
+                "segment": " "
+            },
+            {
+                "annotation": {
+                    "tag": "TypeOperator"
+                },
+                "segment": "->"
+            },
+            {
+                "annotation": null,
+                "segment": " "
+            },
+            {
+                "annotation": {
+                    "tag": "DelayForceChar"
+                },
+                "segment": "'"
+            },
+            {
+                "annotation": {
+                    "tag": "AbilityBraces"
+                },
+                "segment": "{"
+            },
+            {
+                "annotation": {
+                    "tag": "Var"
+                },
+                "segment": "g"
+            },
+            {
+                "annotation": {
+                    "tag": "AbilityBraces"
+                },
+                "segment": "}"
+            },
+            {
+                "annotation": null,
+                "segment": " "
+            },
+            {
+                "annotation": {
+                    "tag": "Var"
+                },
+                "segment": "t"
+            },
+            {
+                "annotation": null,
+                "segment": " "
+            },
+            {
+                "annotation": {
+                    "tag": "TypeOperator"
+                },
+                "segment": "->"
+            },
+            {
+                "annotation": {
+                    "tag": "AbilityBraces"
+                },
+                "segment": "{"
+            },
+            {
+                "annotation": {
+                    "tag": "Var"
+                },
+                "segment": "g"
+            },
+            {
+                "annotation": null,
+                "segment": ","
+            },
+            {
+                "annotation": null,
+                "segment": " "
+            },
+            {
+                "annotation": {
+                    "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro",
+                    "tag": "TypeReference"
+                },
+                "segment": "Stream"
+            },
+            {
+                "annotation": null,
+                "segment": " "
+            },
+            {
+                "annotation": {
+                    "tag": "Var"
+                },
+                "segment": "a"
+            },
+            {
+                "annotation": {
+                    "tag": "AbilityBraces"
+                },
+                "segment": "}"
+            },
+            {
+                "annotation": null,
+                "segment": " "
+            },
+            {
+                "annotation": {
+                    "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg",
+                    "tag": "TypeReference"
+                },
+                "segment": "Optional"
+            },
+            {
+                "annotation": null,
+                "segment": " "
+            },
+            {
+                "annotation": {
+                    "tag": "Var"
+                },
+                "segment": "t"
+            }
+        ],
+        "termDefinition": {
+            "contents": [
+                {
+                    "annotation": {
+                        "contents": "take",
+                        "tag": "HashQualifier"
+                    },
+                    "segment": "take"
+                },
+                {
+                    "annotation": {
+                        "tag": "TypeAscriptionColon"
+                    },
+                    "segment": " :"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "##Nat",
+                        "tag": "TypeReference"
+                    },
+                    "segment": "Nat"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "TypeOperator"
+                    },
+                    "segment": "->"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "DelayForceChar"
+                    },
+                    "segment": "'"
+                },
+                {
+                    "annotation": {
+                        "tag": "AbilityBraces"
+                    },
+                    "segment": "{"
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "g"
+                },
+                {
+                    "annotation": {
+                        "tag": "AbilityBraces"
+                    },
+                    "segment": "}"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "t"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "TypeOperator"
+                    },
+                    "segment": "->"
+                },
+                {
+                    "annotation": {
+                        "tag": "AbilityBraces"
+                    },
+                    "segment": "{"
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "g"
+                },
+                {
+                    "annotation": null,
+                    "segment": ","
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro",
+                        "tag": "TypeReference"
+                    },
+                    "segment": "Stream"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "a"
+                },
+                {
+                    "annotation": {
+                        "tag": "AbilityBraces"
+                    },
+                    "segment": "}"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg",
+                        "tag": "TypeReference"
+                    },
+                    "segment": "Optional"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "t"
+                },
+                {
+                    "annotation": null,
+                    "segment": "\n"
+                },
+                {
+                    "annotation": {
+                        "contents": "take",
+                        "tag": "HashQualifier"
+                    },
+                    "segment": "take"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "n"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "s"
+                },
+                {
+                    "annotation": {
+                        "tag": "BindingEquals"
+                    },
+                    "segment": " ="
+                },
+                {
+                    "annotation": null,
+                    "segment": "\n"
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": {
+                        "tag": "UseKeyword"
+                    },
+                    "segment": "use "
+                },
+                {
+                    "annotation": {
+                        "tag": "UsePrefix"
+                    },
+                    "segment": "Nat"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "UseSuffix"
+                    },
+                    "segment": "-"
+                },
+                {
+                    "annotation": {
+                        "tag": "UseSuffix"
+                    },
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "UseSuffix"
+                    },
+                    "segment": ">"
+                },
+                {
+                    "annotation": null,
+                    "segment": "\n"
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": {
+                        "contents": "h",
+                        "tag": "HashQualifier"
+                    },
+                    "segment": "h"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "n"
+                },
+                {
+                    "annotation": {
+                        "tag": "BindingEquals"
+                    },
+                    "segment": " ="
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "ControlKeyword"
+                    },
+                    "segment": "cases"
+                },
+                {
+                    "annotation": null,
+                    "segment": "\n"
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": {
+                        "tag": "DelimiterChar"
+                    },
+                    "segment": "{"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro#a0",
+                        "tag": "TermReference"
+                    },
+                    "segment": "emit"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "a"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "ControlKeyword"
+                    },
+                    "segment": "->"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "k"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "DelimiterChar"
+                    },
+                    "segment": "}"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "ControlKeyword"
+                    },
+                    "segment": "->"
+                },
+                {
+                    "annotation": null,
+                    "segment": "\n"
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": {
+                        "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro#a0",
+                        "tag": "TermReference"
+                    },
+                    "segment": "emit"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "a"
+                },
+                {
+                    "annotation": null,
+                    "segment": "\n"
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": {
+                        "tag": "ControlKeyword"
+                    },
+                    "segment": "if"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "n"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "##Nat.>",
+                        "tag": "TermReference"
+                    },
+                    "segment": ">"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "NumericLiteral"
+                    },
+                    "segment": "0"
+                },
+                {
+                    "annotation": {
+                        "tag": "ControlKeyword"
+                    },
+                    "segment": " then"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "ControlKeyword"
+                    },
+                    "segment": "handle"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "k"
+                },
+                {
+                    "annotation": {
+                        "tag": "Unit"
+                    },
+                    "segment": "()"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "ControlKeyword"
+                    },
+                    "segment": "with"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "h"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Parenthesis"
+                    },
+                    "segment": "("
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "n"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "##Nat.drop",
+                        "tag": "TermReference"
+                    },
+                    "segment": "-"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "NumericLiteral"
+                    },
+                    "segment": "1"
+                },
+                {
+                    "annotation": {
+                        "tag": "Parenthesis"
+                    },
+                    "segment": ")"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "ControlKeyword"
+                    },
+                    "segment": "else"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d1",
+                        "tag": "TermReference"
+                    },
+                    "segment": "None"
+                },
+                {
+                    "annotation": null,
+                    "segment": "\n"
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": {
+                        "tag": "DelimiterChar"
+                    },
+                    "segment": "{"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "r"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "DelimiterChar"
+                    },
+                    "segment": "}"
+                },
+                {
+                    "annotation": null,
+                    "segment": "           "
+                },
+                {
+                    "annotation": {
+                        "tag": "ControlKeyword"
+                    },
+                    "segment": "->"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d0",
+                        "tag": "TermReference"
+                    },
+                    "segment": "Some"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "r"
+                },
+                {
+                    "annotation": null,
+                    "segment": "\n"
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": {
+                        "tag": "ControlKeyword"
+                    },
+                    "segment": "if"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "n"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "##Nat.>",
+                        "tag": "TermReference"
+                    },
+                    "segment": ">"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "NumericLiteral"
+                    },
+                    "segment": "0"
+                },
+                {
+                    "annotation": {
+                        "tag": "ControlKeyword"
+                    },
+                    "segment": " then"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "ControlKeyword"
+                    },
+                    "segment": "handle"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "s"
+                },
+                {
+                    "annotation": {
+                        "tag": "Unit"
+                    },
+                    "segment": "()"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "ControlKeyword"
+                    },
+                    "segment": "with"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "h"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Parenthesis"
+                    },
+                    "segment": "("
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "n"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "##Nat.drop",
+                        "tag": "TermReference"
+                    },
+                    "segment": "-"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "NumericLiteral"
+                    },
+                    "segment": "1"
+                },
+                {
+                    "annotation": {
+                        "tag": "Parenthesis"
+                    },
+                    "segment": ")"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "ControlKeyword"
+                    },
+                    "segment": "else"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d1",
+                        "tag": "TermReference"
+                    },
+                    "segment": "None"
+                }
+            ],
+            "tag": "UserObject"
+        },
+        "termDocs": [],
+        "termNames": [
+            "take"
+        ]
+    },
+    "oldBranchRef": "main",
+    "oldTerm": {
+        "bestTermName": "take",
+        "defnTermTag": "Plain",
+        "signature": [
+            {
+                "annotation": {
+                    "contents": "##Nat",
+                    "tag": "TypeReference"
+                },
+                "segment": "Nat"
+            },
+            {
+                "annotation": null,
+                "segment": " "
+            },
+            {
+                "annotation": {
+                    "tag": "TypeOperator"
+                },
+                "segment": "->"
+            },
+            {
+                "annotation": null,
+                "segment": " "
+            },
+            {
+                "annotation": {
+                    "tag": "DelayForceChar"
+                },
+                "segment": "'"
+            },
+            {
+                "annotation": {
+                    "tag": "AbilityBraces"
+                },
+                "segment": "{"
+            },
+            {
+                "annotation": {
+                    "tag": "Var"
+                },
+                "segment": "g"
+            },
+            {
+                "annotation": {
+                    "tag": "AbilityBraces"
+                },
+                "segment": "}"
+            },
+            {
+                "annotation": null,
+                "segment": " "
+            },
+            {
+                "annotation": {
+                    "tag": "Var"
+                },
+                "segment": "t"
+            },
+            {
+                "annotation": null,
+                "segment": " "
+            },
+            {
+                "annotation": {
+                    "tag": "TypeOperator"
+                },
+                "segment": "->"
+            },
+            {
+                "annotation": {
+                    "tag": "AbilityBraces"
+                },
+                "segment": "{"
+            },
+            {
+                "annotation": {
+                    "tag": "Var"
+                },
+                "segment": "g"
+            },
+            {
+                "annotation": null,
+                "segment": ","
+            },
+            {
+                "annotation": null,
+                "segment": " "
+            },
+            {
+                "annotation": {
+                    "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro",
+                    "tag": "TypeReference"
+                },
+                "segment": "Stream"
+            },
+            {
+                "annotation": null,
+                "segment": " "
+            },
+            {
+                "annotation": {
+                    "tag": "Var"
+                },
+                "segment": "a"
+            },
+            {
+                "annotation": {
+                    "tag": "AbilityBraces"
+                },
+                "segment": "}"
+            },
+            {
+                "annotation": null,
+                "segment": " "
+            },
+            {
+                "annotation": {
+                    "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg",
+                    "tag": "TypeReference"
+                },
+                "segment": "Optional"
+            },
+            {
+                "annotation": null,
+                "segment": " "
+            },
+            {
+                "annotation": {
+                    "tag": "Var"
+                },
+                "segment": "t"
+            }
+        ],
+        "termDefinition": {
+            "contents": [
+                {
+                    "annotation": {
+                        "contents": "take",
+                        "tag": "HashQualifier"
+                    },
+                    "segment": "take"
+                },
+                {
+                    "annotation": {
+                        "tag": "TypeAscriptionColon"
+                    },
+                    "segment": " :"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "##Nat",
+                        "tag": "TypeReference"
+                    },
+                    "segment": "Nat"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "TypeOperator"
+                    },
+                    "segment": "->"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "DelayForceChar"
+                    },
+                    "segment": "'"
+                },
+                {
+                    "annotation": {
+                        "tag": "AbilityBraces"
+                    },
+                    "segment": "{"
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "g"
+                },
+                {
+                    "annotation": {
+                        "tag": "AbilityBraces"
+                    },
+                    "segment": "}"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "t"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "TypeOperator"
+                    },
+                    "segment": "->"
+                },
+                {
+                    "annotation": {
+                        "tag": "AbilityBraces"
+                    },
+                    "segment": "{"
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "g"
+                },
+                {
+                    "annotation": null,
+                    "segment": ","
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro",
+                        "tag": "TypeReference"
+                    },
+                    "segment": "Stream"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "a"
+                },
+                {
+                    "annotation": {
+                        "tag": "AbilityBraces"
+                    },
+                    "segment": "}"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg",
+                        "tag": "TypeReference"
+                    },
+                    "segment": "Optional"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "t"
+                },
+                {
+                    "annotation": null,
+                    "segment": "\n"
+                },
+                {
+                    "annotation": {
+                        "contents": "take",
+                        "tag": "HashQualifier"
+                    },
+                    "segment": "take"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "n"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "s"
+                },
+                {
+                    "annotation": {
+                        "tag": "BindingEquals"
+                    },
+                    "segment": " ="
+                },
+                {
+                    "annotation": null,
+                    "segment": "\n"
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": {
+                        "tag": "UseKeyword"
+                    },
+                    "segment": "use "
+                },
+                {
+                    "annotation": {
+                        "tag": "UsePrefix"
+                    },
+                    "segment": "Nat"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "UseSuffix"
+                    },
+                    "segment": "-"
+                },
+                {
+                    "annotation": {
+                        "tag": "UseSuffix"
+                    },
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "UseSuffix"
+                    },
+                    "segment": ">"
+                },
+                {
+                    "annotation": null,
+                    "segment": "\n"
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": {
+                        "contents": "h",
+                        "tag": "HashQualifier"
+                    },
+                    "segment": "h"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "n"
+                },
+                {
+                    "annotation": {
+                        "tag": "BindingEquals"
+                    },
+                    "segment": " ="
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "ControlKeyword"
+                    },
+                    "segment": "cases"
+                },
+                {
+                    "annotation": null,
+                    "segment": "\n"
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": {
+                        "tag": "DelimiterChar"
+                    },
+                    "segment": "{"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro#a0",
+                        "tag": "TermReference"
+                    },
+                    "segment": "emit"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "a"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "ControlKeyword"
+                    },
+                    "segment": "->"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "k"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "DelimiterChar"
+                    },
+                    "segment": "}"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "ControlKeyword"
+                    },
+                    "segment": "->"
+                },
+                {
+                    "annotation": null,
+                    "segment": "\n"
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": {
+                        "tag": "ControlKeyword"
+                    },
+                    "segment": "if "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "n"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "##Nat.>",
+                        "tag": "TermReference"
+                    },
+                    "segment": ">"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "NumericLiteral"
+                    },
+                    "segment": "0"
+                },
+                {
+                    "annotation": {
+                        "tag": "ControlKeyword"
+                    },
+                    "segment": " then"
+                },
+                {
+                    "annotation": null,
+                    "segment": "\n"
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": {
+                        "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro#a0",
+                        "tag": "TermReference"
+                    },
+                    "segment": "emit"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "a"
+                },
+                {
+                    "annotation": null,
+                    "segment": "\n"
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": {
+                        "tag": "ControlKeyword"
+                    },
+                    "segment": "handle"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "k"
+                },
+                {
+                    "annotation": {
+                        "tag": "Unit"
+                    },
+                    "segment": "()"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "ControlKeyword"
+                    },
+                    "segment": "with"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "h"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Parenthesis"
+                    },
+                    "segment": "("
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "n"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "##Nat.drop",
+                        "tag": "TermReference"
+                    },
+                    "segment": "-"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "NumericLiteral"
+                    },
+                    "segment": "1"
+                },
+                {
+                    "annotation": {
+                        "tag": "Parenthesis"
+                    },
+                    "segment": ")"
+                },
+                {
+                    "annotation": null,
+                    "segment": "\n"
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": {
+                        "tag": "ControlKeyword"
+                    },
+                    "segment": "else"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d1",
+                        "tag": "TermReference"
+                    },
+                    "segment": "None"
+                },
+                {
+                    "annotation": null,
+                    "segment": "\n"
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": {
+                        "tag": "DelimiterChar"
+                    },
+                    "segment": "{"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "r"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "DelimiterChar"
+                    },
+                    "segment": "}"
+                },
+                {
+                    "annotation": null,
+                    "segment": "           "
+                },
+                {
+                    "annotation": {
+                        "tag": "ControlKeyword"
+                    },
+                    "segment": "->"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d0",
+                        "tag": "TermReference"
+                    },
+                    "segment": "Some"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "r"
+                },
+                {
+                    "annotation": null,
+                    "segment": "\n"
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": {
+                        "tag": "ControlKeyword"
+                    },
+                    "segment": "handle"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "s"
+                },
+                {
+                    "annotation": {
+                        "tag": "Unit"
+                    },
+                    "segment": "()"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "ControlKeyword"
+                    },
+                    "segment": "with"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "h"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "n"
+                }
+            ],
+            "tag": "UserObject"
+        },
+        "termDocs": [],
+        "termNames": [
+            "take"
+        ]
+    },
+    "project": "diffs"
+}
+```
+
 Diff types
 
 ``` api
@@ -618,12 +3410,12 @@ GET /api/projects/diffs/diff/types?oldBranchRef=main&newBranchRef=new&oldType=Ty
             {
                 "diffTag": "annotationChange",
                 "fromAnnotation": {
-                    "contents": "#0tc9e438eurvtevfa6k9pg04qvv66is75hs8iqejkuoaef140g8vvu92hc1ks4gamgc3i1ukgdn0blchp3038l43vffijpsbjh14igo#d0",
+                    "contents": "#m5hlrmkn9a3kuqabta2e9qs934em1qmkotpsh9tjvta2u86nuesbjbk2k2sprbdiljq7uqibp49vku4gfpg2u60ceiv8net1f0bu2n8#d0",
                     "tag": "TermReference"
                 },
                 "segment": "Type",
                 "toAnnotation": {
-                    "contents": "#mft8mne9i92b6k4m512rn2608rsp6ilq4ejufeof6mbh5aintes4tih1fo93fospmu2t3f0h67uu0mrk2qj75o7k0lj1juefhaidt4g#d0",
+                    "contents": "#uik7pl3klg4u2obtf2fattdaeldui46ohmsi0knpp5hu8tn4d5o8vp570qgh7esgap0pmq9cfrh9dfg1r8qa7qh33g45a3tric24o20#d0",
                     "tag": "TermReference"
                 }
             },
@@ -715,7 +3507,7 @@ GET /api/projects/diffs/diff/types?oldBranchRef=main&newBranchRef=new&oldType=Ty
                 },
                 {
                     "annotation": {
-                        "contents": "#mft8mne9i92b6k4m512rn2608rsp6ilq4ejufeof6mbh5aintes4tih1fo93fospmu2t3f0h67uu0mrk2qj75o7k0lj1juefhaidt4g#d0",
+                        "contents": "#uik7pl3klg4u2obtf2fattdaeldui46ohmsi0knpp5hu8tn4d5o8vp570qgh7esgap0pmq9cfrh9dfg1r8qa7qh33g45a3tric24o20#d0",
                         "tag": "TermReference"
                     },
                     "segment": "Type"
@@ -780,7 +3572,7 @@ GET /api/projects/diffs/diff/types?oldBranchRef=main&newBranchRef=new&oldType=Ty
                 },
                 {
                     "annotation": {
-                        "contents": "#0tc9e438eurvtevfa6k9pg04qvv66is75hs8iqejkuoaef140g8vvu92hc1ks4gamgc3i1ukgdn0blchp3038l43vffijpsbjh14igo#d0",
+                        "contents": "#m5hlrmkn9a3kuqabta2e9qs934em1qmkotpsh9tjvta2u86nuesbjbk2k2sprbdiljq7uqibp49vku4gfpg2u60ceiv8net1f0bu2n8#d0",
                         "tag": "TermReference"
                     },
                     "segment": "Type"


### PR DESCRIPTION
## Overview

In a definition diff we tag changes where only the hash changed differently by emitting an annotationChange; but previously we would emit one for ANY annotation changes, even if the annotations were completely unrelated things. This restricts it so we only treat something as an annotation change if it's a hash change.

## Implementation notes

When collapsing annotation changes, check that both annotations are hashy syntax elements beforehand.

## Interesting/controversial decisions

Nah not really, talked it over with @hojberg 

## Test coverage

Added a regression test containing one of the examples where this got weird.
