### PR TITLE
clear latestTypecheckedFile on `update`

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
@@ -7,6 +7,7 @@ module Unison.Codebase.Editor.HandleInput.Update2
   )
 where
 
+import Control.Lens ((.=))
 import Control.Monad.RWS (ask)
 import Data.Bifoldable (bifoldMap)
 import Data.List qualified as List
@@ -148,6 +149,7 @@ handleUpdate2 = do
         (\typeName -> Right (Map.lookup typeName declNameLookup.declToConstructors))
         secondTuf
   Cli.stepAt "update" (path, Branch.batchUpdates branchUpdates)
+  #latestTypecheckedFile .= Nothing
 
   Cli.respond Output.Success
 

--- a/unison-src/transcripts/fix3424.md
+++ b/unison-src/transcripts/fix3424.md
@@ -1,0 +1,26 @@
+```ucm
+scratch/main> builtins.merge lib.builtins
+```
+
+```unison:hide
+a = do b
+b = "Hello, " ++ c ++ "!"
+c = "World"
+```
+
+```ucm
+scratch/main> add
+scratch/main> run a
+```
+
+```unison:hide
+a = do b
+c = "Unison"
+```
+
+```ucm
+scratch/main> update
+scratch/main> run a
+```
+
+The result should be "Hello, Unison!".

--- a/unison-src/transcripts/fix3424.output.md
+++ b/unison-src/transcripts/fix3424.output.md
@@ -1,0 +1,50 @@
+``` ucm
+scratch/main> builtins.merge lib.builtins
+
+  Done.
+
+```
+``` unison
+a = do b
+b = "Hello, " ++ c ++ "!"
+c = "World"
+```
+
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    a : 'Text
+    b : Text
+    c : Text
+
+scratch/main> run a
+
+  "Hello, World!"
+
+```
+``` unison
+a = do b
+c = "Unison"
+```
+
+``` ucm
+scratch/main> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
+
+  Done.
+
+scratch/main> run a
+
+  "Hello, World!"
+
+```
+The result should be "Hello, Unison\!".
+

--- a/unison-src/transcripts/fix3424.output.md
+++ b/unison-src/transcripts/fix3424.output.md
@@ -43,7 +43,7 @@ scratch/main> update
 
 scratch/main> run a
 
-  "Hello, World!"
+  "Hello, Unison!"
 
 ```
 The result should be "Hello, Unison\!".


### PR DESCRIPTION
## Overview

#3424 restated is:

> You have `a` calls `b` calls `c`, with `a` and `c` in the scratch file but `b` is not in the scratch file. You modify `c` and run update.
> 
> `a`, `b`, `c` will be updated correctly in the branch, but when you `run a` it will use the stale one from the Cli state and not the updated one. So it will not reflect the changes you just made to `c`, which is mystifying.
> 
> Your scratch file looks right and `view` looks right, but `run a` will call old code until you `load` again or restart ucm. 

This PR fixes the issue by clearing `latestTypecheckedFile` at the end of `update`.

## Test coverage

Diff of transcript output before and after the fix: https://github.com/unisonweb/unison/commit/c4f8ffcf399d59f80b7f17a2fd9a7f2fc8b0d9e9
