### PR TITLE
Fix non-deterministic sorting of rows in transcripts

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -3500,7 +3500,11 @@ getProjectReflog numEntries projectId =
       SELECT project_id, project_branch_id, time, from_root_causal_id, to_root_causal_id, reason
       FROM project_branch_reflog
       WHERE project_id = :projectId
-      ORDER BY time DESC
+      ORDER BY
+        time DESC,
+        -- Strictly for breaking ties in transcripts with the same time,
+        -- this will break ties in the correct order, sorting later inserted rows first.
+        ROWID DESC
       LIMIT :numEntries
     |]
 
@@ -3512,7 +3516,11 @@ getProjectBranchReflog numEntries projectBranchId =
       SELECT project_id, project_branch_id, time, from_root_causal_id, to_root_causal_id, reason
       FROM project_branch_reflog
       WHERE project_branch_id = :projectBranchId
-      ORDER BY time DESC
+      ORDER BY
+        time DESC,
+        -- Strictly for breaking ties in transcripts with the same time,
+        -- this will break ties in the correct order, sorting later inserted rows first.
+        ROWID DESC
       LIMIT :numEntries
     |]
 
@@ -3523,7 +3531,11 @@ getGlobalReflog numEntries =
     [sql|
       SELECT project_id, project_branch_id, time, from_root_causal_id, to_root_causal_id, reason
       FROM project_branch_reflog
-      ORDER BY time DESC
+      ORDER BY
+        time DESC,
+        -- Strictly for breaking ties in transcripts with the same time,
+        -- this will break ties in the correct order, sorting later inserted rows first.
+        ROWID DESC
       LIMIT :numEntries
     |]
 


### PR DESCRIPTION
## Overview

fixes  #5271

Results for the global reflog seem to be non-deterministic in transcripts :'( 
It seems unlikely, but the only reason I could think of for this to happen with the current ORDER BY is if two rows are inserted with an identical timestamp; maybe `getCurrentTime` returns the same time if called within a ms or something.

It's extremely unlikely this would ever occur outside of a transcript environment, but either way, just adding the ROWID as an additional sorting column guarantees they'll sort in insert order.

If we see this again we should assume there's some concurrency within the transcript runner (I did a quick scan and couldn't see any, even though we do use TVars for some reason) and look at sorting that out instead 👀 

## Implementation notes

Sort by RowID in addition to time.

## Test coverage

Unfortunately I can't force flakiness, so we'll just have to see if it comes back.

