### PR TITLE
merge API tweaks

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/CodeLookup.hs
+++ b/parser-typechecker/src/Unison/Codebase/CodeLookup.hs
@@ -8,6 +8,7 @@ import Unison.Prelude
 import Unison.Reference qualified as Reference
 import Unison.Term (Term)
 import Unison.Term qualified as Term
+import Unison.Util.Defns (Defns (..))
 import Unison.Util.Set qualified as Set
 import Unison.Var (Var)
 
@@ -56,7 +57,7 @@ transitiveDependencies code seen0 rid =
           getIds = Set.mapMaybe Reference.toId
        in getTerm code rid >>= \case
             Just t ->
-              foldM (transitiveDependencies code) seen (getIds $ Term.dependencies t)
+              foldM (transitiveDependencies code) seen (getIds $ let deps = Term.dependencies t in deps.terms <> deps.types)
             Nothing ->
               getTypeDeclaration code rid >>= \case
                 Nothing -> pure seen

--- a/parser-typechecker/src/Unison/FileParsers.hs
+++ b/parser-typechecker/src/Unison/FileParsers.hs
@@ -9,6 +9,7 @@ import Control.Lens
 import Control.Monad.State (evalStateT)
 import Data.Foldable qualified as Foldable
 import Data.List (partition)
+import Data.List qualified as List
 import Data.List.NonEmpty qualified as List.NonEmpty
 import Data.Map qualified as Map
 import Data.Sequence qualified as Seq
@@ -16,13 +17,14 @@ import Data.Set qualified as Set
 import Unison.ABT qualified as ABT
 import Unison.Blank qualified as Blank
 import Unison.Builtin qualified as Builtin
+import Unison.ConstructorReference qualified as ConstructorReference
 import Unison.Name qualified as Name
 import Unison.Names qualified as Names
 import Unison.NamesWithHistory qualified as Names
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
 import Unison.PrettyPrintEnv.Names qualified as PPE
-import Unison.Reference (Reference)
+import Unison.Reference (TermReference, TypeReference)
 import Unison.Referent qualified as Referent
 import Unison.Result (CompilerBug (..), Note (..), ResultT, pattern Result)
 import Unison.Result qualified as Result
@@ -37,6 +39,7 @@ import Unison.Typechecker.TypeLookup qualified as TL
 import Unison.UnisonFile (definitionLocation)
 import Unison.UnisonFile qualified as UF
 import Unison.UnisonFile.Names qualified as UF
+import Unison.Util.Defns (Defns (..), DefnsF)
 import Unison.Util.List qualified as List
 import Unison.Util.Relation qualified as Rel
 import Unison.Var (Var)
@@ -76,7 +79,7 @@ computeTypecheckingEnvironment ::
   (Var v, Monad m) =>
   ShouldUseTndr m ->
   [Type v] ->
-  (Set Reference -> m (TL.TypeLookup v Ann)) ->
+  (DefnsF Set TermReference TypeReference -> m (TL.TypeLookup v Ann)) ->
   UnisonFile v ->
   m (Typechecker.Env v Ann)
 computeTypecheckingEnvironment shouldUseTndr ambientAbilities typeLookupf uf =
@@ -99,8 +102,15 @@ computeTypecheckingEnvironment shouldUseTndr ambientAbilities typeLookupf uf =
                 let shortname = Name.unsafeParseVar v,
                 name `Name.endsWithReverseSegments` List.NonEmpty.toList (Name.reverseSegments shortname)
             ]
-          possibleRefs = Referent.toReference . view _3 <$> possibleDeps
-      tl <- fmap (UF.declsToTypeLookup uf <>) (typeLookupf (UF.dependencies uf <> Set.fromList possibleRefs))
+          possibleRefs =
+            List.foldl'
+              ( \acc -> \case
+                  (_, _, Referent.Con ref _) -> acc & over #types (Set.insert (ref ^. ConstructorReference.reference_))
+                  (_, _, Referent.Ref ref) -> acc & over #terms (Set.insert ref)
+              )
+              (Defns Set.empty Set.empty)
+              possibleDeps
+      tl <- fmap (UF.declsToTypeLookup uf <>) (typeLookupf (UF.dependencies uf <> possibleRefs))
       -- For populating the TDNR environment, we pick definitions
       -- from the namespace and from the local file whose full name
       -- has a suffix that equals one of the free variables in the file.
@@ -130,7 +140,7 @@ computeTypecheckingEnvironment shouldUseTndr ambientAbilities typeLookupf uf =
                 ]
       pure
         Typechecker.Env
-          { ambientAbilities = ambientAbilities,
+          { ambientAbilities,
             typeLookup = tl,
             termsByShortname = fqnsByShortName
           }

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Merge2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Merge2.hs
@@ -280,8 +280,6 @@ doMerge info = do
       mergedLibdeps <-
         Cli.runTransaction (libdepsToBranch0 (Codebase.getDeclType env.codebase) blob2.libdeps)
 
-      uniqueName <- liftIO env.generateUniqueName
-
       let hasConflicts =
             blob2.hasConflicts
 
@@ -307,7 +305,7 @@ doMerge info = do
       maybeBlob5 <-
         if hasConflicts
           then pure Nothing
-          else case Merge.makeMergeblob4 blob3 uniqueName of
+          else case Merge.makeMergeblob4 blob3 of
             Left _parseErr -> pure Nothing
             Right blob4 -> do
               typeLookup <- Cli.runTransaction (Codebase.typeLookupForDependencies env.codebase blob4.dependencies)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Run.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Run.hs
@@ -40,6 +40,7 @@ import Unison.Typechecker.TypeLookup qualified as TypeLookup
 import Unison.UnisonFile (TypecheckedUnisonFile)
 import Unison.UnisonFile qualified as UF
 import Unison.UnisonFile.Names qualified as UF
+import Unison.Util.Defns (Defns (..))
 import Unison.Var qualified as Var
 
 handleRun :: Bool -> HQ.HashQualified Name -> [String] -> Cli ()
@@ -124,7 +125,9 @@ getTerm' mainName =
         Cli.Env {codebase, runtime} <- ask
         case Typechecker.fitsScheme ty (Runtime.mainType runtime) of
           True -> do
-            typeLookup <- Cli.runTransaction (Codebase.typeLookupForDependencies codebase (Type.dependencies ty))
+            typeLookup <-
+              Cli.runTransaction $
+                Codebase.typeLookupForDependencies codebase Defns {terms = Set.empty, types = Type.dependencies ty}
             f $! synthesizeForce typeLookup ty
           False -> pure (TermHasBadType ty)
    in Cli.getLatestTypecheckedFile >>= \case

--- a/unison-cli/src/Unison/Codebase/Editor/SlurpComponent.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/SlurpComponent.hs
@@ -25,21 +25,22 @@ import Data.Set qualified as Set
 import Data.Tuple (swap)
 import Unison.DataDeclaration qualified as DD
 import Unison.Prelude hiding (empty)
-import Unison.Reference (Reference)
+import Unison.Reference (TypeReference)
 import Unison.Symbol (Symbol)
 import Unison.Term qualified as Term
 import Unison.UnisonFile (TypecheckedUnisonFile)
 import Unison.UnisonFile qualified as UF
+import Unison.Util.Defns (Defns (..))
 
 data SlurpComponent = SlurpComponent
   { types :: Set Symbol,
     terms :: Set Symbol,
     ctors :: Set Symbol
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Generic, Ord, Show)
 
 isEmpty :: SlurpComponent -> Bool
-isEmpty sc = Set.null (types sc) && Set.null (terms sc) && Set.null (ctors sc)
+isEmpty sc = Set.null sc.types && Set.null sc.terms && Set.null sc.ctors
 
 empty :: SlurpComponent
 empty = SlurpComponent {types = Set.empty, terms = Set.empty, ctors = Set.empty}
@@ -47,23 +48,23 @@ empty = SlurpComponent {types = Set.empty, terms = Set.empty, ctors = Set.empty}
 difference :: SlurpComponent -> SlurpComponent -> SlurpComponent
 difference c1 c2 = SlurpComponent {types = types', terms = terms', ctors = ctors'}
   where
-    types' = types c1 `Set.difference` types c2
-    terms' = terms c1 `Set.difference` terms c2
-    ctors' = ctors c1 `Set.difference` ctors c2
+    types' = c1.types `Set.difference` c2.types
+    terms' = c1.terms `Set.difference` c2.terms
+    ctors' = c1.ctors `Set.difference` c2.ctors
 
 intersection :: SlurpComponent -> SlurpComponent -> SlurpComponent
 intersection c1 c2 = SlurpComponent {types = types', terms = terms', ctors = ctors'}
   where
-    types' = types c1 `Set.intersection` types c2
-    terms' = terms c1 `Set.intersection` terms c2
-    ctors' = ctors c1 `Set.intersection` ctors c2
+    types' = c1.types `Set.intersection` c2.types
+    terms' = c1.terms `Set.intersection` c2.terms
+    ctors' = c1.ctors `Set.intersection` c2.ctors
 
 instance Semigroup SlurpComponent where
   c1 <> c2 =
     SlurpComponent
-      { types = types c1 <> types c2,
-        terms = terms c1 <> terms c2,
-        ctors = ctors c1 <> ctors c2
+      { types = c1.types <> c2.types,
+        terms = c1.terms <> c2.terms,
+        ctors = c1.ctors <> c2.ctors
       }
 
 instance Monoid SlurpComponent where
@@ -79,31 +80,30 @@ closeWithDependencies ::
   SlurpComponent
 closeWithDependencies uf inputs = seenDefns {ctors = constructorDeps}
   where
-    seenDefns = foldl' termDeps (SlurpComponent {terms = mempty, types = seenTypes, ctors = mempty}) (terms inputs)
-    seenTypes = foldl' typeDeps mempty (types inputs)
+    seenDefns = foldl' termDeps (SlurpComponent {terms = mempty, types = seenTypes, ctors = mempty}) inputs.terms
+    seenTypes = foldl' typeDeps mempty inputs.types
 
     constructorDeps :: Set Symbol
     constructorDeps = UF.constructorsForDecls seenTypes uf
 
     termDeps :: SlurpComponent -> Symbol -> SlurpComponent
-    termDeps seen v | Set.member v (terms seen) = seen
-    termDeps seen v = fromMaybe seen $ do
+    termDeps seen v | Set.member v seen.terms = seen
+    termDeps seen v = fromMaybe seen do
       term <- findTerm v
       let -- get the `v`s for the transitive dependency types
           -- (the ones for terms are just the `freeVars below`)
           -- although this isn't how you'd do it for a term that's already in codebase
           tdeps :: [Symbol]
-          tdeps = resolveTypes $ Term.dependencies term
+          tdeps = resolveTypes (Term.dependencies term).types
           seenTypes :: Set Symbol
-          seenTypes = foldl' typeDeps (types seen) tdeps
-          seenTerms = Set.insert v (terms seen)
+          seenTypes = foldl' typeDeps seen.types tdeps
+          seenTerms = Set.insert v seen.terms
       pure $
         foldl'
           termDeps
           ( seen
-              { types = seenTypes,
-                terms = seenTerms
-              }
+              & #types .~ seenTypes
+              & #terms .~ seenTerms
           )
           (Term.freeVars term)
 
@@ -115,7 +115,7 @@ closeWithDependencies uf inputs = seenDefns {ctors = constructorDeps}
           <|> fmap (DD.toDataDecl . snd) (Map.lookup v (UF.effectDeclarations' uf))
       pure $ foldl' typeDeps (Set.insert v seen) (resolveTypes $ DD.typeDependencies dd)
 
-    resolveTypes :: Set Reference -> [Symbol]
+    resolveTypes :: Set TypeReference -> [Symbol]
     resolveTypes rs = [v | r <- Set.toList rs, Just v <- [Map.lookup r typeNames]]
 
     findTerm :: Symbol -> Maybe (Term.Term Symbol a)
@@ -123,17 +123,17 @@ closeWithDependencies uf inputs = seenDefns {ctors = constructorDeps}
 
     allTerms = UF.allTerms uf
 
-    typeNames :: Map Reference Symbol
+    typeNames :: Map TypeReference Symbol
     typeNames = invert (fst <$> UF.dataDeclarations' uf) <> invert (fst <$> UF.effectDeclarations' uf)
 
     invert :: forall k v. (Ord k) => (Ord v) => Map k v -> Map v k
     invert m = Map.fromList (swap <$> Map.toList m)
 
 fromTypes :: Set Symbol -> SlurpComponent
-fromTypes vs = mempty {types = vs}
+fromTypes vs = SlurpComponent {terms = Set.empty, types = vs, ctors = Set.empty}
 
 fromTerms :: Set Symbol -> SlurpComponent
-fromTerms vs = mempty {terms = vs}
+fromTerms vs = SlurpComponent {terms = vs, types = Set.empty, ctors = Set.empty}
 
 fromCtors :: Set Symbol -> SlurpComponent
-fromCtors vs = mempty {ctors = vs}
+fromCtors vs = SlurpComponent {terms = Set.empty, types = Set.empty, ctors = vs}

--- a/unison-core/src/Unison/DataDeclaration.hs
+++ b/unison-core/src/Unison/DataDeclaration.hs
@@ -49,7 +49,7 @@ import Unison.LabeledDependency qualified as LD
 import Unison.Name qualified as Name
 import Unison.Names.ResolutionResult qualified as Names
 import Unison.Prelude
-import Unison.Reference (Reference)
+import Unison.Reference (Reference, TypeReference)
 import Unison.Reference qualified as Reference
 import Unison.Referent qualified as Referent
 import Unison.ReferentPrime qualified as Referent'
@@ -222,7 +222,7 @@ bindReferences unsafeVarToName keepFree names (DataDeclaration m a bound constru
 -- (unless the decl is self-referential)
 -- Note: Does NOT include the referents for fields and field accessors.
 -- Those must be computed separately because we need access to the typechecker to do so.
-typeDependencies :: (Ord v) => DataDeclaration v a -> Set Reference
+typeDependencies :: (Ord v) => DataDeclaration v a -> Set TypeReference
 typeDependencies dd =
   Set.unions (Type.dependencies <$> constructorTypes dd)
 

--- a/unison-core/src/Unison/Term.hs
+++ b/unison-core/src/Unison/Term.hs
@@ -8,6 +8,7 @@ import Control.Monad.State (evalState)
 import Control.Monad.State qualified as State
 import Control.Monad.Writer.Strict qualified as Writer
 import Data.Generics.Sum (_Ctor)
+import Data.List qualified as List
 import Data.Map qualified as Map
 import Data.Sequence qualified as Sequence
 import Data.Set qualified as Set
@@ -17,6 +18,7 @@ import Text.Show
 import Unison.ABT qualified as ABT
 import Unison.Blank qualified as B
 import Unison.ConstructorReference (ConstructorReference, GConstructorReference (..))
+import Unison.ConstructorReference qualified as ConstructorReference
 import Unison.ConstructorType qualified as CT
 import Unison.DataDeclaration.ConstructorId (ConstructorId)
 import Unison.HashQualified qualified as HQ
@@ -30,12 +32,13 @@ import Unison.NamesWithHistory qualified as Names
 import Unison.Pattern (Pattern)
 import Unison.Pattern qualified as Pattern
 import Unison.Prelude
-import Unison.Reference (Reference, TermReference, pattern Builtin)
+import Unison.Reference (Reference, TermReference, TypeReference, pattern Builtin)
 import Unison.Reference qualified as Reference
 import Unison.Referent (Referent)
 import Unison.Referent qualified as Referent
 import Unison.Type (Type)
 import Unison.Type qualified as Type
+import Unison.Util.Defns (Defns (..), DefnsF)
 import Unison.Util.List (multimap, validate)
 import Unison.Var (Var)
 import Unison.Var qualified as Var
@@ -1211,27 +1214,27 @@ unReqOrCtor (Request' r) = Just r
 unReqOrCtor _ = Nothing
 
 -- Dependencies including referenced data and effect decls
-dependencies :: (Ord v, Ord vt) => Term2 vt at ap v a -> Set Reference
-dependencies t = Set.map (LD.fold id Referent.toReference) (labeledDependencies t)
+dependencies :: (Ord v, Ord vt) => Term2 vt at ap v a -> DefnsF Set TermReference TypeReference
+dependencies =
+  List.foldl' f (Defns Set.empty Set.empty) . Set.toList . labeledDependencies
+  where
+    f ::
+      DefnsF Set TermReference TypeReference ->
+      LabeledDependency ->
+      DefnsF Set TermReference TypeReference
+    f deps = \case
+      LD.TermReferent (Referent.Con ref _) -> deps & over #types (Set.insert (ref ^. ConstructorReference.reference_))
+      LD.TermReferent (Referent.Ref ref) -> deps & over #terms (Set.insert ref)
+      LD.TypeReference ref -> deps & over #types (Set.insert ref)
 
 termDependencies :: (Ord v, Ord vt) => Term2 vt at ap v a -> Set TermReference
 termDependencies =
-  Set.fromList
-    . mapMaybe
-      ( LD.fold
-          (\_typeRef -> Nothing)
-          ( Referent.fold
-              (\termRef -> Just termRef)
-              (\_typeConRef _i _ct -> Nothing)
-          )
-      )
-    . toList
-    . labeledDependencies
+  (.terms) . dependencies
 
 -- gets types from annotations and constructors
 typeDependencies :: (Ord v, Ord vt) => Term2 vt at ap v a -> Set Reference
 typeDependencies =
-  Set.fromList . mapMaybe (LD.fold Just (const Nothing)) . toList . labeledDependencies
+  (.types) . dependencies
 
 -- Gets the types to which this term contains references via patterns and
 -- data constructors.

--- a/unison-merge/src/Unison/Merge/Mergeblob2.hs
+++ b/unison-merge/src/Unison/Merge/Mergeblob2.hs
@@ -14,7 +14,6 @@ import Unison.DeclNameLookup (DeclNameLookup)
 import Unison.Merge.EitherWay (EitherWay (..))
 import Unison.Merge.FindConflictedAlias (findConflictedAlias)
 import Unison.Merge.Mergeblob1 (Mergeblob1 (..))
-import Unison.Merge.PartialDeclNameLookup (PartialDeclNameLookup)
 import Unison.Merge.PartitionCombinedDiffs (narrowConflictsToNonBuiltins)
 import Unison.Merge.ThreeWay (ThreeWay)
 import Unison.Merge.ThreeWay qualified as ThreeWay
@@ -53,7 +52,6 @@ data Mergeblob2 libdep = Mergeblob2
             (TermReferenceId, (Term Symbol Ann, Type Symbol Ann))
             (TypeReferenceId, Decl Symbol Ann)
         ),
-    lcaDeclNameLookup :: PartialDeclNameLookup,
     libdeps :: Map NameSegment libdep,
     soloUpdatesAndDeletes :: TwoWay (DefnsF Set Name Name),
     unconflicts :: DefnsF Unconflicts Referent TypeReference
@@ -88,7 +86,6 @@ makeMergeblob2 blob = do
         -- Eh, they'd either both be null, or neither, but just check both maps anyway
         hasConflicts = not (defnsAreEmpty conflicts.alice) || not (defnsAreEmpty conflicts.bob),
         hydratedDefns = ThreeWay.forgetLca blob.hydratedDefns,
-        lcaDeclNameLookup = blob.lcaDeclNameLookup,
         libdeps = blob.libdeps,
         soloUpdatesAndDeletes,
         unconflicts = blob.unconflicts

--- a/unison-merge/src/Unison/Merge/Mergeblob4.hs
+++ b/unison-merge/src/Unison/Merge/Mergeblob4.hs
@@ -4,6 +4,7 @@ module Unison.Merge.Mergeblob4
   )
 where
 
+import Data.Map.Strict qualified as Map
 import Unison.Merge.Mergeblob3 (Mergeblob3 (..))
 import Unison.Names (Names (..))
 import Unison.Parser.Ann (Ann)
@@ -11,7 +12,7 @@ import Unison.Parsers qualified as Parsers
 import Unison.Prelude
 import Unison.Reference (Reference)
 import Unison.Symbol (Symbol)
-import Unison.Syntax.Parser (ParsingEnv (..), UniqueName)
+import Unison.Syntax.Parser (ParsingEnv (..))
 import Unison.Syntax.Parser qualified as Parser
 import Unison.UnisonFile (UnisonFile)
 import Unison.UnisonFile qualified as UnisonFile
@@ -24,18 +25,18 @@ data Mergeblob4 = Mergeblob4
     file :: UnisonFile Symbol Ann
   }
 
-makeMergeblob4 :: Mergeblob3 -> UniqueName -> Either (Parser.Err Symbol) Mergeblob4
-makeMergeblob4 blob uniqueName = do
+makeMergeblob4 :: Mergeblob3 -> Either (Parser.Err Symbol) Mergeblob4
+makeMergeblob4 blob = do
   let stageOneNames =
         Names (Relation.fromMap blob.stageOne.terms) (Relation.fromMap blob.stageOne.types) <> blob.libdeps
 
       parsingEnv =
         ParsingEnv
-          { uniqueNames = uniqueName,
-            -- The codebase names are disjoint from the file names, i.e. there aren't any things that
-            -- would be classified as an update upon parsing. So, there's no need to try to look up any
-            -- existing unique type GUIDs to reuse.
-            uniqueTypeGuid = \_ -> Identity Nothing,
+          { -- We don't expect to have to generate any new GUIDs, since the uniqueTypeGuid lookup function below should
+            -- cover all name in the merged file we're about to parse and typecheck. So, this might be more correct as a
+            -- call to `error`.
+            uniqueNames = Parser.UniqueName \_ _ -> Nothing,
+            uniqueTypeGuid = \name -> Identity (Map.lookup name blob.uniqueTypeGuids),
             names = stageOneNames
           }
   file <- runIdentity (Parsers.parseFile "<merge>" (Pretty.toPlain 80 blob.unparsedFile) parsingEnv)

--- a/unison-merge/src/Unison/Merge/Mergeblob4.hs
+++ b/unison-merge/src/Unison/Merge/Mergeblob4.hs
@@ -10,18 +10,18 @@ import Unison.Names (Names (..))
 import Unison.Parser.Ann (Ann)
 import Unison.Parsers qualified as Parsers
 import Unison.Prelude
-import Unison.Reference (Reference)
+import Unison.Reference (TermReference, TypeReference)
 import Unison.Symbol (Symbol)
 import Unison.Syntax.Parser (ParsingEnv (..))
 import Unison.Syntax.Parser qualified as Parser
 import Unison.UnisonFile (UnisonFile)
 import Unison.UnisonFile qualified as UnisonFile
-import Unison.Util.Defns (Defns (..))
+import Unison.Util.Defns (Defns (..), DefnsF)
 import Unison.Util.Pretty qualified as Pretty
 import Unison.Util.Relation qualified as Relation
 
 data Mergeblob4 = Mergeblob4
-  { dependencies :: Set Reference,
+  { dependencies :: DefnsF Set TermReference TypeReference,
     file :: UnisonFile Symbol Ann
   }
 

--- a/unison-src/transcripts/merge.output.md
+++ b/unison-src/transcripts/merge.output.md
@@ -1024,7 +1024,7 @@ Bob, meanwhile, first deletes the term, then sort of deletes the type and re-add
 ``` ucm
 project/bob> view Foo.Bar
 
-  type Foo.Bar = Hello Nat Nat | Baz Nat
+  type Foo.Bar = Baz Nat | Hello Nat Nat
 
 ```
 At this point, Bob and alice have both updated the name `Foo.Bar.Hello` in different ways, so that's a conflict. Therefore, Bob's entire type (`Foo.Bar` with constructors `Foo.Bar.Baz` and `Foo.Bar.Hello`) gets rendered into the scratch file.
@@ -1061,7 +1061,7 @@ Foo.Bar.Hello : Nat
 Foo.Bar.Hello = 18
 
 -- project/bob
-type Foo.Bar = Hello Nat Nat | Baz Nat
+type Foo.Bar = Baz Nat | Hello Nat Nat
 
 ```
 

--- a/unison-syntax/src/Unison/Syntax/Parser.hs
+++ b/unison-syntax/src/Unison/Syntax/Parser.hs
@@ -9,7 +9,7 @@ module Unison.Syntax.Parser
     Input (..),
     P,
     ParsingEnv (..),
-    UniqueName(..),
+    UniqueName (..),
     anyToken,
     blank,
     bytesToken,

--- a/unison-syntax/src/Unison/Syntax/Parser.hs
+++ b/unison-syntax/src/Unison/Syntax/Parser.hs
@@ -9,7 +9,7 @@ module Unison.Syntax.Parser
     Input (..),
     P,
     ParsingEnv (..),
-    UniqueName,
+    UniqueName(..),
     anyToken,
     blank,
     bytesToken,


### PR DESCRIPTION
## Overview

This PR contains a small number of tweaks to the merge API from the last round of review:

1. Reuse unique type GUIDs rather than make up new ones.
2. Remove requirement to provide a `UniqueName` to the parser.
3. Distinguish between term and type dependencies (for the step of merge that needs to make a `TypeLookup`.

Other misc cleanup: deleted a couple unused record fields.