### PR TITLE
Change handling of “blank” identifiers

### DIFF
--- a/unison-core/src/Unison/Name.hs
+++ b/unison-core/src/Unison/Name.hs
@@ -32,6 +32,7 @@ module Unison.Name
     parent,
     stripNamePrefix,
     unqualified,
+    isUnqualified,
 
     -- * To organize later
     commonPrefix,
@@ -503,6 +504,11 @@ suffixFrom (Name p0 ss0) (Name _ ss1) = do
 unqualified :: Name -> Name
 unqualified (Name _ (s :| _)) =
   Name Relative (s :| [])
+
+isUnqualified :: Name -> Bool
+isUnqualified = \case
+  Name Relative (_ :| []) -> True
+  Name _ (_ :| _) -> False
 
 -- Tries to shorten `fqn` to the smallest suffix that still unambiguously refers to the same name. Uses an efficient
 -- logarithmic lookup in the provided relation.

--- a/unison-src/transcripts/fix2822.md
+++ b/unison-src/transcripts/fix2822.md
@@ -1,0 +1,53 @@
+# Inability to reference a term or type with a name that has segments starting with an underscore
+
+```ucm:hide
+scratch/main> builtins.mergeio
+```
+
+There should be no issue having terms with an underscore-led component
+
+```unison
+_a.blah = 2
+
+b = _a.blah + 1
+```
+
+Or even that _are_ a single “blank” component
+
+```unison
+_b = 2
+
+x = _b + 1
+```
+Types can also have underscore-led components.
+
+```unison
+unique type _a.Blah = A
+
+c : _a.Blah
+c = A
+```
+
+And we should also be able to access underscore-led fields.
+
+```unison
+type Hello = {_value : Nat}
+
+doStuff = _value.modify
+```
+
+But pattern matching shouldn’t bind to underscore-led names.
+
+```unison:error
+dontMap f = cases
+  None -> false
+  Some _used -> f _used
+```
+
+But we can use them as unbound patterns.
+
+```unison
+dontMap f = cases
+  None -> false
+  Some _unused -> f 2
+```

--- a/unison-src/transcripts/fix2822.output.md
+++ b/unison-src/transcripts/fix2822.output.md
@@ -1,0 +1,49 @@
+# Inability to reference a term or type with a name that has segments starting with an underscore
+
+There should be no issue having terms with an underscore-led component
+
+``` unison
+_a.blah = 2
+
+b = _a.blah + 1
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I couldn't figure out what .blah refers to here:
+  
+      3 | b = _a.blah + 1
+  
+  I also don't know what type it should be.
+  
+  Some common causes of this error include:
+    * Your current namespace is too deep to contain the
+      definition in its subtree
+    * The definition is part of a library which hasn't been
+      added to this project
+    * You have a typo in the name
+
+```
+
+
+
+🛑
+
+The transcript failed due to an error in the stanza above. The error is:
+
+
+  I couldn't figure out what .blah refers to here:
+  
+      3 | b = _a.blah + 1
+  
+  I also don't know what type it should be.
+  
+  Some common causes of this error include:
+    * Your current namespace is too deep to contain the
+      definition in its subtree
+    * The definition is part of a library which hasn't been
+      added to this project
+    * You have a typo in the name
+

--- a/unison-src/transcripts/fix2822.output.md
+++ b/unison-src/transcripts/fix2822.output.md
@@ -12,9 +12,101 @@ b = _a.blah + 1
 
   Loading changes detected in scratch.u.
 
-  I couldn't figure out what .blah refers to here:
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
   
-      3 | b = _a.blah + 1
+    ⍟ These new definitions are ok to `add`:
+    
+      _a.blah : Nat
+      b       : Nat
+
+```
+Or even that *are* a single “blank” component
+
+``` unison
+_b = 2
+
+x = _b + 1
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      _b : Nat
+      x  : Nat
+
+```
+Types can also have underscore-led components.
+
+``` unison
+unique type _a.Blah = A
+
+c : _a.Blah
+c = A
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      type _a.Blah
+      c : Blah
+
+```
+And we should also be able to access underscore-led fields.
+
+``` unison
+type Hello = {_value : Nat}
+
+doStuff = _value.modify
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      type Hello
+      Hello._value        : Hello -> Nat
+      Hello._value.modify : (Nat ->{g} Nat) -> Hello ->{g} Hello
+      Hello._value.set    : Nat -> Hello -> Hello
+      doStuff             : (Nat ->{g} Nat) -> Hello ->{g} Hello
+
+```
+But pattern matching shouldn’t bind to underscore-led names.
+
+``` unison
+dontMap f = cases
+  None -> false
+  Some _used -> f _used
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I couldn't figure out what _used refers to here:
+  
+      3 |   Some _used -> f _used
   
   I also don't know what type it should be.
   
@@ -26,24 +118,24 @@ b = _a.blah + 1
     * You have a typo in the name
 
 ```
+But we can use them as unbound patterns.
 
+``` unison
+dontMap f = cases
+  None -> false
+  Some _unused -> f 2
+```
 
+``` ucm
 
-🛑
+  Loading changes detected in scratch.u.
 
-The transcript failed due to an error in the stanza above. The error is:
-
-
-  I couldn't figure out what .blah refers to here:
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
   
-      3 | b = _a.blah + 1
-  
-  I also don't know what type it should be.
-  
-  Some common causes of this error include:
-    * Your current namespace is too deep to contain the
-      definition in its subtree
-    * The definition is part of a library which hasn't been
-      added to this project
-    * You have a typo in the name
+    ⍟ These new definitions are ok to `add`:
+    
+      dontMap : (Nat ->{g} Boolean) -> Optional a ->{g} Boolean
 
+```

--- a/unison-syntax/src/Unison/Syntax/Parser.hs
+++ b/unison-syntax/src/Unison/Syntax/Parser.hs
@@ -288,8 +288,8 @@ isBlank n = Name.isUnqualified n && Text.isPrefixOf "_" (INameSegment.toUnescape
 -- | A HQ Name is blank when its Name is blank and it has no hash.
 isBlank' :: HQ'.HashQualified Name -> Bool
 isBlank' = \case
-    HQ'.NameOnly n -> isBlank n
-    HQ'.HashQualified _ _ -> False
+  HQ'.NameOnly n -> isBlank n
+  HQ'.HashQualified _ _ -> False
 
 wordyPatternName :: (Var v) => P v m (L.Token v)
 wordyPatternName = queryToken \case


### PR DESCRIPTION
## Overview

The proximate bug was that the lexer for `Blank` would “steal” the first segment of an identifier. E.g., `_a.blah` would be lexed as `[Blank "a", WordyId ".blah"]`, rather than `[WordyId "_a.blah"]`. However, fixing that directly was fragile, and left other cases like the one in #4681.

Also, most uses of `Blank` exactly mirrored `WordyId`, often rebuilding the original segment.

This PR removes the `Blank` token, instead treating it as any other `WordyId`. The parser now checks identifiers for “blankness” as needed.

Fixes #2822.

## Implementation notes

There were two places that treated `Blank` differently than `WordyId`, and those are preserved. There were also two places where a “true” `Blank` (`_`) was treated differently than a suffixed`Blank` (`_withSomeSuffix`), and those have been eliminated.

I considered storing “blankness” in an extra field of `WordyId`, but that suffers from boolean blindness and also means that it’s possible to create inconsistent terms (e.g., `WordyId IsBlank "definitely.not.blank"`).

## Test coverage

There is a new transcript with examples pulled from both #2822 and #4681, as well as other coverage I thought was useful.