### PR TITLE
Improve transcript runner output

### DIFF
--- a/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
+++ b/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
@@ -300,16 +300,21 @@ run isTest verbosity dir stanzas codebase runtime sbRuntime nRuntime config ucmV
             _ <- liftIO (writeIORef mStanza maybeStanza)
             case maybeStanza of
               Nothing -> do
-                liftIO (putStrLn "")
+                liftIO (putStrLn "\r✔️   Completed transcript.                   ")
                 pure $ Right QuitI
-              Just (s, idx) -> do
+              Just (s, midx) -> do
                 unless (Verbosity.isSilent verbosity) . liftIO $ do
                   putStr $
-                    "\r⚙️   Processing stanza "
-                      ++ show idx
-                      ++ " of "
-                      ++ show (length stanzas)
-                      ++ "."
+                    maybe
+                      "\r⏩   Skipping non-executable Markdown block."
+                      ( \idx ->
+                          "\r⚙️   Processing stanza "
+                            ++ show idx
+                            ++ " of "
+                            ++ show (length stanzas)
+                            ++ ".          "
+                      )
+                      midx
                   IO.hFlush IO.stdout
                 either
                   ( \node -> do

--- a/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
+++ b/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
@@ -299,11 +299,13 @@ run isTest verbosity dir stanzas codebase runtime sbRuntime nRuntime config ucmV
             maybeStanza <- atomically (Q.tryDequeue inputQueue)
             _ <- liftIO (writeIORef mStanza maybeStanza)
             case maybeStanza of
-              Nothing -> do
-                liftIO (putStrLn "\r✔️   Completed transcript.                   ")
+              Nothing -> liftIO do
+                clearCurrentLine
+                putStrLn "\r✔️   Completed transcript."
                 pure $ Right QuitI
               Just (s, midx) -> do
                 unless (Verbosity.isSilent verbosity) . liftIO $ do
+                  clearCurrentLine
                   putStr $
                     maybe
                       "\r⏩   Skipping non-executable Markdown block."
@@ -312,7 +314,7 @@ run isTest verbosity dir stanzas codebase runtime sbRuntime nRuntime config ucmV
                             ++ show idx
                             ++ " of "
                             ++ show (length stanzas)
-                            ++ ".          "
+                            ++ "."
                       )
                       midx
                   IO.hFlush IO.stdout


### PR DESCRIPTION
## Overview

Previously, it would output messages like

    ⚙️   Processing stanza Just 6 of 7.

and

    ⚙️   Processing stanza Nothing of 7.

which was especially confusing when there was text or some other non-Unison block at the end of the transcript.

Now the messages look like

    ⏩   Skipping non-executable Markdown block.
    ⚙️   Processing stanza 6 of 7.
    ✔️   Completed transcript.

## Interesting/controversial decisions

The one shortcoming is that I don’t know how to clear the line after the carriage return, so I added whitespace padding to make sure the previous messages get overwritten.

## Test coverage

I’ve only tested this by hand.