### PR TITLE
Fix dev-ui-install.sh

### DIFF
--- a/dev-ui-install.sh
+++ b/dev-ui-install.sh
@@ -1,3 +1,6 @@
+#!/usr/bin/env sh
+set -eu
+
 echo "This script downloads the latest Unison Local UI release"
 echo "and puts it in the correct spot next to the unison"
 echo "executable built by stack."
@@ -7,4 +10,4 @@ stack build
 curl -L https://github.com/unisonweb/unison-local-ui/releases/download/latest/unisonLocal.zip --output unisonLocal.zip
 parent_dir="$(dirname -- $(stack exec which unison))"
 mkdir -p "$parent_dir/ui"
-unzip -o unisonLocal.zip -d "$parent_dir/ui"
+unzip -q -o unisonLocal.zip -d "$parent_dir/ui"


### PR DESCRIPTION
## Overview

I ran into this when i tried running it in a non-POSIX shell. Nothing happened. Bash, when asked to run a script without a shebang will interpret it itself, while other shells behave differently (and I think this even depends on the OS – BSD (like macOS) & Linux handle `execvp` differently).

This adds a shebang and some “strict” settings.

## Test coverage

I only tested this by hand.