### PR TITLE
Numbers binary notation

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -87,3 +87,4 @@ The format for this list: name, GitHub handle
 * Dan Doel (@dolio)
 * Eric Torreborre (@etorreborre)
 * Eduard Nicodei (@neduard)
+* Ruslan Simchuk (@SimaDovakin)

--- a/editor-support/vim/syntax/unison.vim
+++ b/editor-support/vim/syntax/unison.vim
@@ -48,7 +48,7 @@ syn match   uSpecialCharError	contained "\\&\|'''\+"
 syn region  uString		start=+"+  skip=+\\\\\|\\"+  end=+"+  contains=uSpecialChar
 syn match   uCharacter		"[^a-zA-Z0-9_']'\([^\\]\|\\[^']\+\|\\'\)'"lc=1 contains=uSpecialChar,uSpecialCharError
 syn match   uCharacter		"^'\([^\\]\|\\[^']\+\|\\'\)'" contains=uSpecialChar,uSpecialCharError
-syn match   uNumber		"\<[0-9]\+\>\|\<0[xX][0-9a-fA-F]\+\>\|\<0[oO][0-7]\+\>|\<0b[01]\+\>"
+syn match   uNumber		"\<[0-9]\+\>\|\<0[xX][0-9a-fA-F]\+\>\|\<0[oO][0-7]\+\>\|\<0b[01]\+\>"
 syn match   uFloat		"\<[0-9]\+\.[0-9]\+\([eE][-+]\=[0-9]\+\)\=\>"
 
 " Keyword definitions. These must be patterns instead of keywords

--- a/editor-support/vim/syntax/unison.vim
+++ b/editor-support/vim/syntax/unison.vim
@@ -48,7 +48,7 @@ syn match   uSpecialCharError	contained "\\&\|'''\+"
 syn region  uString		start=+"+  skip=+\\\\\|\\"+  end=+"+  contains=uSpecialChar
 syn match   uCharacter		"[^a-zA-Z0-9_']'\([^\\]\|\\[^']\+\|\\'\)'"lc=1 contains=uSpecialChar,uSpecialCharError
 syn match   uCharacter		"^'\([^\\]\|\\[^']\+\|\\'\)'" contains=uSpecialChar,uSpecialCharError
-syn match   uNumber		"\<[0-9]\+\>\|\<0[xX][0-9a-fA-F]\+\>\|\<0[oO][0-7]\+\>"
+syn match   uNumber		"\<[0-9]\+\>\|\<0[xX][0-9a-fA-F]\+\>\|\<0[oO][0-7]\+\>|\<0b[01]\+\>"
 syn match   uFloat		"\<[0-9]\+\.[0-9]\+\([eE][-+]\=[0-9]\+\)\=\>"
 
 " Keyword definitions. These must be patterns instead of keywords
@@ -83,7 +83,7 @@ syn region  uDocDirective     contained matchgroup=unisonDocDirective start="\(@
 
 syn match uDebug "\<\(todo\|bug\|Debug.trace\)\>"
 
-" things like 
+" things like
 "    > my_func 1 3
 "    test> Function.tap.tests.t1 = check let
 "      use Nat == +
@@ -101,7 +101,7 @@ if version >= 508 || !exists("did_u_syntax_inits")
   else
     command -nargs=+ HiLink hi def link <args>
   endif
-   
+
    HiLink       uWatch                           Debug
    HiLink       uDocMono                         Delimiter
    HiLink       unisonDocDirective               Import

--- a/editor-support/vim/syntax/unison.vim
+++ b/editor-support/vim/syntax/unison.vim
@@ -48,7 +48,7 @@ syn match   uSpecialCharError	contained "\\&\|'''\+"
 syn region  uString		start=+"+  skip=+\\\\\|\\"+  end=+"+  contains=uSpecialChar
 syn match   uCharacter		"[^a-zA-Z0-9_']'\([^\\]\|\\[^']\+\|\\'\)'"lc=1 contains=uSpecialChar,uSpecialCharError
 syn match   uCharacter		"^'\([^\\]\|\\[^']\+\|\\'\)'" contains=uSpecialChar,uSpecialCharError
-syn match   uNumber		"\<[0-9]\+\>\|\<0[xX][0-9a-fA-F]\+\>\|\<0[oO][0-7]\+\>\|\<0b[01]\+\>"
+syn match   uNumber		"\<[0-9]\+\>\|\<0[xX][0-9a-fA-F]\+\>\|\<0[oO][0-7]\+\>\|\<0[bB][01]\+\>"
 syn match   uFloat		"\<[0-9]\+\.[0-9]\+\([eE][-+]\=[0-9]\+\)\=\>"
 
 " Keyword definitions. These must be patterns instead of keywords

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -1427,6 +1427,18 @@ renderParseErrors s = \case
                   <> "after the"
                   <> Pr.group (style ErrorSite "0o" <> ".")
             ]
+        L.InvalidBinaryLiteral ->
+          Pr.lines
+            [ "This number isn't valid syntax: ",
+              "",
+              excerpt,
+              Pr.wrap $
+                "I was expecting only binary characters"
+                  <> "(one of"
+                  <> Pr.group (style Code "01" <> ")")
+                  <> "after the"
+                  <> Pr.group (style ErrorSite "0b" <> ".")
+            ]
         L.InvalidShortHash h ->
           Pr.lines
             [ "Invalid hash: " <> style ErrorSite (fromString h),

--- a/unison-src/transcripts/error-messages.md
+++ b/unison-src/transcripts/error-messages.md
@@ -27,7 +27,7 @@ x = 1e- -- missing an exponent
 x = 1E+ -- missing an exponent
 ```
 
-### Hex, octal, and bytes literals
+### Hex, octal, binary, and bytes literals
 
 ```unison:error
 x = 0xoogabooga -- invalid hex chars

--- a/unison-src/transcripts/error-messages.md
+++ b/unison-src/transcripts/error-messages.md
@@ -38,6 +38,10 @@ x = 0o987654321 -- 9 and 8 are not valid octal char
 ```
 
 ```unison:error
+x = 0b3201 -- 3 and 2 are not valid binary chars
+```
+
+```unison:error
 x = 0xsf -- odd number of hex chars in a bytes literal
 ```
 
@@ -81,7 +85,7 @@ foo = cases
 ```unison:error
 -- Missing a '->'
 x = match Some a with
-      None -> 
+      None ->
         1
       Some _
         2

--- a/unison-src/transcripts/error-messages.output.md
+++ b/unison-src/transcripts/error-messages.output.md
@@ -70,7 +70,7 @@ x = 1E+ -- missing an exponent
   `1e+37`.
 
 ```
-### Hex, octal, and bytes literals
+### Hex, octal, binary, and bytes literals
 
 ``` unison
 x = 0xoogabooga -- invalid hex chars

--- a/unison-src/transcripts/error-messages.output.md
+++ b/unison-src/transcripts/error-messages.output.md
@@ -105,6 +105,22 @@ x = 0o987654321 -- 9 and 8 are not valid octal char
 
 ```
 ``` unison
+x = 0b3201 -- 3 and 2 are not valid binary chars
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  This number isn't valid syntax: 
+  
+      1 | x = 0b3201 -- 3 and 2 are not valid binary chars
+  
+  I was expecting only binary characters (one of 01) after the
+  0b.
+
+```
+``` unison
 x = 0xsf -- odd number of hex chars in a bytes literal
 ```
 
@@ -245,7 +261,7 @@ foo = cases
 ``` unison
 -- Missing a '->'
 x = match Some a with
-      None -> 
+      None ->
         1
       Some _
         2


### PR DESCRIPTION
## Overview

This PR adds support for the binary notation for Nat and Int types (e.g., `0b101`, `-0b11`). At first, I added a binary literal in the transcript that had invalid binary characters in the middle of the literal (e.g., `0b1210`), and I got this error:
```
This looks like a function call, but with a Nat where the function should be. Are you missing an operator?
```
But the same error is thrown with hexadecimal and octal notations. So I assumed that this is an expected behavior for now. Also, I added syntax highlighting for Vim. I found that Atom's config doesn't distinguish number notations. Did I miss something?

In addition, I have to add binary notation in documentation for Nat and Int in Unison Share, right?
