### PR TITLE
Turn a possible “impossible” into a parse failure

### DIFF
--- a/unison-syntax/src/Unison/Syntax/Lexer/Unison.hs
+++ b/unison-syntax/src/Unison/Syntax/Lexer/Unison.hs
@@ -203,7 +203,9 @@ token'' tok p = do
             else
               if column p < top l
                 then S.put (env {layout = pop l}) >> ((Token Close p p :) <$> pops p)
-                else error "impossible"
+                else -- we hit this branch exactly when `token''` is given the state
+                -- `{layout = [], opening = Nothing, inLayout = True}`
+                  fail "internal error: token''"
 
     -- don't emit virtual semis in (, {, or [ blocks
     topContainsVirtualSemis :: Layout -> Bool


### PR DESCRIPTION
## Overview

From #5179, there’s a case where we hit an `error "impossible"`, which doesn’t provide much context. This turns it into a parse failure, so we have #thte state of the lexer when this happens again. It also adds a comment that describes when this “impossible” case gets hit.

## Test coverage

No coverage – this is to improve the diagnostics when this case gets hit again.

## Loose ends

Ormolu is bad at formatting comments on conditional branches.
