### PR TITLE
Support pattern matching on empty types

### DIFF
--- a/parser-typechecker/src/Unison/PatternMatchCoverage/Desugar.hs
+++ b/parser-typechecker/src/Unison/PatternMatchCoverage/Desugar.hs
@@ -3,7 +3,6 @@ module Unison.PatternMatchCoverage.Desugar
   )
 where
 
-import Data.List.NonEmpty (NonEmpty (..))
 import U.Core.ABT qualified as ABT
 import Unison.Pattern
 import Unison.Pattern qualified as Pattern
@@ -25,7 +24,7 @@ desugarMatch ::
   -- | scrutinee variable
   v ->
   -- | match cases
-  NonEmpty (MatchCase loc (Term' vt v loc)) ->
+  [MatchCase loc (Term' vt v loc)] ->
   m (GrdTree (PmGrd vt v loc) loc)
 desugarMatch scrutineeType v0 cs0 = Fork <$> traverse desugarClause cs0
   where

--- a/parser-typechecker/src/Unison/PatternMatchCoverage/GrdTree.hs
+++ b/parser-typechecker/src/Unison/PatternMatchCoverage/GrdTree.hs
@@ -10,8 +10,6 @@ module Unison.PatternMatchCoverage.GrdTree
   )
 where
 
-import Data.List.NonEmpty (NonEmpty (..))
-import Data.List.NonEmpty qualified as NEL
 import Data.ListLike (ListLike)
 import Unison.PatternMatchCoverage.Fix
 import Unison.Prelude
@@ -55,7 +53,7 @@ data GrdTreeF n l a
   | -- | A constraint of some kind (structural pattern match, boolan guard, etc)
     GrdF n a
   | -- | A list of alternative matches, tried in order
-    ForkF (NonEmpty a)
+    ForkF [a]
   deriving stock (Functor, Show)
 
 prettyGrdTree :: forall n l s. (ListLike s Char, IsString s) => (n -> Pretty s) -> (l -> Pretty s) -> GrdTree n l -> Pretty s
@@ -64,7 +62,7 @@ prettyGrdTree prettyNode prettyLeaf = cata phi
     phi = \case
       LeafF l -> prettyLeaf l
       GrdF n rest -> sep " " [prettyNode n, "──", rest]
-      ForkF xs -> "──" <> group (sep "\n" (makeTree $ NEL.toList xs))
+      ForkF xs -> "──" <> group (sep "\n" $ makeTree xs)
     makeTree :: [Pretty s] -> [Pretty s]
     makeTree = \case
       [] -> []
@@ -82,7 +80,7 @@ pattern Leaf x = Fix (LeafF x)
 pattern Grd :: n -> GrdTree n l -> GrdTree n l
 pattern Grd x rest = Fix (GrdF x rest)
 
-pattern Fork :: NonEmpty (GrdTree n l) -> GrdTree n l
+pattern Fork :: [GrdTree n l] -> GrdTree n l
 pattern Fork alts = Fix (ForkF alts)
 
 {-# COMPLETE Leaf, Grd, Fork #-}

--- a/parser-typechecker/src/Unison/PatternMatchCoverage/Solve.hs
+++ b/parser-typechecker/src/Unison/PatternMatchCoverage/Solve.hs
@@ -16,7 +16,6 @@ import Data.Foldable
 import Data.Function
 import Data.Functor
 import Data.Functor.Compose
-import Data.List.NonEmpty (NonEmpty (..))
 import Data.Map qualified as Map
 import Data.Sequence qualified as Seq
 import Data.Set qualified as Set
@@ -74,12 +73,11 @@ uncoverAnnotate z grdtree0 = cata phi grdtree0 z
       LeafF l -> \nc -> do
         nc' <- ensureInhabited' nc
         pure (Set.empty, Leaf (nc', l))
-      ForkF (kinit :| ks) -> \nc0 -> do
+      ForkF ks -> \nc0 -> do
         -- depth-first fold in match-case order to acculate the
         -- constraints for a match failure at every case.
-        (nc1, t1) <- kinit nc0
-        (ncfinal, ts) <- foldlM (\(nc, ts) a -> a nc >>= \(nc', t) -> pure (nc', t : ts)) (nc1, []) ks
-        pure (ncfinal, Fork (t1 :| reverse ts))
+        (ncfinal, ts) <- foldlM (\(nc, ts) a -> a nc >>= \(nc', t) -> pure (nc', t : ts)) (nc0, []) ks
+        pure (ncfinal, Fork $ reverse ts)
       GrdF grd k -> \nc0 -> case grd of
         PmEffect var con convars -> handleGrd (PosEffect var (Effect con) convars) (NegEffect var (Effect con)) k nc0
         PmEffectPure var resume -> handleGrd (PosEffect var NoEffect [resume]) (NegEffect var NoEffect) k nc0

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -1774,21 +1774,6 @@ renderParseErrors s = \case
                 tokenAsErrorSite s tok
               ]
        in (msg, [rangeForToken tok])
-    go (Parser.EmptyMatch tok) =
-      let msg =
-            Pr.indentN 2 . Pr.callout "😶" $
-              Pr.lines
-                [ Pr.wrap
-                    ( "I expected some patterns after a "
-                        <> style ErrorSite "match"
-                        <> "/"
-                        <> style ErrorSite "with"
-                        <> " or cases but I didn't find any."
-                    ),
-                  "",
-                  tokenAsErrorSite s tok
-                ]
-       in (msg, [rangeForToken tok])
     go (Parser.EmptyWatch tok) =
       let msg =
             Pr.lines

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -1526,10 +1526,8 @@ ensurePatternCoverage theMatch _theMatchType _scrutinee scrutineeType cases = do
           }
   (redundant, _inaccessible, uncovered) <- flip evalStateT pmcState do
     checkMatch scrutineeType cases
-  let checkUncovered = case Nel.nonEmpty uncovered of
-        Nothing -> pure ()
-        Just xs -> failWith (UncoveredPatterns matchLoc xs)
-      checkRedundant = foldr (\a b -> failWith (RedundantPattern a) *> b) (pure ()) redundant
+  let checkUncovered = maybe (pure ()) (failWith . UncoveredPatterns matchLoc) $ Nel.nonEmpty uncovered
+      checkRedundant = foldr ((*>) . failWith . RedundantPattern) (pure ()) redundant
   checkUncovered *> checkRedundant
 
 checkCases ::

--- a/unison-src/transcripts/error-messages.output.md
+++ b/unison-src/transcripts/error-messages.output.md
@@ -191,13 +191,12 @@ foo = match 1 with
 
   Loading changes detected in scratch.u.
 
-    😶
-    
-    I expected some patterns after a match / with or cases but I
-    didn't find any.
-    
+  Pattern match doesn't cover all possible cases:
         2 | foo = match 1 with
     
+  
+  Patterns not matched:
+   * _
 
 ```
 ``` unison

--- a/unison-src/transcripts/fix4731.md
+++ b/unison-src/transcripts/fix4731.md
@@ -1,0 +1,33 @@
+```unison
+structural type Void =
+```
+
+```ucm
+scratch/main> add
+```
+
+We should be able to `match` on empty types like `Void`.
+
+```unison
+Void.absurdly : '{e} Void ->{e} a
+Void.absurdly v = match !v with
+```
+
+```unison
+Void.absurdly : Void -> a
+Void.absurdly v = match v with
+```
+
+And empty `cases` should also work.
+
+```unison
+Void.absurdly : Void -> a
+Void.absurdly = cases
+```
+
+But empty function bodies are not allowed.
+
+```unison:error
+Void.absurd : Void -> a
+Void.absurd x =
+```

--- a/unison-src/transcripts/fix4731.output.md
+++ b/unison-src/transcripts/fix4731.output.md
@@ -34,28 +34,66 @@ Void.absurdly v = match !v with
 
   Loading changes detected in scratch.u.
 
-    😶
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
     
-    I expected some patterns after a match / with or cases but I
-    didn't find any.
-    
-        2 | Void.absurdly v = match !v with
-    
+      Void.absurdly : '{e} Void ->{e} a
 
 ```
+``` unison
+Void.absurdly : Void -> a
+Void.absurdly v = match v with
+```
 
+``` ucm
 
+  Loading changes detected in scratch.u.
 
-🛑
-
-The transcript failed due to an error in the stanza above. The error is:
-
-
-    😶
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
     
-    I expected some patterns after a match / with or cases but I
-    didn't find any.
-    
-        2 | Void.absurdly v = match !v with
-    
+      Void.absurdly : Void -> a
 
+```
+And empty `cases` should also work.
+
+``` unison
+Void.absurdly : Void -> a
+Void.absurdly = cases
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      Void.absurdly : Void -> a
+
+```
+But empty function bodies are not allowed.
+
+``` unison
+Void.absurd : Void -> a
+Void.absurd x =
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I expected a block after this (in red), but there wasn't one.  Maybe check your indentation:
+      2 | Void.absurd x =
+  
+
+```

--- a/unison-src/transcripts/fix4731.output.md
+++ b/unison-src/transcripts/fix4731.output.md
@@ -1,0 +1,61 @@
+``` unison
+structural type Void =
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      structural type Void
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    structural type Void
+
+```
+We should be able to `match` on empty types like `Void`.
+
+``` unison
+Void.absurdly : '{e} Void ->{e} a
+Void.absurdly v = match !v with
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+    😶
+    
+    I expected some patterns after a match / with or cases but I
+    didn't find any.
+    
+        2 | Void.absurdly v = match !v with
+    
+
+```
+
+
+
+🛑
+
+The transcript failed due to an error in the stanza above. The error is:
+
+
+    😶
+    
+    I expected some patterns after a match / with or cases but I
+    didn't find any.
+    
+        2 | Void.absurdly v = match !v with
+    
+

--- a/unison-syntax/src/Unison/Parser/Ann.hs
+++ b/unison-syntax/src/Unison/Parser/Ann.hs
@@ -29,6 +29,7 @@ startingLine _ = Nothing
 instance Monoid Ann where
   mempty = External
 
+-- | This instance is commutative.
 instance Semigroup Ann where
   Ann s1 e1 <> Ann s2 e2 = Ann (min s1 s2) (max e1 e2)
   -- If we have a concrete location from a file, use it

--- a/unison-syntax/src/Unison/Syntax/Parser.hs
+++ b/unison-syntax/src/Unison/Syntax/Parser.hs
@@ -164,8 +164,6 @@ data Error v
   | UnknownType (L.Token (HQ.HashQualified Name)) (Set Reference)
   | UnknownId (L.Token (HQ.HashQualified Name)) (Set Referent) (Set Reference)
   | ExpectedBlockOpen String (L.Token L.Lexeme)
-  | -- | Indicates a cases or match/with which doesn't have any patterns
-    EmptyMatch (L.Token ())
   | EmptyWatch Ann
   | UseInvalidPrefixSuffix (Either (L.Token Name) (L.Token Name)) (Maybe [L.Token Name])
   | UseEmpty (L.Token String) -- an empty `use` statement


### PR DESCRIPTION
## Overview

Previously, `match` and `cases` expressions needed to have at least one pattern to match on. This allows them to work with zero patterns, which is useful for matching on empty types.

Since `EmptyMatch` is no longer a failure case, errors that previously said “I expected some patterns after a match / with or cases but I didn't find any,” now say “Pattern match doesn't cover all possible cases”.

Fixes #4731.

## Test coverage

There is a new transcript that covers the new cases. The existing error-messages transcript captures the change in error message with empty `cases` that are applied to non-empty types.