### PR TITLE
Kill Configurator

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -52,7 +52,6 @@ These are listed in alphabetical order.
 | [comonad-5.0.6](https://hackage.haskell.org/package/comonad-5.0.6) | [BSD3](https://hackage.haskell.org/package/comonad-5.0.6/src/LICENSE) |
 | [concurrent-supply-0.1.8](https://hackage.haskell.org/package/concurrent-supply-0.1.8) | [BSD3](https://hackage.haskell.org/package/concurrent-supply-0.1.8/src/LICENSE) |
 | [conduit-1.3.2](https://hackage.haskell.org/package/conduit-1.3.2) | [MIT](https://hackage.haskell.org/package/conduit-1.3.2/src/LICENSE) |
-| [configurator-0.3.0.0](https://hackage.haskell.org/package/configurator-0.3.0.0) | [BSD3](https://hackage.haskell.org/package/configurator-0.3.0.0/src/LICENSE) |
 | [containers-0.6.2.1](https://hackage.haskell.org/package/containers-0.6.2.1) | [BSD3](https://hackage.haskell.org/package/containers-0.6.2.1/src/LICENSE) |
 | [contravariant-1.5.2](https://hackage.haskell.org/package/contravariant-1.5.2) | [BSD3](https://hackage.haskell.org/package/contravariant-1.5.2/src/LICENSE) |
 | [cryptohash-md5-0.11.100.1](https://hackage.haskell.org/package/cryptohash-md5-0.11.100.1) | [BSD3](https://hackage.haskell.org/package/cryptohash-md5-0.11.100.1/src/LICENSE) |

--- a/contrib/cabal.project
+++ b/contrib/cabal.project
@@ -38,11 +38,6 @@ packages:
 
 source-repository-package
   type: git
-  location: https://github.com/unisonweb/configurator.git
-  tag: e47e9e9fe1f576f8c835183b9def52d73c01327a
-
-source-repository-package
-  type: git
   location: https://github.com/unisonweb/haskeline.git
   tag: 9275eea7982dabbf47be2ba078ced669ae7ef3d5
 

--- a/nix/unison-project.nix
+++ b/nix/unison-project.nix
@@ -25,7 +25,6 @@ in
       }
     ];
     branchMap = {
-      "https://github.com/unisonweb/configurator.git"."e47e9e9fe1f576f8c835183b9def52d73c01327a" = "unison";
       "https://github.com/unisonweb/shellmet.git"."2fd348592c8f51bb4c0ca6ba4bc8e38668913746" = "topic/avoid-callCommand";
     };
   }

--- a/parser-typechecker/package.yaml
+++ b/parser-typechecker/package.yaml
@@ -37,7 +37,6 @@ dependencies:
   - cereal
   - clock
   - concurrent-output
-  - configurator
   - containers >= 0.6.3
   - cryptonite
   - data-default

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -242,7 +242,6 @@ library
     , cereal
     , clock
     , concurrent-output
-    , configurator
     , containers >=0.6.3
     , crypton-x509
     , crypton-x509-store
@@ -437,7 +436,6 @@ test-suite parser-typechecker-tests
     , clock
     , code-page
     , concurrent-output
-    , configurator
     , containers >=0.6.3
     , crypton-x509
     , crypton-x509-store

--- a/stack.yaml
+++ b/stack.yaml
@@ -51,9 +51,6 @@ packages:
 resolver: lts-22.26
 
 extra-deps:
-  # broken version in snapshot
-  - github: unisonweb/configurator
-    commit: e47e9e9fe1f576f8c835183b9def52d73c01327a
   # This custom Haskeline alters ANSI rendering on Windows.
   # If changing the haskeline dependency, please ensure color renders properly in a
   # Windows terminal.

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,17 +5,6 @@
 
 packages:
 - completed:
-    name: configurator
-    pantry-tree:
-      sha256: 90547cd983fd15ebdc803e057d3ef8735fe93a75e29a00f8a74eadc13ee0f6e9
-      size: 955
-    sha256: d4fd87fb7bfc5d8e9fbc3e4ee7302c6b1500cdc00fdb9b659d0f4849b6ebe2d5
-    size: 15989
-    url: https://github.com/unisonweb/configurator/archive/e47e9e9fe1f576f8c835183b9def52d73c01327a.tar.gz
-    version: 0.3.0.0
-  original:
-    url: https://github.com/unisonweb/configurator/archive/e47e9e9fe1f576f8c835183b9def52d73c01327a.tar.gz
-- completed:
     name: haskeline
     pantry-tree:
       sha256: c14fd8b9ad5e9fcf629e50affe26e655d6c4d18c3f77169995b857b5fd32ca44

--- a/unison-cli/package.yaml
+++ b/unison-cli/package.yaml
@@ -23,7 +23,6 @@ dependencies:
   - co-log-core
   - code-page
   - concurrent-output
-  - configurator
   - containers >= 0.6.3
   - cryptonite
   - directory

--- a/unison-cli/src/Unison/Cli/Monad.hs
+++ b/unison-cli/src/Unison/Cli/Monad.hs
@@ -62,7 +62,6 @@ import Control.Lens
 import Control.Monad.Reader (MonadReader (..))
 import Control.Monad.State.Strict (MonadState)
 import Control.Monad.State.Strict qualified as State
-import Data.Configurator.Types qualified as Configurator
 import Data.List.NonEmpty qualified as List (NonEmpty)
 import Data.List.NonEmpty qualified as List.NonEmpty
 import Data.List.NonEmpty qualified as NonEmpty
@@ -160,7 +159,6 @@ type SourceName = Text
 data Env = Env
   { authHTTPClient :: AuthenticatedHttpClient,
     codebase :: Codebase IO Symbol Ann,
-    config :: Configurator.Config,
     credentialManager :: CredentialManager,
     -- | Generate a unique name.
     generateUniqueName :: IO Parser.UniqueName,

--- a/unison-cli/src/Unison/Cli/MonadUtils.hs
+++ b/unison-cli/src/Unison/Cli/MonadUtils.hs
@@ -1,10 +1,7 @@
 -- | This module contains miscellaneous helper utils for rote actions in the Cli monad, like resolving a relative path
 -- to an absolute path, per the current path.
 module Unison.Cli.MonadUtils
-  ( -- * @.unisonConfig@ things
-    getConfig,
-
-    -- * Paths
+  ( -- * Paths
     getCurrentPath,
     getCurrentProjectName,
     getCurrentProjectBranchName,
@@ -88,8 +85,6 @@ where
 import Control.Lens
 import Control.Monad.Reader (ask)
 import Control.Monad.State
-import Data.Configurator qualified as Configurator
-import Data.Configurator.Types qualified as Configurator
 import Data.Foldable
 import Data.Set qualified as Set
 import U.Codebase.Branch qualified as V2 (Branch)
@@ -137,15 +132,6 @@ import Unison.UnisonFile qualified as UF
 import Unison.UnisonFile.Names qualified as UFN
 import Unison.Util.Set qualified as Set
 import Unison.Var qualified as Var
-
-------------------------------------------------------------------------------------------------------------------------
--- .unisonConfig things
-
--- | Lookup a config value by key.
-getConfig :: (Configurator.Configured a) => Text -> Cli (Maybe a)
-getConfig key = do
-  Cli.Env {config} <- ask
-  liftIO (Configurator.lookup config key)
 
 ------------------------------------------------------------------------------------------------------------------------
 -- Getting paths, path resolution, etc.

--- a/unison-cli/src/Unison/CommandLine.hs
+++ b/unison-cli/src/Unison/CommandLine.hs
@@ -6,7 +6,6 @@ module Unison.CommandLine
   ( allow,
     parseInput,
     prompt,
-    watchConfig,
     watchFileSystem,
   )
 where
@@ -15,9 +14,6 @@ import Control.Concurrent (forkIO, killThread)
 import Control.Lens hiding (aside)
 import Control.Monad.Except
 import Control.Monad.Trans.Except
-import Data.Configurator (autoConfig, autoReload)
-import Data.Configurator qualified as Config
-import Data.Configurator.Types (Config, Worth (..))
 import Data.List (isPrefixOf, isSuffixOf)
 import Data.Map qualified as Map
 import Data.Semialign qualified as Align
@@ -50,22 +46,11 @@ import Unison.Util.TQueue qualified as Q
 import UnliftIO.STM
 import Prelude hiding (readFile, writeFile)
 
-disableWatchConfig :: Bool
-disableWatchConfig = False
-
 allow :: FilePath -> Bool
 allow p =
   -- ignore Emacs .# prefixed files, see https://github.com/unisonweb/unison/issues/457
   not (".#" `isPrefixOf` takeFileName p)
     && (isSuffixOf ".u" p || isSuffixOf ".uu" p)
-
-watchConfig :: FilePath -> IO (Config, IO ())
-watchConfig path =
-  if disableWatchConfig
-    then pure (Config.empty, pure ())
-    else do
-      (config, t) <- autoReload autoConfig [Optional path]
-      pure (config, killThread t)
 
 watchFileSystem :: Q.TQueue Event -> FilePath -> IO (IO ())
 watchFileSystem q dir = do

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -9,7 +9,6 @@ import Control.Exception (catch, displayException, finally, mask)
 import Control.Lens ((?~))
 import Control.Lens.Lens
 import Crypto.Random qualified as Random
-import Data.Configurator.Types (Config)
 import Data.IORef
 import Data.List.NonEmpty qualified as NEL
 import Data.List.NonEmpty qualified as NonEmpty
@@ -124,7 +123,6 @@ main ::
   FilePath ->
   Welcome.Welcome ->
   PP.ProjectPathIds ->
-  Config ->
   [Either Event Input] ->
   Runtime.Runtime Symbol ->
   Runtime.Runtime Symbol ->
@@ -135,7 +133,7 @@ main ::
   (PP.ProjectPathIds -> IO ()) ->
   ShouldWatchFiles ->
   IO ()
-main dir welcome ppIds config initialInputs runtime sbRuntime nRuntime codebase serverBaseUrl ucmVersion lspCheckForChanges shouldWatchFiles = Ki.scoped \scope -> do
+main dir welcome ppIds initialInputs runtime sbRuntime nRuntime codebase serverBaseUrl ucmVersion lspCheckForChanges shouldWatchFiles = Ki.scoped \scope -> do
   _ <- Ki.fork scope do
     -- Pre-load the project root in the background so it'll be ready when a command needs it.
     projectRoot <- Codebase.expectProjectBranchRoot codebase ppIds.project ppIds.branch
@@ -221,7 +219,6 @@ main dir welcome ppIds config initialInputs runtime sbRuntime nRuntime codebase 
         Cli.Env
           { authHTTPClient,
             codebase,
-            config,
             credentialManager,
             loadSource = loadSourceFile,
             writeSource = writeSourceFile,

--- a/unison-cli/tests/Unison/Test/Ucm.hs
+++ b/unison-cli/tests/Unison/Test/Ucm.hs
@@ -67,7 +67,7 @@ runTranscript (Codebase codebasePath fmt) transcript = do
   let err e = fail $ "Parse error: \n" <> show e
       cbInit = case fmt of CodebaseFormat2 -> SC.init
       isTest = True
-  Transcript.withRunner isTest Verbosity.Silent "Unison.Test.Ucm.runTranscript Invalid Version String" rtp configFile $
+  Transcript.withRunner isTest Verbosity.Silent "Unison.Test.Ucm.runTranscript Invalid Version String" rtp $
     \runner -> do
       result <- Codebase.Init.withOpenCodebase cbInit "transcript" codebasePath SC.DoLock SC.DontMigrate \codebase -> do
         Codebase.runTransaction codebase (Codebase.installUcmDependencies codebase)
@@ -77,7 +77,6 @@ runTranscript (Codebase codebasePath fmt) transcript = do
         pure output
       either (fail . P.toANSI 80 . P.shown) pure result
   where
-    configFile = Nothing
     -- Note: this needs to be properly configured if these tests ever
     -- need to do native compiles. But I suspect they won't.
     rtp = "native-compiler/bin"

--- a/unison-cli/transcripts/Transcripts.hs
+++ b/unison-cli/transcripts/Transcripts.hs
@@ -49,7 +49,7 @@ testBuilder ::
 testBuilder expectFailure recordFailure runtimePath dir prelude transcript = scope transcript $ do
   outputs <- io . withTemporaryUcmCodebase SC.init Verbosity.Silent "transcript" SC.DoLock $ \(codebasePath, codebase) -> do
     let isTest = True
-    Transcript.withRunner isTest Verbosity.Silent "TODO: pass version here" runtimePath Nothing \runTranscript -> do
+    Transcript.withRunner isTest Verbosity.Silent "TODO: pass version here" runtimePath \runTranscript -> do
       for files \filePath -> do
         transcriptSrc <- readUtf8 filePath
         out <- silence $ runTranscript filePath transcriptSrc (codebasePath, codebase)

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -205,7 +205,6 @@ library
     , co-log-core
     , code-page
     , concurrent-output
-    , configurator
     , containers >=0.6.3
     , cryptonite
     , directory
@@ -347,7 +346,6 @@ executable transcripts
     , co-log-core
     , code-page
     , concurrent-output
-    , configurator
     , containers >=0.6.3
     , cryptonite
     , directory
@@ -496,7 +494,6 @@ test-suite cli-tests
     , co-log-core
     , code-page
     , concurrent-output
-    , configurator
     , containers >=0.6.3
     , cryptonite
     , directory


### PR DESCRIPTION
## Overview

Realized we weren't actually using the codebase config for anything anymore.

AFAIK most maintainers aren't much a fan of configurator and we've talked in the past about replacing it. Getting rid of it now seems like an auspicious plan so we're actually motivated to replace it with something better if/when we need to.

For codebase-level config it seems like we've been leaning towards just putting things in SQLite, but could also just use TOML, YAML or JSON or w/e

As a bonus, getting rid of this removes a file-watch thread and means we don't need to parse the config on every startup.

## Implementation notes

Wipe out configurator entirely.