### PR TITLE
bugfix: fix suffixification logic in update

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
@@ -325,16 +325,18 @@ makePPE ::
   Names ->
   DefnsF (Map Name) TermReferenceId TypeReferenceId ->
   PrettyPrintEnvDecl
-makePPE hashLen names initialFileNames dependents =
+makePPE hashLen namespaceNames initialFileNames dependents =
   PPED.addFallback
-    (PPED.makeFilePPED (initialFileNames <> Names.fromUnconflictedReferenceIds dependents))
+    ( let names = initialFileNames <> Names.fromUnconflictedReferenceIds dependents
+       in PPED.makePPED (PPE.namer names) (PPE.suffixifyByName (Names.shadowing names namespaceNames))
+    )
     ( PPED.makePPED
-        (PPE.hqNamer hashLen names)
+        (PPE.hqNamer hashLen namespaceNames)
         -- We don't want to over-suffixify for a reference in the namespace. For example, say we have "foo.bar" in the
         -- namespace and "oink.bar" in the file. "bar" may be a unique suffix among the namespace names, but would be
         -- ambiguous in the context of namespace + file names.
         --
         -- So, we use `shadowing`, which starts with the LHS names (the namespace), and adds to it names from the
         -- RHS (the initial file names, i.e. what was originally saved) that don't already exist in the LHS.
-        (PPE.suffixifyByHash (Names.shadowing names initialFileNames))
+        (PPE.suffixifyByHash (Names.shadowing namespaceNames initialFileNames))
     )

--- a/unison-src/transcripts/fix-5276.md
+++ b/unison-src/transcripts/fix-5276.md
@@ -19,6 +19,6 @@ scratch/main> add
 x = 100
 ```
 
-```ucm:error
+```ucm
 scratch/main> update
 ```

--- a/unison-src/transcripts/fix-5276.md
+++ b/unison-src/transcripts/fix-5276.md
@@ -1,0 +1,24 @@
+```ucm
+scratch/main> builtins.merge lib.builtin
+```
+
+```unison
+x = 17
+
+a.y = 18
+b.y = x + 1
+
+c = b.y + 1
+```
+
+```ucm
+scratch/main> add
+```
+
+```unison
+x = 100
+```
+
+```ucm:error
+scratch/main> update
+```

--- a/unison-src/transcripts/fix-5276.output.md
+++ b/unison-src/transcripts/fix-5276.output.md
@@ -1,0 +1,91 @@
+``` ucm
+scratch/main> builtins.merge lib.builtin
+
+  Done.
+
+```
+``` unison
+x = 17
+
+a.y = 18
+b.y = x + 1
+
+c = b.y + 1
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      a.y : Nat
+      b.y : Nat
+      c   : Nat
+      x   : Nat
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    a.y : Nat
+    b.y : Nat
+    c   : Nat
+    x   : Nat
+
+```
+``` unison
+x = 100
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      x : Nat
+
+```
+``` ucm
+scratch/main> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Typechecking failed. I've updated your scratch file with the
+  definitions that need fixing. Once the file is compiling, try
+  `update` again.
+
+```
+``` unison:added-by-ucm scratch.u
+x = 100
+
+-- The definitions below no longer typecheck with the changes above.
+-- Please fix the errors and try `update` again.
+
+b.y : Nat
+b.y =
+  use Nat +
+  x + 1
+
+c : Nat
+c =
+  use Nat +
+  y + 1
+
+```
+

--- a/unison-src/transcripts/fix-5276.output.md
+++ b/unison-src/transcripts/fix-5276.output.md
@@ -66,26 +66,8 @@ scratch/main> update
 
   That's done. Now I'm making sure everything typechecks...
 
-  Typechecking failed. I've updated your scratch file with the
-  definitions that need fixing. Once the file is compiling, try
-  `update` again.
+  Everything typechecks, so I'm saving the results...
+
+  Done.
 
 ```
-``` unison:added-by-ucm scratch.u
-x = 100
-
--- The definitions below no longer typecheck with the changes above.
--- Please fix the errors and try `update` again.
-
-b.y : Nat
-b.y =
-  use Nat +
-  x + 1
-
-c : Nat
-c =
-  use Nat +
-  y + 1
-
-```
-


### PR DESCRIPTION
## Overview

The name suffixification logic in `update` was not properly updated for the new parsing logic implemented in #5276. This PR fixes that.

## Test coverage

I've added a failing test in the first commit that is fixed by the second.