### PR TITLE
temporarily disable failing Nix workflow

### DIFF
--- a/.github/workflows/nix-dev-cache.yaml
+++ b/.github/workflows/nix-dev-cache.yaml
@@ -21,7 +21,7 @@ jobs:
         os:
           - ubuntu-20.04
           - macOS-12
-          - macOS-14
+          # - macOS-14
     steps:
     - uses: actions/checkout@v4
     - name: mount Nix store on larger partition


### PR DESCRIPTION
It's running out of disk space on macOS-14 and eating up all the runners.