### PR TITLE
bugfix: make the term parser consider `lower.Upper` a constructor

### DIFF
--- a/parser-typechecker/src/Unison/Syntax/TermParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermParser.hs
@@ -350,7 +350,7 @@ parsePattern = label "pattern" root
                   pure (Set.findMin s <$ tok)
               | otherwise -> die names tok s
       where
-        isLower = Text.all Char.isLower . Text.take 1 . Name.toText
+        isLower = Text.all Char.isLower . Text.take 1 . NameSegment.toUnescapedText . Name.lastSegment
         isIgnored n = Text.take 1 (Name.toText n) == "_"
         die :: Names -> L.Token (HQ.HashQualified Name) -> Set ConstructorReference -> P v m a
         die names hq s = case L.payload hq of

--- a/unison-src/transcripts/fix-5320.md
+++ b/unison-src/transcripts/fix-5320.md
@@ -1,0 +1,8 @@
+```ucm
+scratch/main> builtins.merge lib.builtin
+```
+
+```unison
+foo = cases
+    bar.Baz -> 5
+```

--- a/unison-src/transcripts/fix-5320.md
+++ b/unison-src/transcripts/fix-5320.md
@@ -2,7 +2,7 @@
 scratch/main> builtins.merge lib.builtin
 ```
 
-```unison
+```unison:error
 foo = cases
     bar.Baz -> 5
 ```

--- a/unison-src/transcripts/fix-5320.output.md
+++ b/unison-src/transcripts/fix-5320.output.md
@@ -1,0 +1,24 @@
+``` ucm
+scratch/main> builtins.merge lib.builtin
+
+  Done.
+
+```
+``` unison
+foo = cases
+    bar.Baz -> 5
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      foo : q1533035nd1 -> Nat
+
+```

--- a/unison-src/transcripts/fix-5320.output.md
+++ b/unison-src/transcripts/fix-5320.output.md
@@ -13,12 +13,17 @@ foo = cases
 
   Loading changes detected in scratch.u.
 
-  I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
   
-    ⍟ These new definitions are ok to `add`:
+    ❓
     
-      foo : q1533035nd1 -> Nat
+    I couldn't resolve any of these symbols:
+    
+        2 |     bar.Baz -> 5
+    
+    
+    Symbol    Suggestions
+              
+    bar.Baz   No matches
+  
 
 ```


### PR DESCRIPTION
## Overview

Fixes #5320

## Test coverage

I've added a transcript that demonstrates the fix