### PR TITLE
bugfix: pretty printer should prefer direct dependencies

### DIFF
--- a/unison-src/transcripts/fix-5267.md
+++ b/unison-src/transcripts/fix-5267.md
@@ -3,10 +3,7 @@ scratch/main> builtins.merge lib.builtin
 ```
 
 ```unison
-lib.direct.foo : Nat
 lib.direct.foo = 17
-
-lib.direct.lib.indirect.foo : Nat
 lib.direct.lib.indirect.foo = 18
 
 bar : Nat
@@ -19,4 +16,18 @@ indirect dependency. It used to render as `direct.foo + direct.foo`.
 ```ucm
 scratch/main> add
 scratch/main> view bar
+```
+
+Same test, but for types.
+
+```unison
+type lib.direct.Foo = MkFoo
+type lib.direct.lib.indirect.Foo = MkFoo
+
+type Bar = MkBar direct.Foo
+```
+
+```ucm
+scratch/main> add
+scratch/main> view Bar
 ```

--- a/unison-src/transcripts/fix-5267.md
+++ b/unison-src/transcripts/fix-5267.md
@@ -13,7 +13,8 @@ bar : Nat
 bar = direct.foo + direct.foo
 ```
 
-Here, `bar` should render as `foo + foo`, but it renders as `direct.foo + direct.foo`.
+Here, `bar` renders as `foo + foo`, even though there are two names with suffix `foo` in scope, because one is an
+indirect dependency. It used to render as `direct.foo + direct.foo`.
 
 ```ucm
 scratch/main> add

--- a/unison-src/transcripts/fix-5267.md
+++ b/unison-src/transcripts/fix-5267.md
@@ -1,0 +1,21 @@
+```ucm:hide
+scratch/main> builtins.merge lib.builtin
+```
+
+```unison
+lib.direct.foo : Nat
+lib.direct.foo = 17
+
+lib.direct.lib.indirect.foo : Nat
+lib.direct.lib.indirect.foo = 18
+
+bar : Nat
+bar = direct.foo + direct.foo
+```
+
+Here, `bar` should render as `foo + foo`, but it renders as `direct.foo + direct.foo`.
+
+```ucm
+scratch/main> add
+scratch/main> view bar
+```

--- a/unison-src/transcripts/fix-5267.output.md
+++ b/unison-src/transcripts/fix-5267.output.md
@@ -13,9 +13,9 @@ bar = direct.foo + direct.foo
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
-
+  
     ⍟ These new definitions are ok to `add`:
-
+    
       bar                         : Nat
       lib.direct.foo              : Nat
       lib.direct.lib.indirect.foo : Nat
@@ -28,7 +28,7 @@ indirect dependency. It used to render as `direct.foo + direct.foo`.
 scratch/main> add
 
   ⍟ I've added these definitions:
-
+  
     bar                         : Nat
     lib.direct.foo              : Nat
     lib.direct.lib.indirect.foo : Nat
@@ -57,9 +57,9 @@ type Bar = MkBar direct.Foo
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
-
+  
     ⍟ These new definitions are ok to `add`:
-
+    
       type Bar
       type lib.direct.Foo
       type lib.direct.lib.indirect.Foo
@@ -69,7 +69,7 @@ type Bar = MkBar direct.Foo
 scratch/main> add
 
   ⍟ I've added these definitions:
-
+  
     type Bar
     type lib.direct.Foo
     type lib.direct.lib.indirect.Foo
@@ -78,17 +78,4 @@ scratch/main> view Bar
 
   type Bar = MkBar Foo
 
-scratch/main> edit Bar
-
-  ☝️
-
-  I added 1 definitions to the top of scratch.u
-
-  You can edit them there, then run `update` to replace the
-  definitions currently in this namespace.
-
 ```
-``` unison:added-by-ucm scratch.u
-type Bar = MkBar Foo
-```
-

--- a/unison-src/transcripts/fix-5267.output.md
+++ b/unison-src/transcripts/fix-5267.output.md
@@ -1,8 +1,5 @@
 ``` unison
-lib.direct.foo : Nat
 lib.direct.foo = 17
-
-lib.direct.lib.indirect.foo : Nat
 lib.direct.lib.indirect.foo = 18
 
 bar : Nat
@@ -16,9 +13,9 @@ bar = direct.foo + direct.foo
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
-  
+
     ⍟ These new definitions are ok to `add`:
-    
+
       bar                         : Nat
       lib.direct.foo              : Nat
       lib.direct.lib.indirect.foo : Nat
@@ -31,7 +28,7 @@ indirect dependency. It used to render as `direct.foo + direct.foo`.
 scratch/main> add
 
   ⍟ I've added these definitions:
-  
+
     bar                         : Nat
     lib.direct.foo              : Nat
     lib.direct.lib.indirect.foo : Nat
@@ -44,3 +41,54 @@ scratch/main> view bar
     foo + foo
 
 ```
+Same test, but for types.
+
+``` unison
+type lib.direct.Foo = MkFoo
+type lib.direct.lib.indirect.Foo = MkFoo
+
+type Bar = MkBar direct.Foo
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+
+    ⍟ These new definitions are ok to `add`:
+
+      type Bar
+      type lib.direct.Foo
+      type lib.direct.lib.indirect.Foo
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+
+    type Bar
+    type lib.direct.Foo
+    type lib.direct.lib.indirect.Foo
+
+scratch/main> view Bar
+
+  type Bar = MkBar Foo
+
+scratch/main> edit Bar
+
+  ☝️
+
+  I added 1 definitions to the top of scratch.u
+
+  You can edit them there, then run `update` to replace the
+  definitions currently in this namespace.
+
+```
+``` unison:added-by-ucm scratch.u
+type Bar = MkBar Foo
+```
+

--- a/unison-src/transcripts/fix-5267.output.md
+++ b/unison-src/transcripts/fix-5267.output.md
@@ -1,0 +1,46 @@
+``` unison
+lib.direct.foo : Nat
+lib.direct.foo = 17
+
+lib.direct.lib.indirect.foo : Nat
+lib.direct.lib.indirect.foo = 18
+
+bar : Nat
+bar = direct.foo + direct.foo
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      bar                         : Nat
+      lib.direct.foo              : Nat
+      lib.direct.lib.indirect.foo : Nat
+
+```
+Here, `bar` should render as `foo + foo`, but it renders as `direct.foo + direct.foo`.
+
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    bar                         : Nat
+    lib.direct.foo              : Nat
+    lib.direct.lib.indirect.foo : Nat
+
+scratch/main> view bar
+
+  bar : Nat
+  bar =
+    use Nat +
+    use direct foo
+    foo + foo
+
+```

--- a/unison-src/transcripts/fix-5267.output.md
+++ b/unison-src/transcripts/fix-5267.output.md
@@ -24,7 +24,8 @@ bar = direct.foo + direct.foo
       lib.direct.lib.indirect.foo : Nat
 
 ```
-Here, `bar` should render as `foo + foo`, but it renders as `direct.foo + direct.foo`.
+Here, `bar` renders as `foo + foo`, even though there are two names with suffix `foo` in scope, because one is an
+indirect dependency. It used to render as `direct.foo + direct.foo`.
 
 ``` ucm
 scratch/main> add
@@ -40,7 +41,6 @@ scratch/main> view bar
   bar : Nat
   bar =
     use Nat +
-    use direct foo
     foo + foo
 
 ```


### PR DESCRIPTION
## Overview

Fixes #5267

This PR gets the pretty printer in sync with the parser with respect to the preference for terms and types that are not indirect dependencies.

Now, a suffix `foo` that matches one local definition (outside `lib`) or one direct dependency (inside `lib` but outside `lib.*.lib`) will resolve to that definition, regardless of how many indirect dependencies (inside `lib.*.lib.*`) it also matches.

## Test coverage

I've added a transcript.