### PR TITLE
bugfix: fix name resolution logic bug related to indirect dependencies

### DIFF
--- a/unison-core/src/Unison/Names.hs
+++ b/unison-core/src/Unison/Names.hs
@@ -50,9 +50,12 @@ module Unison.Names
     hashQualifyTermsRelation,
     fromTermsAndTypes,
     lenientToNametree,
+    resolveName,
   )
 where
 
+import Control.Lens (_2)
+import Data.List qualified as List
 import Data.Map qualified as Map
 import Data.Semialign (alignWith)
 import Data.Set qualified as Set
@@ -68,6 +71,7 @@ import Unison.LabeledDependency qualified as LD
 import Unison.Name (Name)
 import Unison.Name qualified as Name
 import Unison.NameSegment (NameSegment)
+import Unison.Names.ResolvesTo (ResolvesTo (..))
 import Unison.Prelude
 import Unison.Reference (Reference, TermReference, TermReferenceId, TypeReference, TypeReferenceId)
 import Unison.Reference qualified as Reference
@@ -208,10 +212,11 @@ restrictReferences refs Names {..} = Names terms' types'
 -- e.g. @shadowing scratchFileNames codebaseNames@
 shadowing :: Names -> Names -> Names
 shadowing a b =
-  Names (shadowing a.terms b.terms) (shadowing a.types b.types)
-  where
-    shadowing xs ys =
-      Relation.fromMultimap (Map.unionWith (\x _ -> x) (Relation.domain xs) (Relation.domain ys))
+  Names (shadowing1 a.terms b.terms) (shadowing1 a.types b.types)
+
+shadowing1 :: (Ord a, Ord b) => Relation a b -> Relation a b -> Relation a b
+shadowing1 xs ys =
+  Relation.fromMultimap (Map.unionWith (\x _ -> x) (Relation.domain xs) (Relation.domain ys))
 
 -- | TODO: get this from database. For now it's a constant.
 numHashChars :: Int
@@ -497,3 +502,32 @@ lenientToNametree names =
       -- The partial `Set.findMin` is fine here because Relation.domain only has non-empty Set values. A NESet would be
       -- better.
       unflattenNametree . Map.map Set.findMin . Relation.domain
+
+-- Given a namespace and locally-bound names that shadow it (i.e. from a Unison file that hasn't been typechecked yet),
+-- determine what the name resolves to, per the usual suffix-matching rules (where local defnintions and direct
+-- dependencies are preferred to indirect dependencies).
+resolveName :: forall ref. (Ord ref) => Relation Name ref -> Set Name -> Name -> Set (ResolvesTo ref)
+resolveName namespace locals name
+  | Set.member name locals = Set.singleton (ResolvesToLocal name)
+  | Set.size exactNamespaceMatches == 1 = Set.mapMonotonic ResolvesToNamespace exactNamespaceMatches
+  | otherwise = localsPlusNamespaceSuffixMatches
+  where
+    exactNamespaceMatches :: Set ref
+    exactNamespaceMatches =
+      Relation.lookupDom name namespace
+
+    localsPlusNamespaceSuffixMatches :: Set (ResolvesTo ref)
+    localsPlusNamespaceSuffixMatches =
+      Name.searchByRankedSuffix
+        name
+        ( shadowing1
+            ( List.foldl'
+                (\acc name -> Relation.insert name (ResolvesToLocal name) acc)
+                Relation.empty
+                (Set.toList locals)
+            )
+            ( Relation.map
+                (over _2 ResolvesToNamespace)
+                namespace
+            )
+        )

--- a/unison-src/transcripts/fix-5340.md
+++ b/unison-src/transcripts/fix-5340.md
@@ -1,0 +1,28 @@
+```ucm:hide
+scratch/main> builtins.merge lib.builtin
+```
+
+```unison
+type my.Foo = MkFoo
+type lib.dep.lib.dep.Foo = MkFoo
+
+my.foo = 17
+lib.dep.lib.dep.foo = 18
+```
+
+```ucm
+scratch/main> add
+```
+
+These references to type `Foo` and term `foo` should be unambiguous (resolving to the `my.Foo` and `my.foo` in the
+file). However, the indirect dependencies `lib.dep.lib.dep.Foo` and `lib.dep.lib.dep.foo` cause them to be ambiguous.
+
+```unison:error
+type my.Foo = MkFoo
+type Bar = MkBar Foo
+```
+
+```unison:error
+my.foo = 17
+bar = foo Nat.+ foo
+```

--- a/unison-src/transcripts/fix-5340.md
+++ b/unison-src/transcripts/fix-5340.md
@@ -14,7 +14,7 @@ lib.dep.lib.dep.foo = 18
 scratch/main> add
 ```
 
-These references to type `Foo` and term `foo` are be unambiguous (resolving to the `my.Foo` and `my.foo` in the
+These references to type `Foo` and term `foo` are unambiguous (resolving to the `my.Foo` and `my.foo` in the
 file), even though indirect dependencies `lib.dep.lib.dep.Foo` and `lib.dep.lib.dep.foo` match by suffix.
 
 ```unison

--- a/unison-src/transcripts/fix-5340.md
+++ b/unison-src/transcripts/fix-5340.md
@@ -14,15 +14,15 @@ lib.dep.lib.dep.foo = 18
 scratch/main> add
 ```
 
-These references to type `Foo` and term `foo` should be unambiguous (resolving to the `my.Foo` and `my.foo` in the
-file). However, the indirect dependencies `lib.dep.lib.dep.Foo` and `lib.dep.lib.dep.foo` cause them to be ambiguous.
+These references to type `Foo` and term `foo` are be unambiguous (resolving to the `my.Foo` and `my.foo` in the
+file), even though indirect dependencies `lib.dep.lib.dep.Foo` and `lib.dep.lib.dep.foo` match by suffix.
 
-```unison:error
+```unison
 type my.Foo = MkFoo
 type Bar = MkBar Foo
 ```
 
-```unison:error
+```unison
 my.foo = 17
 bar = foo Nat.+ foo
 ```

--- a/unison-src/transcripts/fix-5340.output.md
+++ b/unison-src/transcripts/fix-5340.output.md
@@ -1,0 +1,85 @@
+``` unison
+type my.Foo = MkFoo
+type lib.dep.lib.dep.Foo = MkFoo
+
+my.foo = 17
+lib.dep.lib.dep.foo = 18
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      type lib.dep.lib.dep.Foo
+      type my.Foo
+      lib.dep.lib.dep.foo : Nat
+      my.foo              : Nat
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    type lib.dep.lib.dep.Foo
+    type my.Foo
+    lib.dep.lib.dep.foo : Nat
+    my.foo              : Nat
+
+```
+These references to type `Foo` and term `foo` should be unambiguous (resolving to the `my.Foo` and `my.foo` in the
+file). However, the indirect dependencies `lib.dep.lib.dep.Foo` and `lib.dep.lib.dep.foo` cause them to be ambiguous.
+
+``` unison
+type my.Foo = MkFoo
+type Bar = MkBar Foo
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  
+    ❓
+    
+    I couldn't resolve any of these symbols:
+    
+        2 | type Bar = MkBar Foo
+    
+    
+    Symbol   Suggestions
+             
+    Foo      lib.dep.lib.dep.Foo
+             my.Foo
+  
+
+```
+``` unison
+my.foo = 17
+bar = foo Nat.+ foo
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I couldn't figure out what foo refers to here:
+  
+      2 | bar = foo Nat.+ foo
+  
+  The name foo is ambiguous. Its type should be: Nat
+  
+  I found some terms in scope that have matching names and
+  types. Maybe you meant one of these:
+  
+  my.foo : Nat
+  my.foo : Nat
+  dep.foo : Nat
+
+```

--- a/unison-src/transcripts/fix-5340.output.md
+++ b/unison-src/transcripts/fix-5340.output.md
@@ -33,7 +33,7 @@ scratch/main> add
     my.foo              : Nat
 
 ```
-These references to type `Foo` and term `foo` are be unambiguous (resolving to the `my.Foo` and `my.foo` in the
+These references to type `Foo` and term `foo` are unambiguous (resolving to the `my.Foo` and `my.foo` in the
 file), even though indirect dependencies `lib.dep.lib.dep.Foo` and `lib.dep.lib.dep.foo` match by suffix.
 
 ``` unison

--- a/unison-src/transcripts/fix-5340.output.md
+++ b/unison-src/transcripts/fix-5340.output.md
@@ -33,8 +33,8 @@ scratch/main> add
     my.foo              : Nat
 
 ```
-These references to type `Foo` and term `foo` should be unambiguous (resolving to the `my.Foo` and `my.foo` in the
-file). However, the indirect dependencies `lib.dep.lib.dep.Foo` and `lib.dep.lib.dep.foo` cause them to be ambiguous.
+These references to type `Foo` and term `foo` are be unambiguous (resolving to the `my.Foo` and `my.foo` in the
+file), even though indirect dependencies `lib.dep.lib.dep.Foo` and `lib.dep.lib.dep.foo` match by suffix.
 
 ``` unison
 type my.Foo = MkFoo
@@ -45,19 +45,15 @@ type Bar = MkBar Foo
 
   Loading changes detected in scratch.u.
 
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
   
-    ❓
+    ⊡ Previously added definitions will be ignored: my.Foo
     
-    I couldn't resolve any of these symbols:
+    ⍟ These new definitions are ok to `add`:
     
-        2 | type Bar = MkBar Foo
-    
-    
-    Symbol   Suggestions
-             
-    Foo      lib.dep.lib.dep.Foo
-             my.Foo
-  
+      type Bar
 
 ```
 ``` unison
@@ -69,17 +65,14 @@ bar = foo Nat.+ foo
 
   Loading changes detected in scratch.u.
 
-  I couldn't figure out what foo refers to here:
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
   
-      2 | bar = foo Nat.+ foo
-  
-  The name foo is ambiguous. Its type should be: Nat
-  
-  I found some terms in scope that have matching names and
-  types. Maybe you meant one of these:
-  
-  my.foo : Nat
-  my.foo : Nat
-  dep.foo : Nat
+    ⊡ Previously added definitions will be ignored: my.foo
+    
+    ⍟ These new definitions are ok to `add`:
+    
+      bar : Nat
 
 ```


### PR DESCRIPTION
## Overview

Fixes #5340

This PR cleans up some name binding logic and fixes a bug related to indirect dependencies causing ambiguity errors when they shouldn't.

## Test coverage

I've added a transcript
