### PR TITLE
fix bindNames performance by building namespace+locals names only once

### DIFF
--- a/unison-core/src/Unison/Term.hs
+++ b/unison-core/src/Unison/Term.hs
@@ -157,6 +157,8 @@ bindNames ::
   Term v a ->
   Names.ResolutionResult a (Term v a)
 bindNames unsafeVarToName nameToVar localVars namespace =
+  -- term is bound here because the where-clause binds a data structure that we only want to compute once, then share
+  -- across all calls to `bindNames` with different terms
   \term -> do
     let freeTmVars = ABT.freeVarOccurrences localVars term
         freeTyVars =

--- a/unison-core/src/Unison/Type/Names.hs
+++ b/unison-core/src/Unison/Type/Names.hs
@@ -28,49 +28,54 @@ bindNames ::
   Names ->
   Type v a ->
   Names.ResolutionResult a (Type v a)
-bindNames unsafeVarToName nameToVar localVars namespace ty =
-  let -- Identify the unresolved variables in the type: those whose names aren't an *exact* match for some locally-bound
-      -- type.
-      --
-      -- For example:
-      --
-      --   type Foo.Bar = ...
-      --   type Baz.Qux = ...
-      --   type Whatever = Whatever Foo.Bar Qux
-      --                            ^^^^^^^ ^^^
-      --                               |    this variable *is* unresolved: it doesn't match any locally-bound type exactly
-      --                               |
-      --                            this variable is *not* unresolved: it matches locally-bound `Foo.Bar` exactly
-      unresolvedVars :: [(v, a)]
-      unresolvedVars =
-        ABT.freeVarOccurrences localVars ty
+bindNames unsafeVarToName nameToVar localVars namespace =
+  \ty ->
+    let -- Identify the unresolved variables in the type: those whose names aren't an *exact* match for some locally-bound
+        -- type.
+        --
+        -- For example:
+        --
+        --   type Foo.Bar = ...
+        --   type Baz.Qux = ...
+        --   type Whatever = Whatever Foo.Bar Qux
+        --                            ^^^^^^^ ^^^
+        --                               |    this variable *is* unresolved: it doesn't match any locally-bound type exactly
+        --                               |
+        --                            this variable is *not* unresolved: it matches locally-bound `Foo.Bar` exactly
+        unresolvedVars :: [(v, a)]
+        unresolvedVars =
+          ABT.freeVarOccurrences localVars ty
 
-      okTy :: (v, a) -> Names.ResolutionResult a (v, ResolvesTo TypeReference)
-      okTy (v, a) =
-        case Set.size matches of
-          1 -> good (Set.findMin matches)
-          0 -> bad Names.NotFound
-          _ ->
-            let (namespaceMatches, localMatches) =
-                  matches
-                    & Set.toList
-                    & map \case
-                      ResolvesToNamespace ref -> Left ref
-                      ResolvesToLocal name -> Right name
-                    & partitionEithers
-                    & bimap Set.fromList Set.fromList
-             in bad (Names.Ambiguous namespace namespaceMatches localMatches)
-        where
-          matches :: Set (ResolvesTo TypeReference)
-          matches =
-            Names.resolveName (Names.types namespace) (Set.map unsafeVarToName localVars) (unsafeVarToName v)
+        okTy :: (v, a) -> Names.ResolutionResult a (v, ResolvesTo TypeReference)
+        okTy (v, a) =
+          case Set.size matches of
+            1 -> good (Set.findMin matches)
+            0 -> bad Names.NotFound
+            _ ->
+              let (namespaceMatches, localMatches) =
+                    matches
+                      & Set.toList
+                      & map \case
+                        ResolvesToNamespace ref -> Left ref
+                        ResolvesToLocal name -> Right name
+                      & partitionEithers
+                      & bimap Set.fromList Set.fromList
+               in bad (Names.Ambiguous namespace namespaceMatches localMatches)
+          where
+            matches :: Set (ResolvesTo TypeReference)
+            matches =
+              resolveTypeName (unsafeVarToName v)
 
-          bad = Left . Seq.singleton . Names.TypeResolutionFailure (HQ.NameOnly (unsafeVarToName v)) a
-          good = Right . (v,)
-   in List.validate okTy unresolvedVars <&> \resolutions ->
-        let (namespaceResolutions, localResolutions) = partitionResolutions resolutions
-         in ty
-              -- Apply namespace resolutions (replacing "Foo" with #Foo where "Foo" refers to namespace)
-              & bindExternal namespaceResolutions
-              -- Apply local resolutions (replacing "Foo" with "Full.Name.Foo" where "Full.Name.Foo" is in local vars)
-              & ABT.substsInheritAnnotation [(v, Type.var () (nameToVar name)) | (v, name) <- localResolutions]
+            bad = Left . Seq.singleton . Names.TypeResolutionFailure (HQ.NameOnly (unsafeVarToName v)) a
+            good = Right . (v,)
+     in List.validate okTy unresolvedVars <&> \resolutions ->
+          let (namespaceResolutions, localResolutions) = partitionResolutions resolutions
+           in ty
+                -- Apply namespace resolutions (replacing "Foo" with #Foo where "Foo" refers to namespace)
+                & bindExternal namespaceResolutions
+                -- Apply local resolutions (replacing "Foo" with "Full.Name.Foo" where "Full.Name.Foo" is in local vars)
+                & ABT.substsInheritAnnotation [(v, Type.var () (nameToVar name)) | (v, name) <- localResolutions]
+  where
+    resolveTypeName :: Name -> Set (ResolvesTo TypeReference)
+    resolveTypeName =
+      Names.resolveName (Names.types namespace) (Set.map unsafeVarToName localVars)

--- a/unison-core/src/Unison/Type/Names.hs
+++ b/unison-core/src/Unison/Type/Names.hs
@@ -29,6 +29,8 @@ bindNames ::
   Type v a ->
   Names.ResolutionResult a (Type v a)
 bindNames unsafeVarToName nameToVar localVars namespace =
+  -- type is bound here because the where-clause binds a data structure that we only want to compute once, then share
+  -- across all calls to `bindNames` with different types
   \ty ->
     let -- Identify the unresolved variables in the type: those whose names aren't an *exact* match for some locally-bound
         -- type.


### PR DESCRIPTION
## Overview

This PR fixes a big performance problem in #5343. In order to bind names only need to build a data structure that combines the underlying namespace with the file names once. However, we were accidentally building it once per name resolution.
## Implementation notes

## Test coverage

I tested this change manually