### PR TITLE
Handle empty code blocks in `Doc2`

### DIFF
--- a/unison-src/transcripts/fix5349.md
+++ b/unison-src/transcripts/fix5349.md
@@ -1,0 +1,21 @@
+```ucm:hide
+scratch/main> builtins.mergeio
+```
+
+Empty code blocks are invalid in Unison, but shouldn’t crash the parser.
+
+````unison:error
+README = {{
+```
+```
+}}
+````
+
+````unison:error
+README = {{ {{ }} }}
+````
+
+
+````unison:error
+README = {{ `` `` }}
+````

--- a/unison-src/transcripts/fix5349.output.md
+++ b/unison-src/transcripts/fix5349.output.md
@@ -1,0 +1,78 @@
+Empty code blocks are invalid in Unison, but shouldn’t crash the parser.
+
+```` unison
+README = {{
+```
+```
+}}
+````
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I expected a block after this (in red), but there wasn't one.  Maybe check your indentation:
+      0 | README = {{
+  
+
+```
+``` unison
+README = {{ {{ }} }}
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I got confused here:
+  
+  
+  
+  I was surprised to find an end of input here.
+  I was expecting one of these instead:
+  
+  * bang
+  * do
+  * false
+  * force
+  * handle
+  * if
+  * lambda
+  * let
+  * quote
+  * termLink
+  * true
+  * tuple
+  * typeLink
+
+```
+``` unison
+README = {{ `` `` }}
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I got confused here:
+  
+  
+  
+  I was surprised to find an end of input here.
+  I was expecting one of these instead:
+  
+  * bang
+  * do
+  * false
+  * force
+  * handle
+  * if
+  * lambda
+  * let
+  * quote
+  * termLink
+  * true
+  * tuple
+  * typeLink
+
+```

--- a/unison-syntax/test/Main.hs
+++ b/unison-syntax/test/Main.hs
@@ -19,7 +19,8 @@ main =
 test :: Test ()
 test =
   scope "lexer" . tests $
-    [ t "1" [Numeric "1"],
+    [ t "" [],
+      t "1" [Numeric "1"],
       t "+1" [Numeric "+1"],
       t "-1" [Numeric "-1"],
       t "-1.0" [Numeric "-1.0"],


### PR DESCRIPTION
## Overview

Empty code blocks still fail, but as a normal Unison error, not a Haskell exception. This matches their behavior in previous releases.

Fixes #5349.

## Implementation notes

With the update to the Doc2 parser in #5187, there was the introduction of a dummy layout block used to delimit the boundary of the Unison parser state outside the current Doc2 block and inside it.

There were two bugs here – the first was using `List.last`, which is what crashed the lexer when there were no tokens lexed. That is avoided by always getting a fresh position rather than the position of the last token.

But that hid the real issue, which is that if there were no tokens lexed, the dummy block never moved to layout and rather than inserting the correct number of `Close` tokens to complete the block, it closed _all_ of the blocks, including the ones outside of the Doc2 block. Since the `ParsingEnv` is `local`, we can just start with an empty `layout`, making it impossible to close extra blocks.

## Test coverage

There is a new transcript that covers a few different code blocks in Doc cases, and a trivial empty lex case in unison-syntax tests.

## Loose ends

There is still some overly complicated layout-based logic spread throughout the lexer, notably in `token''`.

Empty blocks still fail, which matches the previous behavior, but we should handle this more gracefully inside Doc, so that bad Docs don’t fail the parser.
