### PR TITLE
Some JIT tweaks for improved general performance

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ on:
 env:
   ## Some version numbers that are used during CI
   ormolu_version: 0.7.2.0
-  jit_version: "@unison/internal/releases/0.0.19"
+  jit_version: "@unison/internal/releases/0.0.20"
   runtime_tests_version: "@unison/runtime-tests/main"
 
   ## Some cached directories

--- a/scheme-libs/racket/unison/boot.ss
+++ b/scheme-libs/racket/unison/boot.ss
@@ -258,12 +258,12 @@
               (name:impl #:pure pure? . args))))))))
 
 (define-for-syntax
-  (make-main loc recursive? name:stx ref:stx name:impl:stx n)
+  (make-main loc inline? name:stx ref:stx name:impl:stx n)
   (with-syntax ([name name:stx]
                 [name:impl name:impl:stx]
                 [gr ref:stx]
                 [n (datum->syntax loc n)])
-    (if recursive?
+    (if inline?
       (syntax/loc loc
         (define name
           (unison-curry #:inline n gr name:impl)))
@@ -358,7 +358,7 @@
                #:force-pure #t ; force-pure?
                loc name:fast:stx name:impl:stx arg:stx)]
        [impl (make-impl name:impl:stx arg:stx expr:stx)]
-       [main (make-main loc recursive? name:stx ref:stx name:impl:stx arity)]
+       [main (make-main loc inline? name:stx ref:stx name:impl:stx arity)]
        [(decls ...)
         (link-decl no-link-decl? loc name:stx name:fast:stx name:impl:stx)]
        [(traces ...)

--- a/scheme-libs/racket/unison/boot.ss
+++ b/scheme-libs/racket/unison/boot.ss
@@ -359,8 +359,8 @@
                loc name:fast:stx name:impl:stx arg:stx)]
        [impl (make-impl name:impl:stx arg:stx expr:stx)]
        [main (make-main loc inline? name:stx ref:stx name:impl:stx arity)]
-       [(decls ...)
-        (link-decl no-link-decl? loc name:stx name:fast:stx name:impl:stx)]
+       ; [(decls ...)
+       ;  (link-decl no-link-decl? loc name:stx name:fast:stx name:impl:stx)]
        [(traces ...)
         (trace-decls trace? loc name:impl:stx)])
       (quasisyntax/loc loc
@@ -369,8 +369,7 @@
           #,(if (or recursive? inline?) #'(begin-encourage-inline impl) #'impl)
           traces ...
           #,(if (or recursive? inline?) #'(begin-encourage-inline fast) #'fast)
-          #,(if inline? #'(begin-encourage-inline main) #'main)
-          decls ...)))))
+          #,(if inline? #'(begin-encourage-inline main) #'main))))))
 
 ; Function definition supporting various unison features, like
 ; partial application and continuation serialization. See above for

--- a/scheme-libs/racket/unison/boot.ss
+++ b/scheme-libs/racket/unison/boot.ss
@@ -244,7 +244,9 @@
                 [args arg:stx])
     (if force-pure?
       (syntax/loc loc
-        (define name:fast name:impl))
+        ; note: for some reason this performs better than
+        ; (define name:fast name:impl)
+        (define (name:fast . args) (name:impl . args)))
 
       (syntax/loc loc
         (define (name:fast #:pure pure? . args)

--- a/scheme-libs/racket/unison/boot.ss
+++ b/scheme-libs/racket/unison/boot.ss
@@ -411,16 +411,16 @@
   (syntax-case stx ()
     [(define-unison-builtin #:local n #:hints [h ...] . rest)
      (syntax/loc stx
-       (define-unison #:local n #:hints [internal gen-link h ...] . rest))]
+       (define-unison #:local n #:hints [inline internal gen-link h ...] . rest))]
     [(define-unison-builtin #:local n . rest)
      (syntax/loc stx
-       (define-unison #:local n #:hints [internal gen-link] . rest))]
+       (define-unison #:local n #:hints [inline internal gen-link] . rest))]
     [(define-unison-builtin #:hints [h ...] . rest)
      (syntax/loc stx
-       (define-unison #:hints [internal gen-link h ...] . rest))]
+       (define-unison #:hints [inline internal gen-link h ...] . rest))]
     [(define-unison-builtin . rest)
      (syntax/loc stx
-       (define-unison #:hints [internal gen-link] . rest))]))
+       (define-unison #:hints [inline internal gen-link] . rest))]))
 
 ; call-by-name bindings
 (define-syntax (name stx)

--- a/scheme-libs/racket/unison/boot.ss
+++ b/scheme-libs/racket/unison/boot.ss
@@ -299,7 +299,7 @@
              [no-link-decl? #f]
              [trace? #f]
              [inline? #f]
-             [recursive? #t])
+             [recursive? #f])
             ([h hs])
     (values
       (or internal? (eq? h 'internal))

--- a/unison-src/transcripts-manual/gen-racket-libs.md
+++ b/unison-src/transcripts-manual/gen-racket-libs.md
@@ -4,7 +4,7 @@ When we start out, `./scheme-libs/racket` contains a bunch of library files that
 Next, we'll download the jit project and generate a few Racket files from it.
 
 ```ucm
-jit-setup/main> lib.install @unison/internal/releases/0.0.19
+jit-setup/main> lib.install @unison/internal/releases/0.0.20
 ```
 
 ```unison

--- a/unison-src/transcripts-manual/gen-racket-libs.output.md
+++ b/unison-src/transcripts-manual/gen-racket-libs.output.md
@@ -3,12 +3,12 @@ When we start out, `./scheme-libs/racket` contains a bunch of library files that
 Next, we'll download the jit project and generate a few Racket files from it.
 
 ``` ucm
-jit-setup/main> lib.install @unison/internal/releases/0.0.19
+jit-setup/main> lib.install @unison/internal/releases/0.0.20
 
-  Downloaded 14926 entities.
+  Downloaded 14935 entities.
 
-  I installed @unison/internal/releases/0.0.19 as
-  unison_internal_0_0_19.
+  I installed @unison/internal/releases/0.0.20 as
+  unison_internal_0_0_20.
 
 ```
 ``` unison


### PR DESCRIPTION
This PR implements some changes to the JIT to improve performance for more cases.

The biggest change is that it implements a way of generated unison code to directly call into the fast path for known-saturated cases, so long as the function that is being called is in the same compilation unit as the caller. This is important for getting good performance on loops, and it was difficult to get the racket compiler to do it for us with the wrappers we have on functions in general.

I've also turned on the inlining hint for all unison builtins, so that it isn't necessary to sprinkle it manually on every builtin definition, which might be about what we want. Obviously this can be revisted later.

The arity stuff could also be extended in the future to allow faster calls to functions outside a single compilation unit, but that would require storing the arity information, and exporting the fast paths from modules, so I'm leaving that a future time when we decide it actually matters.