### PR TITLE
Search your codebase for text or numeric literals

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -61,7 +61,7 @@ import Unison.Codebase.Editor.HandleInput.DebugSynhashTerm (handleDebugSynhashTe
 import Unison.Codebase.Editor.HandleInput.DeleteBranch (handleDeleteBranch)
 import Unison.Codebase.Editor.HandleInput.DeleteProject (handleDeleteProject)
 import Unison.Codebase.Editor.HandleInput.EditNamespace (handleEditNamespace)
-import Unison.Codebase.Editor.HandleInput.FindAndReplace (handleStructuredFindI, handleStructuredFindReplaceI)
+import Unison.Codebase.Editor.HandleInput.FindAndReplace (handleStructuredFindI, handleStructuredFindReplaceI, handleTextFindI)
 import Unison.Codebase.Editor.HandleInput.FormatFile qualified as Format
 import Unison.Codebase.Editor.HandleInput.Global qualified as Global
 import Unison.Codebase.Editor.HandleInput.InstallLib (handleInstallLib)
@@ -620,6 +620,7 @@ loop e = do
             FindI isVerbose fscope ws -> handleFindI isVerbose fscope ws input
             StructuredFindI _fscope ws -> handleStructuredFindI ws
             StructuredFindReplaceI ws -> handleStructuredFindReplaceI ws
+            TextFindI allowLib ws -> handleTextFindI allowLib ws
             LoadI maybePath -> handleLoad maybePath
             ClearI -> Cli.respond ClearScreen
             AddI requestedNames -> do
@@ -1041,6 +1042,7 @@ inputDescription input =
     ShowDefinitionI {} -> wat
     StructuredFindI {} -> wat
     StructuredFindReplaceI {} -> wat
+    TextFindI {} -> wat
     ShowRootReflogI {} -> pure "deprecated.root-reflog"
     ShowGlobalReflogI {} -> pure "reflog.global"
     ShowProjectReflogI mayProjName -> do

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/FindAndReplace.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/FindAndReplace.hs
@@ -116,7 +116,7 @@ handleTextFindI allowLib tokens = do
   results0 <- traverse ok results
   let results = Alphabetical.sortAlphabetically [hq | (hq, True) <- results0]
   Cli.setNumberedArgs $ map SA.HashQualified results
-  Cli.respond (ListStructuredFind results) 
+  Cli.respond (ListTextFind allowLib results) 
   where
     tokensTxt = Text.pack <$> tokens
     containsTokens tm = 

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/FindAndReplace.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/FindAndReplace.hs
@@ -1,6 +1,7 @@
 module Unison.Codebase.Editor.HandleInput.FindAndReplace
   ( handleStructuredFindReplaceI,
     handleStructuredFindI,
+    handleTextFindI
   )
 where
 
@@ -28,6 +29,7 @@ import Unison.Names (Names)
 import Unison.Names qualified as Names
 import Unison.NamesWithHistory qualified as Names
 import Unison.Parser.Ann (Ann (..))
+import Unison.Pattern qualified as Pattern
 import Unison.Prelude
 import Unison.PrettyPrintEnv qualified as PPE
 import Unison.PrettyPrintEnv.Names qualified as PPE
@@ -90,6 +92,47 @@ handleStructuredFindI rule = do
   let results = Alphabetical.sortAlphabetically [hq | (hq, True) <- results0]
   Cli.setNumberedArgs $ map SA.HashQualified results
   Cli.respond (ListStructuredFind results)
+
+handleTextFindI :: Bool -> [String] -> Cli ()
+handleTextFindI allowLib tokens = do
+  Cli.Env {codebase} <- ask
+  currentBranch <- Cli.getCurrentBranch0
+  hqLength <- Cli.runTransaction Codebase.hashLength
+  let names = Branch.toNames currentBranch
+  let ppe = PPED.makePPED (PPE.hqNamer hqLength names) (PPE.suffixifyByHash names)
+  let fqppe = PPED.unsuffixifiedPPE ppe
+  results :: [(HQ.HashQualified Name, Referent)] <- pure $ do
+    r <- Set.toList (Relation.ran $ Names.terms names)
+    Just hq <- [PPE.terms fqppe r]
+    fullName <- [HQ'.toName hq]
+    guard (allowLib || not (Name.beginsWithSegment fullName NameSegment.libSegment))
+    Referent.Ref _ <- pure r
+    Just shortName <- [PPE.terms (PPED.suffixifiedPPE ppe) r]
+    pure (HQ'.toHQ shortName, r)
+  let ok (hq, Referent.Ref (Reference.DerivedId r)) = do
+        oe <- Cli.runTransaction (Codebase.getTerm codebase r)
+        pure $ (hq, maybe False containsTokens oe)
+      ok (hq, _) = pure (hq, False)
+  results0 <- traverse ok results
+  let results = Alphabetical.sortAlphabetically [hq | (hq, True) <- results0]
+  Cli.setNumberedArgs $ map SA.HashQualified results
+  Cli.respond (ListStructuredFind results) 
+  where
+    tokensTxt = Text.pack <$> tokens
+    containsTokens tm = 
+      hasAll . join $ ABT.find txts tm
+      where 
+        hasAll txts = all (\tok -> any (\haystack -> Text.isInfixOf tok haystack) txts) tokensTxt 
+        txts (Term.Text' haystack) = ABT.Found [haystack]
+        txts (Term.Nat' haystack) = ABT.Found [Text.pack (show haystack)]
+        txts (Term.Int' haystack) = ABT.Found [Text.pack (show haystack)]
+        txts (Term.Float' haystack) = ABT.Found [Text.pack (show haystack)]
+        txts (Term.Char' haystack) = ABT.Found [Text.pack [haystack]]
+        txts (Term.Match' _ cases) = ABT.Found r
+          where r = join $ Pattern.foldMap' txtPattern . Term.matchPattern <$> cases
+        txts _ = ABT.Continue
+        txtPattern (Pattern.Text _ txt) = [txt]
+        txtPattern _ = []
 
 lookupRewrite ::
   (HQ.HashQualified Name -> Output) ->

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -188,6 +188,7 @@ data Input
   | FindShallowI Path'
   | StructuredFindI FindScope (HQ.HashQualified Name) -- sfind findScope query
   | StructuredFindReplaceI (HQ.HashQualified Name) -- sfind.replace rewriteQuery
+  | TextFindI Bool [String] -- TextFindI allowLib tokens
   | -- Show provided definitions.
     ShowDefinitionI OutputLocation ShowDefinitionScope (NonEmpty (HQ.HashQualified Name))
   | ShowRootReflogI {- Deprecated -}

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -275,6 +275,7 @@ data Output
   | ListOfDefinitions FindScope PPE.PrettyPrintEnv ListDetailed [SearchResult' Symbol Ann]
   | ListShallow (IO PPE.PrettyPrintEnv) [ShallowListEntry Symbol Ann]
   | ListStructuredFind [HQ.HashQualified Name]
+  | ListTextFind Bool [HQ.HashQualified Name] -- whether lib was included in the search
   | GlobalFindBranchResults (ProjectAndBranch ProjectName ProjectBranchName) PPE.PrettyPrintEnv ListDetailed [SearchResult' Symbol Ann]
   | -- ListStructuredFind patternMatchingUsages termBodyUsages
     -- show the result of add/update
@@ -552,6 +553,7 @@ isFailure o = case o of
   ListOfDefinitions _ _ _ ds -> null ds
   GlobalFindBranchResults _ _ _ _ -> False
   ListStructuredFind tms -> null tms
+  ListTextFind _ tms -> null tms
   SlurpOutput _ _ sr -> not $ SR.isOk sr
   ParseErrors {} -> True
   TypeErrors {} -> True

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -104,6 +104,7 @@ module Unison.CommandLine.InputPatterns
     saveExecuteResult,
     sfind,
     sfindReplace,
+    textfind,
     test,
     testAll,
     todo,
@@ -1079,6 +1080,28 @@ undo =
     []
     "`undo` reverts the most recent change to the codebase."
     (const $ pure Input.UndoI)
+
+textfind :: Bool -> InputPattern
+textfind allowLib =
+  InputPattern cmdName aliases I.Visible [("token", OnePlus, noCompletionsArg)] msg parse
+  where
+    (cmdName, aliases, alternate) = 
+      if allowLib then 
+        ("text.find.all", ["grep.all"], "Use `text.find` to exclude `lib` from search.")
+      else
+        ("text.find", ["grep"], "Use `text.find.all` to include search of `lib`.")
+    parse = \case
+      [] -> Left (P.text "Please supply at least one token.")
+      words -> pure $ Input.TextFindI allowLib (traceShowId [ e | Left e <- words ])
+    msg =
+      P.lines
+        [ P.wrap $
+            makeExample (textfind allowLib) ["token1", "token2"]
+              <> " finds terms with literals (text or numeric) containing both"
+              <> "`token1` and `word2`.",
+          "",
+          P.wrap alternate
+        ]
 
 sfind :: InputPattern
 sfind =
@@ -3442,6 +3465,8 @@ validInputs =
       findVerboseAll,
       sfind,
       sfindReplace,
+      textfind False,
+      textfind True,
       forkLocal,
       help,
       helpTopics,

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1448,7 +1448,12 @@ notifyUser dir = \case
   ListDependencies ppe lds types terms ->
     pure $ listDependentsOrDependencies ppe "Dependencies" "dependencies" lds types terms
   ListStructuredFind terms ->
-    pure $ listStructuredFind terms
+    pure $ listFind False Nothing terms
+  ListTextFind True terms -> 
+    pure $ listFind True Nothing terms
+  ListTextFind False terms ->
+    pure $ listFind False (Just tip) terms
+    where tip = (IP.makeExample (IP.textfind True) [] <> " will search `lib` as well.")
   DumpUnisonFileHashes hqLength datas effects terms ->
     pure . P.syntaxToColor . P.lines $
       ( effects <&> \(n, r) ->
@@ -3586,17 +3591,19 @@ endangeredDependentsTable ppeDecl m =
         & fmap (\(n, dep) -> numArg n <> prettyLabeled fqnEnv dep)
         & P.lines
 
-listStructuredFind :: [HQ.HashQualified Name] -> Pretty
-listStructuredFind [] = "😶 I couldn't find any matches."
-listStructuredFind tms =
+listFind :: Bool -> Maybe Pretty -> [HQ.HashQualified Name] -> Pretty
+listFind _ Nothing [] = "😶 I couldn't find any matches."
+listFind _ (Just onMissing) [] = P.lines ["😶 I couldn't find any matches.", "", tip onMissing]
+listFind allowLib _ tms =
   P.callout "🔎" . P.lines $
-    [ "These definitions from the current namespace (excluding `lib`) have matches:",
+    [ "These definitions from the current namespace " <> parenthetical <> "have matches:",
       "",
       P.indentN 2 $ P.numberedList (pnames tms),
       "",
       tip (msg (length tms))
     ]
   where
+    parenthetical = if allowLib then "" else "(excluding `lib`) "
     pnames hqs = P.syntaxToColor . prettyHashQualified <$> hqs
     msg 1 = "Try " <> IP.makeExample IP.edit ["1"] <> " to bring this into your scratch file."
     msg n =

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1449,11 +1449,12 @@ notifyUser dir = \case
     pure $ listDependentsOrDependencies ppe "Dependencies" "dependencies" lds types terms
   ListStructuredFind terms ->
     pure $ listFind False Nothing terms
-  ListTextFind True terms -> 
+  ListTextFind True terms ->
     pure $ listFind True Nothing terms
   ListTextFind False terms ->
     pure $ listFind False (Just tip) terms
-    where tip = (IP.makeExample (IP.textfind True) [] <> " will search `lib` as well.")
+    where
+      tip = (IP.makeExample (IP.textfind True) [] <> " will search `lib` as well.")
   DumpUnisonFileHashes hqLength datas effects terms ->
     pure . P.syntaxToColor . P.lines $
       ( effects <&> \(n, r) ->

--- a/unison-src/transcripts/help.output.md
+++ b/unison-src/transcripts/help.output.md
@@ -778,6 +778,24 @@ scratch/main> help
   test.all
   `test.all` runs unit tests for the current branch (including the `lib` namespace).
   
+  text.find (or grep)
+  `text.find token1 "99" token2` finds terms with literals (text
+  or numeric) containing `token1`, `99`, and `token2`.
+  
+  Numeric literals must be quoted (ex: "42") but single words
+  need not be quoted.
+  
+  Use `text.find.all` to include search of `lib`.
+  
+  text.find.all (or grep.all)
+  `text.find.all token1 "99" token2` finds terms with literals
+  (text or numeric) containing `token1`, `99`, and `token2`.
+  
+  Numeric literals must be quoted (ex: "42") but single words
+  need not be quoted.
+  
+  Use `text.find` to exclude `lib` from search.
+  
   todo
   `todo` lists the current namespace's outstanding issues,
   including conflicted names, dependencies with missing names,

--- a/unison-src/transcripts/textfind.md
+++ b/unison-src/transcripts/textfind.md
@@ -8,10 +8,12 @@ scratch/main> builtins.merge lib.builtin
 The `text.find` (or `grep`) command can be used to search for text or numeric literals appearing anywhere in your project. Just supply one or more tokens to search for. Unlike regular grep over the text of your code, this ignores local variables and function names that happen to match your search tokens (use `dependents` or `find` for that purpose). It's only searching for text or numeric literals that match.
 
 ```ucm
-scratch/main> help text.find.all
+scratch/main> help grep
 ```
 
-You can use `grep.all` to search in `lib` as well. 
+```ucm
+scratch/main> help text.find.all
+```
 
 Here's an example:
 
@@ -37,14 +39,32 @@ scratch/main> add
 ```
 
 ```ucm
+scratch/main> grep hi
+scratch/main> view 1 
 scratch/main> grep "hi"
-scratch/main> text.find.all "hi"
+scratch/main> text.find.all hi
 scratch/main> view 1-5
+scratch/main> grep oog
+scratch/main> view 1 
 ```
 
 ```ucm
 scratch/main> grep quaffle 
+scratch/main> view 1-5
+scratch/main> text.find "interesting const"
+scratch/main> view 1-5
+scratch/main> text.find "99" "23"
 scratch/main> view 1
-scratch/main> text.find interesting
-scratch/main> view 1
+```
+
+Now some failed searches:
+
+```ucm:error
+scratch/main> grep lsdkfjlskdjfsd
+```
+
+Notice it gives the tip about `text.find.all`. But not here:
+
+```ucm:error
+scratch/main> grep.all lsdkfjlskdjfsd
 ```

--- a/unison-src/transcripts/textfind.md
+++ b/unison-src/transcripts/textfind.md
@@ -1,0 +1,50 @@
+
+# The `text.find` command
+
+```ucm:hide
+scratch/main> builtins.merge lib.builtin
+```
+
+The `text.find` (or `grep`) command can be used to search for text or numeric literals appearing anywhere in your project. Just supply one or more tokens to search for. Unlike regular grep over the text of your code, this ignores local variables and function names that happen to match your search tokens (use `dependents` or `find` for that purpose). It's only searching for text or numeric literals that match.
+
+```ucm
+scratch/main> help text.find.all
+```
+
+You can use `grep.all` to search in `lib` as well. 
+
+Here's an example:
+
+```unison
+foo = 
+  _ = "an interesting constant"
+  1
+bar = match "well hi there" with
+  "ooga" -> 99
+  "booga" -> 23
+  _ -> 0
+baz = ["an", "quaffle", "tres"] 
+qux = 
+  quaffle = 99
+  quaffle + 1
+
+lib.foo = [Any 46, Any "hi", Any "zoink"]
+lib.bar = 3
+```
+
+```ucm:hide
+scratch/main> add
+```
+
+```ucm
+scratch/main> grep "hi"
+scratch/main> text.find.all "hi"
+scratch/main> view 1-5
+```
+
+```ucm
+scratch/main> grep quaffle 
+scratch/main> view 1
+scratch/main> text.find interesting
+scratch/main> view 1
+```

--- a/unison-src/transcripts/textfind.output.md
+++ b/unison-src/transcripts/textfind.output.md
@@ -1,0 +1,73 @@
+# The `text.find` command
+
+The `text.find` (or `grep`) command can be used to search for text or numeric literals appearing anywhere in your project. Just supply one or more tokens to search for. Unlike regular grep over the text of your code, this ignores local variables and function names that happen to match your search tokens (use `dependents` or `find` for that purpose). It's only searching for text or numeric literals that match.
+
+``` ucm
+scratch/main> help text.find.all
+
+  text.find.all (or grep.all)
+  `text.find.all token1 token2` finds terms with literals (text
+  or numeric) containing both `token1` and `word2`.
+  
+  Use `text.find` to exclude `lib` from search.
+
+```
+You can use `grep.all` to search in `lib` as well.
+
+Here's an example:
+
+``` unison
+foo = 
+  _ = "an interesting constant"
+  1
+bar = match "well hi there" with
+  "ooga" -> 99
+  "booga" -> 23
+  _ -> 0
+baz = ["an", "quaffle", "tres"] 
+qux = 
+  quaffle = 99
+  quaffle + 1
+
+lib.foo = [Any 46, Any "hi", Any "zoink"]
+lib.bar = 3
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      bar     : Nat
+      baz     : [Text]
+      foo     : Nat
+      lib.bar : Nat
+      lib.foo : [Any]
+      qux     : Nat
+
+```
+``` ucm
+scratch/main> grep "hi"
+
+  😶 I couldn't find any matches.
+
+```
+
+``` ucm
+scratch/main> grep "hi"scratch/main> text.find.all "hi"scratch/main> view 1-5
+```
+
+
+
+🛑
+
+The transcript failed due to an error in the stanza above. The error is:
+
+
+  😶 I couldn't find any matches.
+

--- a/unison-src/transcripts/textfind.output.md
+++ b/unison-src/transcripts/textfind.output.md
@@ -3,17 +3,31 @@
 The `text.find` (or `grep`) command can be used to search for text or numeric literals appearing anywhere in your project. Just supply one or more tokens to search for. Unlike regular grep over the text of your code, this ignores local variables and function names that happen to match your search tokens (use `dependents` or `find` for that purpose). It's only searching for text or numeric literals that match.
 
 ``` ucm
+scratch/main> help grep
+
+  text.find (or grep)
+  `text.find token1 "99" token2` finds terms with literals (text
+  or numeric) containing `token1`, `99`, and `token2`.
+  
+  Numeric literals must be quoted (ex: "42") but single words
+  need not be quoted.
+  
+  Use `text.find.all` to include search of `lib`.
+
+```
+``` ucm
 scratch/main> help text.find.all
 
   text.find.all (or grep.all)
-  `text.find.all token1 token2` finds terms with literals (text
-  or numeric) containing both `token1` and `word2`.
+  `text.find.all token1 "99" token2` finds terms with literals
+  (text or numeric) containing `token1`, `99`, and `token2`.
+  
+  Numeric literals must be quoted (ex: "42") but single words
+  need not be quoted.
   
   Use `text.find` to exclude `lib` from search.
 
 ```
-You can use `grep.all` to search in `lib` as well.
-
 Here's an example:
 
 ``` unison
@@ -52,22 +66,143 @@ lib.bar = 3
 
 ```
 ``` ucm
+scratch/main> grep hi
+
+  🔎
+  
+  These definitions from the current namespace (excluding `lib`) have matches:
+  
+    1. bar
+  
+  Tip: Try `edit 1` to bring this into your scratch file.
+
+scratch/main> view 1 
+
+  bar : Nat
+  bar = match "well hi there" with
+    "ooga"  -> 99
+    "booga" -> 23
+    _       -> 0
+
 scratch/main> grep "hi"
 
-  😶 I couldn't find any matches.
+  🔎
+  
+  These definitions from the current namespace (excluding `lib`) have matches:
+  
+    1. bar
+  
+  Tip: Try `edit 1` to bring this into your scratch file.
+
+scratch/main> text.find.all hi
+
+  🔎
+  
+  These definitions from the current namespace have matches:
+  
+    1. bar
+    2. lib.foo
+  
+  Tip: Try `edit 1` or `edit 1-2` to bring these into your
+       scratch file.
+
+scratch/main> view 1-5
+
+  bar : Nat
+  bar = match "well hi there" with
+    "ooga"  -> 99
+    "booga" -> 23
+    _       -> 0
+  
+  lib.foo : [Any]
+  lib.foo = [Any 46, Any "hi", Any "zoink"]
+
+scratch/main> grep oog
+
+  🔎
+  
+  These definitions from the current namespace (excluding `lib`) have matches:
+  
+    1. bar
+  
+  Tip: Try `edit 1` to bring this into your scratch file.
+
+scratch/main> view 1 
+
+  bar : Nat
+  bar = match "well hi there" with
+    "ooga"  -> 99
+    "booga" -> 23
+    _       -> 0
 
 ```
+``` ucm
+scratch/main> grep quaffle 
+
+  🔎
+  
+  These definitions from the current namespace (excluding `lib`) have matches:
+  
+    1. baz
+  
+  Tip: Try `edit 1` to bring this into your scratch file.
+
+scratch/main> view 1-5
+
+  baz : [Text]
+  baz = ["an", "quaffle", "tres"]
+
+scratch/main> text.find "interesting const"
+
+  🔎
+  
+  These definitions from the current namespace (excluding `lib`) have matches:
+  
+    1. foo
+  
+  Tip: Try `edit 1` to bring this into your scratch file.
+
+scratch/main> view 1-5
+
+  foo : Nat
+  foo =
+    _ = "an interesting constant"
+    1
+
+scratch/main> text.find "99" "23"
+
+  🔎
+  
+  These definitions from the current namespace (excluding `lib`) have matches:
+  
+    1. bar
+  
+  Tip: Try `edit 1` to bring this into your scratch file.
+
+scratch/main> view 1
+
+  bar : Nat
+  bar = match "well hi there" with
+    "ooga"  -> 99
+    "booga" -> 23
+    _       -> 0
+
+```
+Now some failed searches:
 
 ``` ucm
-scratch/main> grep "hi"scratch/main> text.find.all "hi"scratch/main> view 1-5
+scratch/main> grep lsdkfjlskdjfsd
+
+  😶 I couldn't find any matches.
+  
+  Tip: `text.find.all` will search `lib` as well.
+
 ```
+Notice it gives the tip about `text.find.all`. But not here:
 
-
-
-🛑
-
-The transcript failed due to an error in the stanza above. The error is:
-
+``` ucm
+scratch/main> grep.all lsdkfjlskdjfsd
 
   😶 I couldn't find any matches.
 
+```


### PR DESCRIPTION
This PR adds `text.find` (alternately `grep`) commands. They can be used to search for text or numeric literals appearing anywhere in your project. Just supply one or more tokens to search for and it will do substring matching. Unlike regular grep over the text of your code, this will ignore local variables and function names that happen to match your search tokens (use `dependents` or `find` for that purpose). It's only searching among the text literals and numeric literals that appear in your functions. Here's the help:

<img width="1184" alt="CleanShot 2024-09-21 at 19 23 18@2x" src="https://github.com/user-attachments/assets/5442735a-c709-4f02-bdff-0cd6eb08249c">

So you can search either the current project, or you can include all of `lib` as well.

<img width="960" alt="CleanShot 2024-09-21 at 19 22 16@2x" src="https://github.com/user-attachments/assets/078fe9ec-3782-4d3e-8a72-53eb015c93b2">

Added transcript to test and illustrate.

I didn't try to do regex matching, leaving that for future work or someone else should feel to take over this PR. I also didn't try to include a preview of each search result but that would be cool as well.

Thanks to @etorreborre for inspiring this. :)

# Implementation notes

The implementation isn't using any sort of index; it has to load each term in memory and scan the ABT. This is very fast for most projects. For including search of `lib` too, it's actually still fast enough but you do notice a pause of a few seconds. It is scanning the definitions by hash, so it's only actually searching the total number of unique hashes that appear in `lib`.