### PR TITLE
tweak: don't truncate long names in some output messages

### DIFF
--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -1127,10 +1127,7 @@ renderContext env ctx@(C.Context es) =
 
 renderTerm :: (IsString s, Var v) => Env -> Term.Term' (TypeVar.TypeVar loc0 v) v loc1 -> s
 renderTerm env e =
-  let s = Color.toPlain $ TermPrinter.pretty' (Just 80) env (TypeVar.lowerTerm e)
-   in if length s > Settings.renderTermMaxLength
-        then fromString ("..." <> drop (length s - Settings.renderTermMaxLength) s)
-        else fromString s
+  fromString (Color.toPlain $ TermPrinter.pretty' (Just 80) env (TypeVar.lowerTerm e))
 
 renderPattern :: Env -> Pattern ann -> ColorText
 renderPattern env e = Pr.renderUnbroken . Pr.syntaxToColor . fst $ TermPrinter.prettyPattern env TermPrinter.emptyAc Precedence.Annotation ([] :: [Symbol]) e


### PR DESCRIPTION
## Overview

This PR just deletes the logic that truncates a long name if it can't fit in the preferred terminal width.

Before:

```
  I couldn't figure out what contentLength.get refers to here:

      2 | Body.decodeNonChunkedBody headers = match contentLength.get headers with

  The name contentLength.get is ambiguous. Its type should be: Headers -> Optional Nat

  I found some terms in scope that have matching names and types. Maybe you meant one
  of these:

  ...ers.standard.contentLength.get : Headers -> Optional Nat
  standard.contentLength.get : Headers -> Optional Nat
```

After:

```
  I couldn't figure out what contentLength.get refers to here:

      2 | Body.decodeNonChunkedBody headers = match contentLength.get headers with

  The name contentLength.get is ambiguous. Its type should be: Headers -> Optional Nat

  I found some terms in scope that have matching names and types. Maybe you meant one
  of these:

  Headers.standard.contentLength.get : Headers -> Optional Nat
  standard.contentLength.get : Headers -> Optional Nat
```

## Test coverage

I tested this change manually