### PR TITLE
JIT compiled code profiling, and sqrt

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Runtime.hs
+++ b/parser-typechecker/src/Unison/Codebase/Runtime.hs
@@ -29,6 +29,13 @@ type Error = P.Pretty P.ColorText
 
 type Term v = Term.Term v ()
 
+data CompileOpts = COpts
+  { profile :: Bool
+  }
+
+defaultCompileOpts :: CompileOpts
+defaultCompileOpts = COpts { profile = False }
+
 data Runtime v = Runtime
   { terminate :: IO (),
     evaluate ::
@@ -37,6 +44,7 @@ data Runtime v = Runtime
       Term v ->
       IO (Either Error ([Error], Term v)),
     compileTo ::
+      CompileOpts ->
       CL.CodeLookup v IO () ->
       PPE.PrettyPrintEnv ->
       Reference ->

--- a/scheme-libs/racket/unison/math.rkt
+++ b/scheme-libs/racket/unison/math.rkt
@@ -19,6 +19,8 @@
   builtin-Float.max:termlink
   builtin-Float.min
   builtin-Float.min:termlink
+  builtin-Float.sqrt
+  builtin-Float.sqrt:termlink
   builtin-Float.tan
   builtin-Float.tan:termlink
   builtin-Float.tanh
@@ -129,6 +131,9 @@
 
 (define-unison-builtin
   (builtin-Float.pow n m) (expt n m))
+
+(define-unison-builtin
+  (builtin-Float.sqrt x) (sqrt x))
 
 (define (EXPF n) (exp n))
 (define ABSF abs)

--- a/scheme-libs/racket/unison/primops.ss
+++ b/scheme-libs/racket/unison/primops.ss
@@ -49,6 +49,8 @@
   builtin-Float.max:termlink
   builtin-Float.min
   builtin-Float.min:termlink
+  builtin-Float.sqrt
+  builtin-Float.sqrt:termlink
   builtin-Float.tan
   builtin-Float.tan:termlink
   builtin-Float.tanh

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -175,8 +175,8 @@ data Input
     MakeStandaloneI String (HQ.HashQualified Name)
   | -- execute an IO thunk using scheme
     ExecuteSchemeI (HQ.HashQualified Name) [String]
-  | -- compile to a scheme file
-    CompileSchemeI Text (HQ.HashQualified Name)
+  | -- compile to a scheme file; profiling flag
+    CompileSchemeI Bool Text (HQ.HashQualified Name)
   | TestI TestInput
   | CreateAuthorI NameSegment {- identifier -} Text {- name -}
   | -- Display provided definitions.

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -2991,9 +2991,10 @@ compileScheme =
     "compile.native"
     []
     I.Hidden
-    [("definition to compile", Required, exactDefinitionTermQueryArg),
-     ("output file", Required, filePathArg),
-     ("profile", Optional, profileArg)]
+    [ ("definition to compile", Required, exactDefinitionTermQueryArg),
+      ("output file", Required, filePathArg),
+      ("profile", Optional, profileArg)
+    ]
     ( P.wrapColumn2
         [ ( makeExample compileScheme ["main", "file", "profile"],
             "Creates stand alone executable via compilation to"
@@ -3006,20 +3007,21 @@ compileScheme =
     $ \case
       [main, file] -> mkCompileScheme False file main
       [main, file, prof] -> do
-        unsupportedStructuredArgument compileScheme "profile" prof >>=
-          \case
+        unsupportedStructuredArgument compileScheme "profile" prof
+          >>= \case
             "profile" -> mkCompileScheme True file main
-            parg -> Left . P.text $
-              "I expected the third argument to be `profile`, but"
-                <> " instead recieved `" <> Text.pack parg <> "`."
+            parg ->
+              Left . P.text $
+                "I expected the third argument to be `profile`, but"
+                  <> " instead recieved `"
+                  <> Text.pack parg
+                  <> "`."
       args -> wrongArgsLength "two or three arguments" args
-
   where
-  mkCompileScheme pf fn mn =
-    Input.CompileSchemeI pf . Text.pack
-      <$> unsupportedStructuredArgument compileScheme "a file name" fn
-      <*> handleHashQualifiedNameArg mn
-
+    mkCompileScheme pf fn mn =
+      Input.CompileSchemeI pf . Text.pack
+        <$> unsupportedStructuredArgument compileScheme "a file name" fn
+        <*> handleHashQualifiedNameArg mn
 
 createAuthor :: InputPattern
 createAuthor =

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -3004,18 +3004,21 @@ compileScheme =
         ]
     )
     $ \case
-      [main, file] ->
-        Input.CompileSchemeI False . Text.pack
-          <$> unsupportedStructuredArgument compileScheme "a file name" file
-          <*> handleHashQualifiedNameArg main
-      [main, file, profile] ->
-        mk
-          <$> unsupportedStructuredArgument compileScheme "profile" profile
-          <*> unsupportedStructuredArgument compileScheme "a file name" file
-          <*> handleHashQualifiedNameArg main
-        where
-          mk _ fn mn = Input.CompileSchemeI True (Text.pack fn) mn
+      [main, file] -> mkCompileScheme False file main
+      [main, file, prof] -> do
+        unsupportedStructuredArgument compileScheme "profile" prof >>=
+          \case
+            "profile" -> mkCompileScheme True file main
+            parg -> Left . P.text $
+              "I expected the third argument to be `profile`, but"
+                <> " instead recieved `" <> Text.pack parg <> "`."
       args -> wrongArgsLength "two or three arguments" args
+
+  where
+  mkCompileScheme pf fn mn =
+    Input.CompileSchemeI pf . Text.pack
+      <$> unsupportedStructuredArgument compileScheme "a file name" fn
+      <*> handleHashQualifiedNameArg mn
 
 
 createAuthor :: InputPattern

--- a/unison-runtime/src/Unison/Runtime/Interface.hs
+++ b/unison-runtime/src/Unison/Runtime/Interface.hs
@@ -74,7 +74,7 @@ import System.Process
 import Unison.Builtin.Decls qualified as RF
 import Unison.Codebase.CodeLookup (CodeLookup (..))
 import Unison.Codebase.MainTerm (builtinIOTestTypes, builtinMain)
-import Unison.Codebase.Runtime (Error, CompileOpts (..), Runtime (..))
+import Unison.Codebase.Runtime (CompileOpts (..), Error, Runtime (..))
 import Unison.ConstructorReference (ConstructorReference, GConstructorReference (..))
 import Unison.ConstructorReference qualified as RF
 import Unison.DataDeclaration (Decl, declFields, declTypeDependencies)
@@ -954,8 +954,9 @@ nativeCompileCodes copts executable codes base path = do
       racoError (e :: IOException) =
         throwIO $ PE callStack (racoErrMsg (makeRacoCmd RawCommand) (Right e))
       dargs = ["-G", srcPath]
-      pargs | profile copts = "--profile" : dargs
-            | otherwise = dargs
+      pargs
+        | profile copts = "--profile" : dargs
+        | otherwise = dargs
       p = ucrCompileProc executable pargs
       makeRacoCmd :: (FilePath -> [String] -> a) -> a
       makeRacoCmd f = f "raco" ["exe", "-o", path, srcPath]

--- a/unison-runtime/src/Unison/Runtime/Interface.hs
+++ b/unison-runtime/src/Unison/Runtime/Interface.hs
@@ -74,7 +74,7 @@ import System.Process
 import Unison.Builtin.Decls qualified as RF
 import Unison.Codebase.CodeLookup (CodeLookup (..))
 import Unison.Codebase.MainTerm (builtinIOTestTypes, builtinMain)
-import Unison.Codebase.Runtime (Error, Runtime (..))
+import Unison.Codebase.Runtime (Error, CompileOpts (..), Runtime (..))
 import Unison.ConstructorReference (ConstructorReference, GConstructorReference (..))
 import Unison.ConstructorReference qualified as RF
 import Unison.DataDeclaration (Decl, declFields, declTypeDependencies)
@@ -637,27 +637,29 @@ racoErrMsg c = \case
 nativeCompile ::
   FilePath ->
   IORef EvalCtx ->
+  CompileOpts ->
   CodeLookup Symbol IO () ->
   PrettyPrintEnv ->
   Reference ->
   FilePath ->
   IO (Maybe Error)
-nativeCompile executable ctxVar cl ppe base path = tryM $ do
+nativeCompile executable ctxVar copts cl ppe base path = tryM $ do
   ctx <- readIORef ctxVar
   (tyrs, tmrs) <- collectRefDeps cl base
   (ctx, codes) <- loadDeps cl ppe ctx tyrs tmrs
   Just ibase <- pure $ baseToIntermed ctx base
-  nativeCompileCodes executable codes ibase path
+  nativeCompileCodes copts executable codes ibase path
 
 interpCompile ::
   Text ->
   IORef EvalCtx ->
+  CompileOpts ->
   CodeLookup Symbol IO () ->
   PrettyPrintEnv ->
   Reference ->
   FilePath ->
   IO (Maybe Error)
-interpCompile version ctxVar cl ppe rf path = tryM $ do
+interpCompile version ctxVar _copts cl ppe rf path = tryM $ do
   ctx <- readIORef ctxVar
   (tyrs, tmrs) <- collectRefDeps cl rf
   (ctx, _) <- loadDeps cl ppe ctx tyrs tmrs
@@ -927,12 +929,13 @@ nativeEvalInContext executable ppe ctx serv port codes base = do
     `UnliftIO.catch` ucrError
 
 nativeCompileCodes ::
+  CompileOpts ->
   FilePath ->
   [(Reference, SuperGroup Symbol)] ->
   Reference ->
   FilePath ->
   IO ()
-nativeCompileCodes executable codes base path = do
+nativeCompileCodes copts executable codes base path = do
   ensureRuntimeExists executable
   ensureRacoExists
   genDir <- getXdgDirectory XdgCache "unisonlanguage/racket-tmp"
@@ -950,7 +953,10 @@ nativeCompileCodes executable codes base path = do
         throwIO $ PE callStack (runtimeErrMsg (cmdspec p) (Right e))
       racoError (e :: IOException) =
         throwIO $ PE callStack (racoErrMsg (makeRacoCmd RawCommand) (Right e))
-      p = ucrCompileProc executable ["-G", srcPath]
+      dargs = ["-G", srcPath]
+      pargs | profile copts = "--profile" : dargs
+            | otherwise = dargs
+      p = ucrCompileProc executable pargs
       makeRacoCmd :: (FilePath -> [String] -> a) -> a
       makeRacoCmd f = f "raco" ["exe", "-o", path, srcPath]
   withCreateProcess p callout


### PR DESCRIPTION
The main change in this PR is to add an argument to `compile.native` that turns on profiling around the main entry point. This means that the whole program gets profiled, printing out summaries every 60s and on program exit.

This doesn't allow you to profile particular sections of code, but it's easy to toggle when you're creating the program.

I also included the implementation of `sqrt` which Mitchell noticed was missing.