### PR TITLE
bugfix: fix tdnr + name resolution bug

### DIFF
--- a/parser-typechecker/src/Unison/DataDeclaration/Dependencies.hs
+++ b/parser-typechecker/src/Unison/DataDeclaration/Dependencies.hs
@@ -121,5 +121,6 @@ hashFieldAccessors ppe declName vars declRef dd = do
                 dataDecls = Map.singleton declRef (void dd),
                 effectDecls = mempty
               },
-          termsByShortname = mempty
+          termsByShortname = mempty,
+          topLevelComponents = Map.empty
         }

--- a/parser-typechecker/src/Unison/FileParsers.hs
+++ b/parser-typechecker/src/Unison/FileParsers.hs
@@ -93,7 +93,8 @@ computeTypecheckingEnvironment shouldUseTndr ambientAbilities typeLookupf uf =
         Typechecker.Env
           { ambientAbilities = ambientAbilities,
             typeLookup = tl,
-            termsByShortname = Map.empty
+            termsByShortname = Map.empty,
+            topLevelComponents = Map.empty
           }
     ShouldUseTndr'Yes parsingEnv -> do
       let tm = UF.typecheckingTerm uf
@@ -137,7 +138,8 @@ computeTypecheckingEnvironment shouldUseTndr ambientAbilities typeLookupf uf =
         Typechecker.Env
           { ambientAbilities,
             typeLookup = tl,
-            termsByShortname
+            termsByShortname,
+            topLevelComponents = Map.empty
           }
 
 synthesizeFile ::

--- a/parser-typechecker/src/Unison/FileParsers.hs
+++ b/parser-typechecker/src/Unison/FileParsers.hs
@@ -10,7 +10,6 @@ import Control.Monad.State (evalStateT)
 import Data.Foldable qualified as Foldable
 import Data.List (partition)
 import Data.List qualified as List
-import Data.List.NonEmpty qualified as List.NonEmpty
 import Data.Map qualified as Map
 import Data.Sequence qualified as Seq
 import Data.Set qualified as Set
@@ -18,12 +17,14 @@ import Unison.ABT qualified as ABT
 import Unison.Blank qualified as Blank
 import Unison.Builtin qualified as Builtin
 import Unison.ConstructorReference qualified as ConstructorReference
-import Unison.Name qualified as Name
+import Unison.Name (Name)
 import Unison.Names qualified as Names
+import Unison.Names.ResolvesTo (ResolvesTo (..))
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
 import Unison.PrettyPrintEnv.Names qualified as PPE
 import Unison.Reference (TermReference, TypeReference)
+import Unison.Referent (Referent)
 import Unison.Referent qualified as Referent
 import Unison.Result (CompilerBug (..), Note (..), ResultT, pattern Result)
 import Unison.Result qualified as Result
@@ -40,6 +41,8 @@ import Unison.UnisonFile qualified as UF
 import Unison.UnisonFile.Names qualified as UF
 import Unison.Util.Defns (Defns (..), DefnsF)
 import Unison.Util.List qualified as List
+import Unison.Util.Map qualified as Map (upsert)
+import Unison.Util.Relation (Relation)
 import Unison.Util.Relation qualified as Rel
 import Unison.Var (Var)
 import Unison.Var qualified as Var
@@ -75,6 +78,7 @@ data ShouldUseTndr m
 --     * The parsing environment that was used to parse the parsed Unison file.
 --     * The parsed Unison file for which the typechecking environment is applicable.
 computeTypecheckingEnvironment ::
+  forall m v.
   (Var v, Monad m) =>
   ShouldUseTndr m ->
   [Type v] ->
@@ -92,56 +96,48 @@ computeTypecheckingEnvironment shouldUseTndr ambientAbilities typeLookupf uf =
             termsByShortname = Map.empty
           }
     ShouldUseTndr'Yes parsingEnv -> do
-      let preexistingNames = Parser.names parsingEnv
-          tm = UF.typecheckingTerm uf
-          possibleDeps =
-            [ (name, shortname, r)
-              | (name, r) <- Rel.toList (Names.terms preexistingNames),
-                v <- Set.toList (Term.freeVars tm),
-                let shortname = Name.unsafeParseVar v,
-                name `Name.endsWithReverseSegments` List.NonEmpty.toList (Name.reverseSegments shortname)
-            ]
+      let tm = UF.typecheckingTerm uf
+          resolveName :: Name -> Relation Name (ResolvesTo Referent)
+          resolveName =
+            Names.resolveNameIncludingNames
+              (Names.shadowing1 (Names.terms (UF.toNames uf)) (Names.terms (Parser.names parsingEnv)))
+              (Set.map Name.unsafeParseVar (UF.toTermAndWatchNames uf))
+          possibleDeps = do
+            v <- Set.toList (Term.freeVars tm)
+            let shortname = Name.unsafeParseVar v
+            (name, ref) <- Rel.toList (resolveName shortname)
+            [(name, shortname, ref)]
           possibleRefs =
             List.foldl'
               ( \acc -> \case
-                  (_, _, Referent.Con ref _) -> acc & over #types (Set.insert (ref ^. ConstructorReference.reference_))
-                  (_, _, Referent.Ref ref) -> acc & over #terms (Set.insert ref)
+                  (_, _, ResolvesToNamespace ref0) ->
+                    case ref0 of
+                      Referent.Con ref _ -> acc & over #types (Set.insert (ref ^. ConstructorReference.reference_))
+                      Referent.Ref ref -> acc & over #terms (Set.insert ref)
+                  (_, _, ResolvesToLocal _) -> acc
               )
               (Defns Set.empty Set.empty)
               possibleDeps
       tl <- fmap (UF.declsToTypeLookup uf <>) (typeLookupf (UF.dependencies uf <> possibleRefs))
-      -- For populating the TDNR environment, we pick definitions
-      -- from the namespace and from the local file whose full name
-      -- has a suffix that equals one of the free variables in the file.
-      -- Example, the namespace has [foo.bar.baz, qux.quaffle] and
-      -- the file has definitons [utils.zonk, utils.blah] and
-      -- the file has free variables [bar.baz, zonk].
-      --
-      -- In this case, [foo.bar.baz, utils.zonk] are used to create
-      -- the TDNR environment.
-      let fqnsByShortName =
-            List.multimap $
-              -- external TDNR possibilities
-              [ (shortname, nr)
-                | (name, shortname, r) <- possibleDeps,
-                  typ <- toList $ TL.typeOfReferent tl r,
-                  let nr = Typechecker.NamedReference name typ (Context.ReplacementRef r)
-              ]
-                <>
-                -- local file TDNR possibilities
-                [ (shortname, nr)
-                  | (name, r) <- Rel.toList (Names.terms $ UF.toNames uf),
-                    v <- Set.toList (Term.freeVars tm),
-                    let shortname = Name.unsafeParseVar v,
-                    name `Name.endsWithReverseSegments` List.NonEmpty.toList (Name.reverseSegments shortname),
-                    typ <- toList $ TL.typeOfReferent tl r,
-                    let nr = Typechecker.NamedReference name typ (Context.ReplacementRef r)
-                ]
+      let termsByShortname :: Map Name [Either Name (Typechecker.NamedReference v Ann)]
+          termsByShortname =
+            List.foldl'
+              ( \acc -> \case
+                  (name, shortname, ResolvesToLocal _) -> let v = Left name in Map.upsert (maybe [v] (v :)) shortname acc
+                  (name, shortname, ResolvesToNamespace ref) ->
+                    case TL.typeOfReferent tl ref of
+                      Just ty ->
+                        let v = Right (Typechecker.NamedReference name ty (Context.ReplacementRef ref))
+                         in Map.upsert (maybe [v] (v :)) shortname acc
+                      Nothing -> acc
+              )
+              Map.empty
+              possibleDeps
       pure
         Typechecker.Env
           { ambientAbilities,
             typeLookup = tl,
-            termsByShortname = fqnsByShortName
+            termsByShortname
           }
 
 synthesizeFile ::

--- a/parser-typechecker/src/Unison/Typechecker.hs
+++ b/parser-typechecker/src/Unison/Typechecker.hs
@@ -21,15 +21,11 @@ where
 
 import Control.Lens
 import Control.Monad.Fail (fail)
-import Control.Monad.State
-  ( State,
-    StateT,
-    execState,
-    get,
-    modify,
-  )
+import Control.Monad.State (StateT, get, modify)
 import Control.Monad.Writer
 import Data.Foldable
+import Data.Foldable qualified as Foldable
+import Data.List qualified as List
 import Data.Map qualified as Map
 import Data.Sequence qualified as Seq
 import Data.Sequence.NonEmpty qualified as NESeq (toSeq)
@@ -92,7 +88,11 @@ data Env v loc = Env
     --
     -- This mapping is populated before typechecking with as few entries
     -- as are needed to help resolve variables needing TDNR in the file.
-    termsByShortname :: Map Name.Name [NamedReference v loc]
+    --
+    -- - Left means a term in the file (for which we don't have a type before typechecking)
+    -- - Right means a term/constructor in the namespace, or a constructor in the file (for which we do have a type
+    --   before typechecking)
+    termsByShortname :: Map Name.Name [Either Name.Name (NamedReference v loc)]
   }
   deriving stock (Generic)
 
@@ -213,30 +213,37 @@ typeDirectedNameResolution ::
   Env v loc ->
   TDNR f v loc (Type v loc)
 typeDirectedNameResolution ppe oldNotes oldType env = do
-  -- Add typed components (local definitions) to the TDNR environment.
-  let tdnrEnv = execState (traverse_ addTypedComponent $ infos oldNotes) env
   -- Resolve blanks in the notes and generate some resolutions
   resolutions <-
-    liftResult . traverse (resolveNote tdnrEnv) . toList $
+    liftResult . traverse resolveNote . toList $
       infos oldNotes
   case catMaybes resolutions of
     [] -> pure oldType
     resolutions -> do
       substituted <- traverse substSuggestion resolutions
       case or substituted of
-        True -> synthesizeAndResolve ppe tdnrEnv
+        True -> synthesizeAndResolve ppe env
         False -> do
           -- The type hasn't changed
           liftResult $ suggest resolutions
           pure oldType
   where
-    addTypedComponent :: Context.InfoNote v loc -> State (Env v loc) ()
-    addTypedComponent (Context.TopLevelComponent vtts) =
-      for_ vtts \(v, typ, _) ->
-        let name = Name.unsafeParseVar (Var.reset v)
-         in for_ (Name.suffixes name) \suffix ->
-              #termsByShortname %= Map.insertWith (<>) suffix [NamedReference name typ (Context.ReplacementVar v)]
-    addTypedComponent _ = pure ()
+    topLevelComponents :: Map Name.Name (NamedReference v loc)
+    topLevelComponents =
+        List.foldl'
+          ( \acc0 -> \case
+              Context.TopLevelComponent vtts ->
+                List.foldl'
+                  ( \acc (v, typ, _) ->
+                      let name = Name.unsafeParseVar (Var.reset v)
+                       in Map.insert name (NamedReference name typ (Context.ReplacementVar v)) acc
+                  )
+                  acc0
+                  vtts
+              _ -> acc0
+          )
+          Map.empty
+          (Foldable.toList @Seq (infos oldNotes))
 
     suggest :: [Resolution v loc] -> Result (Notes v loc) ()
     suggest =
@@ -299,13 +306,17 @@ typeDirectedNameResolution ppe oldNotes oldType env = do
 
     -- Returns Nothing for irrelevant notes
     resolveNote ::
-      Env v loc ->
       Context.InfoNote v loc ->
       Result (Notes v loc) (Maybe (Resolution v loc))
-    resolveNote env = \case
+    resolveNote = \case
       Context.SolvedBlank (B.Resolve loc str) v it -> do
         let shortname = Name.unsafeParseText (Text.pack str)
-            matches = Map.findWithDefault [] shortname env.termsByShortname
+            matches =
+              env.termsByShortname
+                & Map.findWithDefault [] shortname
+                & mapMaybe \case
+                  Left longname -> Map.lookup longname topLevelComponents
+                  Right namedRef -> Just namedRef
         suggestions <- wither (resolve it) matches
         pure $
           Just

--- a/unison-cli/src/Unison/Cli/TypeCheck.hs
+++ b/unison-cli/src/Unison/Cli/TypeCheck.hs
@@ -49,7 +49,8 @@ typecheckTerm codebase tm = do
         Typechecker.Env
           { ambientAbilities = [],
             typeLookup,
-            termsByShortname = Map.empty
+            termsByShortname = Map.empty,
+            topLevelComponents = Map.empty
           }
   pure $ fmap extract $ FileParsers.synthesizeFile typecheckingEnv file
   where

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Run.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Run.hs
@@ -165,7 +165,8 @@ synthesizeForce tl typeOfFunc = do
         Typechecker.Env
           { ambientAbilities = [DD.exceptionType External, Type.builtinIO External],
             typeLookup = mempty {TypeLookup.typeOfTerms = Map.singleton ref typeOfFunc} <> tl,
-            termsByShortname = Map.empty
+            termsByShortname = Map.empty,
+            topLevelComponents = Map.empty
           }
   case Result.runResultT
     ( Typechecker.synthesize

--- a/unison-merge/src/Unison/Merge/Mergeblob5.hs
+++ b/unison-merge/src/Unison/Merge/Mergeblob5.hs
@@ -25,7 +25,8 @@ makeMergeblob5 blob typeLookup =
         Typechecker.Env
           { ambientAbilities = [],
             termsByShortname = Map.empty,
-            typeLookup
+            typeLookup,
+            topLevelComponents = Map.empty
           }
    in case runIdentity (Result.runResultT (FileParsers.synthesizeFile typecheckingEnv blob.file)) of
         (Nothing, notes) -> Left notes

--- a/unison-src/transcripts/fix-5369.md
+++ b/unison-src/transcripts/fix-5369.md
@@ -1,0 +1,23 @@
+```ucm
+scratch/main> builtins.merge
+```
+
+```unison
+one.foo : Nat
+one.foo = 17
+
+two.foo : Text
+two.foo = "blah"
+```
+
+```ucm
+scratch/main> add
+```
+
+```unison:error
+one.foo : Nat
+one.foo = 18
+
+bar : Nat
+bar = foo + foo
+```

--- a/unison-src/transcripts/fix-5369.md
+++ b/unison-src/transcripts/fix-5369.md
@@ -14,7 +14,7 @@ two.foo = "blah"
 scratch/main> add
 ```
 
-```unison:error
+```unison
 one.foo : Nat
 one.foo = 18
 

--- a/unison-src/transcripts/fix-5369.output.md
+++ b/unison-src/transcripts/fix-5369.output.md
@@ -1,0 +1,62 @@
+``` ucm
+scratch/main> builtins.merge
+
+  Done.
+
+```
+``` unison
+one.foo : Nat
+one.foo = 17
+
+two.foo : Text
+two.foo = "blah"
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      one.foo : Nat
+      two.foo : Text
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    one.foo : Nat
+    two.foo : Text
+
+```
+``` unison
+one.foo : Nat
+one.foo = 18
+
+bar : Nat
+bar = foo + foo
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I couldn't figure out what foo refers to here:
+  
+      5 | bar = foo + foo
+  
+  The name foo is ambiguous. Its type should be: Nat
+  
+  I found some terms in scope that have matching names and
+  types. Maybe you meant one of these:
+  
+  one.foo : Nat
+  one.foo : Nat
+
+```

--- a/unison-src/transcripts/fix-5369.output.md
+++ b/unison-src/transcripts/fix-5369.output.md
@@ -47,16 +47,17 @@ bar = foo + foo
 
   Loading changes detected in scratch.u.
 
-  I couldn't figure out what foo refers to here:
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
   
-      5 | bar = foo + foo
-  
-  The name foo is ambiguous. Its type should be: Nat
-  
-  I found some terms in scope that have matching names and
-  types. Maybe you meant one of these:
-  
-  one.foo : Nat
-  one.foo : Nat
+    ⍟ These new definitions are ok to `add`:
+    
+      bar : Nat
+    
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      one.foo : Nat
 
 ```

--- a/unison-src/transcripts/tdnr.md
+++ b/unison-src/transcripts/tdnr.md
@@ -1,0 +1,486 @@
+TDNR selects local term (in file) that typechecks over local term (in file) that doesn't.
+
+```ucm:hide
+scratch/main> builtins.merge lib.builtin
+```
+
+```unison
+good.foo = 17
+bad.foo = "bar"
+thing = foo Nat.+ foo
+```
+
+```ucm:hide
+scratch/main> delete.project scratch
+```
+
+TDNR selects local term (in file) that typechecks over local term (in namespace) that doesn't.
+
+```ucm:hide
+scratch/main> builtins.merge lib.builtin
+```
+
+```unison
+bad.foo = "bar"
+```
+
+```ucm
+scratch/main> add
+```
+
+```unison
+good.foo = 17
+thing = foo Nat.+ foo
+```
+
+```ucm:hide
+scratch/main> delete.project scratch
+```
+
+TDNR selects local term (in file) that typechecks over local term (shadowing namespace) that doesn't.
+
+```ucm:hide
+scratch/main> builtins.merge lib.builtin
+```
+
+```unison
+bad.foo = "bar"
+```
+
+```ucm
+scratch/main> add
+```
+
+```unison
+good.foo = 17
+bad.foo = "baz"
+thing = foo Nat.+ foo
+```
+
+```ucm:hide
+scratch/main> delete.project scratch
+```
+
+TDNR selects local term (in namespace) that typechecks over local term (in file) that doesn't.
+
+```ucm:hide
+scratch/main> builtins.merge lib.builtin
+```
+
+```unison
+good.foo = 17
+```
+
+```ucm
+scratch/main> add
+```
+
+```unison
+bad.foo = "bar"
+thing = foo Nat.+ foo
+```
+
+```ucm:hide
+scratch/main> delete.project scratch
+```
+
+TDNR selects local term (in namespace) that typechecks over local term (in namespace) that doesn't.
+
+```ucm:hide
+scratch/main> builtins.merge lib.builtin
+```
+
+```unison
+good.foo = 17
+bad.foo = "bar"
+```
+
+```ucm
+scratch/main> add
+```
+
+```unison
+thing = foo Nat.+ foo
+```
+
+```ucm:hide
+scratch/main> delete.project scratch
+```
+
+TDNR selects local term (in namespace) that typechecks over local term (shadowing namespace) that doesn't.
+
+```ucm:hide
+scratch/main> builtins.merge lib.builtin
+```
+
+```unison
+good.foo = 17
+bad.foo = "bar"
+```
+
+```ucm
+scratch/main> add
+```
+
+```unison
+bad.foo = "baz"
+thing = foo Nat.+ foo
+```
+
+```ucm:hide
+scratch/main> delete.project scratch
+```
+
+TDNR selects local term (shadowing namespace) that typechecks over local term (in file) that doesn't.
+
+```ucm:hide
+scratch/main> builtins.merge lib.builtin
+```
+
+```unison
+good.foo = 17
+```
+
+```ucm
+scratch/main> add
+```
+
+```unison
+good.foo = 18
+bad.foo = "bar"
+thing = foo Nat.+ foo
+```
+
+```ucm:hide
+scratch/main> delete.project scratch
+```
+
+TDNR selects local term (shadowing namespace) that typechecks over local term (in namespace) that doesn't.
+
+```ucm:hide
+scratch/main> builtins.merge lib.builtin
+```
+
+```unison
+good.foo = 17
+bad.foo = "bar"
+```
+
+```ucm
+scratch/main> add
+```
+
+```unison
+good.foo = 18
+thing = foo Nat.+ foo
+```
+
+```ucm:hide
+scratch/main> delete.project scratch
+```
+
+TDNR selects local term (shadowing namespace) that typechecks over local term (shadowing namespace) that doesn't.
+
+```ucm:hide
+scratch/main> builtins.merge lib.builtin
+```
+
+```unison
+good.foo = 17
+bad.foo = "bar"
+```
+
+```ucm
+scratch/main> add
+```
+
+```unison
+good.foo = 18
+bad.foo = "baz"
+thing = foo Nat.+ foo
+```
+
+```ucm:hide
+scratch/main> delete.project scratch
+```
+
+=== start local over direct dep
+
+TDNR selects local term (in file) that typechecks over direct dependency that doesn't.
+
+```ucm:hide
+scratch/main> builtins.merge lib.builtin
+```
+
+```unison
+lib.bad.foo = "bar"
+```
+
+```ucm
+scratch/main> add
+```
+
+```unison
+good.foo = 17
+thing = foo Nat.+ foo
+```
+
+```ucm:hide
+scratch/main> delete.project scratch
+```
+
+TDNR selects local term (in namespace) that typechecks over direct dependency that doesn't.
+
+```ucm:hide
+scratch/main> builtins.merge lib.builtin
+```
+
+```unison
+good.foo = 17
+lib.bad.foo = "bar"
+```
+
+```ucm
+scratch/main> add
+```
+
+```unison
+thing = foo Nat.+ foo
+```
+
+```ucm:hide
+scratch/main> delete.project scratch
+```
+
+TDNR selects local term (shadowing namespace) that typechecks over direct dependency that doesn't.
+
+```ucm:hide
+scratch/main> builtins.merge lib.builtin
+```
+
+```unison
+good.foo = 17
+lib.bad.foo = "bar"
+```
+
+```ucm
+scratch/main> add
+```
+
+```unison
+good.foo = 18
+thing = foo Nat.+ foo
+```
+
+```ucm:hide
+scratch/main> delete.project scratch
+```
+
+TDNR not used to select local term (in file) that typechecks over indirect dependency that also typechecks.
+
+```ucm:hide
+scratch/main> builtins.merge lib.builtin
+```
+
+```unison
+lib.dep.lib.dep.foo = 217
+```
+
+```ucm
+scratch/main> add
+```
+
+```unison
+good.foo = 17
+thing = foo Nat.+ foo
+```
+
+```ucm:hide
+scratch/main> delete.project scratch
+```
+
+TDNR not used to select local term (in namespace) that typechecks over indirect dependency that also typechecks.
+
+```ucm:hide
+scratch/main> builtins.merge lib.builtin
+```
+
+```unison
+good.foo = 17
+lib.dep.lib.dep.foo = 217
+```
+
+```ucm
+scratch/main> add
+```
+
+```unison
+thing = foo Nat.+ foo
+```
+
+```ucm:hide
+scratch/main> delete.project scratch
+```
+
+TDNR not used to select local term (shadowing namespace) that typechecks over indirect dependency that also typechecks.
+
+```ucm:hide
+scratch/main> builtins.merge lib.builtin
+```
+
+```unison
+good.foo = 17
+lib.dep.lib.dep.foo = 217
+```
+
+```ucm
+scratch/main> add
+```
+
+```unison
+good.foo = 18
+thing = foo Nat.+ foo
+```
+
+```ucm:hide
+scratch/main> delete.project scratch
+```
+
+TDNR selects direct dependency that typechecks over local term (in file) that doesn't.
+
+```ucm:hide
+scratch/main> builtins.merge lib.builtin
+```
+
+```unison
+lib.good.foo = 17
+```
+
+```ucm
+scratch/main> add
+```
+
+```unison
+bad.foo = "bar"
+thing = foo Nat.+ foo
+```
+
+```ucm:hide
+scratch/main> delete.project scratch
+```
+
+TDNR selects direct dependency that typechecks over local term (in namespace) that doesn't.
+
+```ucm:hide
+scratch/main> builtins.merge lib.builtin
+```
+
+```unison
+lib.good.foo = 17
+bad.foo = "bar"
+```
+
+```ucm
+scratch/main> add
+```
+
+```unison
+thing = foo Nat.+ foo
+```
+
+```ucm:hide
+scratch/main> delete.project scratch
+```
+
+TDNR selects direct dependency that typechecks over local term (shadowing namespace) that doesn't.
+
+```ucm:hide
+scratch/main> builtins.merge lib.builtin
+```
+
+```unison
+lib.good.foo = 17
+bad.foo = "bar"
+```
+
+```ucm
+scratch/main> add
+```
+
+```unison
+bad.foo = "baz"
+thing = foo Nat.+ foo
+```
+
+```ucm:hide
+scratch/main> delete.project scratch
+```
+
+TDNR selects direct dependency that typechecks over direct dependency that doesn't.
+
+```ucm:hide
+scratch/main> builtins.merge lib.builtin
+```
+
+```unison
+lib.good.foo = 17
+lib.bad.foo = "bar"
+```
+
+```ucm
+scratch/main> add
+```
+
+```unison
+thing = foo Nat.+ foo
+```
+
+```ucm:hide
+scratch/main> delete.project scratch
+```
+
+TDNR not used to select direct dependency that typechecks over indirect dependency that also typechecks.
+
+```ucm:hide
+scratch/main> builtins.merge lib.builtin
+```
+
+```unison
+lib.good.foo = 17
+lib.dep.lib.dep.foo = 217
+```
+
+```ucm
+scratch/main> add
+```
+
+```unison
+thing = foo Nat.+ foo
+```
+
+```ucm:hide
+scratch/main> delete.project scratch
+```
+
+TDNR selects indirect dependency that typechecks over indirect dependency that doesn't.
+
+```ucm:hide
+scratch/main> builtins.merge lib.builtin
+```
+
+```unison
+lib.dep.lib.good.foo = 17
+lib.dep.lib.bad.foo = "bar"
+```
+
+```ucm
+scratch/main> add
+```
+
+```unison
+thing = foo Nat.+ foo
+```
+
+```ucm:hide
+scratch/main> delete.project scratch
+```

--- a/unison-src/transcripts/tdnr.output.md
+++ b/unison-src/transcripts/tdnr.output.md
@@ -1,0 +1,1008 @@
+TDNR selects local term (in file) that typechecks over local term (in file) that doesn't.
+
+``` unison
+good.foo = 17
+bad.foo = "bar"
+thing = foo Nat.+ foo
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      bad.foo  : Text
+      good.foo : Nat
+      thing    : Nat
+
+```
+TDNR selects local term (in file) that typechecks over local term (in namespace) that doesn't.
+
+``` unison
+bad.foo = "bar"
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      bad.foo : Text
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    bad.foo : Text
+
+```
+``` unison
+good.foo = 17
+thing = foo Nat.+ foo
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      good.foo : Nat
+      thing    : Nat
+
+```
+TDNR selects local term (in file) that typechecks over local term (shadowing namespace) that doesn't.
+
+``` unison
+bad.foo = "bar"
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      bad.foo : Text
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    bad.foo : Text
+
+```
+``` unison
+good.foo = 17
+bad.foo = "baz"
+thing = foo Nat.+ foo
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      good.foo : Nat
+      thing    : Nat
+    
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      bad.foo : Text
+
+```
+TDNR selects local term (in namespace) that typechecks over local term (in file) that doesn't.
+
+``` unison
+good.foo = 17
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      good.foo : Nat
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    good.foo : Nat
+
+```
+``` unison
+bad.foo = "bar"
+thing = foo Nat.+ foo
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      bad.foo : Text
+      thing   : Nat
+
+```
+TDNR selects local term (in namespace) that typechecks over local term (in namespace) that doesn't.
+
+``` unison
+good.foo = 17
+bad.foo = "bar"
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      bad.foo  : Text
+      good.foo : Nat
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    bad.foo  : Text
+    good.foo : Nat
+
+```
+``` unison
+thing = foo Nat.+ foo
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      thing : Nat
+
+```
+TDNR selects local term (in namespace) that typechecks over local term (shadowing namespace) that doesn't.
+
+``` unison
+good.foo = 17
+bad.foo = "bar"
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      bad.foo  : Text
+      good.foo : Nat
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    bad.foo  : Text
+    good.foo : Nat
+
+```
+``` unison
+bad.foo = "baz"
+thing = foo Nat.+ foo
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      thing : Nat
+    
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      bad.foo : Text
+
+```
+TDNR selects local term (shadowing namespace) that typechecks over local term (in file) that doesn't.
+
+``` unison
+good.foo = 17
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      good.foo : Nat
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    good.foo : Nat
+
+```
+``` unison
+good.foo = 18
+bad.foo = "bar"
+thing = foo Nat.+ foo
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      bad.foo : Text
+      thing   : Nat
+    
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      good.foo : Nat
+
+```
+TDNR selects local term (shadowing namespace) that typechecks over local term (in namespace) that doesn't.
+
+``` unison
+good.foo = 17
+bad.foo = "bar"
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      bad.foo  : Text
+      good.foo : Nat
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    bad.foo  : Text
+    good.foo : Nat
+
+```
+``` unison
+good.foo = 18
+thing = foo Nat.+ foo
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      thing : Nat
+    
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      good.foo : Nat
+
+```
+TDNR selects local term (shadowing namespace) that typechecks over local term (shadowing namespace) that doesn't.
+
+``` unison
+good.foo = 17
+bad.foo = "bar"
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      bad.foo  : Text
+      good.foo : Nat
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    bad.foo  : Text
+    good.foo : Nat
+
+```
+``` unison
+good.foo = 18
+bad.foo = "baz"
+thing = foo Nat.+ foo
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      thing : Nat
+    
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      bad.foo  : Text
+      good.foo : Nat
+
+```
+\=== start local over direct dep
+
+TDNR selects local term (in file) that typechecks over direct dependency that doesn't.
+
+``` unison
+lib.bad.foo = "bar"
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      lib.bad.foo : Text
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    lib.bad.foo : Text
+
+```
+``` unison
+good.foo = 17
+thing = foo Nat.+ foo
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      good.foo : Nat
+      thing    : Nat
+
+```
+TDNR selects local term (in namespace) that typechecks over direct dependency that doesn't.
+
+``` unison
+good.foo = 17
+lib.bad.foo = "bar"
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      good.foo    : Nat
+      lib.bad.foo : Text
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    good.foo    : Nat
+    lib.bad.foo : Text
+
+```
+``` unison
+thing = foo Nat.+ foo
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      thing : Nat
+
+```
+TDNR selects local term (shadowing namespace) that typechecks over direct dependency that doesn't.
+
+``` unison
+good.foo = 17
+lib.bad.foo = "bar"
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      good.foo    : Nat
+      lib.bad.foo : Text
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    good.foo    : Nat
+    lib.bad.foo : Text
+
+```
+``` unison
+good.foo = 18
+thing = foo Nat.+ foo
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      thing : Nat
+    
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      good.foo : Nat
+
+```
+TDNR not used to select local term (in file) that typechecks over indirect dependency that also typechecks.
+
+``` unison
+lib.dep.lib.dep.foo = 217
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      lib.dep.lib.dep.foo : Nat
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    lib.dep.lib.dep.foo : Nat
+
+```
+``` unison
+good.foo = 17
+thing = foo Nat.+ foo
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      good.foo : Nat
+      thing    : Nat
+
+```
+TDNR not used to select local term (in namespace) that typechecks over indirect dependency that also typechecks.
+
+``` unison
+good.foo = 17
+lib.dep.lib.dep.foo = 217
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      good.foo            : Nat
+      lib.dep.lib.dep.foo : Nat
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    good.foo            : Nat
+    lib.dep.lib.dep.foo : Nat
+
+```
+``` unison
+thing = foo Nat.+ foo
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      thing : Nat
+
+```
+TDNR not used to select local term (shadowing namespace) that typechecks over indirect dependency that also typechecks.
+
+``` unison
+good.foo = 17
+lib.dep.lib.dep.foo = 217
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      good.foo            : Nat
+      lib.dep.lib.dep.foo : Nat
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    good.foo            : Nat
+    lib.dep.lib.dep.foo : Nat
+
+```
+``` unison
+good.foo = 18
+thing = foo Nat.+ foo
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      thing : Nat
+    
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      good.foo : Nat
+
+```
+TDNR selects direct dependency that typechecks over local term (in file) that doesn't.
+
+``` unison
+lib.good.foo = 17
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      lib.good.foo : Nat
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    lib.good.foo : Nat
+
+```
+``` unison
+bad.foo = "bar"
+thing = foo Nat.+ foo
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      bad.foo : Text
+      thing   : Nat
+
+```
+TDNR selects direct dependency that typechecks over local term (in namespace) that doesn't.
+
+``` unison
+lib.good.foo = 17
+bad.foo = "bar"
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      bad.foo      : Text
+      lib.good.foo : Nat
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    bad.foo      : Text
+    lib.good.foo : Nat
+
+```
+``` unison
+thing = foo Nat.+ foo
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      thing : Nat
+
+```
+TDNR selects direct dependency that typechecks over local term (shadowing namespace) that doesn't.
+
+``` unison
+lib.good.foo = 17
+bad.foo = "bar"
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      bad.foo      : Text
+      lib.good.foo : Nat
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    bad.foo      : Text
+    lib.good.foo : Nat
+
+```
+``` unison
+bad.foo = "baz"
+thing = foo Nat.+ foo
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      thing : Nat
+    
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      bad.foo : Text
+
+```
+TDNR selects direct dependency that typechecks over direct dependency that doesn't.
+
+``` unison
+lib.good.foo = 17
+lib.bad.foo = "bar"
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      lib.bad.foo  : Text
+      lib.good.foo : Nat
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    lib.bad.foo  : Text
+    lib.good.foo : Nat
+
+```
+``` unison
+thing = foo Nat.+ foo
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      thing : Nat
+
+```
+TDNR not used to select direct dependency that typechecks over indirect dependency that also typechecks.
+
+``` unison
+lib.good.foo = 17
+lib.dep.lib.dep.foo = 217
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      lib.dep.lib.dep.foo : Nat
+      lib.good.foo        : Nat
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    lib.dep.lib.dep.foo : Nat
+    lib.good.foo        : Nat
+
+```
+``` unison
+thing = foo Nat.+ foo
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      thing : Nat
+
+```
+TDNR selects indirect dependency that typechecks over indirect dependency that doesn't.
+
+``` unison
+lib.dep.lib.good.foo = 17
+lib.dep.lib.bad.foo = "bar"
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      lib.dep.lib.bad.foo  : Text
+      lib.dep.lib.good.foo : Nat
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    lib.dep.lib.bad.foo  : Text
+    lib.dep.lib.good.foo : Nat
+
+```
+``` unison
+thing = foo Nat.+ foo
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      thing : Nat
+
+```


### PR DESCRIPTION
## Overview

Fixes #5369 

This PR fixes the bug demonstrated in #5369. As of this PR, name resolution (logically) works as follows:

- When resolving a name `foo`,
  - Start with all names in scope (the project local definitions, direct dependencies, and indirect dependencies)
  - Throw away names that don't end in `foo`
  - Throw away indirect dependencies, unless they're all indirect dependencies
    - This implements the "prefer direct deps to indirect deps" logic
  - (for terms only) Throw away names that don't typecheck (i.e. do TDNR) 

Previously, the last step did not properly shadow namespace names with file names, and furthermore was a little out of sync with the "prefer direct deps" rule.

## Test coverage

I've added a regression test for #5369, and another big transcript that shows how TDNR works in a number of different situations