### PR TITLE
Statically resolve literal types at code-gen

### DIFF
--- a/unison-runtime/src/Unison/Runtime/Builtin.hs
+++ b/unison-runtime/src/Unison/Runtime/Builtin.hs
@@ -42,6 +42,7 @@ import Crypto.PubKey.Ed25519 qualified as Ed25519
 import Crypto.PubKey.RSA.PKCS15 qualified as RSA
 import Crypto.Random (getRandomBytes)
 import Data.Bits (shiftL, shiftR, (.|.))
+import Unison.Runtime.Builtin.TypeNumbering
 import Data.ByteArray qualified as BA
 import Data.ByteString (hGet, hGetSome, hPut)
 import Data.ByteString.Lazy qualified as L
@@ -3619,14 +3620,6 @@ verifyRsaWrapper (public0, msg0, sig0) = case validated of
     sig = Bytes.toArray sig0 :: ByteString
     validated = Rsa.parseRsaPublicKey (Bytes.toArray public0 :: ByteString)
 
-typeReferences :: [(Reference, Word64)]
-typeReferences = zip rs [1 ..]
-  where
-    rs =
-      [r | (_, r) <- Ty.builtinTypes]
-        ++ [DerivedId i | (_, i, _) <- Ty.builtinDataDecls]
-        ++ [DerivedId i | (_, i, _) <- Ty.builtinEffectDecls]
-
 foreignDeclResults ::
   Bool -> (Word64, [(Data.Text.Text, (Sandbox, SuperNormal Symbol))], EnumMap Word64 (Data.Text.Text, ForeignFunc))
 foreignDeclResults sanitize =
@@ -3646,9 +3639,6 @@ builtinTermNumbering =
 builtinTermBackref :: EnumMap Word64 Reference
 builtinTermBackref =
   mapFromList . zip [1 ..] . Map.keys $ builtinLookup
-
-builtinTypeNumbering :: Map Reference Word64
-builtinTypeNumbering = Map.fromList typeReferences
 
 builtinTypeBackref :: EnumMap Word64 Reference
 builtinTypeBackref = mapFromList $ swap <$> typeReferences

--- a/unison-runtime/src/Unison/Runtime/Builtin.hs
+++ b/unison-runtime/src/Unison/Runtime/Builtin.hs
@@ -42,7 +42,7 @@ import Crypto.PubKey.Ed25519 qualified as Ed25519
 import Crypto.PubKey.RSA.PKCS15 qualified as RSA
 import Crypto.Random (getRandomBytes)
 import Data.Bits (shiftL, shiftR, (.|.))
-import Unison.Runtime.Builtin.TypeNumbering
+import Unison.Runtime.Builtin.Types
 import Data.ByteArray qualified as BA
 import Data.ByteString (hGet, hGetSome, hPut)
 import Data.ByteString.Lazy qualified as L
@@ -155,7 +155,6 @@ import System.Process as SYS
   )
 import System.X509 qualified as X
 import Unison.ABT.Normalized hiding (TTm)
-import Unison.Builtin qualified as Ty (builtinTypes)
 import Unison.Builtin.Decls qualified as Ty
 import Unison.Prelude hiding (Text, some)
 import Unison.Reference
@@ -3639,11 +3638,6 @@ builtinTermNumbering =
 builtinTermBackref :: EnumMap Word64 Reference
 builtinTermBackref =
   mapFromList . zip [1 ..] . Map.keys $ builtinLookup
-
-builtinTypeBackref :: EnumMap Word64 Reference
-builtinTypeBackref = mapFromList $ swap <$> typeReferences
-  where
-    swap (x, y) = (y, x)
 
 builtinForeigns :: EnumMap Word64 ForeignFunc
 builtinForeigns | (_, _, m) <- foreignDeclResults False = snd <$> m

--- a/unison-runtime/src/Unison/Runtime/Builtin/TypeNumbering.hs
+++ b/unison-runtime/src/Unison/Runtime/Builtin/TypeNumbering.hs
@@ -1,0 +1,18 @@
+module Unison.Runtime.Builtin.TypeNumbering (typeReferences, builtinTypeNumbering) where
+
+import Data.Map qualified as Map
+import Unison.Builtin qualified as Ty (builtinTypes)
+import Unison.Builtin.Decls qualified as Ty
+import Unison.Prelude hiding (Text, some)
+import Unison.Reference
+
+builtinTypeNumbering :: Map Reference Word64
+builtinTypeNumbering = Map.fromList typeReferences
+
+typeReferences :: [(Reference, Word64)]
+typeReferences = zip rs [1 ..]
+  where
+    rs =
+      [r | (_, r) <- Ty.builtinTypes]
+        ++ [DerivedId i | (_, i, _) <- Ty.builtinDataDecls]
+        ++ [DerivedId i | (_, i, _) <- Ty.builtinEffectDecls]

--- a/unison-runtime/src/Unison/Runtime/Builtin/Types.hs
+++ b/unison-runtime/src/Unison/Runtime/Builtin/Types.hs
@@ -1,10 +1,16 @@
-module Unison.Runtime.Builtin.TypeNumbering (typeReferences, builtinTypeNumbering) where
+module Unison.Runtime.Builtin.Types
+  ( typeReferences,
+    builtinTypeNumbering,
+    builtinTypeBackref,
+  )
+where
 
 import Data.Map qualified as Map
 import Unison.Builtin qualified as Ty (builtinTypes)
 import Unison.Builtin.Decls qualified as Ty
 import Unison.Prelude hiding (Text, some)
 import Unison.Reference
+import Unison.Util.EnumContainers as EC
 
 builtinTypeNumbering :: Map Reference Word64
 builtinTypeNumbering = Map.fromList typeReferences
@@ -16,3 +22,8 @@ typeReferences = zip rs [1 ..]
       [r | (_, r) <- Ty.builtinTypes]
         ++ [DerivedId i | (_, i, _) <- Ty.builtinDataDecls]
         ++ [DerivedId i | (_, i, _) <- Ty.builtinEffectDecls]
+
+builtinTypeBackref :: EnumMap Word64 Reference
+builtinTypeBackref = mapFromList $ swap <$> typeReferences
+  where
+    swap (x, y) = (y, x)

--- a/unison-runtime/src/Unison/Runtime/MCode.hs
+++ b/unison-runtime/src/Unison/Runtime/MCode.hs
@@ -91,7 +91,7 @@ import Unison.Runtime.ANF
     pattern TVar,
   )
 import Unison.Runtime.ANF qualified as ANF
-import Unison.Runtime.Builtin.TypeNumbering (builtinTypeNumbering)
+import Unison.Runtime.Builtin.Types (builtinTypeNumbering)
 import Unison.Util.EnumContainers as EC
 import Unison.Util.Text (Text)
 import Unison.Var (Var)

--- a/unison-runtime/src/Unison/Runtime/MCode/Serialize.hs
+++ b/unison-runtime/src/Unison/Runtime/MCode/Serialize.hs
@@ -183,7 +183,7 @@ putInstr pCix = \case
   (Pack r w a) -> putTag PackT *> putReference r *> pWord w *> putArgs a
   (Unpack mr i) -> putTag UnpackT *> putMaybe mr putReference *> pInt i
   (Lit l) -> putTag LitT *> putLit l
-  (BLit r l) -> putTag BLitT *> putReference r *> putLit l
+  (BLit r tt l) -> putTag BLitT *> putReference r *> putNat tt *> putLit l
   (Print i) -> putTag PrintT *> pInt i
   (Reset s) -> putTag ResetT *> putEnumSet pWord s
   (Fork i) -> putTag ForkT *> pInt i
@@ -206,7 +206,7 @@ getInstr gCix =
     PackT -> Pack <$> getReference <*> gWord <*> getArgs
     UnpackT -> Unpack <$> getMaybe getReference <*> gInt
     LitT -> Lit <$> getLit
-    BLitT -> BLit <$> getReference <*> getLit
+    BLitT -> BLit <$> getReference <*> getNat <*> getLit
     PrintT -> Print <$> gInt
     ResetT -> Reset <$> getEnumSet gWord
     ForkT -> Fork <$> gInt

--- a/unison-runtime/unison-runtime.cabal
+++ b/unison-runtime/unison-runtime.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -33,6 +33,7 @@ library
       Unison.Runtime.ANF.Serialize
       Unison.Runtime.Array
       Unison.Runtime.Builtin
+      Unison.Runtime.Builtin.TypeNumbering
       Unison.Runtime.Crypto.Rsa
       Unison.Runtime.Debug
       Unison.Runtime.Decompile

--- a/unison-runtime/unison-runtime.cabal
+++ b/unison-runtime/unison-runtime.cabal
@@ -33,7 +33,7 @@ library
       Unison.Runtime.ANF.Serialize
       Unison.Runtime.Array
       Unison.Runtime.Builtin
-      Unison.Runtime.Builtin.TypeNumbering
+      Unison.Runtime.Builtin.Types
       Unison.Runtime.Crypto.Rsa
       Unison.Runtime.Debug
       Unison.Runtime.Decompile


### PR DESCRIPTION
## Overview

Found a Map Lookup on a Reference for every numerical `BLit` instruction we process 😬;
Instead, do the lookup statically ahead of time when generating the code.

Unsurprisingly this helps the most with the micro benchmarks which do arithmetic on literals, we see a 1.2X improvement on the counting benchmarks, but it should help a little with any number-literal heavy loops and such.

### Benchmarks

**Trunk -> This branch**

```
Decode Nat
740ns -> 653ns
  
Generate 100 random numbers 
464.203µs -> 411.53µs
  
Count to 1 million
440.3634ms ->  364.804ms
  
Json parsing (per document)
376.44µs -> 360.04µs
  
Count to N (per element)
521ns -> 440ns
  
Count to 1000
527.065µs -> 440.988µs
  
Mutate a Ref 1000 times 
980.655µs -> 842.221µs
  
CAS an IO.ref 1000 times 
1.260218ms -> 1.141522ms
  
List.range (per element)
644ns -> 599ns
  
List.range 0 1000 
660.021µs -> 604.377µs
  
Set.fromList (range 0 1000)
3.024044ms -> 2.824032ms
  
Map.fromList (range 0 1000)
2.279482ms -> 2.113257ms
  
Map.lookup (1k element map)
5.775µs -> 5.239µs
  
Map.insert (1k element map)
14.5µs -> 13.019µs
  
List.at (1k element list)
584ns -> 481ns
  
Text.split /
40.354µs -> 40.099µs
```


## Implementation notes

* Split off part of the `Unison.Runtime.Builtins` module to `Unison.Runtime.Builtins.Types` to break cyclic dependencies
* Add the type-tag to the `BLit` instruction type
* Populate it when compiling.

## Interesting/controversial decisions

Pretty uncontroversial changes with a strictly positive benefit.