### PR TITLE
bugfix: fix suffixification of indirect dependencies

### DIFF
--- a/unison-core/src/Unison/Name.hs
+++ b/unison-core/src/Unison/Name.hs
@@ -575,7 +575,7 @@ suffixifyByHash fqn rel =
 
     isOk :: Name -> Bool
     isOk suffix =
-      Set.size matchingRefs == 1 || matchingRefs == allRefs
+      matchingRefs == allRefs
       where
         matchingRefs :: Set r
         matchingRefs =
@@ -598,7 +598,7 @@ suffixifyByHashName fqn rel =
 
     isOk :: Name -> Bool
     isOk suffix =
-      (Set.size matchingRefs == 1 || matchingRefs == allRefs)
+      matchingRefs == allRefs
         -- Don't use a suffix of 2+ aliases if any of then are non-local names
         && case numLocalNames of
           0 -> True

--- a/unison-src/transcripts/fix-5374.md
+++ b/unison-src/transcripts/fix-5374.md
@@ -1,0 +1,16 @@
+```ucm
+scratch/main> builtins.merge lib.builtin
+```
+
+```unison
+lib.direct.foo = 17
+lib.direct.lib.indirect.foo = 18
+
+thing = indirect.foo + indirect.foo
+```
+
+```ucm
+scratch/main> add
+scratch/main> view thing
+scratch/main> edit thing
+```

--- a/unison-src/transcripts/fix-5374.output.md
+++ b/unison-src/transcripts/fix-5374.output.md
@@ -40,6 +40,7 @@ scratch/main> view thing
   thing : Nat
   thing =
     use Nat +
+    use indirect foo
     foo + foo
 
 scratch/main> edit thing
@@ -56,6 +57,7 @@ scratch/main> edit thing
 thing : Nat
 thing =
   use Nat +
+  use indirect foo
   foo + foo
 ```
 

--- a/unison-src/transcripts/fix-5374.output.md
+++ b/unison-src/transcripts/fix-5374.output.md
@@ -1,0 +1,61 @@
+``` ucm
+scratch/main> builtins.merge lib.builtin
+
+  Done.
+
+```
+``` unison
+lib.direct.foo = 17
+lib.direct.lib.indirect.foo = 18
+
+thing = indirect.foo + indirect.foo
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      lib.direct.foo              : Nat
+      lib.direct.lib.indirect.foo : Nat
+      thing                       : Nat
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    lib.direct.foo              : Nat
+    lib.direct.lib.indirect.foo : Nat
+    thing                       : Nat
+
+scratch/main> view thing
+
+  thing : Nat
+  thing =
+    use Nat +
+    foo + foo
+
+scratch/main> edit thing
+
+  ☝️
+  
+  I added 1 definitions to the top of scratch.u
+  
+  You can edit them there, then run `update` to replace the
+  definitions currently in this namespace.
+
+```
+``` unison:added-by-ucm scratch.u
+thing : Nat
+thing =
+  use Nat +
+  foo + foo
+```
+


### PR DESCRIPTION
## Overview

Fixes #5374

This PR fixes a bug in suffixification of indirect dependencies. The bug was caused by the _unnecessary-but-harmless_ optimization to the stopping condition of suffixification (`Set.size matchingRefs == 1`), which has been around forever, and which suddenly became _necessary-not-to-do-and-decidedly-harmful-if-done_ after suffixification was amended to prefer direct deps to indirect deps in https://github.com/unisonweb/unison/pull/5338. The fix was simply to delete that optimization.

## Test coverage

I've added a transcript (failing in the first commit) that demonstrates the fix.