### PR TITLE
bugfix: name capture bug

### DIFF
--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -20,7 +20,6 @@ import Control.Monad.State qualified as State
 import Data.Char (isPrint)
 import Data.List
 import Data.List qualified as List
-import Data.List.NonEmpty qualified as NEL
 import Data.Map qualified as Map
 import Data.Set qualified as Set
 import Data.Text (unpack)
@@ -39,7 +38,6 @@ import Unison.HashQualified qualified as HQ
 import Unison.HashQualifiedPrime qualified as HQ'
 import Unison.Name (Name)
 import Unison.Name qualified as Name
-import Unison.NameSegment (NameSegment)
 import Unison.Pattern (Pattern)
 import Unison.Pattern qualified as Pattern
 import Unison.Prelude
@@ -2092,7 +2090,9 @@ nameEndsWith ppe suffix r = case PrettyPrintEnv.termName ppe (Referent.Ref r) of
 --   1. Form the set of all local variables used anywhere in the term
 --   2. When picking a name for a term, see if it is contained in this set.
 --      If yes: use a minimally qualified name which is longer than the suffixed name,
---              but doesn't conflict with any local vars.
+--              but doesn't conflict with any local vars. If even the fully-qualified
+--              name conflicts with any local vars, make it absolute. (This relies on
+--              disallowing absolute names for local variables).
 --      If no: use the suffixed name for the term
 --
 -- The algorithm does the same for type references in signatures.
@@ -2116,25 +2116,19 @@ avoidShadowing tm (PrettyPrintEnv terms types) =
     usedTypeNames =
       Set.fromList [n | Ann' _ ty <- ABT.subterms tm, v <- ABT.allVars ty, n <- varToName v]
     tweak :: Set Name -> (HQ'.HashQualified Name, HQ'.HashQualified Name) -> (HQ'.HashQualified Name, HQ'.HashQualified Name)
-    tweak used (fullName, HQ'.NameOnly suffixedName)
+    tweak used (HQ'.NameOnly fullName, HQ'.NameOnly suffixedName)
       | Set.member suffixedName used =
-          let revFQNSegments :: NEL.NonEmpty NameSegment
-              revFQNSegments = Name.reverseSegments (HQ'.toName fullName)
-              minimallySuffixed :: HQ'.HashQualified Name
-              minimallySuffixed =
-                revFQNSegments
-                  -- Get all suffixes (it's inits instead of tails because name segments are in reverse order)
-                  & NEL.inits
-                  -- Drop the empty 'init'
-                  & NEL.tail
-                  & mapMaybe (fmap Name.fromReverseSegments . NEL.nonEmpty) -- Convert back into names
+          let resuffixifiedName :: Name
+              resuffixifiedName =
+                fullName
+                  & Name.suffixes
                   -- Drop the suffixes that we know are shorter than the suffixified name
                   & List.drop (Name.countSegments suffixedName)
-                  -- Drop the suffixes that are equal to local variables
-                  & filter ((\n -> n `Set.notMember` used))
-                  & listToMaybe
-                  & maybe fullName HQ'.NameOnly
-           in (fullName, minimallySuffixed)
+                  -- Find the first (shortest) suffix that isn't in the used set
+                  & find (\n -> n `Set.notMember` used)
+                  -- If there isn't one, use the absolut-ified full name
+                  & fromMaybe (Name.makeAbsolute fullName)
+           in (HQ'.NameOnly fullName, HQ'.NameOnly resuffixifiedName)
     tweak _ p = p
     varToName :: (Var v) => v -> [Name]
     varToName = toList . Name.parseText . Var.name

--- a/parser-typechecker/tests/Unison/Core/Test/Name.hs
+++ b/parser-typechecker/tests/Unison/Core/Test/Name.hs
@@ -80,9 +80,9 @@ testSplitName =
 testSuffixes :: [Test ()]
 testSuffixes =
   [ scope "one namespace" $ expectEqual (suffixes (Name.unsafeParseText "bar")) [Name.unsafeParseText "bar"],
-    scope "two namespaces" $ expectEqual (suffixes (Name.unsafeParseText "foo.bar")) [Name.unsafeParseText "foo.bar", Name.unsafeParseText "bar"],
-    scope "multiple namespaces" $ expectEqual (suffixes (Name.unsafeParseText "foo.bar.baz")) [Name.unsafeParseText "foo.bar.baz", Name.unsafeParseText "bar.baz", Name.unsafeParseText "baz"],
-    scope "terms named `.`" $ expectEqual (suffixes (Name.unsafeParseText "base.`.`")) [Name.unsafeParseText "base.`.`", Name.unsafeParseText "`.`"]
+    scope "two namespaces" $ expectEqual (suffixes (Name.unsafeParseText "foo.bar")) [Name.unsafeParseText "bar", Name.unsafeParseText "foo.bar"],
+    scope "multiple namespaces" $ expectEqual (suffixes (Name.unsafeParseText "foo.bar.baz")) [Name.unsafeParseText "baz", Name.unsafeParseText "bar.baz", Name.unsafeParseText "foo.bar.baz"],
+    scope "terms named `.`" $ expectEqual (suffixes (Name.unsafeParseText "base.`.`")) [Name.unsafeParseText "`.`", Name.unsafeParseText "base.`.`"]
   ]
 
 testSuffixSearch :: [Test ()]

--- a/unison-core/src/Unison/Name.hs
+++ b/unison-core/src/Unison/Name.hs
@@ -464,7 +464,7 @@ stripNamePrefix (Name p0 ss0) (Name p1 ss1) = do
   s : ss <- List.stripPrefix (reverse (toList ss0)) (reverse (toList ss1))
   pure (Name Relative (List.NonEmpty.reverse (s :| ss)))
 
--- | Return all relative suffixes of a name, in descending-length order. The returned list will always be non-empty.
+-- | Return all relative suffixes of a name, in ascending-length order. The returned list will always be non-empty.
 --
 -- >>> suffixes "a.b.c"
 -- ["a.b.c", "a.b", "c"]
@@ -472,13 +472,7 @@ stripNamePrefix (Name p0 ss0) (Name p1 ss1) = do
 -- >>> suffixes ".a.b.c"
 -- ["a.b.c", "a.b", "c"]
 suffixes :: Name -> [Name]
-suffixes =
-  reverse . suffixes'
-
--- Like `suffixes`, but returns names in ascending-length order. Currently unexported, as it's only used in the
--- implementation of `shortestUniqueSuffix`.
-suffixes' :: Name -> [Name]
-suffixes' (Name _ ss0) = do
+suffixes (Name _ ss0) = do
   ss <- List.NonEmpty.tail (List.NonEmpty.inits ss0)
   -- fromList is safe here because all elements of `tail . inits` are non-empty
   pure (Name Relative (List.NonEmpty.fromList ss))
@@ -541,7 +535,7 @@ isUnqualified = \case
 -- NB: Only works if the `Ord` instance for `Name` orders based on `Name.reverseSegments`.
 suffixifyByName :: forall r. (Ord r) => Name -> R.Relation Name r -> Name
 suffixifyByName fqn rel =
-  fromMaybe fqn (List.find isOk (suffixes' fqn))
+  fromMaybe fqn (List.find isOk (suffixes fqn))
   where
     isOk :: Name -> Bool
     isOk suffix = matchingNameCount == 1
@@ -567,7 +561,7 @@ suffixifyByName fqn rel =
 -- NB: Only works if the `Ord` instance for `Name` orders based on `Name.reverseSegments`.
 suffixifyByHash :: forall r. (Ord r) => Name -> R.Relation Name r -> Name
 suffixifyByHash fqn rel =
-  fromMaybe fqn (List.find isOk (suffixes' fqn))
+  fromMaybe fqn (List.find isOk (suffixes fqn))
   where
     allRefs :: Set r
     allRefs =
@@ -590,7 +584,7 @@ suffixifyByHash fqn rel =
 -- edited in a scratch file, where "suffixify by hash" doesn't work.
 suffixifyByHashName :: forall r. (Ord r) => Name -> R.Relation Name r -> Name
 suffixifyByHashName fqn rel =
-  fromMaybe fqn (List.find isOk (suffixes' fqn))
+  fromMaybe fqn (List.find isOk (suffixes fqn))
   where
     allRefs :: Set r
     allRefs =

--- a/unison-src/transcripts/fix-5380.md
+++ b/unison-src/transcripts/fix-5380.md
@@ -1,0 +1,20 @@
+```ucm
+scratch/main> builtins.merge lib.builtin
+```
+
+```unison
+foo : Nat
+foo = 17
+
+bar : Nat
+bar =
+  qux : Nat
+  qux = 18
+  foo + qux
+```
+
+```ucm
+scratch/main> add
+scratch/main> move.term foo qux
+scratch/main> view bar
+```

--- a/unison-src/transcripts/fix-5380.output.md
+++ b/unison-src/transcripts/fix-5380.output.md
@@ -1,0 +1,53 @@
+``` ucm
+scratch/main> builtins.merge lib.builtin
+
+  Done.
+
+```
+``` unison
+foo : Nat
+foo = 17
+
+bar : Nat
+bar =
+  qux : Nat
+  qux = 18
+  foo + qux
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      bar : Nat
+      foo : Nat
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    bar : Nat
+    foo : Nat
+
+scratch/main> move.term foo qux
+
+  Done.
+
+scratch/main> view bar
+
+  bar : Nat
+  bar =
+    use Nat +
+    qux : Nat
+    qux = 18
+    qux + qux
+
+```

--- a/unison-src/transcripts/fix-5380.output.md
+++ b/unison-src/transcripts/fix-5380.output.md
@@ -48,6 +48,6 @@ scratch/main> view bar
     use Nat +
     qux : Nat
     qux = 18
-    qux + qux
+    .qux + qux
 
 ```


### PR DESCRIPTION
## Overview

Fixes #5380 

This PR fixes the name capture bug above simply by rendering names with a leading dot whenever the fully-qualified name is captured by a local binding.

No other changes appear to be necessary – we already parsed absolute names correctly, and we already disallow using an absolute name as a local variable binding.

## Test coverage

I've added a transcript 