### PR TITLE
repeat certain CI tests if transcripts/source files change

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,7 +97,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{env.ucm_local_bin}}
-          key: ucm-${{ matrix.os }}-${{ hashFiles('**/stack.yaml', '**/package.yaml', '**/*.hs')}}
+          key: ucm-${{ matrix.os }}-${{ hashFiles('**/stack.yaml', '**/package.yaml', '**/*.hs', '**/unison-cli-integration/integrationtests/IntegrationTests/*')}}
+          # added the integration test dependencies here as if they were source, for simplicity
 
       - name: restore stack caches
         if: steps.cache-ucm-binaries.outputs.cache-hit != 'true'
@@ -244,7 +245,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{env.transcript_test_results}}
-          key: transcripts-results-${{ matrix.os }}-${{ hashFiles('**/stack.yaml', '**/package.yaml', '**/*.hs')}}-${{ hashFiles('**/unison-src/**/*.md') }}
+          key: transcripts-results-${{ matrix.os }}-${{ hashFiles('**/stack.yaml', '**/package.yaml', '**/*.hs')}}-${{ hashFiles('**/unison-src/**/*.md', '**/unison-src/**/*.u') }}
       - name: restore binaries
         uses: actions/cache/restore@v4
         if: steps.cache-transcript-test-results.outputs.cache-hit != 'true'

--- a/unison-src/transcripts-round-trip/main.output.md
+++ b/unison-src/transcripts-round-trip/main.output.md
@@ -135,8 +135,8 @@ fixity =
       (%) = Nat.mod
       ($) = (+)
       c = 1 * (2 + 3) * 4
-      minus = 1 + 2 + 3
-      minus2 = 1 + (2 + 3)
+      plus = 1 + 2 + 3
+      plus2 = 1 + (2 + 3)
       d = true && (false || true)
       z = true || false && true
       e = 1 + 2 >= 3 + 4


### PR DESCRIPTION
## Overview

The integration tests were not being repeated when files they depended on change, and the same was true for round trip tests, leading to a CI failure in trunk due to an improperly skipped test during PR review.

## Implementation notes

Adds some more dependents to the ucm binaries cache key and transcript result cache key.

## Interesting/controversial decisions

Could have been more granular in either case -- pulling the integration test changes out from the other binaries, or splitting the round trip tests into a separate result cache, but it didn't seem worth the effort.

## Test coverage

## Loose ends
