### PR TITLE
mac arm builds

### DIFF
--- a/.github/workflows/bundle-ucm.yaml
+++ b/.github/workflows/bundle-ucm.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-12, windows-2019]
+        os: [ubuntu-20.04, macos-12, macos-14, windows-2019]
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v4
@@ -133,6 +133,7 @@ jobs:
         os:
           - ubuntu-20.04
           - macos-12
+          - macos-14
           - windows-2019
     runs-on: ${{matrix.os}}
     steps:
@@ -196,7 +197,7 @@ jobs:
       - name: set up environment
         run: |
           staging_dir="${RUNNER_TEMP//\\//}/ucm-staging"
-          artifact_os="$(echo $RUNNER_OS | tr '[:upper:]' '[:lower:]')"
+          artifact_os="$(echo "${RUNNER_OS}-${RUNNER_ARCH}" | tr '[:upper:]' '[:lower:]')"
           echo "staging_dir=$staging_dir" >> $GITHUB_ENV
           echo "artifact_os=$artifact_os" >> $GITHUB_ENV
       - name: download ucm

--- a/.github/workflows/bundle-ucm.yaml
+++ b/.github/workflows/bundle-ucm.yaml
@@ -91,7 +91,16 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
       - name: set up environment
-        run: echo "ucm=${{ runner.temp }}/unison" >> $GITHUB_ENV
+        run: |
+          echo "ucm=${{ runner.temp }}/unison" >> $GITHUB_ENV
+          case "$RUNNER_ARCH" in
+            X86) racket_arch=x86 ;;
+            X64) racket_arch=x64 ;;
+            ARM) racket_arch=arm32 ;;
+            ARM64) racket_arch=arm64 ;;
+            *) echo "Unsupported architecture: ${{runner.arch}}"; exit 1 ;;
+          esac
+          echo "racket_arch=$racket_arch" >> $GITHUB_ENV
       - name: download racket `unison` source
         uses: actions/checkout@v4
         with:
@@ -107,7 +116,7 @@ jobs:
           ${{ env.ucm }} transcript unison-src/transcripts-manual/gen-racket-libs.md
       - uses: Bogdanp/setup-racket@v1.11
         with:
-          architecture: "x64"
+          architecture: ${{ env.racket_arch }}
           distribution: "full"
           variant: "CS"
           version: ${{env.racket_version}}
@@ -156,9 +165,19 @@ jobs:
           # This isn't right because unison.zip is going to include different dates each time.
           # Maybe we can unpack it and hash the contents.
           key: ${{ runner.os }}-racket-${{env.racket_version}}-${{hashFiles('scheme-libs/racket/unison.zip')}}
+      - name: set up environment
+        run: |
+          case "$RUNNER_ARCH" in
+            X86) racket_arch=x86 ;;
+            X64) racket_arch=x64 ;;
+            ARM) racket_arch=arm32 ;;
+            ARM64) racket_arch=arm64 ;;
+            *) echo "Unsupported architecture: ${{runner.arch}}"; exit 1 ;;
+          esac
+          echo "racket_arch=$racket_arch" >> $GITHUB_ENV
       - uses: Bogdanp/setup-racket@v1.11
         with:
-          architecture: "x64"
+          architecture: ${{ env.racket_arch }}
           distribution: "full"
           variant: "CS"
           version: ${{env.racket_version}}

--- a/.github/workflows/bundle-ucm.yaml
+++ b/.github/workflows/bundle-ucm.yaml
@@ -211,7 +211,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-12, windows-2019]
+        os: [ubuntu-20.04, macos-12, macos-14, windows-2019]
     steps:
       - name: set up environment
         run: |


### PR DESCRIPTION
## Overview

Add some CI support for building on multiple platforms besides x86_64.

Adds a new runner for releases, and changes the filenames of release packages to include an architecture tag:
* ucm-linux-x64.tar.gz
* ucm-macos-arm64.tar.gz
* ucm-macos-x64.tar.gz
* ucm-windows-x64.zip

Closes #3045

## Interesting/controversial decisions

Wasn't sure whether mac arm and x64 both need to be run in CI or just during releases; as of now, it's just x64 in CI, like before.

## Test coverage

I ran it here: https://github.com/unisonweb/unison/releases/tag/mac-arm-build-build

## Loose ends
