### PR TITLE
Pin CI to a release version of @unison/runtime-tests

### DIFF
--- a/.github/workflows/ci-test-jit.yaml
+++ b/.github/workflows/ci-test-jit.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
 
 env:
-  runtime_tests_version: "@unison/runtime-tests/main"
+  runtime_tests_version: "@unison/runtime-tests/releases/0.0.1"
   # for best results, this should match the path in ci.yaml too; but GH doesn't make it easy to share them.
   runtime_tests_codebase: "~/.cache/unisonlanguage/runtime-tests.unison"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ env:
   ## Some version numbers that are used during CI
   ormolu_version: 0.7.2.0
   jit_version: "@unison/internal/releases/0.0.20"
-  runtime_tests_version: "@unison/runtime-tests/main"
+  runtime_tests_version: "@unison/runtime-tests/releases/0.0.1"
 
   ## Some cached directories
   # a temp path for caching a built `ucm`

--- a/unison-src/builtin-tests/interpreter-tests.sh
+++ b/unison-src/builtin-tests/interpreter-tests.sh
@@ -4,7 +4,7 @@ set -ex
 ucm=$(stack exec -- which unison)
 echo "$ucm"
 
-runtime_tests_version="@unison/runtime-tests/main"
+runtime_tests_version="@unison/runtime-tests/releases/0.0.1"
 echo $runtime_tests_version
 
 codebase=${XDG_CACHE_HOME:-"$HOME/.cache"}/unisonlanguage/runtime-tests.unison

--- a/unison-src/builtin-tests/jit-tests.sh
+++ b/unison-src/builtin-tests/jit-tests.sh
@@ -8,7 +8,7 @@ if [ -z "$1" ]; then
   exit 1
 fi
 
-runtime_tests_version="@unison/runtime-tests/main"
+runtime_tests_version="@unison/runtime-tests/releases/0.0.1"
 echo $runtime_tests_version
 
 codebase=${XDG_CACHE_HOME:-"$HOME/.cache"}/unisonlanguage/runtime-tests.unison


### PR DESCRIPTION
This changes the CI files to use a specific release version of `@unison/runtime-tests`, so that they can be changed without temporarily breaking CI until a corresponding github PR has been merged.