### PR TITLE
transcripts: Don’t trim spaces from Unison blocks

### DIFF
--- a/unison-cli/src/Unison/Codebase/Transcript/Parser.hs
+++ b/unison-cli/src/Unison/Codebase/Transcript/Parser.hs
@@ -119,9 +119,9 @@ fenced = do
       hide <- lineToken hidden
       err <- lineToken expectingError
       fileName <- optional untilSpace1
-      pure . Unison hide err fileName <$> (spaces *> P.getInput)
-    "api" -> do
-      pure . API <$> (spaces *> P.manyTill apiRequest P.eof)
+      P.single '\n'
+      pure . Unison hide err fileName <$> P.getInput
+    "api" -> pure . API <$> (spaces *> P.manyTill apiRequest P.eof)
     _ -> pure Nothing
 
 word :: Text -> P Text

--- a/unison-src/transcripts-using-base/nat-coersion.output.md
+++ b/unison-src/transcripts-using-base/nat-coersion.output.md
@@ -1,4 +1,5 @@
 ``` unison
+
 testNat: Nat -> Optional Int -> Optional Float -> {Stream Result}()
 testNat n expectInt expectFloat =
   float = Float.fromRepresentation n

--- a/unison-src/transcripts-using-base/net.output.md
+++ b/unison-src/transcripts-using-base/net.output.md
@@ -132,6 +132,7 @@ scratch/main> io.test testDefaultPort
 This example demonstrates connecting a TCP client socket to a TCP server socket. A thread is started for both client and server. The server socket asks for any availalbe port (by passing "0" as the port number). The server thread then queries for the actual assigned port number, and puts that into an MVar which the client thread can read. The client thread then reads a string from the server and reports it back to the main thread via a different MVar.
 
 ``` unison
+
 serverThread: MVar Nat -> Text -> '{io2.IO}()
 serverThread portVar toSend = 'let
   go : '{io2.IO, Exception}()

--- a/unison-src/transcripts-using-base/serial-test-04.output.md
+++ b/unison-src/transcripts-using-base/serial-test-04.output.md
@@ -1,4 +1,5 @@
 ``` unison
+
 mutual0 = cases
   0 -> "okay"
   n ->

--- a/unison-src/transcripts/abilities.output.md
+++ b/unison-src/transcripts/abilities.output.md
@@ -1,6 +1,7 @@
 Some random ability stuff to ensure things work.
 
 ``` unison
+
 unique ability A where
   one : Nat ->{A} Nat
   two : Nat -> Nat ->{A} Nat

--- a/unison-src/transcripts/any-extract.output.md
+++ b/unison-src/transcripts/any-extract.output.md
@@ -3,6 +3,7 @@
 Any.unsafeExtract is a way to extract the value contained in an Any. This is unsafe because it allows the programmer to coerce a value into any type, which would cause undefined behaviour if used to coerce a value to the wrong type.
 
 ``` unison
+
 test> Any.unsafeExtract.works =
   use Nat !=
   checks [1 == Any.unsafeExtract (Any 1),
@@ -26,7 +27,7 @@ test> Any.unsafeExtract.works =
   Now evaluating any watch expressions (lines starting with
   `>`)... Ctrl+C cancels.
 
-    3 |   checks [1 == Any.unsafeExtract (Any 1),
+    4 |   checks [1 == Any.unsafeExtract (Any 1),
     
     ✅ Passed Passed
 

--- a/unison-src/transcripts/ed25519.output.md
+++ b/unison-src/transcripts/ed25519.output.md
@@ -1,4 +1,5 @@
 ``` unison
+
 up = 0xs0123456789abcdef
 down = 0xsfedcba9876543210
 
@@ -40,12 +41,12 @@ sigOkay = match signature with
   Now evaluating any watch expressions (lines starting with
   `>`)... Ctrl+C cancels.
 
-    17 | > signature
+    18 | > signature
            ⧩
            Right
              0xs0b76988ce7e5147d36597d2a526ec7b8e178b3ae29083598c33c9fbcdf0f84b4ff2f8c5409123dd9a0c54447861c07e21296500a98540f5d5f15d927eaa6d30a
   
-    18 | > sigOkay
+    19 | > sigOkay
            ⧩
            Right true
 

--- a/unison-src/transcripts/fix2187.output.md
+++ b/unison-src/transcripts/fix2187.output.md
@@ -1,4 +1,5 @@
 ``` unison
+
 lexicalScopeEx: [Text]
 lexicalScopeEx =
   parent = "outer"

--- a/unison-src/transcripts/fix2712.output.md
+++ b/unison-src/transcripts/fix2712.output.md
@@ -29,6 +29,7 @@ scratch/main> add
 
 ```
 ``` unison
+
 naiomi = 
   susan: Nat -> Nat -> ()
   susan a b = ()

--- a/unison-src/transcripts/fix2826.output.md
+++ b/unison-src/transcripts/fix2826.output.md
@@ -7,6 +7,7 @@ scratch/main> builtins.mergeio
 Supports fences that are longer than three backticks.
 
 ```` unison
+
 doc = {{
   @typecheck ```
   x = 3

--- a/unison-src/transcripts/fix3244.output.md
+++ b/unison-src/transcripts/fix3244.output.md
@@ -3,6 +3,7 @@ that the variables bound in a guard matched the variables bound in the rest of
 the branch exactly, but apparently this needn't be the case.
 
 ``` unison
+
 foo t =
   (x, _) = t
   f w = w + x
@@ -30,7 +31,7 @@ foo t =
   Now evaluating any watch expressions (lines starting with
   `>`)... Ctrl+C cancels.
 
-    10 | > foo (10,20)
+    11 | > foo (10,20)
            ⧩
            30
 

--- a/unison-src/transcripts/fix3752.output.md
+++ b/unison-src/transcripts/fix3752.output.md
@@ -2,6 +2,7 @@ These were failing to type check before, because id was not
 generalized.
 
 ``` unison
+
 foo = do
   id x =
     _ = 1

--- a/unison-src/transcripts/lsp-fold-ranges.output.md
+++ b/unison-src/transcripts/lsp-fold-ranges.output.md
@@ -1,4 +1,5 @@
 ``` unison
+
 {{ Type doc }}
 structural type Optional a =
   None
@@ -26,6 +27,7 @@ test> z = let
 ``` ucm
 scratch/main> debug.lsp.fold-ranges
 
+  
   《{{ Type doc }}》
   《structural type Optional a =
     None

--- a/unison-src/transcripts/rsa.output.md
+++ b/unison-src/transcripts/rsa.output.md
@@ -1,4 +1,5 @@
 ``` unison
+
 up = 0xs0123456789abcdef
 down = 0xsfedcba9876543210
 
@@ -53,16 +54,16 @@ sigKo = match signature with
   Now evaluating any watch expressions (lines starting with
   `>`)... Ctrl+C cancels.
 
-    27 | > signature
+    28 | > signature
            ⧩
            Right
              0xs84b02b6bb0e1196b65378cb12b727f7b4b38e5979f0632e8a51cfab088827f6d3da4221788029f75a0a5f4d740372cfa590462888a1189bbd9de9b084f26116640e611af5a1a17229beec7fb2570887181bbdced8f0ebfec6cad6bdd318a616ba4f01c90e1436efe44b18417d18ce712a0763be834f8c76e0c39b2119b061373
   
-    28 | > sigOkay
+    29 | > sigOkay
            ⧩
            Right true
   
-    29 | > sigKo
+    30 | > sigKo
            ⧩
            Right false
 


### PR DESCRIPTION
## Overview

This was making it impossible to write a transcript replicating #5179.

## Test coverage

A number of transcripts have trivially-different outputs now, reflecting leading whitespace in the input.