### PR TITLE
Update Ormolu version in reformatting workflow

### DIFF
--- a/.github/workflows/ormolu.yaml
+++ b/.github/workflows/ormolu.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  ormolu_version: "0.5.2.0"
+  ormolu_version: "0.7.2.0"
 
 jobs:
   ormolu:


### PR DESCRIPTION
## Overview

The workflow that checks for correct formatting was using the correct version (0.7.2.0), but the one that reformats was still using 0.5.2.0.

## Loose ends

Ideally, we would only specify the Ormolu version in one place. Currently there are three
- the Nix flake
- two different GitHub workflows

The flake could read it from JSON/YAML/whatever (as it already does for Stack, etc.), but it’s annoying at best to read files in GH workflows.