### PR TITLE
bugfix: `namespace` + top level `use` parse error

### DIFF
--- a/parser-typechecker/src/Unison/Syntax/FileParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/FileParser.hs
@@ -54,7 +54,10 @@ file = do
   maybeNamespace :: Maybe Name.Name <-
     optional (reserved "namespace") >>= \case
       Nothing -> pure Nothing
-      Just _ -> Just . L.payload <$> (importWordyId <|> importSymbolyId)
+      Just _ -> do
+        namespace <- importWordyId <|> importSymbolyId
+        void (optional semi)
+        pure (Just (L.payload namespace))
   let maybeNamespaceVar = Name.toVar <$> maybeNamespace
 
   -- The file may optionally contain top-level imports,

--- a/unison-src/transcripts/fix-5402.md
+++ b/unison-src/transcripts/fix-5402.md
@@ -1,0 +1,13 @@
+`namespace` + top level `use` should work. Previously, they didn't.
+
+```unison:error
+namespace foo
+use bar baz
+x = 10
+```
+
+```unison:error
+use bar baz
+namespace foo
+x = 10
+```

--- a/unison-src/transcripts/fix-5402.md
+++ b/unison-src/transcripts/fix-5402.md
@@ -1,12 +1,12 @@
 `namespace` + top level `use` should work. Previously, they didn't.
 
-```unison:error
+```unison
 namespace foo
 use bar baz
 x = 10
 ```
 
-```unison:error
+```unison
 use bar baz
 namespace foo
 x = 10

--- a/unison-src/transcripts/fix-5402.output.md
+++ b/unison-src/transcripts/fix-5402.output.md
@@ -1,0 +1,74 @@
+`namespace` + top level `use` should work. Previously, they didn't.
+
+``` unison
+namespace foo
+use bar baz
+x = 10
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I got confused here:
+  
+      2 | use bar baz
+  
+  
+  I was surprised to find a 'use' here.
+  I was expecting one of these instead:
+  
+  * ability
+  * bang
+  * binding
+  * do
+  * false
+  * force
+  * handle
+  * if
+  * lambda
+  * let
+  * quote
+  * termLink
+  * true
+  * tuple
+  * type
+  * typeLink
+
+```
+``` unison
+use bar baz
+namespace foo
+x = 10
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I got confused here:
+  
+      1 | use bar baz
+  
+  
+  I was surprised to find a 'use' here.
+  I was expecting one of these instead:
+  
+  * ability
+  * bang
+  * binding
+  * do
+  * false
+  * force
+  * handle
+  * if
+  * lambda
+  * let
+  * quote
+  * termLink
+  * true
+  * tuple
+  * type
+  * typeLink
+
+```

--- a/unison-src/transcripts/fix-5402.output.md
+++ b/unison-src/transcripts/fix-5402.output.md
@@ -10,30 +10,13 @@ x = 10
 
   Loading changes detected in scratch.u.
 
-  I got confused here:
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
   
-      2 | use bar baz
-  
-  
-  I was surprised to find a 'use' here.
-  I was expecting one of these instead:
-  
-  * ability
-  * bang
-  * binding
-  * do
-  * false
-  * force
-  * handle
-  * if
-  * lambda
-  * let
-  * quote
-  * termLink
-  * true
-  * tuple
-  * type
-  * typeLink
+    ⍟ These new definitions are ok to `add`:
+    
+      foo.x : ##Nat
 
 ```
 ``` unison
@@ -46,29 +29,12 @@ x = 10
 
   Loading changes detected in scratch.u.
 
-  I got confused here:
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
   
-      1 | use bar baz
-  
-  
-  I was surprised to find a 'use' here.
-  I was expecting one of these instead:
-  
-  * ability
-  * bang
-  * binding
-  * do
-  * false
-  * force
-  * handle
-  * if
-  * lambda
-  * let
-  * quote
-  * termLink
-  * true
-  * tuple
-  * type
-  * typeLink
+    ⍟ These new definitions are ok to `add`:
+    
+      foo.x : ##Nat
 
 ```


### PR DESCRIPTION
## Overview

Fixes #5402

The `namespace` directive parser was erroneously not consuming the virtual semi that follows. Because the top-level `use` parser consumed _its_ virtual semi, things still appeared to work as long as either a `namespace` directive was present, or top-level `use`, but not both.

## Test coverage

I've added a transcript (failing in first commit).