### PR TITLE
feat: render merge conflicts preferring Alice's names

### DIFF
--- a/lib/unison-util-relation/src/Unison/Util/Relation.hs
+++ b/lib/unison-util-relation/src/Unison/Util/Relation.hs
@@ -88,6 +88,8 @@ module Unison.Util.Relation
     outerJoinRanMultimaps,
     union,
     unions,
+    unionDomainWith,
+    unionRangeWith,
 
     -- * Converting to other data structures
     toList,
@@ -229,6 +231,14 @@ union r s =
     { domain = M.unionWith S.union (domain r) (domain s),
       range = M.unionWith S.union (range r) (range s)
     }
+
+unionDomainWith :: (Ord a, Ord b) => (a -> Set b -> Set b -> Set b) -> Relation a b -> Relation a b -> Relation a b
+unionDomainWith f xs ys =
+  fromMultimap (Map.unionWithKey f (domain xs) (domain ys))
+
+unionRangeWith :: (Ord a, Ord b) => (b -> Set a -> Set a -> Set a) -> Relation a b -> Relation a b -> Relation a b
+unionRangeWith f xs ys =
+  swap (fromMultimap (Map.unionWithKey f (range xs) (range ys)))
 
 intersection :: (Ord a, Ord b) => Relation a b -> Relation a b -> Relation a b
 intersection r s =

--- a/unison-merge/src/Unison/Merge/Mergeblob3.hs
+++ b/unison-merge/src/Unison/Merge/Mergeblob3.hs
@@ -19,7 +19,7 @@ import Unison.DataDeclaration qualified as DataDeclaration
 import Unison.DeclNameLookup (DeclNameLookup, expectConstructorNames)
 import Unison.DeclNameLookup qualified as DeclNameLookup
 import Unison.Merge.Mergeblob2 (Mergeblob2 (..))
-import Unison.Merge.PrettyPrintEnv (makePrettyPrintEnvs)
+import Unison.Merge.PrettyPrintEnv (makePrettyPrintEnv)
 import Unison.Merge.ThreeWay (ThreeWay)
 import Unison.Merge.ThreeWay qualified as ThreeWay
 import Unison.Merge.TwoWay (TwoWay)
@@ -30,6 +30,7 @@ import Unison.Name (Name)
 import Unison.Names (Names (..))
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
+import Unison.PrettyPrintEnvDecl (PrettyPrintEnvDecl)
 import Unison.Reference (Reference' (..), TermReferenceId, TypeReference, TypeReferenceId)
 import Unison.Referent (Referent)
 import Unison.Referent qualified as Referent
@@ -256,13 +257,12 @@ renderConflictsAndDependents ::
   )
 renderConflictsAndDependents declNameLookups hydratedDefns conflicts dependents names libdepsNames =
   unzip $
-    ( \declNameLookup (conflicts, dependents) ppe ->
+    ( \declNameLookup (conflicts, dependents) ->
         let render = renderDefnsForUnisonFile declNameLookup ppe . over (#terms . mapped) snd
          in (render conflicts, render dependents)
     )
       <$> declNameLookups
       <*> hydratedConflictsAndDependents
-      <*> makePrettyPrintEnvs names libdepsNames
   where
     hydratedConflictsAndDependents ::
       TwoWay
@@ -278,6 +278,10 @@ renderConflictsAndDependents declNameLookups hydratedDefns conflicts dependents 
         <$> hydratedDefns
         <*> conflicts
         <*> dependents
+
+    ppe :: PrettyPrintEnvDecl
+    ppe =
+      makePrettyPrintEnv names libdepsNames
 
 defnsToNames :: Defns (BiMultimap Referent Name) (BiMultimap TypeReference Name) -> Names
 defnsToNames defns =

--- a/unison-merge/src/Unison/Merge/PrettyPrintEnv.hs
+++ b/unison-merge/src/Unison/Merge/PrettyPrintEnv.hs
@@ -1,18 +1,21 @@
 module Unison.Merge.PrettyPrintEnv
-  ( makePrettyPrintEnvs,
+  ( makePrettyPrintEnv,
   )
 where
 
-import Unison.Merge.TwoWay (TwoWay)
+import Unison.Merge.TwoWay (TwoWay (..))
 import Unison.Names (Names)
+import Unison.Names qualified as Names
 import Unison.Prelude
 import Unison.PrettyPrintEnv.Names qualified as PPE
 import Unison.PrettyPrintEnvDecl (PrettyPrintEnvDecl)
 import Unison.PrettyPrintEnvDecl.Names qualified as PPED
 
--- Make PPE for Alice that contains all of Alice's names, but suffixified against her names + Bob's names
-makePrettyPrintEnvs :: TwoWay Names -> Names -> TwoWay PrettyPrintEnvDecl
-makePrettyPrintEnvs names2 libdepsNames =
-  names2 <&> \names -> PPED.makePPED (PPE.namer (names <> libdepsNames)) suffixifier
+-- Create a PPE that uses Alice's names whenever possible, falling back to Bob's names only when Alice doesn't have any.
+-- This results in a file that "looks familiar" to Alice (the one merging in Bob's changes), and avoids superfluous
+-- textual conflicts that would arise from preferring Bob's names for Bob's code (where his names differ).
+makePrettyPrintEnv :: TwoWay Names -> Names -> PrettyPrintEnvDecl
+makePrettyPrintEnv names libdepsNames =
+  PPED.makePPED (PPE.namer (Names.preferring names.alice names.bob <> libdepsNames)) suffixifier
   where
-    suffixifier = PPE.suffixifyByName (fold names2 <> libdepsNames)
+    suffixifier = PPE.suffixifyByName (fold names <> libdepsNames)

--- a/unison-src/transcripts/merge.md
+++ b/unison-src/transcripts/merge.md
@@ -1747,3 +1747,51 @@ scratch/alice> names Bar
 ``` ucm :hide
 scratch/main> project.delete scratch
 ```
+
+### Using Alice's names for Bob's things
+
+Previously, we'd render Alice's stuff with her names and Bob's stuff with his. But because Alice is doing the merge,
+we now use her names whenever possible. In this example, Alice calls something `foo` and Bob calls it `bar`. When
+rendering conflicts, in Bob's term that references (what he calls) `bar`, we render `foo` instead.
+
+``` ucm :hide
+scratch/main> builtins.mergeio lib.builtins
+```
+
+``` unison
+hello = 17
+```
+
+``` ucm
+scratch/main> add
+scratch/main> branch alice
+```
+
+``` unison
+hello = 18 + foo
+foo = 100
+```
+
+``` ucm
+scratch/alice> update
+scratch/main> branch bob
+```
+
+``` unison
+hello = 19 + bar
+bar = 100
+```
+
+``` ucm
+scratch/bob> update
+```
+
+Note Bob's `hello` references `foo` (Alice's name), not `bar` (Bob's name).
+
+``` ucm :error
+scratch/alice> merge /bob
+```
+
+``` ucm :hide
+scratch/main> project.delete scratch
+```

--- a/unison-src/transcripts/merge.output.md
+++ b/unison-src/transcripts/merge.output.md
@@ -2425,3 +2425,149 @@ scratch/alice> names Bar
   Names: Bar
 
 ```
+### Using Alice's names for Bob's things
+
+Previously, we'd render Alice's stuff with her names and Bob's stuff with his. But because Alice is doing the merge,
+we now use her names whenever possible. In this example, Alice calls something `foo` and Bob calls it `bar`. When
+rendering conflicts, in Bob's term that references (what he calls) `bar`, we render `foo` instead.
+
+``` unison
+hello = 17
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      hello : Nat
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    hello : Nat
+
+scratch/main> branch alice
+
+  Done. I've created the alice branch based off of main.
+  
+  Tip: To merge your work back into the main branch, first
+       `switch /main` then `merge /alice`.
+
+```
+``` unison
+hello = 18 + foo
+foo = 100
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      foo : Nat
+    
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      hello : Nat
+
+```
+``` ucm
+scratch/alice> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+
+scratch/main> branch bob
+
+  Done. I've created the bob branch based off of main.
+  
+  Tip: To merge your work back into the main branch, first
+       `switch /main` then `merge /bob`.
+
+```
+``` unison
+hello = 19 + bar
+bar = 100
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      bar : Nat
+    
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      hello : Nat
+
+```
+``` ucm
+scratch/bob> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+
+```
+Note Bob's `hello` references `foo` (Alice's name), not `bar` (Bob's name).
+
+``` ucm
+scratch/alice> merge /bob
+
+  I couldn't automatically merge scratch/bob into scratch/alice.
+  However, I've added the definitions that need attention to the
+  top of scratch.u.
+  
+  When you're done, you can run
+  
+    merge.commit
+  
+  to merge your changes back into alice and delete the temporary
+  branch. Or, if you decide to cancel the merge instead, you can
+  run
+  
+    delete.branch /merge-bob-into-alice
+  
+  to delete the temporary branch and switch back to alice.
+
+```
+``` unison :added-by-ucm scratch.u
+-- scratch/alice
+hello : Nat
+hello =
+  use Nat +
+  18 + foo
+
+-- scratch/bob
+hello : Nat
+hello =
+  use Nat +
+  19 + foo
+
+```
+


### PR DESCRIPTION
## Overview

Fixes #5208 

This PR adjusts the PPE we use for rendering merge conflicts to prefer Alice's names when available (even for Bob's stuff). Previously, we'd render Alice's stuff preferring her names, and Bob's stuff preferring his names.

This makes merges easier to resolve as they will no longer have spurious differences in mergetools (or when merging manually) that could occur whenever Alice and Bob have different sets of aliases for the same term.

## Test coverage

I've added a transcript that demonstrates the change
