### PR TITLE
Add ANF and MCode serialization property tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Get changed files
-        id: changed-files
         uses: tj-actions/changed-files@v44
         with:
           # globs copied from default settings for run-ormolu

--- a/unison-runtime/package.yaml
+++ b/unison-runtime/package.yaml
@@ -89,20 +89,26 @@ tests:
         other-modules: Paths_unison_parser_typechecker
     dependencies:
       - base
+      - bytes
+      - cereal
       - code-page
       - containers
       - cryptonite
       - directory
       - easytest
+      - hedgehog
       - filemanip
       - filepath
       - hex-text
       - lens
       - megaparsec
       - mtl
+      - primitive
       - stm
       - text
       - unison-core1
+      - unison-hash
+      - unison-util-bytes
       - unison-parser-typechecker
       - unison-prelude
       - unison-pretty-printer

--- a/unison-runtime/src/Unison/Runtime/ANF.hs
+++ b/unison-runtime/src/Unison/Runtime/ANF.hs
@@ -1533,7 +1533,7 @@ type ANFM v =
 type ANFD v = Compose (ANFM v) (Directed ())
 
 data GroupRef = GR Reference Word64
-  deriving (Show)
+  deriving (Show, Eq)
 
 -- | A value which is either unboxed or boxed.
 type UBValue = Either Word64 Value
@@ -1547,7 +1547,7 @@ data Value
   | Data Reference Word64 ValList
   | Cont ValList Cont
   | BLit BLit
-  deriving (Show)
+  deriving (Show, Eq)
 
 -- Since we can now track cacheability of supergroups, this type
 -- pairs the two together. This is the type that should be used
@@ -1587,7 +1587,7 @@ data Cont
       Word64 -- Pending args
       GroupRef
       Cont
-  deriving (Show)
+  deriving (Show, Eq)
 
 data BLit
   = Text Util.Text.Text
@@ -1603,7 +1603,7 @@ data BLit
   | Char Char
   | Float Double
   | Arr (PA.Array Value)
-  deriving (Show)
+  deriving (Show, Eq)
 
 groupVars :: ANFM v (Set v)
 groupVars = ask

--- a/unison-runtime/src/Unison/Runtime/ANF/Serialize.hs
+++ b/unison-runtime/src/Unison/Runtime/ANF/Serialize.hs
@@ -36,6 +36,7 @@ import Prelude hiding (getChar, putChar)
 -- code/values to be restored later. Hash means we're just getting
 -- bytes for hashing, so we don't need perfect information.
 data Version = Transfer Word32 | Hash Word32
+  deriving (Show)
 
 data TmTag
   = VarT

--- a/unison-runtime/src/Unison/Runtime/MCode.hs
+++ b/unison-runtime/src/Unison/Runtime/MCode.hs
@@ -320,7 +320,7 @@ data UPrim1
   | FLOR -- intToFloat,natToFloat,ceiling,floor
   | TRNF
   | RNDF -- truncate,round
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Enum, Bounded)
 
 data UPrim2
   = -- integral
@@ -353,7 +353,7 @@ data UPrim2
   | LOGB
   | MAXF
   | MINF -- pow,low,max,min
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Enum, Bounded)
 
 data BPrim1
   = -- text
@@ -387,7 +387,7 @@ data BPrim1
   -- debug
   | DBTX -- debug text
   | SDBL -- sandbox link list
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Enum, Bounded)
 
 data BPrim2
   = -- universal
@@ -422,7 +422,7 @@ data BPrim2
   -- code
   | SDBX -- sandbox
   | SDBV -- sandbox Value
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Enum, Bounded)
 
 data MLit
   = MI !Int

--- a/unison-runtime/src/Unison/Runtime/Machine.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine.hs
@@ -863,7 +863,6 @@ repush !env !activeThreads !stk = go
     go !_ (CB _) !_ = die "repush: impossible"
 {-# INLINE repush #-}
 
--- TODO: Double-check this one
 moveArgs ::
   Stack ->
   Args ->

--- a/unison-runtime/tests/Suite.hs
+++ b/unison-runtime/tests/Suite.hs
@@ -11,6 +11,7 @@ import Unison.Test.Runtime.ANF qualified as ANF
 import Unison.Test.Runtime.ANF.Serialization qualified as ANF.Serialization
 import Unison.Test.Runtime.Crypto.Rsa qualified as Rsa
 import Unison.Test.Runtime.MCode qualified as MCode
+import Unison.Test.Runtime.MCode.Serialization qualified as MCode.Serialization
 import Unison.Test.UnisonSources qualified as UnisonSources
 
 test :: Test ()
@@ -19,6 +20,7 @@ test =
     [ ANF.test,
       ANF.Serialization.test,
       MCode.test,
+      MCode.Serialization.test,
       Rsa.test,
       UnisonSources.test
     ]

--- a/unison-runtime/tests/Suite.hs
+++ b/unison-runtime/tests/Suite.hs
@@ -8,9 +8,9 @@ import System.Environment (getArgs)
 import System.IO
 import System.IO.CodePage (withCP65001)
 import Unison.Test.Runtime.ANF qualified as ANF
+import Unison.Test.Runtime.ANF.Serialization qualified as ANF.Serialization
 import Unison.Test.Runtime.Crypto.Rsa qualified as Rsa
 import Unison.Test.Runtime.MCode qualified as MCode
-import Unison.Test.Runtime.ANF.Serialization qualified as ANF.Serialization
 import Unison.Test.UnisonSources qualified as UnisonSources
 
 test :: Test ()

--- a/unison-runtime/tests/Suite.hs
+++ b/unison-runtime/tests/Suite.hs
@@ -10,12 +10,14 @@ import System.IO.CodePage (withCP65001)
 import Unison.Test.Runtime.ANF qualified as ANF
 import Unison.Test.Runtime.Crypto.Rsa qualified as Rsa
 import Unison.Test.Runtime.MCode qualified as MCode
+import Unison.Test.Runtime.ANF.Serialization qualified as ANF.Serialization
 import Unison.Test.UnisonSources qualified as UnisonSources
 
 test :: Test ()
 test =
   tests
     [ ANF.test,
+      ANF.Serialization.test,
       MCode.test,
       Rsa.test,
       UnisonSources.test

--- a/unison-runtime/tests/Unison/Test/Gen.hs
+++ b/unison-runtime/tests/Unison/Test/Gen.hs
@@ -1,0 +1,51 @@
+-- | Hedgehog generators for common unison types.
+module Unison.Test.Gen where
+
+import Data.Text qualified as Text
+import Hedgehog hiding (Rec, Test, test)
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Unison.ConstructorReference
+import Unison.ConstructorType qualified as CT
+import Unison.Hash (Hash)
+import Unison.Hash qualified as Hash
+import Unison.Prelude
+import Unison.Reference qualified as Reference
+import Unison.Referent qualified as Referent
+import Unison.Util.Text qualified as Unison.Text
+
+genSmallWord64 :: Gen Word64
+genSmallWord64 = Gen.word64 (Range.linear 0 100)
+
+genSmallInt :: Gen Int
+genSmallInt = Gen.int (Range.linear 0 100)
+
+genReference :: Gen Reference.Reference
+genReference =
+  Gen.choice
+    [ Reference.ReferenceBuiltin <$> genSmallText,
+      Reference.ReferenceDerived <$> genRefId
+    ]
+  where
+    genRefId :: Gen (Reference.Id' Hash)
+    genRefId = Reference.Id <$> genHash <*> genSmallWord64
+
+-- This can generate invalid hashes, but that's not really an issue for testing serialization.
+genHash :: Gen Hash
+genHash = Hash.fromByteString <$> Gen.bytes (Range.singleton 32)
+
+genReferent :: Gen Referent.Referent
+genReferent =
+  Gen.choice
+    [ Referent.Ref <$> genReference,
+      Referent.Con <$> genConstructorReference <*> genConstructorType
+    ]
+  where
+    genConstructorType = Gen.choice [pure CT.Data, pure CT.Effect]
+    genConstructorReference = ConstructorReference <$> genReference <*> genSmallWord64
+
+genSmallText :: Gen Text
+genSmallText = Gen.text (Range.linear 2 4) Gen.alphaNum
+
+genUText :: Gen Unison.Text.Text
+genUText = Unison.Text.pack . Text.unpack <$> genSmallText

--- a/unison-runtime/tests/Unison/Test/Runtime/ANF/Serialization.hs
+++ b/unison-runtime/tests/Unison/Test/Runtime/ANF/Serialization.hs
@@ -1,0 +1,151 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Round trip tests for ANF serialization.
+module Unison.Test.Runtime.ANF.Serialization (Unison.Test.Runtime.ANF.Serialization.test) where
+
+import Data.Bytes.Get (runGetS)
+import Data.Bytes.Put (runPutS)
+import Data.Primitive.Array (Array)
+import Data.Primitive.Array qualified as Array
+import Data.Primitive.ByteArray (ByteArray)
+import Data.Primitive.ByteArray qualified as ByteArray
+import Data.Primitive.Types (Prim)
+import Data.Serialize.Get (Get)
+import Data.Serialize.Put (Put)
+import Data.Text qualified as Text
+import EasyTest qualified as EasyTest
+import Hedgehog hiding (Rec, Test, test)
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Unison.ConstructorReference
+import Unison.ConstructorType qualified as CT
+import Unison.Hash (Hash)
+import Unison.Hash qualified as Hash
+import Unison.Prelude
+import Unison.Reference qualified as Reference
+import Unison.Referent qualified as Referent
+import Unison.Runtime.ANF
+import Unison.Runtime.ANF.Serialize
+import Unison.Util.Bytes qualified as Util.Bytes
+import Unison.Util.Text qualified as Util.Text
+
+test :: EasyTest.Test ()
+test =
+  void . EasyTest.scope "anf.serialization" $ do
+    success <-
+      EasyTest.io $
+        checkParallel $
+          Group
+            "roundtrip"
+            [ ("value", valueRoundtrip)
+            ]
+    EasyTest.expect success
+
+genWord64 :: Gen Word64
+genWord64 = Gen.word64 (Range.linear 0 100)
+
+genSmallText :: Gen Text
+genSmallText = Gen.text (Range.linear 2 4) Gen.alphaNum
+
+genUText :: Gen Util.Text.Text
+genUText = Util.Text.pack . Text.unpack <$> genSmallText
+
+genUBytes :: Gen Util.Bytes.Bytes
+genUBytes = Util.Bytes.fromByteString <$> Gen.bytes (Range.linear 0 4)
+
+-- This can generate invalid hashes, but that's not really an issue for testing serialization.
+genHash :: Gen Hash
+genHash = Hash.fromByteString <$> Gen.bytes (Range.singleton 32)
+
+genReference :: Gen Reference.Reference
+genReference =
+  Gen.choice
+    [ Reference.ReferenceBuiltin <$> genSmallText,
+      Reference.ReferenceDerived <$> genRefId
+    ]
+  where
+    genRefId :: Gen (Reference.Id' Hash)
+    genRefId = Reference.Id <$> genHash <*> genWord64
+
+genReferent :: Gen Referent.Referent
+genReferent =
+  Gen.choice
+    [ Referent.Ref <$> genReference,
+      Referent.Con <$> genConstructorReference <*> genConstructorType
+    ]
+  where
+    genConstructorType = Gen.choice [pure CT.Data, pure CT.Effect]
+    genConstructorReference = ConstructorReference <$> genReference <*> genWord64
+
+genGroupRef :: Gen GroupRef
+genGroupRef = GR <$> genReference <*> genWord64
+
+genUBValue :: Gen UBValue
+genUBValue =
+  Gen.choice
+    [ -- Unboxed values are no longer valid in ANF serialization.
+      -- Left <$> genWord64,
+      Right <$> genValue
+    ]
+
+genValList :: Gen ValList
+genValList = Gen.list (Range.linear 0 4) genUBValue
+
+genCont :: Gen Cont
+genCont = do
+  Gen.choice
+    [ pure KE,
+      Mark <$> genWord64 <*> Gen.list (Range.linear 0 4) genReference <*> Gen.map (Range.linear 0 4) ((,) <$> genReference <*> genValue) <*> genCont,
+      Push <$> genWord64 <*> genWord64 <*> genGroupRef <*> genCont
+    ]
+
+genArray :: Range Int -> Gen a -> Gen (Array a)
+genArray range gen =
+  Array.arrayFromList <$> Gen.list range gen
+
+genByteArray :: (Prim p) => Gen p -> Gen ByteArray
+genByteArray genP = do
+  ByteArray.byteArrayFromList <$> Gen.list (Range.linear 0 20) genP
+
+genBLit :: Gen BLit
+genBLit =
+  Gen.choice
+    [ Text <$> genUText,
+      List <$> Gen.seq (Range.linear 0 4) genValue,
+      TmLink <$> genReferent,
+      TyLink <$> genReference,
+      Bytes <$> genUBytes,
+      Quote <$> genValue,
+      -- Code is not yet included, generating valid ANF terms is complex.
+      -- , Code <$> genCode
+      BArr <$> genByteArray genWord64,
+      Pos <$> genWord64,
+      Neg <$> genWord64,
+      Char <$> Gen.unicode,
+      Float <$> Gen.double (Range.linearFrac 0 100),
+      Arr <$> genArray (Range.linear 0 4) genValue
+    ]
+
+genValue :: Gen Value
+genValue = Gen.sized \n -> do
+  -- Limit amount of recursion to avoid infinitely deep values
+  let gValList
+        | n > 1 = Gen.small genValList
+        | otherwise = pure []
+  Gen.choice
+    [ Partial <$> genGroupRef <*> gValList,
+      Data <$> genReference <*> genWord64 <*> gValList,
+      Cont <$> gValList <*> genCont,
+      BLit <$> genBLit
+    ]
+
+valueRoundtrip :: Property
+valueRoundtrip =
+  getPutRoundtrip (getValue (Hash valueVersion)) (putValue (Hash valueVersion)) genValue
+
+getPutRoundtrip :: (Eq a, Show a) => Get a -> (a -> Put) -> Gen a -> Property
+getPutRoundtrip get put builder =
+  property $ do
+    v <- forAll builder
+    let bytes = runPutS (put v)
+    runGetS get bytes === Right v

--- a/unison-runtime/tests/Unison/Test/Runtime/MCode/Serialization.hs
+++ b/unison-runtime/tests/Unison/Test/Runtime/MCode/Serialization.hs
@@ -1,0 +1,185 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Round trip tests runtime serialization
+module Unison.Test.Runtime.MCode.Serialization (Unison.Test.Runtime.MCode.Serialization.test) where
+
+import Data.Bytes.Get (runGetS)
+import Data.Bytes.Put (runPutS)
+import Data.Primitive (Prim, PrimArray, primArrayFromList)
+import Data.Serialize.Get (Get)
+import Data.Serialize.Put (Put)
+import EasyTest qualified as EasyTest
+import Hedgehog hiding (Rec, Test, test)
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Unison.Prelude
+import Unison.Runtime.Interface
+import Unison.Runtime.MCode (Args (..), BPrim1, BPrim2, Branch, Comb, CombIx (..), GBranch (..), GComb (..), GCombInfo (..), GInstr (..), GRef (..), GSection (..), Instr, MLit (..), Ref, Section, UPrim1, UPrim2)
+import Unison.Runtime.Machine (Combs)
+import Unison.Test.Gen
+import Unison.Util.EnumContainers (EnumMap, EnumSet)
+import Unison.Util.EnumContainers qualified as EC
+
+test :: EasyTest.Test ()
+test =
+  void . EasyTest.scope "mcode.serialization" $ do
+    success <-
+      EasyTest.io $
+        checkParallel $
+          Group
+            "roundtrip"
+            [ ("SCache", sCacheRoundtrip)
+            ]
+    EasyTest.expect success
+
+genEnumMap :: (EC.EnumKey k) => Gen k -> Gen v -> Gen (EnumMap k v)
+genEnumMap genK genV = EC.mapFromList <$> Gen.list (Range.linear 0 10) ((,) <$> genK <*> genV)
+
+genEnumSet :: Gen Word64 -> Gen (EnumSet Word64)
+genEnumSet gen = EC.setFromList <$> Gen.list (Range.linear 0 10) gen
+
+genCombs :: Gen Combs
+genCombs = genEnumMap genSmallWord64 genComb
+
+genPrimArray :: (Prim a) => Gen a -> Gen (PrimArray a)
+genPrimArray gen = primArrayFromList <$> Gen.list (Range.linear 0 10) gen
+
+genArgs :: Gen Args
+genArgs =
+  Gen.choice
+    [ pure ZArgs,
+      VArg1 <$> genSmallInt,
+      VArg2 <$> genSmallInt <*> genSmallInt,
+      VArgR <$> genSmallInt <*> genSmallInt,
+      VArgN <$> genPrimArray genSmallInt,
+      VArgV <$> genSmallInt
+    ]
+
+genCombIx :: Gen CombIx
+genCombIx =
+  CIx
+    <$> genReference
+    <*> genSmallWord64
+    <*> genSmallWord64
+
+genGRef :: Gen Ref
+genGRef =
+  Gen.choice
+    [ Stk <$> genSmallInt,
+      Env <$> genCombIx <*> genCombIx,
+      Dyn <$> genSmallWord64
+    ]
+
+genBranch :: Gen Branch
+genBranch =
+  Gen.choice
+    [ Test1 <$> genSmallWord64 <*> genSection <*> genSection,
+      Test2 <$> genSmallWord64 <*> genSection <*> genSmallWord64 <*> genSection <*> genSection,
+      TestW <$> genSection <*> genEnumMap genSmallWord64 genSection,
+      TestT <$> genSection <*> Gen.map (Range.linear 0 10) ((,) <$> genUText <*> genSection)
+    ]
+
+genUPrim1 :: Gen UPrim1
+genUPrim1 = Gen.enumBounded
+
+genUPrim2 :: Gen UPrim2
+genUPrim2 = Gen.enumBounded
+
+genBPrim1 :: Gen BPrim1
+genBPrim1 = Gen.enumBounded
+
+genBPrim2 :: Gen BPrim2
+genBPrim2 = Gen.enumBounded
+
+genMLit :: Gen MLit
+genMLit =
+  Gen.choice
+    [ MI <$> genSmallInt,
+      MD <$> Gen.double (Range.linearFrac 0 100),
+      MT <$> genUText,
+      MM <$> genReferent,
+      MY <$> genReference
+    ]
+
+genInstr :: Gen Instr
+genInstr =
+  Gen.choice
+    [ UPrim1 <$> genUPrim1 <*> genSmallInt,
+      UPrim2 <$> genUPrim2 <*> genSmallInt <*> genSmallInt,
+      BPrim1 <$> genBPrim1 <*> genSmallInt,
+      BPrim2 <$> genBPrim2 <*> genSmallInt <*> genSmallInt,
+      ForeignCall <$> Gen.bool <*> genSmallWord64 <*> genArgs,
+      SetDyn <$> genSmallWord64 <*> genSmallInt,
+      Capture <$> genSmallWord64,
+      Name <$> genGRef <*> genArgs,
+      Info <$> Gen.string (Range.linear 0 10) Gen.alphaNum,
+      Pack <$> genReference <*> genSmallWord64 <*> genArgs,
+      Lit <$> genMLit,
+      BLit <$> genReference <*> genSmallWord64 <*> genMLit,
+      Print <$> genSmallInt,
+      Reset <$> genEnumSet genSmallWord64,
+      Fork <$> genSmallInt,
+      Atomically <$> genSmallInt,
+      Seq <$> genArgs,
+      TryForce <$> genSmallInt
+    ]
+
+genSection :: Gen Section
+genSection = do
+  Gen.recursive
+    Gen.choice
+    [ Yield <$> genArgs,
+      Die <$> Gen.string (Range.linear 0 10) Gen.alphaNum,
+      pure Exit
+    ]
+    [ App <$> Gen.bool <*> genGRef <*> genArgs,
+      Call <$> Gen.bool <*> genCombIx <*> genCombIx <*> genArgs,
+      Match <$> genSmallInt <*> genBranch,
+      Ins <$> genInstr <*> genSection,
+      Let <$> genSection <*> genCombIx <*> genSmallInt <*> genSection,
+      DMatch <$> Gen.maybe genReference <*> genSmallInt <*> genBranch,
+      NMatch <$> Gen.maybe genReference <*> genSmallInt <*> genBranch,
+      RMatch <$> genSmallInt <*> genSection <*> genEnumMap genSmallWord64 genBranch
+    ]
+
+genCombInfo :: Gen (GCombInfo CombIx)
+genCombInfo =
+  LamI
+    <$> Gen.int (Range.linear 0 10)
+    <*> Gen.int (Range.linear 0 10)
+    <*> genSection
+
+genComb :: Gen Comb
+genComb =
+  Gen.choice
+    [ Comb <$> genCombInfo
+    -- We omit cached closures from roundtrip tests since we don't currently serialize cached closure results
+    -- CachedClosure
+    ]
+
+genStoredCache :: Gen StoredCache
+genStoredCache =
+  SCache
+    <$> (genEnumMap genSmallWord64 genCombs)
+    <*> (genEnumMap genSmallWord64 genReference)
+    <*> (genEnumSet genSmallWord64)
+    <*> (genEnumMap genSmallWord64 genReference)
+    <*> genSmallWord64
+    <*> genSmallWord64
+    <*>
+    -- We don't yet generate supergroups because generating valid ones is difficult.
+    mempty
+    <*> (Gen.map (Range.linear 0 10) ((,) <$> genReference <*> genSmallWord64))
+    <*> (Gen.map (Range.linear 0 10) ((,) <$> genReference <*> genSmallWord64))
+    <*> (Gen.map (Range.linear 0 10) ((,) <$> genReference <*> (Gen.set (Range.linear 0 10) genReference)))
+
+sCacheRoundtrip :: Property
+sCacheRoundtrip =
+  getPutRoundtrip getStoredCache (putStoredCache) genStoredCache
+
+getPutRoundtrip :: (Eq a, Show a) => Get a -> (a -> Put) -> Gen a -> Property
+getPutRoundtrip get put builder =
+  property $ do
+    v <- forAll builder
+    let bytes = runPutS (put v)
+    runGetS get bytes === Right v

--- a/unison-runtime/unison-runtime.cabal
+++ b/unison-runtime/unison-runtime.cabal
@@ -147,10 +147,12 @@ test-suite runtime-tests
   main-is: Suite.hs
   other-modules:
       Unison.Test.Common
+      Unison.Test.Gen
       Unison.Test.Runtime.ANF
       Unison.Test.Runtime.ANF.Serialization
       Unison.Test.Runtime.Crypto.Rsa
       Unison.Test.Runtime.MCode
+      Unison.Test.Runtime.MCode.Serialization
       Unison.Test.UnisonSources
       Paths_unison_runtime
   hs-source-dirs:

--- a/unison-runtime/unison-runtime.cabal
+++ b/unison-runtime/unison-runtime.cabal
@@ -148,6 +148,7 @@ test-suite runtime-tests
   other-modules:
       Unison.Test.Common
       Unison.Test.Runtime.ANF
+      Unison.Test.Runtime.ANF.Serialization
       Unison.Test.Runtime.Crypto.Rsa
       Unison.Test.Runtime.MCode
       Unison.Test.UnisonSources
@@ -187,6 +188,8 @@ test-suite runtime-tests
   ghc-options: -Wall -O0 -W -threaded -rtsopts "-with-rtsopts=-N -T" -v0
   build-depends:
       base
+    , bytes
+    , cereal
     , code-page
     , containers
     , cryptonite
@@ -194,18 +197,22 @@ test-suite runtime-tests
     , easytest
     , filemanip
     , filepath
+    , hedgehog
     , hex-text
     , lens
     , megaparsec
     , mtl
+    , primitive
     , stm
     , text
     , unison-core1
+    , unison-hash
     , unison-parser-typechecker
     , unison-prelude
     , unison-pretty-printer
     , unison-runtime
     , unison-syntax
+    , unison-util-bytes
   default-language: Haskell2010
   if flag(optimized)
     ghc-options: -funbox-strict-fields -O2


### PR DESCRIPTION
- [x] Depends on merging #5397 first

## Overview

Adds Hedgehog tests to assert that `get (put x) == x` for MCode and ANF.

Having these would've saved me a few hours on the stack stuff, so figured I'd add it now since I'll be continuing to work in this area.


## Implementation notes

* Adds new hedgehog property tests for roundtripping an `SCache` which is what we store when compiling `.uc` files
* Adds new hedgehog property tests for roundtripping ANF `Value` types

## Interesting/controversial decisions

Include anything that you thought twice about, debated, chose arbitrarily, etc.
What could have been done differently, but wasn't? And why?

## Test coverage

Yes it is.

## Loose ends

Note: The ANF tests omit testing serialized `Code`, which is important, but takes a significant effort to generate because the serialization actually requires _correct_ ANF terms which aren't trivial to generate. It would be nice to add this later.