### PR TITLE
Make Ref.read Ref.write instructions

### DIFF
--- a/unison-runtime/src/Unison/Runtime/ANF.hs
+++ b/unison-runtime/src/Unison/Runtime/ANF.hs
@@ -1445,6 +1445,9 @@ data POp
   | TFRC -- try force
   | SDBL -- sandbox link list
   | SDBV -- sandbox check for Values
+  -- Refs
+  | RREF -- Ref.read
+  | WREF -- Ref.write
   deriving (Show, Eq, Ord, Enum, Bounded)
 
 type ANormal = ABTN.Term ANormalF

--- a/unison-runtime/src/Unison/Runtime/ANF/Serialize.hs
+++ b/unison-runtime/src/Unison/Runtime/ANF/Serialize.hs
@@ -649,6 +649,8 @@ pOpCode op = case op of
   IXOB -> 121
   SDBL -> 122
   SDBV -> 123
+  RREF -> 124
+  WREF -> 125
 
 pOpAssoc :: [(POp, Word16)]
 pOpAssoc = map (\op -> (op, pOpCode op)) [minBound .. maxBound]

--- a/unison-runtime/src/Unison/Runtime/Foreign.hs
+++ b/unison-runtime/src/Unison/Runtime/Foreign.hs
@@ -256,6 +256,7 @@ instance BuiltinForeign FilePath where foreignRef = Tagged Ty.filePathRef
 instance BuiltinForeign TLS.Context where foreignRef = Tagged Ty.tlsRef
 
 instance BuiltinForeign Code where foreignRef = Tagged Ty.codeRef
+
 instance BuiltinForeign Value where foreignRef = Tagged Ty.valueRef
 
 instance BuiltinForeign TimeSpec where foreignRef = Tagged Ty.timeSpecRef

--- a/unison-runtime/src/Unison/Runtime/MCode.hs
+++ b/unison-runtime/src/Unison/Runtime/MCode.hs
@@ -387,6 +387,8 @@ data BPrim1
   -- debug
   | DBTX -- debug text
   | SDBL -- sandbox link list
+  | -- Refs
+    RREF -- Ref.read
   deriving (Show, Eq, Ord, Enum, Bounded)
 
 data BPrim2
@@ -422,6 +424,8 @@ data BPrim2
   -- code
   | SDBX -- sandbox
   | SDBV -- sandbox Value
+  -- Refs
+  | WREF -- Ref.write
   deriving (Show, Eq, Ord, Enum, Bounded)
 
 data MLit
@@ -1285,6 +1289,9 @@ emitPOp ANF.SDBV = emitBP2 SDBV
 emitPOp ANF.EROR = emitBP2 THRO
 emitPOp ANF.TRCE = emitBP2 TRCE
 emitPOp ANF.DBTX = emitBP1 DBTX
+-- Refs
+emitPOp ANF.RREF = emitBP1 RREF
+emitPOp ANF.WREF = emitBP2 WREF
 -- non-prim translations
 emitPOp ANF.BLDS = Seq
 emitPOp ANF.FORK = \case

--- a/unison-runtime/src/Unison/Runtime/Serialize.hs
+++ b/unison-runtime/src/Unison/Runtime/Serialize.hs
@@ -446,6 +446,7 @@ instance Tag BPrim1 where
   tag2word TLTT = 24
   tag2word DBTX = 25
   tag2word SDBL = 26
+  tag2word RREF = 27
 
   word2tag 0 = pure SIZT
   word2tag 1 = pure USNC
@@ -474,6 +475,7 @@ instance Tag BPrim1 where
   word2tag 24 = pure TLTT
   word2tag 25 = pure DBTX
   word2tag 26 = pure SDBL
+  word2tag 27 = pure RREF
   word2tag n = unknownTag "BPrim1" n
 
 instance Tag BPrim2 where
@@ -503,6 +505,7 @@ instance Tag BPrim2 where
   tag2word IXOT = 23
   tag2word IXOB = 24
   tag2word SDBV = 25
+  tag2word WREF = 26
 
   word2tag 0 = pure EQLU
   word2tag 1 = pure CMPU
@@ -530,4 +533,5 @@ instance Tag BPrim2 where
   word2tag 23 = pure IXOT
   word2tag 24 = pure IXOB
   word2tag 25 = pure SDBV
+  word2tag 26 = pure WREF
   word2tag n = unknownTag "BPrim2" n

--- a/unison-runtime/src/Unison/Runtime/Stack.hs
+++ b/unison-runtime/src/Unison/Runtime/Stack.hs
@@ -96,6 +96,8 @@ module Unison.Runtime.Stack
 where
 
 import Control.Monad.Primitive
+import Data.IORef (IORef)
+import Data.Tagged (Tagged (..))
 import Data.Word
 import GHC.Exts as L (IsList (..))
 import Unison.Prelude
@@ -158,6 +160,8 @@ instance Ord K where
 
 newtype Closure = Closure {unClosure :: (GClosure (RComb Closure))}
   deriving stock (Show, Eq, Ord)
+
+instance BuiltinForeign (IORef Closure) where foreignRef = Tagged Ty.refRef
 
 type IxClosure = GClosure CombIx
 


### PR DESCRIPTION
## Overview

Benchmark:

```
  printTime
    "Mutate an IO.Ref 1000 times" 650 (n ->
      repeat n do
        r = IO.ref 0
        repeat 1000 do Ref.write r (Ref.read r + 1))
```

Old:

```
Mutate an IO.Ref 1000 times
675.29µs
```

New

```
Mutate an IO.Ref 1000 times
659.252µs
```

So, a difference of `675.29µs - 659.252µs = 16.038µs`, and `(16.038µs / 1000 repetitions) / 2 calls = 8.019ns per foreign call`

## Implementation notes

Implements Ref.read/Ref.write as instructions. Can also do Ref.cas/Ref.readForCas if it seems worthwhile.

## Interesting/controversial decisions

This seems like a pretty minor optimization, we need to be careful about doing too many of these as well because each one increases the code-size of our critical path.
