### PR TITLE
Perform some optimizations during interpreter code generation

### DIFF
--- a/unison-runtime/src/Unison/Runtime/ANF.hs
+++ b/unison-runtime/src/Unison/Runtime/ANF.hs
@@ -671,18 +671,18 @@ inline inls (Rec bs entry) = Rec (fmap go0 <$> bs) (go0 entry)
           go (n-1) <$> tweak expr args arity
       _ -> Nothing
 
-  tweak (ABTN.TAbss vs body) args arity
-    -- exactly saturated
-    | length args == arity,
-      rn <- Map.fromList (zip vs args) =
-        Just $ ABTN.renames rn body
-    -- oversaturated, only makes sense if body is a call
-    | length args > arity,
-      (pre, post) <- splitAt arity args,
-      rn <- Map.fromList (zip vs pre),
-      TApp f pre <- ABTN.renames rn body =
-        Just $ TApp f (pre ++ post)
-    | otherwise = Nothing
+    tweak (ABTN.TAbss vs body) args arity
+      -- exactly saturated
+      | length args == arity,
+        rn <- Map.fromList (zip vs args) =
+          Just $ ABTN.renames rn body
+      -- oversaturated, only makes sense if body is a call
+      | length args > arity,
+        (pre, post) <- splitAt arity args,
+        rn <- Map.fromList (zip vs pre),
+        TApp f pre <- ABTN.renames rn body =
+          Just $ TApp f (pre ++ post)
+      | otherwise = Nothing
 
 addDefaultCases :: (Var v) => (Monoid a) => Text -> Term v a -> Term v a
 addDefaultCases = ABT.visitPure . defaultCaseVisitor

--- a/unison-runtime/src/Unison/Runtime/ANF.hs
+++ b/unison-runtime/src/Unison/Runtime/ANF.hs
@@ -36,7 +36,9 @@ module Unison.Runtime.ANF
     Cacheability (..),
     Direction (..),
     SuperNormal (..),
+    arity,
     SuperGroup (..),
+    arities,
     POp (..),
     FOp,
     close,
@@ -113,7 +115,7 @@ import Unison.Reference (Id, Reference, Reference' (Builtin, DerivedId))
 import Unison.Referent (Referent, pattern Con, pattern Ref)
 import Unison.Runtime.Array qualified as PA
 import Unison.Symbol (Symbol)
-import Unison.Term hiding (List, Ref, Text, float, fresh, resolve)
+import Unison.Term hiding (List, Ref, Text, float, fresh, resolve, arity)
 import Unison.Type qualified as Ty
 import Unison.Typechecker.Components (minimize')
 import Unison.Util.Bytes (Bytes)
@@ -1507,6 +1509,16 @@ data SGEqv v
     DefnConventions (SuperNormal v) (SuperNormal v)
   | -- mismatched subterms in corresponding definition
     Subterms (ANormal v) (ANormal v)
+
+-- Yields the number of arguments directly accepted by a combinator.
+arity :: SuperNormal v -> Int
+arity (Lambda ccs _) = length ccs
+
+-- Yields the numbers of arguments directly accepted by the
+-- combinators in a group. The main entry is the first element, and
+-- local bindings follow in their original order.
+arities :: SuperGroup v -> [Int]
+arities (Rec bs e) = arity e : fmap (arity . snd) bs
 
 -- Checks if two SuperGroups are equivalent up to renaming. The rest
 -- of the structure must match on the nose. If the two groups are not

--- a/unison-runtime/src/Unison/Runtime/Builtin.hs
+++ b/unison-runtime/src/Unison/Runtime/Builtin.hs
@@ -14,6 +14,7 @@ module Unison.Runtime.Builtin
     builtinTermBackref,
     builtinTypeBackref,
     builtinForeigns,
+    builtinArities,
     sandboxedForeigns,
     numberedTermLookup,
     Sandbox (..),
@@ -3659,6 +3660,11 @@ baseSandboxInfo =
       | (r, (sb, _)) <- Map.toList builtinLookup,
         sb == Tracked
     ]
+
+builtinArities :: Map Reference Int
+builtinArities =
+  Map.fromList $
+    [ (r, arity s) | (r, (_, s)) <- Map.toList builtinLookup ]
 
 unsafeSTMToIO :: STM.STM a -> IO a
 unsafeSTMToIO (STM.STM m) = IO m

--- a/unison-runtime/src/Unison/Runtime/MCode.hs
+++ b/unison-runtime/src/Unison/Runtime/MCode.hs
@@ -1056,10 +1056,12 @@ emitFunction _ grpr grpn rec ctx (FVar v) as
   | otherwise = emitSectionVErr v
 emitFunction rns _grpr _ _ _ (FComb r) as
   | Just k <- anum rns r,
-    countArgs as == k = -- exactly saturated call
+    countArgs as == k -- exactly saturated call
+    =
       Call False cix cix as
   | otherwise -- slow path
-      = App False (Env cix cix) as
+    =
+      App False (Env cix cix) as
   where
     n = cnum rns r
     cix = CIx r n 0

--- a/unison-runtime/src/Unison/Runtime/MCode.hs
+++ b/unison-runtime/src/Unison/Runtime/MCode.hs
@@ -1704,4 +1704,5 @@ prettyIns (Pack r i as) =
 prettyIns i = shows i
 
 prettyArgs :: Args -> ShowS
-prettyArgs v = shows v
+prettyArgs ZArgs = showString "ZArgs"
+prettyArgs v = showParen True $ shows v

--- a/unison-runtime/src/Unison/Runtime/MCode.hs
+++ b/unison-runtime/src/Unison/Runtime/MCode.hs
@@ -1606,15 +1606,17 @@ prettyComb w i = \case
     shows w
       . showString ":"
       . shows i
+      . showString ":"
       . shows a
-      . showString ":\n"
+      . showString "\n"
       . prettySection 2 s
   (CachedClosure a b) ->
     shows w
       . showString ":"
       . shows i
+      . showString ":"
       . shows a
-      . showString ":\n"
+      . showString "\n"
       . shows b
 
 prettySection :: (Show comb) => Int -> GSection comb -> ShowS
@@ -1641,7 +1643,6 @@ prettySection ind sec =
       showString "Let\n"
         . prettySection (ind + 2) s
         . showString "\n"
-        . indent ind
         . prettySection ind b
     Die s -> showString $ "Die " ++ s
     Exit -> showString "Exit"

--- a/unison-runtime/src/Unison/Runtime/Machine.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine.hs
@@ -2026,9 +2026,11 @@ cacheAdd0 ntys0 termSuperGroups sands cc = do
     rtm <- updateMap (M.fromList $ zip rs [ntm ..]) (refTm cc)
     -- check for missing references
     let arities = fmap (head . ANF.arities) int <> builtinArities
+        inlinfo = ANF.buildInlineMap int
         rns = RN (refLookup "ty" rty) (refLookup "tm" rtm) (flip M.lookup arities)
         combinate :: Word64 -> (Reference, SuperGroup Symbol) -> (Word64, EnumMap Word64 Comb)
-        combinate n (r, g) = (n, emitCombs rns r n g)
+        combinate n (r, g) =
+          (n, emitCombs rns r n $ ANF.inline inlinfo g)
     let combRefUpdates = (mapFromList $ zip [ntm ..] rs)
     let combIdFromRefMap = (M.fromList $ zip rs [ntm ..])
     let newCacheableCombs =

--- a/unison-runtime/tests/Unison/Test/Runtime/ANF.hs
+++ b/unison-runtime/tests/Unison/Test/Runtime/ANF.hs
@@ -53,7 +53,7 @@ testLift :: String -> Test ()
 testLift s = case cs of !_ -> ok
   where
     cs =
-      emitCombs (RN (const 0) (const 0)) (Builtin "Test") 0
+      emitCombs (RN (const 0) (const 0) (const Nothing)) (Builtin "Test") 0
         . superNormalize
         . (\(ll, _, _, _) -> ll)
         . lamLift mempty


### PR DESCRIPTION
This PR implements two optimizations for the interpreter.

1. When generating `MCode`, we look up arities for functions and emit more efficient `Call` instructions. This allows things like self-recursive loops to be more efficient.
    - It also fixes an opposite-logic bug with the stack size check in that path. Chris noticed it a while back, but it hadn't mattered because it was never used.
2. Just before generating `MCode`, it runs an inlining pass on the A-normal code. This checks for really simple wrapper-like code like (conceptually) `x y -> f x y y`, or stuff like `x -> 3`. If such things are fully or over-saturated, it will try to inline directly into the call site. Eventually, I think most builtins will be of this form, so saturated calls to builtins will be inlined to directly use the interpreter instructions.
   - Like I said, this pass happens _just_ before generating `MCode`, so it only affects what is actually run on the interpreter. We can't really do it earlier, because the inlined code isn't proper to send around to other machines, and the runtime hashes would change.

Also included are some tweaks to the pretty printing for debugging `MCode` generation. I think I'm going to try one more tweak to that before merging this.