### PR TITLE
Fix bug 5433

### DIFF
--- a/unison-core/src/Unison/Type/Names.hs
+++ b/unison-core/src/Unison/Type/Names.hs
@@ -77,6 +77,8 @@ bindNames unsafeVarToName nameToVar localVars namespace =
                 & bindExternal namespaceResolutions
                 -- Apply local resolutions (replacing "Foo" with "Full.Name.Foo" where "Full.Name.Foo" is in local vars)
                 & ABT.substsInheritAnnotation [(v, Type.var () (nameToVar name)) | (v, name) <- localResolutions]
+                -- Clean up ability lists again – we might have something to de-dupe after resolution
+                & Type.cleanupAbilityLists
   where
     resolveTypeName :: Name -> Set (ResolvesTo TypeReference)
     resolveTypeName =

--- a/unison-src/transcripts/fix-5433.md
+++ b/unison-src/transcripts/fix-5433.md
@@ -1,0 +1,22 @@
+```ucm
+scratch/main> builtins.merge lib.builtin
+```
+
+```unison
+ability foo.Bar where
+  baz : ()
+```
+
+```ucm
+scratch/main> add
+```
+
+```unison:error
+ability foo.Bar where
+  baz : '{Bar} ()
+
+hello : Request {foo.Bar} a -> ()
+hello = cases
+  { baz _ -> _ } -> ()
+  { _ } -> ()
+```

--- a/unison-src/transcripts/fix-5433.md
+++ b/unison-src/transcripts/fix-5433.md
@@ -1,3 +1,5 @@
+This used to cause a "duplicate effects" error because we weren't de-duping ability lists after binding names.
+
 ```ucm
 scratch/main> builtins.merge lib.builtin
 ```
@@ -11,7 +13,7 @@ ability foo.Bar where
 scratch/main> add
 ```
 
-```unison:error
+```unison
 ability foo.Bar where
   baz : '{Bar} ()
 

--- a/unison-src/transcripts/fix-5433.output.md
+++ b/unison-src/transcripts/fix-5433.output.md
@@ -1,3 +1,5 @@
+This used to cause a "duplicate effects" error because we weren't de-duping ability lists after binding names.
+
 ``` ucm
 scratch/main> builtins.merge lib.builtin
 
@@ -44,7 +46,17 @@ hello = cases
 
   Loading changes detected in scratch.u.
 
-  EffectConstructorHadMultipleEffects:
-    {Bar, Bar} Unit
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      hello : Request {Bar} a -> ()
+    
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      ability foo.Bar
 
 ```

--- a/unison-src/transcripts/fix-5433.output.md
+++ b/unison-src/transcripts/fix-5433.output.md
@@ -1,0 +1,50 @@
+``` ucm
+scratch/main> builtins.merge lib.builtin
+
+  Done.
+
+```
+``` unison
+ability foo.Bar where
+  baz : ()
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      ability foo.Bar
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    ability foo.Bar
+
+```
+``` unison
+ability foo.Bar where
+  baz : '{Bar} ()
+
+hello : Request {foo.Bar} a -> ()
+hello = cases
+  { baz _ -> _ } -> ()
+  { _ } -> ()
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  EffectConstructorHadMultipleEffects:
+    {Bar, Bar} Unit
+
+```


### PR DESCRIPTION
## Overview

Fixes #5433 

This bug fixes an issue caused by writing abilities like

```
ability foo.Bar where
  baz : Nat ->{Bar} Nat
```

Namely, that have some suffix (`Bar`) of the full ability name (`foo.Bar`) present in a constructor type.

## Implementation notes

De-dupe abilities after binding names

## Test coverage

I've added a transcript (failing in first commit)