### PR TITLE
FZF: sort current project's branches to the bottom

### DIFF
--- a/unison-src/transcripts/fuzzy-options.output.md
+++ b/unison-src/transcripts/fuzzy-options.output.md
@@ -70,6 +70,8 @@ myproject/main> branch mybranch
 scratch/main> debug.fuzzy-options switch _
 
   Select a project or branch to switch to:
+    * /empty
+    * /main
     * myproject/main
     * myproject/mybranch
     * scratch/empty


### PR DESCRIPTION
## Overview

List branches in the current project near the cursor for improved UX

On trunk:

<img width="544" alt="image" src="https://github.com/user-attachments/assets/291f4aca-4ae7-456c-97ed-53b93025fcc1">

Now:

<img width="520" alt="image" src="https://github.com/user-attachments/assets/8b8942a1-4af7-4a60-90e5-8841a5dc3902">

## Implementation notes

* Put the shortened `/branch-name` close to the cursor, but also the expanded `@user/project/branch-name` at the end of the list in case the user searches for that.

## Interesting/controversial decisions

Do we want both the shortened and expanded names or is that confusing?
