### PR TITLE
Enable top-level value caching in jit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ on:
 env:
   ## Some version numbers that are used during CI
   ormolu_version: 0.7.2.0
-  jit_version: "@unison/internal/releases/0.0.24"
+  jit_version: "@unison/internal/releases/0.0.25"
   runtime_tests_version: "@unison/runtime-tests/releases/0.0.1"
 
   ## Some cached directories

--- a/scheme-libs/racket/unison/boot.ss
+++ b/scheme-libs/racket/unison/boot.ss
@@ -329,8 +329,7 @@
       (or trace? (eq? h 'trace))
       (or inline? (eq? h 'inline))
       (or recursive? (eq? h 'recursive))
-      ; TODO: enable values
-      value?)))
+      (or value? (eq? h 'value)))))
 
 (define-for-syntax
   (make-link-def gen-link? loc name:stx name:link:stx)

--- a/unison-src/transcripts-manual/gen-racket-libs.md
+++ b/unison-src/transcripts-manual/gen-racket-libs.md
@@ -3,7 +3,7 @@ When we start out, `./scheme-libs/racket` contains a bunch of library files that
 Next, we'll download the jit project and generate a few Racket files from it.
 
 ``` ucm
-jit-setup/main> lib.install @unison/internal/releases/0.0.24
+jit-setup/main> lib.install @unison/internal/releases/0.0.25
 ```
 
 ``` unison

--- a/unison-src/transcripts-manual/gen-racket-libs.output.md
+++ b/unison-src/transcripts-manual/gen-racket-libs.output.md
@@ -3,12 +3,12 @@ When we start out, `./scheme-libs/racket` contains a bunch of library files that
 Next, we'll download the jit project and generate a few Racket files from it.
 
 ``` ucm
-jit-setup/main> lib.install @unison/internal/releases/0.0.24
+jit-setup/main> lib.install @unison/internal/releases/0.0.25
 
-  Downloaded 15002 entities.
+  Downloaded 14942 entities.
 
-  I installed @unison/internal/releases/0.0.24 as
-  unison_internal_0_0_24.
+  I installed @unison/internal/releases/0.0.25 as
+  unison_internal_0_0_25.
 
 ```
 ``` unison


### PR DESCRIPTION
This enables the code that will use the top-level caching flag in the jit to generate values that are only evaluated once.

The main change required was upgrading `@unison/internal` to the latest base to get correctly sorted definitions. Otherwise it was just turning on the code that enables the hint that was already being generated.

Fixes #4495 on the jit.