### PR TITLE
Bump macos github actions runners from deprecated macos-12 to macos-13

### DIFF
--- a/.github/workflows/bundle-ucm.yaml
+++ b/.github/workflows/bundle-ucm.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-12, macos-14, windows-2019]
+        os: [ubuntu-20.04, macos-13, macos-14, windows-2019]
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/bundle-ucm.yaml
+++ b/.github/workflows/bundle-ucm.yaml
@@ -141,7 +141,7 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
-          - macos-12
+          - macos-13
           - macos-14
           - windows-2019
     runs-on: ${{matrix.os}}
@@ -211,7 +211,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-12, macos-14, windows-2019]
+        os: [ubuntu-20.04, macos-13, macos-14, windows-2019]
     steps:
       - name: set up environment
         run: |

--- a/.github/workflows/ci-build-jit-binary.yaml
+++ b/.github/workflows/ci-build-jit-binary.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macOS-12, windows-2019]
+        os: [ubuntu-20.04, macOS-13, windows-2019]
     runs-on: ${{matrix.os}}
     steps:
       - name: set up environment
@@ -54,7 +54,7 @@ jobs:
         with:
           name: jit-source
           path: ${{ env.jit_src }}
-      
+
       - name: cache/restore jit binaries
         id: cache-jit-binaries
         uses: actions/cache/restore@v4

--- a/.github/workflows/ci-test-jit.yaml
+++ b/.github/workflows/ci-test-jit.yaml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
-          - macOS-12
+          - macOS-13
           # - windows-2019
     runs-on: ${{matrix.os}}
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -218,7 +218,7 @@ jobs:
         os:
           # While iterating on this file, you can disable one or more of these to speed things up
           - ubuntu-20.04
-          - macOS-12
+          - macos-13
           - windows-2019
           # - windows-2022
     steps:
@@ -297,7 +297,7 @@ jobs:
         os:
           # While iterating on this file, you can disable one or more of these to speed things up
           - ubuntu-20.04
-          - macOS-12
+          - macos-13
           # - windows-2019
           # - windows-2022
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,7 @@ jobs:
         os:
           # While iterating on this file, you can disable one or more of these to speed things up
           - ubuntu-20.04
-          - macOS-12
+          - macOS-13
           - windows-2019
           # - windows-2022
     steps:

--- a/.github/workflows/nix-dev-cache.yaml
+++ b/.github/workflows/nix-dev-cache.yaml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
-          - macOS-12
+          - macOS-13
           # - macOS-14
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/update-transcripts.yaml
+++ b/.github/workflows/update-transcripts.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - macOS-12
+          - macOS-13
     steps:
       - uses: actions/checkout@v4
       - uses: unisonweb/actions/stack/cache/restore@main

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,20 +3,20 @@ pull_request_rules:
     conditions:
       - check-success=check-contributor
       - check-success=build ucm (ubuntu-20.04)
-      - check-success=build ucm (macOS-12)
+      - check-success=build ucm (macos-13)
       - check-success=build ucm (windows-2019)
       - check-success=run transcripts (ubuntu-20.04)
-      - check-success=run transcripts (macOS-12)
+      - check-success=run transcripts (macos-13)
       - check-success=run transcripts (windows-2019)
       - check-success=run interpreter tests (ubuntu-20.04)
-      - check-success=run interpreter tests (macOS-12)
+      - check-success=run interpreter tests (macos-13)
       # - check-success=run interpreter tests (windows-2019)
       - check-success=generate jit source
       - check-success=build jit binary / build jit binary (ubuntu-20.04)
-      - check-success=build jit binary / build jit binary (macOS-12)
+      - check-success=build jit binary / build jit binary (macos-13)
       - check-success=build jit binary / build jit binary (windows-2019)
       - check-success=test jit / test jit (ubuntu-20.04)
-      - check-success=test jit / test jit (macOS-12)
+      - check-success=test jit / test jit (macos-13)
       # - check-success=test jit / test jit (windows-2019)
       - label=ready-to-merge
       - "#approved-reviews-by>=1"


### PR DESCRIPTION
## Overview

macos-12 runners are being sunset: https://github.com/actions/runner-images/issues/10721

## Implementation notes

Bump most macos-12 runners to macos-13; Arya mentioned in chat he'd like to keep an intel-based mac runner in the rotation.

## Interesting/controversial decisions

The runners we use in different spots seems a bit arbitrary, but w/e, I have no real reason to change anything else.

