### PR TITLE
fix #5441 - malformed Unison examples in source code

### DIFF
--- a/parser-typechecker/src/Unison/Syntax/TermParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermParser.hs
@@ -1243,22 +1243,20 @@ verifyRelativeName' name = do
 
 -- example:
 --   (x, y)   = foo
---   hd +: tl | hd < 10 = [1,2,3]
 --   stuff
 --
 -- desugars to:
 --
 --   match foo with
---     (x,y) -> match [1,2,3] with
---       hd +: tl | hd < 10 -> stuff
+--     (x,y) -> stuff
 --
 destructuringBind :: forall m v. (Monad m, Var v) => P v m (Ann, Term v Ann -> Term v Ann)
 destructuringBind = do
   -- We have to look ahead as far as the `=` to know if this is a bind or
   -- just an action, for instance:
-  --   Some 42
+  --   (Some 42)
   --   vs
-  --   Some 42 = List.head elems
+  --   (Some 42) = List.head elems
   (p, boundVars) <- P.try do
     (p, boundVars) <- parsePattern
     let boundVars' = snd <$> boundVars


### PR DESCRIPTION
## Overview

This changes no behavior. It only removes/updates a couple Unison examples in Haskell comments so they're no longer malformed Unison code.

## Interesting/controversial decisions

The docs claim all destructuring bind LHSs must be parenthesized. However, the Haskell code has two examples where this is not true. One of them even uses a special list pattern on the LHS of a restructuring bind. The docs explicitly say this is not supported.

Reading through TermParser, I couldn't find a single reason this *would* fail, and yet I couldn't get it to succeed in UCM.

Suggesting the docs are right and the comments are not.

## Test coverage

No tests because it's just comment changes.

## Loose ends

One of the comments I edited makes a claim about how destructuring binds are desugared to a `match` structure. I have not independently verified this is true; I only edited the malformed restructuring binds.