### PR TITLE
Add instructions for DropN, truncate0, and Refs

### DIFF
--- a/unison-runtime/src/Unison/Runtime/ANF.hs
+++ b/unison-runtime/src/Unison/Runtime/ANF.hs
@@ -1416,6 +1416,9 @@ data POp
   | TFRC -- try force
   | SDBL -- sandbox link list
   | SDBV -- sandbox check for Values
+  -- Refs
+  | RREF -- Ref.read
+  | WREF -- Ref.write
   deriving (Show, Eq, Ord, Enum, Bounded)
 
 type ANormal = ABTN.Term ANormalF

--- a/unison-runtime/src/Unison/Runtime/ANF.hs
+++ b/unison-runtime/src/Unison/Runtime/ANF.hs
@@ -1291,9 +1291,11 @@ data POp
   | DECI -- dec
   | LEQI -- <=
   | EQLI -- ==
+  | TRNC -- truncate0
   -- Nat
   | ADDN -- +
   | SUBN -- -
+  | DRPN -- drop
   | MULN
   | DIVN -- /
   | MODN -- mod

--- a/unison-runtime/src/Unison/Runtime/ANF.hs
+++ b/unison-runtime/src/Unison/Runtime/ANF.hs
@@ -1417,8 +1417,12 @@ data POp
   | SDBL -- sandbox link list
   | SDBV -- sandbox check for Values
   -- Refs
-  | RREF -- Ref.read
-  | WREF -- Ref.write
+  | REFN -- Ref.new
+  | REFR -- Ref.read
+  | REFW -- Ref.write
+  | RCAS -- Ref.cas
+  | RRFC -- Ref.readForCas
+  | TIKR -- Ref.Ticket.read
   deriving (Show, Eq, Ord, Enum, Bounded)
 
 type ANormal = ABTN.Term ANormalF

--- a/unison-runtime/src/Unison/Runtime/ANF/Serialize.hs
+++ b/unison-runtime/src/Unison/Runtime/ANF/Serialize.hs
@@ -654,6 +654,8 @@ pOpCode op = case op of
   IORI -> 126
   XORI -> 127
   COMI -> 128
+  DRPN -> 129
+  TRNC -> 130
 
 pOpAssoc :: [(POp, Word16)]
 pOpAssoc = map (\op -> (op, pOpCode op)) [minBound .. maxBound]

--- a/unison-runtime/src/Unison/Runtime/ANF/Serialize.hs
+++ b/unison-runtime/src/Unison/Runtime/ANF/Serialize.hs
@@ -656,6 +656,8 @@ pOpCode op = case op of
   COMI -> 128
   DRPN -> 129
   TRNC -> 130
+  RREF -> 131
+  WREF -> 132
 
 pOpAssoc :: [(POp, Word16)]
 pOpAssoc = map (\op -> (op, pOpCode op)) [minBound .. maxBound]

--- a/unison-runtime/src/Unison/Runtime/ANF/Serialize.hs
+++ b/unison-runtime/src/Unison/Runtime/ANF/Serialize.hs
@@ -656,8 +656,12 @@ pOpCode op = case op of
   COMI -> 128
   DRPN -> 129
   TRNC -> 130
-  RREF -> 131
-  WREF -> 132
+  REFN -> 131
+  REFR -> 132
+  REFW -> 133
+  RCAS -> 134
+  RRFC -> 135
+  TIKR -> 136
 
 pOpAssoc :: [(POp, Word16)]
 pOpAssoc = map (\op -> (op, pOpCode op)) [minBound .. maxBound]

--- a/unison-runtime/src/Unison/Runtime/Builtin.hs
+++ b/unison-runtime/src/Unison/Runtime/Builtin.hs
@@ -52,8 +52,6 @@ import Data.Digest.Murmur64 (asWord64, hash64)
 import Data.IORef as SYS
   ( IORef,
     newIORef,
-    readIORef,
-    writeIORef,
   )
 import Data.IP (IP)
 import Data.Map qualified as Map
@@ -996,6 +994,16 @@ any'extract =
       TMatch v $
         MatchData Ty.anyRef (mapSingleton 0 $ ([BX], TAbs v1 (TVar v1))) Nothing
 
+-- Refs
+
+ref'read :: SuperNormal Symbol
+ref'read =
+  unop0 0 $ \[ref] -> (TPrm RREF [ref])
+
+ref'write :: SuperNormal Symbol
+ref'write =
+  binop0 0 $ \[ref, val] -> (TPrm WREF [ref, val])
+
 seek'handle :: ForeignOp
 seek'handle instr =
   ([BX, BX, BX],)
@@ -1872,7 +1880,9 @@ builtinLookup =
         ("validateSandboxed", (Untracked, check'sandbox)),
         ("Value.validateSandboxed", (Tracked, value'sandbox)),
         ("sandboxLinks", (Tracked, sandbox'links)),
-        ("IO.tryEval", (Tracked, try'eval))
+        ("IO.tryEval", (Tracked, try'eval)),
+        ("Ref.read", (Tracked, ref'read)),
+        ("Ref.write", (Tracked, ref'write))
       ]
       ++ foreignWrappers
 
@@ -2379,19 +2389,6 @@ declareForeigns = do
   declareForeign Tracked "IO.ref" (argNDirect 1)
     . mkForeign
     $ \(c :: Val) -> evaluate c >>= newIORef
-
-  -- The docs for IORef state that IORef operations can be observed
-  -- out of order ([1]) but actually GHC does emit the appropriate
-  -- load and store barriers nowadays ([2], [3]).
-  --
-  -- [1] https://hackage.haskell.org/package/base-4.17.0.0/docs/Data-IORef.html#g:2
-  -- [2] https://github.com/ghc/ghc/blob/master/compiler/GHC/StgToCmm/Prim.hs#L286
-  -- [3] https://github.com/ghc/ghc/blob/master/compiler/GHC/StgToCmm/Prim.hs#L298
-  declareForeign Untracked "Ref.read" (argNDirect 1) . mkForeign $
-    \(r :: IORef Val) -> readIORef r
-
-  declareForeign Untracked "Ref.write" arg2To0 . mkForeign $
-    \(r :: IORef Val, c :: Val) -> evaluate c >>= writeIORef r
 
   declareForeign Tracked "Ref.readForCas" (argNDirect 1) . mkForeign $
     \(r :: IORef Val) -> readForCAS r

--- a/unison-runtime/src/Unison/Runtime/Foreign.hs
+++ b/unison-runtime/src/Unison/Runtime/Foreign.hs
@@ -22,6 +22,7 @@ where
 import Control.Concurrent (MVar, ThreadId)
 import Control.Concurrent.STM (TVar)
 import Crypto.Hash qualified as Hash
+import Data.Atomics qualified as Atomic
 import Data.IORef (IORef)
 import Data.Tagged (Tagged (..))
 import Data.X509 qualified as X509
@@ -260,6 +261,8 @@ instance BuiltinForeign Code where foreignRef = Tagged Ty.codeRef
 instance BuiltinForeign Value where foreignRef = Tagged Ty.valueRef
 
 instance BuiltinForeign TimeSpec where foreignRef = Tagged Ty.timeSpecRef
+
+instance BuiltinForeign (Atomic.Ticket a) where foreignRef = Tagged Ty.ticketRef
 
 data HashAlgorithm where
   -- Reference is a reference to the hash algorithm

--- a/unison-runtime/src/Unison/Runtime/MCode.hs
+++ b/unison-runtime/src/Unison/Runtime/MCode.hs
@@ -323,6 +323,7 @@ data UPrim1
   | FLOR -- floor
   | TRNF -- truncate
   | RNDF -- round
+  | TRNC -- truncate
   deriving (Show, Eq, Ord, Enum, Bounded)
 
 data UPrim2
@@ -366,6 +367,7 @@ data UPrim2
   | MAXF -- max
   | MINF -- min
   | CAST -- unboxed runtime type cast (int to nat, etc.)
+  | DRPN -- dropn
   deriving (Show, Eq, Ord, Enum, Bounded)
 
 data BPrim1
@@ -1196,6 +1198,7 @@ emitPOp ANF.ADDI = emitP2 ADDI
 emitPOp ANF.ADDN = emitP2 ADDN
 emitPOp ANF.SUBI = emitP2 SUBI
 emitPOp ANF.SUBN = emitP2 SUBN
+emitPOp ANF.DRPN = emitP2 DRPN
 emitPOp ANF.MULI = emitP2 MULI
 emitPOp ANF.MULN = emitP2 MULN
 emitPOp ANF.DIVI = emitP2 DIVI
@@ -1218,6 +1221,7 @@ emitPOp ANF.INCI = emitP1 INCI
 emitPOp ANF.INCN = emitP1 INCN
 emitPOp ANF.DECI = emitP1 DECI
 emitPOp ANF.DECN = emitP1 DECN
+emitPOp ANF.TRNC = emitP1 TRNC
 emitPOp ANF.TZRO = emitP1 TZRO
 emitPOp ANF.LZRO = emitP1 LZRO
 emitPOp ANF.POPC = emitP1 POPC

--- a/unison-runtime/src/Unison/Runtime/MCode.hs
+++ b/unison-runtime/src/Unison/Runtime/MCode.hs
@@ -402,6 +402,8 @@ data BPrim1
   -- debug
   | DBTX -- debug text
   | SDBL -- sandbox link list
+  | -- Refs
+    RREF -- Ref.read
   deriving (Show, Eq, Ord, Enum, Bounded)
 
 data BPrim2
@@ -437,6 +439,8 @@ data BPrim2
   -- code
   | SDBX -- sandbox
   | SDBV -- sandbox Value
+  -- Refs
+  | WREF -- Ref.write
   deriving (Show, Eq, Ord, Enum, Bounded)
 
 data MLit
@@ -1327,6 +1331,9 @@ emitPOp ANF.SDBV = emitBP2 SDBV
 emitPOp ANF.EROR = emitBP2 THRO
 emitPOp ANF.TRCE = emitBP2 TRCE
 emitPOp ANF.DBTX = emitBP1 DBTX
+-- Refs
+emitPOp ANF.RREF = emitBP1 RREF
+emitPOp ANF.WREF = emitBP2 WREF
 -- non-prim translations
 emitPOp ANF.BLDS = Seq
 emitPOp ANF.FORK = \case

--- a/unison-runtime/src/Unison/Runtime/MCode/Serialize.hs
+++ b/unison-runtime/src/Unison/Runtime/MCode/Serialize.hs
@@ -17,8 +17,8 @@ import Data.Bytes.VarInt
 import Data.Void (Void)
 import Data.Word (Word64)
 import GHC.Exts (IsList (..))
-import Unison.Runtime.Array (PrimArray)
 import Unison.Runtime.ANF (PackedTag (..))
+import Unison.Runtime.Array (PrimArray)
 import Unison.Runtime.MCode hiding (MatchT)
 import Unison.Runtime.Serialize
 import Unison.Util.Text qualified as Util.Text
@@ -160,6 +160,7 @@ data InstrT
   | AtomicallyT
   | SeqT
   | TryForceT
+  | RefCAST
 
 instance Tag InstrT where
   tag2word UPrim1T = 0
@@ -179,6 +180,7 @@ instance Tag InstrT where
   tag2word AtomicallyT = 14
   tag2word SeqT = 15
   tag2word TryForceT = 16
+  tag2word RefCAST = 17
 
   word2tag 0 = pure UPrim1T
   word2tag 1 = pure UPrim2T
@@ -197,6 +199,7 @@ instance Tag InstrT where
   word2tag 14 = pure AtomicallyT
   word2tag 15 = pure SeqT
   word2tag 16 = pure TryForceT
+  word2tag 17 = pure RefCAST
   word2tag n = unknownTag "InstrT" n
 
 putInstr :: (MonadPut m) => GInstr cix -> m ()
@@ -205,6 +208,7 @@ putInstr = \case
   (UPrim2 up i j) -> putTag UPrim2T *> putTag up *> pInt i *> pInt j
   (BPrim1 bp i) -> putTag BPrim1T *> putTag bp *> pInt i
   (BPrim2 bp i j) -> putTag BPrim2T *> putTag bp *> pInt i *> pInt j
+  (RefCAS i j k) -> putTag RefCAST *> pInt i *> pInt j *> pInt k
   (ForeignCall b w a) -> putTag ForeignCallT *> serialize b *> pWord w *> putArgs a
   (SetDyn w i) -> putTag SetDynT *> pWord w *> pInt i
   (Capture w) -> putTag CaptureT *> pWord w
@@ -226,6 +230,7 @@ getInstr =
     UPrim2T -> UPrim2 <$> getTag <*> gInt <*> gInt
     BPrim1T -> BPrim1 <$> getTag <*> gInt
     BPrim2T -> BPrim2 <$> getTag <*> gInt <*> gInt
+    RefCAST -> RefCAS <$> gInt <*> gInt <*> gInt
     ForeignCallT -> ForeignCall <$> deserialize <*> gWord <*> getArgs
     SetDynT -> SetDyn <$> gWord <*> gInt
     CaptureT -> Capture <$> gWord

--- a/unison-runtime/src/Unison/Runtime/Machine.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine.hs
@@ -1645,7 +1645,7 @@ bprim1 !stk REFN i = do
   -- Note that the CAS machinery is extremely fussy w/r to whether things are forced because it
   -- uses unsafe pointer equality. The only way we've gotten it to work as expected is with liberal
   -- forcing of the values and tickets.
-  !v <- peekOff stk i
+  !v <- evaluate =<< peekOff stk i
   ref <- IORef.newIORef v
   stk <- bump stk
   pokeBi stk ref

--- a/unison-runtime/src/Unison/Runtime/Machine.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine.hs
@@ -1062,6 +1062,11 @@ uprim1 !stk INCN !i = do
   stk <- bump stk
   pokeN stk (m + 1)
   pure stk
+uprim1 !stk TRNC !i = do
+  v <- peekOffI stk i
+  stk <- bump stk
+  unsafePokeIasN stk (max 0 v)
+  pure stk
 uprim1 !stk NEGI !i = do
   m <- upeekOff stk i
   stk <- bump stk
@@ -1227,6 +1232,13 @@ uprim2 !stk SUBI !i !j = do
   n <- upeekOff stk j
   stk <- bump stk
   pokeI stk (m - n)
+  pure stk
+uprim2 !stk DRPN !i !j = do
+  m <- peekOffN stk i
+  n <- peekOffN stk j
+  stk <- bump stk
+  let r = if n >= m then 0 else m - n
+  pokeN stk r
   pure stk
 uprim2 !stk SUBN !i !j = do
   m <- peekOffI stk i

--- a/unison-runtime/src/Unison/Runtime/Machine.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine.hs
@@ -1641,6 +1641,7 @@ bprim1 !stk REFR i = do
   pure stk
 bprim1 !stk REFN i = do
   v <- peekOff stk i
+  v <- evaluate v
   ref <- IORef.newIORef v
   stk <- bump stk
   pokeBi stk ref

--- a/unison-runtime/src/Unison/Runtime/Machine.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine.hs
@@ -10,6 +10,8 @@ import Control.Exception
 import Control.Lens
 import Data.Bits
 import Data.Functor.Classes (Eq1 (..), Ord1 (..))
+import Data.IORef (IORef)
+import Data.IORef qualified as IORef
 import Data.Map.Strict qualified as M
 import Data.Ord (comparing)
 import Data.Sequence qualified as Sq
@@ -60,7 +62,6 @@ import Unison.Util.EnumContainers as EC
 import Unison.Util.Monoid qualified as Monoid
 import Unison.Util.Pretty (toPlainUnbroken)
 import Unison.Util.Text qualified as Util.Text
-import UnliftIO (IORef)
 import UnliftIO qualified
 import UnliftIO.Concurrent qualified as UnliftIO
 
@@ -1614,6 +1615,21 @@ bprim1 !stk FLTB i = do
   stk <- bump stk
   pokeBi stk $ By.flatten b
   pure stk
+
+-- The docs for IORef state that IORef operations can be observed
+-- out of order ([1]) but actually GHC does emit the appropriate
+-- load and store barriers nowadays ([2], [3]).
+--
+-- [1] https://hackage.haskell.org/package/base-4.17.0.0/docs/Data-IORef.html#g:2
+-- [2] https://github.com/ghc/ghc/blob/master/compiler/GHC/StgToCmm/Prim.hs#L286
+-- [3] https://github.com/ghc/ghc/blob/master/compiler/GHC/StgToCmm/Prim.hs#L298
+bprim1 !stk RREF i = do
+  (ref :: IORef Val) <- peekOffBi stk i
+  v <- IORef.readIORef ref
+  stk <- bump stk
+  poke stk v
+  pure stk
+
 -- impossible
 bprim1 !stk MISS _ = pure stk
 bprim1 !stk CACH _ = pure stk
@@ -1817,6 +1833,13 @@ bprim2 !stk CATB i j = do
   r <- peekOffBi stk j
   stk <- bump stk
   pokeBi stk (l <> r :: By.Bytes)
+  pure stk
+bprim2 !stk WREF i j = do
+  (ref :: IORef Val) <- peekOffBi stk i
+  v <- peekOff stk j
+  IORef.writeIORef ref v
+  stk <- bump stk
+  bpoke stk unitValue
   pure stk
 bprim2 !stk THRO _ _ = pure stk -- impossible
 bprim2 !stk TRCE _ _ = pure stk -- impossible

--- a/unison-runtime/src/Unison/Runtime/Serialize.hs
+++ b/unison-runtime/src/Unison/Runtime/Serialize.hs
@@ -328,6 +328,7 @@ instance Tag UPrim1 where
   tag2word FLOR = 30
   tag2word TRNF = 31
   tag2word RNDF = 32
+  tag2word TRNC = 33
 
   word2tag 0 = pure DECI
   word2tag 1 = pure DECN
@@ -362,6 +363,7 @@ instance Tag UPrim1 where
   word2tag 30 = pure FLOR
   word2tag 31 = pure TRNF
   word2tag 32 = pure RNDF
+  word2tag 33 = pure TRNC
   word2tag n = unknownTag "UPrim1" n
 
 instance Tag UPrim2 where
@@ -403,6 +405,7 @@ instance Tag UPrim2 where
   tag2word MAXF = 35
   tag2word MINF = 36
   tag2word CAST = 37
+  tag2word DRPN = 38
 
   word2tag 0 = pure ADDI
   word2tag 1 = pure ADDN
@@ -442,6 +445,7 @@ instance Tag UPrim2 where
   word2tag 35 = pure MAXF
   word2tag 36 = pure MINF
   word2tag 37 = pure CAST
+  word2tag 38 = pure DRPN
   word2tag n = unknownTag "UPrim2" n
 
 instance Tag BPrim1 where

--- a/unison-runtime/src/Unison/Runtime/Serialize.hs
+++ b/unison-runtime/src/Unison/Runtime/Serialize.hs
@@ -476,6 +476,7 @@ instance Tag BPrim1 where
   tag2word TLTT = 24
   tag2word DBTX = 25
   tag2word SDBL = 26
+  tag2word RREF = 27
 
   word2tag 0 = pure SIZT
   word2tag 1 = pure USNC
@@ -504,6 +505,7 @@ instance Tag BPrim1 where
   word2tag 24 = pure TLTT
   word2tag 25 = pure DBTX
   word2tag 26 = pure SDBL
+  word2tag 27 = pure RREF
   word2tag n = unknownTag "BPrim1" n
 
 instance Tag BPrim2 where
@@ -533,6 +535,7 @@ instance Tag BPrim2 where
   tag2word IXOT = 23
   tag2word IXOB = 24
   tag2word SDBV = 25
+  tag2word WREF = 26
 
   word2tag 0 = pure EQLU
   word2tag 1 = pure CMPU
@@ -560,4 +563,5 @@ instance Tag BPrim2 where
   word2tag 23 = pure IXOT
   word2tag 24 = pure IXOB
   word2tag 25 = pure SDBV
+  word2tag 26 = pure WREF
   word2tag n = unknownTag "BPrim2" n

--- a/unison-runtime/src/Unison/Runtime/Serialize.hs
+++ b/unison-runtime/src/Unison/Runtime/Serialize.hs
@@ -476,7 +476,10 @@ instance Tag BPrim1 where
   tag2word TLTT = 24
   tag2word DBTX = 25
   tag2word SDBL = 26
-  tag2word RREF = 27
+  tag2word REFN = 27
+  tag2word REFR = 28
+  tag2word RRFC = 29
+  tag2word TIKR = 30
 
   word2tag 0 = pure SIZT
   word2tag 1 = pure USNC
@@ -505,7 +508,10 @@ instance Tag BPrim1 where
   word2tag 24 = pure TLTT
   word2tag 25 = pure DBTX
   word2tag 26 = pure SDBL
-  word2tag 27 = pure RREF
+  word2tag 27 = pure REFN
+  word2tag 28 = pure REFR
+  word2tag 29 = pure RRFC
+  word2tag 30 = pure TIKR
   word2tag n = unknownTag "BPrim1" n
 
 instance Tag BPrim2 where
@@ -535,7 +541,7 @@ instance Tag BPrim2 where
   tag2word IXOT = 23
   tag2word IXOB = 24
   tag2word SDBV = 25
-  tag2word WREF = 26
+  tag2word REFW = 26
 
   word2tag 0 = pure EQLU
   word2tag 1 = pure CMPU
@@ -563,5 +569,5 @@ instance Tag BPrim2 where
   word2tag 23 = pure IXOT
   word2tag 24 = pure IXOB
   word2tag 25 = pure SDBV
-  word2tag 26 = pure WREF
+  word2tag 26 = pure REFW
   word2tag n = unknownTag "BPrim2" n

--- a/unison-runtime/src/Unison/Runtime/Stack.hs
+++ b/unison-runtime/src/Unison/Runtime/Stack.hs
@@ -127,9 +127,11 @@ where
 
 import Control.Monad.Primitive
 import Data.Char qualified as Char
+import Data.IORef (IORef)
 import Data.Kind (Constraint)
 import Data.Primitive (sizeOf)
 import Data.Primitive.ByteArray qualified as BA
+import Data.Tagged (Tagged (..))
 import Data.Word
 import GHC.Exts as L (IsList (..))
 import Unison.Prelude
@@ -609,6 +611,8 @@ data Val = Val {getUnboxedVal :: !UVal, getBoxedVal :: !BVal}
   -- unboxed side is garbage and should not be compared.
   -- See universalEq.
   deriving (Show)
+
+instance BuiltinForeign (IORef Val) where foreignRef = Tagged Ty.refRef
 
 -- | A nulled out value you can use when filling empty arrays, etc.
 emptyVal :: Val

--- a/unison-src/transcripts-using-base/ref-promise.md
+++ b/unison-src/transcripts-using-base/ref-promise.md
@@ -6,7 +6,7 @@ change state atomically without locks.
 ``` unison
 casTest: '{io2.IO} [Result]
 casTest = do
-  test = do
+  testPrim = do
     ref = IO.ref 0
     ticket = Ref.readForCas ref
     v1 = Ref.cas ref ticket 5
@@ -14,8 +14,16 @@ casTest = do
     Ref.write ref 10
     v2 = Ref.cas ref ticket 15
     check "CAS fails when there was an intervening write" (not v2)
+  testBoxed = do
+    ref = IO.ref ("a", "b")
+    ticket = Ref.readForCas ref
+    v1 = Ref.cas ref ticket ("c", "d")
+    check "CAS is successful is there were no conflicting writes" v1
+    Ref.write ref ("e", "f")
+    v2 = Ref.cas ref ticket ("g", "h")
+    check "CAS fails when there was an intervening write" (not v2)
 
-  runTest test
+  runTest testPrim ++ runTest testBoxed
 ```
 
 ``` ucm

--- a/unison-src/transcripts-using-base/ref-promise.output.md
+++ b/unison-src/transcripts-using-base/ref-promise.output.md
@@ -6,7 +6,7 @@ change state atomically without locks.
 ``` unison
 casTest: '{io2.IO} [Result]
 casTest = do
-  test = do
+  testPrim = do
     ref = IO.ref 0
     ticket = Ref.readForCas ref
     v1 = Ref.cas ref ticket 5
@@ -14,8 +14,16 @@ casTest = do
     Ref.write ref 10
     v2 = Ref.cas ref ticket 15
     check "CAS fails when there was an intervening write" (not v2)
+  testBoxed = do
+    ref = IO.ref ("a", "b")
+    ticket = Ref.readForCas ref
+    v1 = Ref.cas ref ticket ("c", "d")
+    check "CAS is successful is there were no conflicting writes" v1
+    Ref.write ref ("e", "f")
+    v2 = Ref.cas ref ticket ("g", "h")
+    check "CAS fails when there was an intervening write" (not v2)
 
-  runTest test
+  runTest testPrim ++ runTest testBoxed
 ```
 
 ``` ucm
@@ -42,30 +50,216 @@ scratch/main> io.test casTest
 
     New test results:
   
-    1. casTest   ◉ CAS fails when there was an intervening write
+    1. casTest   ◉ CAS is successful is there were no conflicting writes
+                 ◉ CAS fails when there was an intervening write
+                 ◉ CAS is successful is there were no conflicting writes
+                 ◉ CAS fails when there was an intervening write
   
-    2. casTest   ✗ CAS is successful is there were no conflicting writes
-  
-  🚫 1 test(s) failing, ✅ 1 test(s) passing
+  ✅ 4 test(s) passing
   
   Tip: Use view 1 to view the source of a test.
 
 ```
+Promise is a simple one-shot awaitable condition.
 
+``` unison
+promiseSequentialTest : '{IO} [Result]
+promiseSequentialTest = do
+  test = do
+    use Nat eq
+    use Promise read write
+    p = !Promise.new
+    write p 0 |> void
+    v1 = read p
+    check "Should read a value that's been written" (eq v1 0)
+    write p 1 |> void
+    v2 = read p
+    check "Promise can only be written to once" (eq v2 0)
 
+  runTest test
 
-🛑
+promiseConcurrentTest : '{IO} [Result]
+promiseConcurrentTest = do
+  use Nat eq
+  test = do
+    p = !Promise.new
+    _ = forkComp '(Promise.write p 5)
+    v = Promise.read p
+    check "Reads awaits for completion of the Promise" (eq v 5)
 
-The transcript failed due to an error in the stanza above. The error is:
+  runTest test
+```
 
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      promiseConcurrentTest : '{IO} [Result]
+      promiseSequentialTest : '{IO} [Result]
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    promiseConcurrentTest : '{IO} [Result]
+    promiseSequentialTest : '{IO} [Result]
+
+scratch/main> io.test promiseSequentialTest
 
     New test results:
   
-    1. casTest   ◉ CAS fails when there was an intervening write
+    1. promiseSequentialTest   ◉ Should read a value that's been written
+                               ◉ Promise can only be written to once
   
-    2. casTest   ✗ CAS is successful is there were no conflicting writes
-  
-  🚫 1 test(s) failing, ✅ 1 test(s) passing
+  ✅ 2 test(s) passing
   
   Tip: Use view 1 to view the source of a test.
 
+scratch/main> io.test promiseConcurrentTest
+
+    New test results:
+  
+    1. promiseConcurrentTest   ◉ Reads awaits for completion of the Promise
+  
+  ✅ 1 test(s) passing
+  
+  Tip: Use view 1 to view the source of a test.
+
+```
+CAS can be used to write an atomic update function.
+
+``` unison
+atomicUpdate : Ref {IO} a -> (a -> a) ->{IO} ()
+atomicUpdate ref f =
+  ticket = Ref.readForCas ref
+  value = f (Ticket.read ticket)
+  if Ref.cas ref ticket value then () else atomicUpdate ref f
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      atomicUpdate : Ref {IO} a -> (a -> a) ->{IO} ()
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    atomicUpdate : Ref {IO} a -> (a -> a) ->{IO} ()
+
+```
+Promise can be used to write an operation that spawns N concurrent
+tasks and collects their results
+
+``` unison
+spawnN : Nat -> '{IO} a ->{IO} [a]
+spawnN n fa =
+  use Nat eq drop
+  go i acc =
+    if eq i 0
+    then acc
+    else
+      value = !Promise.new
+      _ = forkComp do Promise.write value !fa
+      go (drop i 1) (acc :+ value)
+
+  map Promise.read (go n [])
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      spawnN : Nat -> '{IO} a ->{IO} [a]
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    spawnN : Nat -> '{IO} a ->{IO} [a]
+
+```
+We can use these primitives to write a more interesting example, where
+multiple threads repeatedly update an atomic counter, we check that
+the value of the counter is correct after all threads are done.
+
+``` unison
+fullTest : '{IO} [Result]
+fullTest = do
+  use Nat * + eq drop
+
+  numThreads = 100
+  iterations = 100
+  expected = numThreads * iterations
+
+  test = do
+    state = IO.ref 0
+    thread n =
+      if eq n 0
+      then ()
+      else
+        atomicUpdate state (v -> v + 1)
+        thread (drop n 1)
+    void (spawnN numThreads '(thread iterations))
+    result = Ref.read state
+    check "The state of the counter is consistent "(eq result expected)
+
+  runTest test
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      fullTest : '{IO} [Result]
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    fullTest : '{IO} [Result]
+
+scratch/main> io.test fullTest
+
+    New test results:
+  
+    1. fullTest   ◉ The state of the counter is consistent 
+  
+  ✅ 1 test(s) passing
+  
+  Tip: Use view 1 to view the source of a test.
+
+```

--- a/unison-src/transcripts-using-base/ref-promise.output.md
+++ b/unison-src/transcripts-using-base/ref-promise.output.md
@@ -42,214 +42,30 @@ scratch/main> io.test casTest
 
     New test results:
   
-    1. casTest   ◉ CAS is successful is there were no conflicting writes
-                 ◉ CAS fails when there was an intervening write
+    1. casTest   ◉ CAS fails when there was an intervening write
   
-  ✅ 2 test(s) passing
+    2. casTest   ✗ CAS is successful is there were no conflicting writes
+  
+  🚫 1 test(s) failing, ✅ 1 test(s) passing
   
   Tip: Use view 1 to view the source of a test.
 
 ```
-Promise is a simple one-shot awaitable condition.
 
-``` unison
-promiseSequentialTest : '{IO} [Result]
-promiseSequentialTest = do
-  test = do
-    use Nat eq
-    use Promise read write
-    p = !Promise.new
-    write p 0 |> void
-    v1 = read p
-    check "Should read a value that's been written" (eq v1 0)
-    write p 1 |> void
-    v2 = read p
-    check "Promise can only be written to once" (eq v2 0)
 
-  runTest test
 
-promiseConcurrentTest : '{IO} [Result]
-promiseConcurrentTest = do
-  use Nat eq
-  test = do
-    p = !Promise.new
-    _ = forkComp '(Promise.write p 5)
-    v = Promise.read p
-    check "Reads awaits for completion of the Promise" (eq v 5)
+🛑
 
-  runTest test
-```
+The transcript failed due to an error in the stanza above. The error is:
 
-``` ucm
-
-  Loading changes detected in scratch.u.
-
-  I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
-  
-    ⍟ These new definitions are ok to `add`:
-    
-      promiseConcurrentTest : '{IO} [Result]
-      promiseSequentialTest : '{IO} [Result]
-
-```
-``` ucm
-scratch/main> add
-
-  ⍟ I've added these definitions:
-  
-    promiseConcurrentTest : '{IO} [Result]
-    promiseSequentialTest : '{IO} [Result]
-
-scratch/main> io.test promiseSequentialTest
 
     New test results:
   
-    1. promiseSequentialTest   ◉ Should read a value that's been written
-                               ◉ Promise can only be written to once
+    1. casTest   ◉ CAS fails when there was an intervening write
   
-  ✅ 2 test(s) passing
+    2. casTest   ✗ CAS is successful is there were no conflicting writes
   
-  Tip: Use view 1 to view the source of a test.
-
-scratch/main> io.test promiseConcurrentTest
-
-    New test results:
-  
-    1. promiseConcurrentTest   ◉ Reads awaits for completion of the Promise
-  
-  ✅ 1 test(s) passing
+  🚫 1 test(s) failing, ✅ 1 test(s) passing
   
   Tip: Use view 1 to view the source of a test.
 
-```
-CAS can be used to write an atomic update function.
-
-``` unison
-atomicUpdate : Ref {IO} a -> (a -> a) ->{IO} ()
-atomicUpdate ref f =
-  ticket = Ref.readForCas ref
-  value = f (Ticket.read ticket)
-  if Ref.cas ref ticket value then () else atomicUpdate ref f
-```
-
-``` ucm
-
-  Loading changes detected in scratch.u.
-
-  I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
-  
-    ⍟ These new definitions are ok to `add`:
-    
-      atomicUpdate : Ref {IO} a -> (a -> a) ->{IO} ()
-
-```
-``` ucm
-scratch/main> add
-
-  ⍟ I've added these definitions:
-  
-    atomicUpdate : Ref {IO} a -> (a -> a) ->{IO} ()
-
-```
-Promise can be used to write an operation that spawns N concurrent
-tasks and collects their results
-
-``` unison
-spawnN : Nat -> '{IO} a ->{IO} [a]
-spawnN n fa =
-  use Nat eq drop
-  go i acc =
-    if eq i 0
-    then acc
-    else
-      value = !Promise.new
-      _ = forkComp do Promise.write value !fa
-      go (drop i 1) (acc :+ value)
-
-  map Promise.read (go n [])
-```
-
-``` ucm
-
-  Loading changes detected in scratch.u.
-
-  I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
-  
-    ⍟ These new definitions are ok to `add`:
-    
-      spawnN : Nat -> '{IO} a ->{IO} [a]
-
-```
-``` ucm
-scratch/main> add
-
-  ⍟ I've added these definitions:
-  
-    spawnN : Nat -> '{IO} a ->{IO} [a]
-
-```
-We can use these primitives to write a more interesting example, where
-multiple threads repeatedly update an atomic counter, we check that
-the value of the counter is correct after all threads are done.
-
-``` unison
-fullTest : '{IO} [Result]
-fullTest = do
-  use Nat * + eq drop
-
-  numThreads = 100
-  iterations = 100
-  expected = numThreads * iterations
-
-  test = do
-    state = IO.ref 0
-    thread n =
-      if eq n 0
-      then ()
-      else
-        atomicUpdate state (v -> v + 1)
-        thread (drop n 1)
-    void (spawnN numThreads '(thread iterations))
-    result = Ref.read state
-    check "The state of the counter is consistent "(eq result expected)
-
-  runTest test
-```
-
-``` ucm
-
-  Loading changes detected in scratch.u.
-
-  I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
-  
-    ⍟ These new definitions are ok to `add`:
-    
-      fullTest : '{IO} [Result]
-
-```
-``` ucm
-scratch/main> add
-
-  ⍟ I've added these definitions:
-  
-    fullTest : '{IO} [Result]
-
-scratch/main> io.test fullTest
-
-    New test results:
-  
-    1. fullTest   ◉ The state of the counter is consistent 
-  
-  ✅ 1 test(s) passing
-  
-  Tip: Use view 1 to view the source of a test.
-
-```


### PR DESCRIPTION
## Overview

`Nat.drop` A.k.a. `Nat.-`  is used a ton in loops and basic math,  it deserves its own instruction. Same with truncate.

We also use `Ref`s a lot in cloud, so anything we can do to speed those up is worth it.

old -> new

**Take these timings with a grain of salt, some of the improvements are just because a native DropN instruction speeds up `repeat` which is used in most of the suites**

```
fib1
536.65µs -> 402.953µs

fib2
2.520067ms -> 2.374009ms

fib3
2.843686ms -> 2.767275ms

Decode Nat
411ns -> 375ns

Generate 100 random numbers
245.586µs -> 236.064µs

List.foldLeft
2.217613ms -> 2.195012ms

Count to 1 million
208.6292ms -> 163.9028ms

Json parsing (per document)
255.672µs -> 255.755µs

Count to N (per element)
272ns -> 239ns

Count to 1000
277.643µs -> 243.931µs

Mutate a Ref 1000 times
476.484µs -> 386.742µs

CAS an IO.ref 1000 times
664.23µs -> 525.431µs

List.range (per element)
373ns -> 386ns

List.range 0 1000
396.78µs -> 396.256µs

Set.fromList (range 0 1000)
2.054391ms -> 2.13431ms

Map.fromList (range 0 1000)
1.413585ms -> 1.439508ms

NatMap.fromList (range 0 1000)
6.032778ms -> 5.781756ms

Map.lookup (1k element map)
3.257µs -> 3.503µs

Map.insert (1k element map)
8.233µs -> 8.833µs

List.at (1k element list)
370ns -> 331ns

Text.split /
32.541µs -> 32.432µs
```