### PR TITLE
bugfix: allow `delete.namespace` even if it would leave nameless references in `lib`

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -572,7 +572,7 @@ loop e = do
                   delete input doutput getTerms getTypes hqs
                 DeleteTarget'Type doutput hqs -> delete input doutput (const (pure Set.empty)) getTypes hqs
                 DeleteTarget'Term doutput hqs -> delete input doutput getTerms (const (pure Set.empty)) hqs
-                DeleteTarget'Namespace insistence path -> handleDeleteNamespace input inputDescription insistence path
+                DeleteTarget'Namespace insistence path -> handleDeleteNamespace input insistence path
                 DeleteTarget'ProjectBranch name -> handleDeleteBranch name
                 DeleteTarget'Project name -> handleDeleteProject name
             DisplayI outputLoc namesToDisplay -> do
@@ -1457,7 +1457,7 @@ checkDeletes typesTermsTuples doutput inputs = do
     Cli.runTransaction $
       traverse
         ( \targetToDelete ->
-            getEndangeredDependents targetToDelete (allTermsToDelete) projectNames
+            getEndangeredDependents targetToDelete allTermsToDelete projectNames
         )
         toDelete
   -- If the overall dependency map is not completely empty, abort deletion

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/DeleteNamespace.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/DeleteNamespace.hs
@@ -1,0 +1,132 @@
+module Unison.Codebase.Editor.HandleInput.DeleteNamespace
+  ( handleDeleteNamespace,
+    getEndangeredDependents,
+  )
+where
+
+import Control.Lens hiding (from)
+import Control.Monad.State qualified as State
+import Data.Map qualified as Map
+import Data.Set qualified as Set
+import Data.Set.NonEmpty (NESet)
+import Data.Set.NonEmpty qualified as NESet
+import U.Codebase.Sqlite.Queries qualified as Queries
+import Unison.Cli.Monad (Cli)
+import Unison.Cli.Monad qualified as Cli
+import Unison.Cli.MonadUtils qualified as Cli
+import Unison.Cli.NamesUtils qualified as Cli
+import Unison.Codebase qualified as Codebase
+import Unison.Codebase.Branch qualified as Branch
+import Unison.Codebase.Branch.Names qualified as Branch
+import Unison.Codebase.Editor.Input
+import Unison.Codebase.Editor.Output
+import Unison.Codebase.Path (Path)
+import Unison.Codebase.Path qualified as Path
+import Unison.LabeledDependency (LabeledDependency)
+import Unison.LabeledDependency qualified as LD
+import Unison.NameSegment qualified as NameSegment
+import Unison.Names (Names)
+import Unison.Names qualified as Names
+import Unison.Prelude
+import Unison.PrettyPrintEnv.Names qualified as PPE
+import Unison.PrettyPrintEnvDecl.Names qualified as PPED
+import Unison.Referent qualified as Referent
+import Unison.Sqlite qualified as Sqlite
+
+handleDeleteNamespace ::
+  Input ->
+  (Input -> Cli Text) ->
+  Insistence ->
+  Maybe (Path, NameSegment.NameSegment) ->
+  Cli ()
+handleDeleteNamespace input inputDescription insistence = \case
+  Nothing -> do
+    hasConfirmed <- confirmedCommand input
+    if hasConfirmed || insistence == Force
+      then do
+        description <- inputDescription input
+        pp <- Cli.getCurrentProjectPath
+        _ <- Cli.updateAt description pp (const Branch.empty)
+        Cli.respond DeletedEverything
+      else Cli.respond DeleteEverythingConfirmation
+  Just p@(parentPath, childName) -> do
+    branch <- Cli.expectBranchAtPath (Path.unsplit p)
+    description <- inputDescription input
+    let toDelete =
+          Names.prefix0
+            (Path.nameFromSplit' $ first (Path.RelativePath' . Path.Relative) p)
+            (Branch.toNames (Branch.head branch))
+    afterDelete <- do
+      names <- Cli.currentNames
+      endangerments <- Cli.runTransaction (getEndangeredDependents toDelete Set.empty names)
+      case (null endangerments, insistence) of
+        (True, _) -> pure (Cli.respond Success)
+        (False, Force) -> do
+          let ppeDecl = PPED.makePPED (PPE.hqNamer 10 names) (PPE.suffixifyByHash names)
+          pure do
+            Cli.respond Success
+            Cli.respondNumbered $ DeletedDespiteDependents ppeDecl endangerments
+        (False, Try) -> do
+          let ppeDecl = PPED.makePPED (PPE.hqNamer 10 names) (PPE.suffixifyByHash names)
+          Cli.respondNumbered $ CantDeleteNamespace ppeDecl endangerments
+          Cli.returnEarlyWithoutOutput
+    parentPathAbs <- Cli.resolvePath parentPath
+    -- We have to modify the parent in order to also wipe out the history at the
+    -- child.
+    Cli.updateAt description parentPathAbs \parentBranch ->
+      parentBranch
+        & Branch.modifyAt (Path.singleton childName) \_ -> Branch.empty
+    afterDelete
+
+confirmedCommand :: Input -> Cli Bool
+confirmedCommand i = do
+  loopState <- State.get
+  pure $ Just i == (loopState ^. #lastInput)
+
+-- | Goal: When deleting, we might be removing the last name of a given definition (i.e. the
+-- definition is going "extinct"). In this case we may wish to take some action or warn the
+-- user about these "endangered" definitions which would now contain unnamed references.
+-- The argument `otherDesiredDeletions` is included in this function because the user might want to
+-- delete a term and all its dependencies in one command, so we give this function access to
+-- the full set of entities that the user wishes to delete.
+getEndangeredDependents ::
+  -- | Prospective target for deletion
+  Names ->
+  -- | All entities we want to delete (including the target)
+  Set LabeledDependency ->
+  -- | Names from the current branch
+  Names ->
+  -- | map from references going extinct to the set of endangered dependents
+  Sqlite.Transaction (Map LabeledDependency (NESet LabeledDependency))
+getEndangeredDependents targetToDelete otherDesiredDeletions rootNames = do
+  -- names of terms left over after target deletion
+  let remainingNames :: Names
+      remainingNames = rootNames `Names.difference` targetToDelete
+  -- target refs for deletion
+  let refsToDelete :: Set LabeledDependency
+      refsToDelete = Names.labeledReferences targetToDelete
+  -- refs left over after deleting target
+  let remainingRefs :: Set LabeledDependency
+      remainingRefs = Names.labeledReferences remainingNames
+  -- remove the other targets for deletion from the remaining terms
+  let remainingRefsWithoutOtherTargets :: Set LabeledDependency
+      remainingRefsWithoutOtherTargets = Set.difference remainingRefs otherDesiredDeletions
+  -- deleting and not left over
+  let extinct :: Set LabeledDependency
+      extinct = refsToDelete `Set.difference` remainingRefs
+  let accumulateDependents :: LabeledDependency -> Sqlite.Transaction (Map LabeledDependency (Set LabeledDependency))
+      accumulateDependents ld =
+        let ref = LD.fold id Referent.toReference ld
+         in Map.singleton ld . Set.map LD.termRef <$> Codebase.dependents Queries.ExcludeOwnComponent ref
+  -- All dependents of extinct, including terms which might themselves be in the process of being deleted.
+  allDependentsOfExtinct :: Map LabeledDependency (Set LabeledDependency) <-
+    Map.unionsWith (<>) <$> for (Set.toList extinct) accumulateDependents
+
+  -- Filtered to only include dependencies which are not being deleted, but depend one which
+  -- is going extinct.
+  let extinctToEndangered :: Map LabeledDependency (NESet LabeledDependency)
+      extinctToEndangered =
+        allDependentsOfExtinct & Map.mapMaybe \endangeredDeps ->
+          let remainingEndangered = endangeredDeps `Set.intersection` remainingRefsWithoutOtherTargets
+           in NESet.nonEmptySet remainingEndangered
+  pure extinctToEndangered

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -60,6 +60,7 @@ library
       Unison.Codebase.Editor.HandleInput.DebugFoldRanges
       Unison.Codebase.Editor.HandleInput.DebugSynhashTerm
       Unison.Codebase.Editor.HandleInput.DeleteBranch
+      Unison.Codebase.Editor.HandleInput.DeleteNamespace
       Unison.Codebase.Editor.HandleInput.DeleteProject
       Unison.Codebase.Editor.HandleInput.EditNamespace
       Unison.Codebase.Editor.HandleInput.FindAndReplace

--- a/unison-src/transcripts/fix-5446.md
+++ b/unison-src/transcripts/fix-5446.md
@@ -13,6 +13,6 @@ lib.two.bar = foo Nat.+ foo
 scratch/main> add
 ```
 
-```ucm:error
+```ucm
 scratch/main> delete.namespace lib.one
 ```

--- a/unison-src/transcripts/fix-5446.md
+++ b/unison-src/transcripts/fix-5446.md
@@ -1,0 +1,18 @@
+Previously `delete.namespace` would refuse to delete a namespace if it would leave any nameless references in `lib`.
+
+```ucm:hide
+scratch/main> builtins.merge lib.builtin
+```
+
+```unison
+lib.one.foo = 17
+lib.two.bar = foo Nat.+ foo
+```
+
+```ucm
+scratch/main> add
+```
+
+```ucm:error
+scratch/main> delete.namespace lib.one
+```

--- a/unison-src/transcripts/fix-5446.output.md
+++ b/unison-src/transcripts/fix-5446.output.md
@@ -1,3 +1,5 @@
+Previously `delete.namespace` would refuse to delete a namespace if it would leave any nameless references in `lib`.
+
 ``` unison
 lib.one.foo = 17
 lib.two.bar = foo Nat.+ foo
@@ -25,36 +27,10 @@ scratch/main> add
     lib.one.foo : Nat
     lib.two.bar : Nat
 
+```
+``` ucm
 scratch/main> delete.namespace lib.one
 
-  ⚠️
-  
-  I didn't delete the namespace because the following
-  definitions are still in use.
-  
-  Dependency   Referenced In
-  foo          1. lib.two.bar
-  
-  If you want to proceed anyways and leave those definitions
-  without names, use delete.namespace.force
+  Done.
 
 ```
-
-
-
-🛑
-
-The transcript failed due to an error in the stanza above. The error is:
-
-
-  ⚠️
-  
-  I didn't delete the namespace because the following
-  definitions are still in use.
-  
-  Dependency   Referenced In
-  foo          1. lib.two.bar
-  
-  If you want to proceed anyways and leave those definitions
-  without names, use delete.namespace.force
-

--- a/unison-src/transcripts/fix-5446.output.md
+++ b/unison-src/transcripts/fix-5446.output.md
@@ -1,0 +1,60 @@
+``` unison
+lib.one.foo = 17
+lib.two.bar = foo Nat.+ foo
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      lib.one.foo : Nat
+      lib.two.bar : Nat
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    lib.one.foo : Nat
+    lib.two.bar : Nat
+
+scratch/main> delete.namespace lib.one
+
+  ⚠️
+  
+  I didn't delete the namespace because the following
+  definitions are still in use.
+  
+  Dependency   Referenced In
+  foo          1. lib.two.bar
+  
+  If you want to proceed anyways and leave those definitions
+  without names, use delete.namespace.force
+
+```
+
+
+
+🛑
+
+The transcript failed due to an error in the stanza above. The error is:
+
+
+  ⚠️
+  
+  I didn't delete the namespace because the following
+  definitions are still in use.
+  
+  Dependency   Referenced In
+  foo          1. lib.two.bar
+  
+  If you want to proceed anyways and leave those definitions
+  without names, use delete.namespace.force
+


### PR DESCRIPTION
## Overview

Fixes #5446

This PR tweaks `delete.namespace` to allow deleting namespaces that would leave something in `lib` without a name. It also eliminates things in `lib` from the output of a legitimate refusal to `delete.namespace`.

## Test coverage

I've added a transcript that demonstrates the fix.