### PR TITLE
Actually calculate inlining info for builtins

### DIFF
--- a/unison-runtime/src/Unison/Runtime/Builtin.hs
+++ b/unison-runtime/src/Unison/Runtime/Builtin.hs
@@ -15,6 +15,7 @@ module Unison.Runtime.Builtin
     builtinTypeBackref,
     builtinForeigns,
     builtinArities,
+    builtinInlineInfo,
     sandboxedForeigns,
     numberedTermLookup,
     Sandbox (..),
@@ -3665,6 +3666,10 @@ builtinArities :: Map Reference Int
 builtinArities =
   Map.fromList $
     [ (r, arity s) | (r, (_, s)) <- Map.toList builtinLookup ]
+
+builtinInlineInfo :: Map Reference (Int, ANormal Symbol)
+builtinInlineInfo =
+  ANF.buildInlineMap $ fmap (Rec [] . snd) builtinLookup
 
 unsafeSTMToIO :: STM.STM a -> IO a
 unsafeSTMToIO (STM.STM m) = IO m

--- a/unison-runtime/src/Unison/Runtime/Machine.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine.hs
@@ -2026,7 +2026,7 @@ cacheAdd0 ntys0 termSuperGroups sands cc = do
     rtm <- updateMap (M.fromList $ zip rs [ntm ..]) (refTm cc)
     -- check for missing references
     let arities = fmap (head . ANF.arities) int <> builtinArities
-        inlinfo = ANF.buildInlineMap int
+        inlinfo = ANF.buildInlineMap int <> builtinInlineInfo
         rns = RN (refLookup "ty" rty) (refLookup "tm" rtm) (flip M.lookup arities)
         combinate :: Word64 -> (Reference, SuperGroup Symbol) -> (Word64, EnumMap Word64 Comb)
         combinate n (r, g) =


### PR DESCRIPTION
This PR fixes an oversight with the inlining pass I wrote a bit ago. I thought the data I was calculating the inlining information from included the builtins, but apparently it didn't. So, this adds a predefined map with all of them, and adds it into the generated stuff.

Again, the gains aren't extreme, but a lot of key builtins aren't actually inlinable without stuff that Chris is working on.

```
fib1
1.373914ms -> 1.231279ms

fib2
5.164774ms -> 4.507025ms

fib3
5.133732ms -> 5.056868ms

Decode Nat
889ns -> 858ns

Generate 100 random numbers
600.667µs -> 569.827µs

List.foldLeft
4.278845ms -> 4.023873ms

Count to 1 million
490.727883ms -> 466.292019ms

Json parsing (per document)
582.807µs -> 451.109µs

Count to N (per element)
641ns -> 595ns

Count to 1000
629.742µs -> 602.579µs

Mutate a Ref 1000 times
1.001907ms -> 947.564µs

CAS an IO.ref 1000 times
1.480368ms -> 1.204739ms

List.range (per element)
832ns -> 716ns

List.range 0 1000
888.355µs -> 757.605µs

Set.fromList (range 0 1000)
3.71154ms -> 3.647534ms

Map.fromList (range 0 1000)
3.189949ms -> 2.841982ms

NatMap.fromList (range 0 1000)
14.157325ms -> 14.01479ms

Map.lookup (1k element map)
7.379µs -> 7.099µs

Map.insert (1k element map)
18.488µs -> 18.224µs

List.at (1k element list)
777ns -> 771ns

Text.split /
63.731µs -> 59.457µs
```