### PR TITLE
Remove ANF.inline'ing

### DIFF
--- a/unison-runtime/src/Unison/Runtime/Machine.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine.hs
@@ -2026,11 +2026,10 @@ cacheAdd0 ntys0 termSuperGroups sands cc = do
     rtm <- updateMap (M.fromList $ zip rs [ntm ..]) (refTm cc)
     -- check for missing references
     let arities = fmap (head . ANF.arities) int <> builtinArities
-        inlinfo = ANF.buildInlineMap int <> builtinInlineInfo
         rns = RN (refLookup "ty" rty) (refLookup "tm" rtm) (flip M.lookup arities)
         combinate :: Word64 -> (Reference, SuperGroup Symbol) -> (Word64, EnumMap Word64 Comb)
         combinate n (r, g) =
-          (n, emitCombs rns r n $ ANF.inline inlinfo g)
+          (n, emitCombs rns r n g)
     let combRefUpdates = (mapFromList $ zip [ntm ..] rs)
     let combIdFromRefMap = (M.fromList $ zip rs [ntm ..])
     let newCacheableCombs =


### PR DESCRIPTION
## Overview

Some bisecting determines that it's actually the ANF inlining that's causing issues with the klogs demo; this change reverts it for the time being so we can hopefully get the other branches tested and merged without it, then re-add this once it's fixed.

## Implementation notes

Removes the call to `ANF.inline`

## Test coverage

I've tested this change with the local nimbus cluster running the klogs demo.