### PR TITLE
Add indicator to prompt when on staging

### DIFF
--- a/unison-cli/src/Unison/Share/Codeserver.hs
+++ b/unison-cli/src/Unison/Share/Codeserver.hs
@@ -1,4 +1,10 @@
-module Unison.Share.Codeserver where
+module Unison.Share.Codeserver
+  ( isCustomCodeserver,
+    defaultCodeserver,
+    resolveCodeserver,
+    CodeserverURI (..),
+  )
+where
 
 import Network.URI (parseURI)
 import System.IO.Unsafe (unsafePerformIO)
@@ -8,18 +14,24 @@ import Unison.Share.Types
 import Unison.Share.Types qualified as Share
 import UnliftIO.Environment (lookupEnv)
 
+shareProd :: CodeserverURI
+shareProd =
+  CodeserverURI
+    { codeserverScheme = Share.Https,
+      codeserverUserInfo = "",
+      codeserverRegName = "api.unison-lang.org",
+      codeserverPort = Nothing,
+      codeserverPath = []
+    }
+
+isCustomCodeserver :: CodeserverURI -> Bool
+isCustomCodeserver = (/=) shareProd
+
 -- | This is the URI where the share API is based.
 defaultCodeserver :: CodeserverURI
 defaultCodeserver = unsafePerformIO $ do
   lookupEnv "UNISON_SHARE_HOST" <&> \case
-    Nothing ->
-      CodeserverURI
-        { codeserverScheme = Share.Https,
-          codeserverUserInfo = "",
-          codeserverRegName = "api.unison-lang.org",
-          codeserverPort = Nothing,
-          codeserverPath = []
-        }
+    Nothing -> shareProd
     Just shareHost ->
       fromMaybe (error $ "Share Host is not a valid URI: " <> shareHost) $ do
         uri <- parseURI shareHost


### PR DESCRIPTION
## Overview

Recently Stew accidentally left an env var linking his UCM to staging, then did a bunch of work against an old HEAD from staging rather than prod, and since we don't have rebase-ing it was a lot of wasted work :'( 

This just adds an indicator to the prompt when you're on a non-standard remote. 

**Everything stays exactly the same unless you have a custom `UNISON_SHARE_HOST`**


<img width="291" alt="Screenshot 2024-11-18 at 7 56 32 PM" src="https://github.com/user-attachments/assets/9c249e55-d2c8-48f4-b7ee-de34b4387d49">


## Implementation notes

Check if we're on a non-standard share and show the additional prompt.
