### PR TITLE
Make `unsafe.force-push` visible

### DIFF
--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -2021,10 +2021,10 @@ pushForce :: InputPattern
 pushForce =
   InputPattern
     "unsafe.force-push"
-    []
-    I.Hidden
+    ["push.unsafe-force"]
+    I.Visible
     [("remote destination", Optional, remoteNamespaceArg), ("local source", Optional, namespaceOrProjectBranchArg suggestionsConfig)]
-    (P.wrap "Like `push`, but overwrites any remote namespace.")
+    (P.wrap "Like `push`, but forcibly overwrites the remote namespace.")
     $ fmap
       ( \sourceTarget ->
           Input.PushRemoteBranchI

--- a/unison-src/transcripts/help.output.md
+++ b/unison-src/transcripts/help.output.md
@@ -810,6 +810,9 @@ scratch/main> help
   undo
   `undo` reverts the most recent change to the codebase.
   
+  unsafe.force-push (or push.unsafe-force)
+  Like `push`, but forcibly overwrites the remote namespace.
+  
   update
   Adds everything in the most recently typechecked file to the
   namespace, replacing existing definitions having the same


### PR DESCRIPTION
## Overview

`unsafe.push-force` exists, but I couldn't find it when I went looking for it, figured we should probably expose it.

The name implies it's unsafe, and most folks know how a force push works anyways.

## Implementation notes

* Make the command visible in help.
* Add an alias so you can find it under `push.`

## Loose ends

I'm not sure if we support `push.force-with-lease` but IMO it should be the default 🤔 
