### PR TITLE
Fix diff computation

### DIFF
--- a/unison-share-api/src/Unison/Server/Backend/DefinitionDiff.hs
+++ b/unison-share-api/src/Unison/Server/Backend/DefinitionDiff.hs
@@ -43,14 +43,15 @@ diffSyntaxText (AnnotatedText fromST) (AnnotatedText toST) =
       fromSegment == toSegment ||
         case (fromAnnotation, toAnnotation) of
           (Nothing, _) -> False
-          (Just a), (Just b) ->
+          (_, Nothing) -> False
+          (Just a, Just b) ->
             case a of
               -- The set of annotations we want to special-case
-              TypeReference{} -> a == b
-              TermReference{} -> a == b
-              DataConstructorReference{} -> a == b
-              AbilityConstructorReference{} -> a == b
-              HashQualifier{} -> a == b
+              Syntax.TypeReference{} -> a == b
+              Syntax.TermReference{} -> a == b
+              Syntax.DataConstructorReference{} -> a == b
+              Syntax.AbilityConstructorReference{} -> a == b
+              Syntax.HashQualifier{} -> a == b
               _ -> False
 
     expandSpecialCases :: [Diff.Diff [AT.Segment (Syntax.Element)]] -> [SemanticSyntaxDiff]

--- a/unison-share-api/src/Unison/Server/Backend/DefinitionDiff.hs
+++ b/unison-share-api/src/Unison/Server/Backend/DefinitionDiff.hs
@@ -38,7 +38,8 @@ diffSyntaxText (AnnotatedText fromST) (AnnotatedText toST) =
     -- So, we treat these elements as equal then detect them in a post-processing step.
     diffEq :: AT.Segment Syntax.Element -> AT.Segment Syntax.Element -> Bool
     diffEq (AT.Segment {segment = fromSegment, annotation = fromAnnotation}) (AT.Segment {segment = toSegment, annotation = toAnnotation}) =
-      fromSegment == toSegment || fromAnnotation == toAnnotation
+      fromSegment == toSegment ||
+        (isJust fromAnnotation && fromAnnotation == toAnnotation)
 
     expandSpecialCases :: [Diff.Diff [AT.Segment (Syntax.Element)]] -> [SemanticSyntaxDiff]
     expandSpecialCases xs =

--- a/unison-share-api/src/Unison/Server/Backend/DefinitionDiff.hs
+++ b/unison-share-api/src/Unison/Server/Backend/DefinitionDiff.hs
@@ -35,11 +35,23 @@ diffSyntaxText (AnnotatedText fromST) (AnnotatedText toST) =
   where
     -- We special-case situations where the name of a definition changed but its hash didn't;
     -- and cases where the name didn't change but the hash did.
-    -- So, we treat these elements as equal then detect them in a post-processing step.
+    --
+    -- The diff algorithm only understands whether items are equal or not, so in order to add this special behavior we
+    -- treat these special cases as equal, then we can detect and expand them in a post-processing step.
     diffEq :: AT.Segment Syntax.Element -> AT.Segment Syntax.Element -> Bool
     diffEq (AT.Segment {segment = fromSegment, annotation = fromAnnotation}) (AT.Segment {segment = toSegment, annotation = toAnnotation}) =
       fromSegment == toSegment ||
-        (isJust fromAnnotation && fromAnnotation == toAnnotation)
+        case (fromAnnotation, toAnnotation) of
+          (Nothing, _) -> False
+          (Just a), (Just b) ->
+            case a of
+              -- The set of annotations we want to special-case
+              TypeReference{} -> a == b
+              TermReference{} -> a == b
+              DataConstructorReference{} -> a == b
+              AbilityConstructorReference{} -> a == b
+              HashQualifier{} -> a == b
+              _ -> False
 
     expandSpecialCases :: [Diff.Diff [AT.Segment (Syntax.Element)]] -> [SemanticSyntaxDiff]
     expandSpecialCases xs =

--- a/unison-src/transcripts/definition-diff-api.output.md
+++ b/unison-src/transcripts/definition-diff-api.output.md
@@ -228,12 +228,26 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=te
                 ]
             },
             {
-                "annotation": {
-                    "tag": "TextLiteral"
-                },
-                "diffTag": "segmentChange",
-                "fromSegment": "\"Here's some text\"",
-                "toSegment": "\"Here's some different text\""
+                "diffTag": "old",
+                "elements": [
+                    {
+                        "annotation": {
+                            "tag": "TextLiteral"
+                        },
+                        "segment": "\"Here's some text\""
+                    }
+                ]
+            },
+            {
+                "diffTag": "new",
+                "elements": [
+                    {
+                        "annotation": {
+                            "tag": "TextLiteral"
+                        },
+                        "segment": "\"Here's some different text\""
+                    }
+                ]
             },
             {
                 "diffTag": "both",
@@ -270,12 +284,26 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=te
                 ]
             },
             {
-                "annotation": {
-                    "tag": "NumericLiteral"
-                },
-                "diffTag": "segmentChange",
-                "fromSegment": "1",
-                "toSegment": "2"
+                "diffTag": "old",
+                "elements": [
+                    {
+                        "annotation": {
+                            "tag": "NumericLiteral"
+                        },
+                        "segment": "1"
+                    }
+                ]
+            },
+            {
+                "diffTag": "new",
+                "elements": [
+                    {
+                        "annotation": {
+                            "tag": "NumericLiteral"
+                        },
+                        "segment": "2"
+                    }
+                ]
             }
         ],
         "tag": "UserObject"
@@ -1019,11 +1047,31 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=ta
                             "tag": "ControlKeyword"
                         },
                         "segment": " then"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "\n"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "  "
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "  "
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "  "
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "  "
                     }
                 ]
             },
             {
-                "diffTag": "new",
+                "diffTag": "both",
                 "elements": [
                     {
                         "annotation": {
@@ -1031,35 +1079,21 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=ta
                             "tag": "TermReference"
                         },
                         "segment": "emit"
-                    }
-                ]
-            },
-            {
-                "annotation": null,
-                "diffTag": "segmentChange",
-                "fromSegment": "\n",
-                "toSegment": " "
-            },
-            {
-                "diffTag": "new",
-                "elements": [
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
                     {
                         "annotation": {
                             "tag": "Var"
                         },
                         "segment": "a"
-                    }
-                ]
-            },
-            {
-                "annotation": null,
-                "diffTag": "segmentChange",
-                "fromSegment": "  ",
-                "toSegment": "\n"
-            },
-            {
-                "diffTag": "both",
-                "elements": [
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "\n"
+                    },
                     {
                         "annotation": null,
                         "segment": "  "
@@ -1078,11 +1112,8 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=ta
                 "diffTag": "old",
                 "elements": [
                     {
-                        "annotation": {
-                            "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro#a0",
-                            "tag": "TermReference"
-                        },
-                        "segment": "emit"
+                        "annotation": null,
+                        "segment": "  "
                     }
                 ]
             },
@@ -1094,66 +1125,32 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=ta
                             "tag": "ControlKeyword"
                         },
                         "segment": "if"
-                    }
-                ]
-            },
-            {
-                "diffTag": "both",
-                "elements": [
-                    {
-                        "annotation": null,
-                        "segment": " "
-                    }
-                ]
-            },
-            {
-                "annotation": {
-                    "tag": "Var"
-                },
-                "diffTag": "segmentChange",
-                "fromSegment": "a",
-                "toSegment": "n"
-            },
-            {
-                "annotation": null,
-                "diffTag": "segmentChange",
-                "fromSegment": "\n",
-                "toSegment": " "
-            },
-            {
-                "diffTag": "old",
-                "elements": [
-                    {
-                        "annotation": null,
-                        "segment": "  "
                     },
                     {
                         "annotation": null,
-                        "segment": "  "
-                    }
-                ]
-            },
-            {
-                "diffTag": "new",
-                "elements": [
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "Var"
+                        },
+                        "segment": "n"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
                     {
                         "annotation": {
                             "contents": "##Nat.>",
                             "tag": "TermReference"
                         },
                         "segment": ">"
-                    }
-                ]
-            },
-            {
-                "annotation": null,
-                "diffTag": "segmentChange",
-                "fromSegment": "  ",
-                "toSegment": " "
-            },
-            {
-                "diffTag": "new",
-                "elements": [
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
                     {
                         "annotation": {
                             "tag": "NumericLiteral"
@@ -1165,14 +1162,12 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=ta
                             "tag": "ControlKeyword"
                         },
                         "segment": " then"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
                     }
                 ]
-            },
-            {
-                "annotation": null,
-                "diffTag": "segmentChange",
-                "fromSegment": "  ",
-                "toSegment": " "
             },
             {
                 "diffTag": "both",
@@ -1265,17 +1260,11 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=ta
                 ]
             },
             {
-                "annotation": null,
-                "diffTag": "segmentChange",
-                "fromSegment": "\n",
-                "toSegment": " "
-            },
-            {
                 "diffTag": "old",
                 "elements": [
                     {
                         "annotation": null,
-                        "segment": "  "
+                        "segment": "\n"
                     },
                     {
                         "annotation": null,
@@ -1284,6 +1273,19 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=ta
                     {
                         "annotation": null,
                         "segment": "  "
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "  "
+                    }
+                ]
+            },
+            {
+                "diffTag": "new",
+                "elements": [
+                    {
+                        "annotation": null,
+                        "segment": " "
                     }
                 ]
             },
@@ -1387,33 +1389,24 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=ta
                 ]
             },
             {
-                "annotation": {
-                    "tag": "ControlKeyword"
-                },
-                "diffTag": "segmentChange",
-                "fromSegment": "handle",
-                "toSegment": "if"
-            },
-            {
-                "diffTag": "both",
+                "diffTag": "new",
                 "elements": [
+                    {
+                        "annotation": {
+                            "tag": "ControlKeyword"
+                        },
+                        "segment": "if"
+                    },
                     {
                         "annotation": null,
                         "segment": " "
-                    }
-                ]
-            },
-            {
-                "annotation": {
-                    "tag": "Var"
-                },
-                "diffTag": "segmentChange",
-                "fromSegment": "s",
-                "toSegment": "n"
-            },
-            {
-                "diffTag": "new",
-                "elements": [
+                    },
+                    {
+                        "annotation": {
+                            "tag": "Var"
+                        },
+                        "segment": "n"
+                    },
                     {
                         "annotation": null,
                         "segment": " "
@@ -1444,7 +1437,12 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=ta
                     {
                         "annotation": null,
                         "segment": " "
-                    },
+                    }
+                ]
+            },
+            {
+                "diffTag": "both",
+                "elements": [
                     {
                         "annotation": {
                             "tag": "ControlKeyword"
@@ -1460,12 +1458,7 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=ta
                             "tag": "Var"
                         },
                         "segment": "s"
-                    }
-                ]
-            },
-            {
-                "diffTag": "both",
-                "elements": [
+                    },
                     {
                         "annotation": {
                             "tag": "Unit"


### PR DESCRIPTION
## Overview

Diffs were rendering very strangely, there was an error with how whitespace (which has no annotation) was being treated.

This fixes whitespace rendering, and also limits the diff special-casing to definition references to limit other strange behaviour.

I also noticed the version on trunk could bomb out if it got certain types of whitespace diffs, so this should resolve that too.

Here are a couple before and afters:

---

`take!`

Before:

<img width="661" alt="image" src="https://github.com/user-attachments/assets/39b31a12-ce3e-4d36-b73e-bd7ffb2836ac">

After:

<img width="667" alt="image" src="https://github.com/user-attachments/assets/5e553cdb-909e-4ca5-aede-469d32d1f5d3">

---

`completion`

Before:

<img width="654" alt="image" src="https://github.com/user-attachments/assets/1065b18c-9344-40d5-af1f-5685c7745e58">


After:

<img width="657" alt="image" src="https://github.com/user-attachments/assets/936615da-725f-444d-8e4a-20db82f606ca">

Simon is going to alter the frontend a bit to avoid unnecessary colouring on the whitespace.

## Implementation notes

* Limit the scope of our diff special-casing to JUST definition references.

