### PR TITLE
Codebase Server: remove the generated port and token

### DIFF
--- a/unison-share-api/package.yaml
+++ b/unison-share-api/package.yaml
@@ -16,7 +16,6 @@ dependencies:
   - bytes
   - bytestring
   - containers
-  - cryptonite
   - Diff
   - directory
   - errors

--- a/unison-share-api/src/Unison/Server/CodebaseServer.hs
+++ b/unison-share-api/src/Unison/Server/CodebaseServer.hs
@@ -461,8 +461,8 @@ startServer env opts rt codebase onStart = do
   let baseUrl = BaseUrl (fromMaybe "http://127.0.0.1" (host opts)) token
   let settings =
         defaultSettings
-          & maybe (setPort 5858) setPort (port opts)
-          & maybe (setHost $ fromString "127.0.0.1") (setHost . fromString) (host opts)
+          & setPort (fromMaybe 5858 $ port opts)
+          & (setHost . fromString) (fromMaybe "127.0.0.1" $ host opts)
   let app' = app env rt codebase envUI token (allowCorsHost opts)
   case port opts of
     Nothing -> withPort settings baseUrl app' 5858

--- a/unison-share-api/unison-share-api.cabal
+++ b/unison-share-api/unison-share-api.cabal
@@ -91,7 +91,6 @@ library
     , bytes
     , bytestring
     , containers
-    , cryptonite
     , directory
     , errors
     , extra


### PR DESCRIPTION
Run the CodebaseServer with a default port and token as well as allowing UCM Desktop domains to perform CORS requests.

Keep the command line options to set a specific port, token, and add allow CORS domains.T