### PR TITLE
Fix diffs involving unit/tuples

### DIFF
--- a/unison-share-api/src/Unison/Server/Backend/DefinitionDiff.hs
+++ b/unison-share-api/src/Unison/Server/Backend/DefinitionDiff.hs
@@ -40,18 +40,18 @@ diffSyntaxText (AnnotatedText fromST) (AnnotatedText toST) =
     -- treat these special cases as equal, then we can detect and expand them in a post-processing step.
     diffEq :: AT.Segment Syntax.Element -> AT.Segment Syntax.Element -> Bool
     diffEq (AT.Segment {segment = fromSegment, annotation = fromAnnotation}) (AT.Segment {segment = toSegment, annotation = toAnnotation}) =
-      fromSegment == toSegment ||
-        case (fromAnnotation, toAnnotation) of
+      fromSegment == toSegment
+        || case (fromAnnotation, toAnnotation) of
           (Nothing, _) -> False
           (_, Nothing) -> False
           (Just a, Just b) ->
             case a of
               -- The set of annotations we want to special-case
-              Syntax.TypeReference{} -> a == b
-              Syntax.TermReference{} -> a == b
-              Syntax.DataConstructorReference{} -> a == b
-              Syntax.AbilityConstructorReference{} -> a == b
-              Syntax.HashQualifier{} -> a == b
+              Syntax.TypeReference {} -> a == b
+              Syntax.TermReference {} -> a == b
+              Syntax.DataConstructorReference {} -> a == b
+              Syntax.AbilityConstructorReference {} -> a == b
+              Syntax.HashQualifier {} -> a == b
               _ -> False
 
     expandSpecialCases :: [Diff.Diff [AT.Segment (Syntax.Element)]] -> [SemanticSyntaxDiff]
@@ -78,7 +78,9 @@ diffSyntaxText (AnnotatedText fromST) (AnnotatedText toST) =
         Just _fromHash <- AT.annotation fromSegment >>= elementHash,
         Just _toHash <- AT.annotation toSegment >>= elementHash =
           Right (AnnotationChange (AT.segment fromSegment) (AT.annotation fromSegment, AT.annotation toSegment))
-      | otherwise = error "diffSyntaxText: found Syntax Elements in 'both' which have nothing in common."
+      | otherwise =
+          -- Otherwise it must not be a special-case, just something that's equal.
+          Left toSegment
       where
         elementHash :: Syntax.Element -> Maybe Syntax.UnisonHash
         elementHash = \case

--- a/unison-src/transcripts/definition-diff-api.md
+++ b/unison-src/transcripts/definition-diff-api.md
@@ -24,6 +24,21 @@ take n s =
                          else None
     { r }  -> Some r
   handle s() with h n
+
+fakeRefModify f g = g []
+
+foreach f xs = match xs with
+    [] -> ()
+    x +: rest -> let
+      f x
+      foreach f rest
+
+handleRequest =
+  use List +:
+  finalizers = [1, 2, 3]
+  addFinalizer f = fakeRefModify finalizers (fs -> f +: fs)
+  foreach (f -> ()) finalizers
+
 ```
 
 ``` ucm
@@ -53,6 +68,20 @@ take n s =
   if n > 0
     then handle s () with h (n - 1)
     else None
+
+fakeRefModify2 f g = g []
+
+foreach xs f = match xs with
+    [] -> ()
+    x +: rest -> let
+      f x
+      foreach rest f
+
+handleRequest =
+    use List +:
+    finalizers = [1, 2, 3]
+    addFinalizer f = fakeRefModify2 finalizers (fs -> (f +: fs, ()))
+    foreach finalizers (f -> ())
 ```
 
 ``` ucm
@@ -69,6 +98,12 @@ More complex diff
 
 ``` api
 GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=take&newTerm=take
+```
+
+Regression test
+
+``` api
+GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=handleRequest&newTerm=handleRequest
 ```
 
 

--- a/unison-src/transcripts/definition-diff-api.md
+++ b/unison-src/transcripts/definition-diff-api.md
@@ -25,19 +25,8 @@ take n s =
     { r }  -> Some r
   handle s() with h n
 
-fakeRefModify f g = g []
-
-foreach f xs = match xs with
-    [] -> ()
-    x +: rest -> let
-      f x
-      foreach f rest
-
-handleRequest =
-  use List +:
-  finalizers = [1, 2, 3]
-  addFinalizer f = fakeRefModify finalizers (fs -> f +: fs)
-  foreach (f -> ()) finalizers
+id x = x
+unitCase = id (x -> 1)
 
 ```
 
@@ -69,19 +58,8 @@ take n s =
     then handle s () with h (n - 1)
     else None
 
-fakeRefModify2 f g = g []
-
-foreach xs f = match xs with
-    [] -> ()
-    x +: rest -> let
-      f x
-      foreach rest f
-
-handleRequest =
-    use List +:
-    finalizers = [1, 2, 3]
-    addFinalizer f = fakeRefModify2 finalizers (fs -> (f +: fs, ()))
-    foreach finalizers (f -> ())
+id x = x
+unitCase = id (x -> (1, ()))
 ```
 
 ``` ucm
@@ -100,10 +78,10 @@ More complex diff
 GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=take&newTerm=take
 ```
 
-Regression test
+Regression test for weird behavior w/r to unit and parens.
 
 ``` api
-GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=handleRequest&newTerm=handleRequest
+GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=unitCase&newTerm=unitCase
 ```
 
 

--- a/unison-src/transcripts/definition-diff-api.output.md
+++ b/unison-src/transcripts/definition-diff-api.output.md
@@ -33,19 +33,8 @@ take n s =
     { r }  -> Some r
   handle s() with h n
 
-fakeRefModify f g = g []
-
-foreach f xs = match xs with
-    [] -> ()
-    x +: rest -> let
-      f x
-      foreach f rest
-
-handleRequest =
-  use List +:
-  finalizers = [1, 2, 3]
-  addFinalizer f = fakeRefModify finalizers (fs -> f +: fs)
-  foreach (f -> ()) finalizers
+id x = x
+unitCase = id (x -> 1)
 
 ```
 
@@ -61,11 +50,10 @@ handleRequest =
     
       ability Stream a
       type Type
-      fakeRefModify : f -> ([elem] ->{g} t) ->{g} t
-      foreach       : (i ->{g} ()) -> [i] ->{g} ()
-      handleRequest : ()
-      take          : Nat -> '{g} t ->{g, Stream a} Optional t
-      term          : Nat
+      id       : x -> x
+      take     : Nat -> '{g} t ->{g, Stream a} Optional t
+      term     : Nat
+      unitCase : x -> Nat
 
 ```
 ``` ucm
@@ -75,11 +63,10 @@ diffs/main> add
   
     ability Stream a
     type Type
-    fakeRefModify : f -> ([elem] ->{g} t) ->{g} t
-    foreach       : (i ->{g} ()) -> [i] ->{g} ()
-    handleRequest : ()
-    take          : Nat -> '{g} t ->{g, Stream a} Optional t
-    term          : Nat
+    id       : x -> x
+    take     : Nat -> '{g} t ->{g, Stream a} Optional t
+    term     : Nat
+    unitCase : x -> Nat
 
 diffs/main> branch.create new
 
@@ -112,19 +99,8 @@ take n s =
     then handle s () with h (n - 1)
     else None
 
-fakeRefModify2 f g = g []
-
-foreach xs f = match xs with
-    [] -> ()
-    x +: rest -> let
-      f x
-      foreach rest f
-
-handleRequest =
-    use List +:
-    finalizers = [1, 2, 3]
-    addFinalizer f = fakeRefModify2 finalizers (fs -> (f +: fs, ()))
-    foreach finalizers (f -> ())
+id x = x
+unitCase = id (x -> (1, ()))
 ```
 
 ``` ucm
@@ -135,21 +111,15 @@ handleRequest =
   do an `add` or `update`, here's how your codebase would
   change:
   
-    ⊡ Previously added definitions will be ignored: Stream
-    
-    ⍟ These new definitions are ok to `add`:
-    
-      fakeRefModify2 : f -> ([elem] ->{g} t) ->{g} t
-        (also named fakeRefModify)
+    ⊡ Previously added definitions will be ignored: Stream id
     
     ⍟ These names already exist. You can `update` them to your
       new definition:
     
       type Type a
-      foreach       : [t] -> (t ->{g} ()) ->{g} ()
-      handleRequest : ()
-      take          : Nat -> '{g} t ->{g, Stream a} Optional t
-      term          : Nat
+      take     : Nat -> '{g} t ->{g, Stream a} Optional t
+      term     : Nat
+      unitCase : x -> (Nat, ())
 
 ```
 ``` ucm
@@ -3387,10 +3357,10 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=ta
 }
 ```
 
-Regression test
+Regression test for weird behavior w/r to unit and parens.
 
 ``` api
-GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=handleRequest&newTerm=handleRequest
+GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=unitCase&newTerm=unitCase
 {
     "diff": {
         "contents": [
@@ -3399,10 +3369,10 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=ha
                 "elements": [
                     {
                         "annotation": {
-                            "contents": "handleRequest",
+                            "contents": "unitCase",
                             "tag": "HashQualifier"
                         },
-                        "segment": "handleRequest"
+                        "segment": "unitCase"
                     },
                     {
                         "annotation": {
@@ -3415,6 +3385,60 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=ha
                         "segment": " "
                     },
                     {
+                        "annotation": {
+                            "tag": "Var"
+                        },
+                        "segment": "x"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "TypeOperator"
+                        },
+                        "segment": "->"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    }
+                ]
+            },
+            {
+                "diffTag": "new",
+                "elements": [
+                    {
+                        "annotation": null,
+                        "segment": "("
+                    }
+                ]
+            },
+            {
+                "diffTag": "both",
+                "elements": [
+                    {
+                        "annotation": {
+                            "contents": "##Nat",
+                            "tag": "TypeReference"
+                        },
+                        "segment": "Nat"
+                    }
+                ]
+            },
+            {
+                "diffTag": "new",
+                "elements": [
+                    {
+                        "annotation": null,
+                        "segment": ","
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
                         "annotation": null,
                         "segment": "("
                     },
@@ -3424,35 +3448,23 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=ha
                     },
                     {
                         "annotation": null,
-                        "segment": "\n"
-                    },
-                    {
-                        "annotation": {
-                            "contents": "handleRequest",
-                            "tag": "HashQualifier"
-                        },
-                        "segment": "handleRequest"
-                    },
-                    {
-                        "annotation": {
-                            "tag": "BindingEquals"
-                        },
-                        "segment": " ="
-                    },
+                        "segment": ")"
+                    }
+                ]
+            },
+            {
+                "diffTag": "both",
+                "elements": [
                     {
                         "annotation": null,
                         "segment": "\n"
                     },
                     {
-                        "annotation": null,
-                        "segment": "  "
-                    },
-                    {
                         "annotation": {
-                            "contents": "finalizers",
+                            "contents": "unitCase",
                             "tag": "HashQualifier"
                         },
-                        "segment": "finalizers"
+                        "segment": "unitCase"
                     },
                     {
                         "annotation": {
@@ -3466,169 +3478,57 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=ha
                     },
                     {
                         "annotation": {
-                            "contents": "##Sequence",
+                            "contents": "#ttjui80dbufvf3vgaddmcr065dpgl0rtp68i5cdht6tq4t2vk3i2vg60hi77rug368qijgijf8oui27te7o5oq0t0osm6dg65c080i0",
+                            "tag": "TermReference"
+                        },
+                        "segment": "id"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "Parenthesis"
+                        },
+                        "segment": "("
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "x"
+                    },
+                    {
+                        "annotation": {
+                            "tag": "ControlKeyword"
+                        },
+                        "segment": " ->"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    }
+                ]
+            },
+            {
+                "diffTag": "new",
+                "elements": [
+                    {
+                        "annotation": {
+                            "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
                             "tag": "TypeReference"
                         },
-                        "segment": "["
-                    },
+                        "segment": "("
+                    }
+                ]
+            },
+            {
+                "diffTag": "both",
+                "elements": [
                     {
                         "annotation": {
                             "tag": "NumericLiteral"
                         },
                         "segment": "1"
-                    },
-                    {
-                        "annotation": {
-                            "contents": "##Sequence",
-                            "tag": "TypeReference"
-                        },
-                        "segment": ", "
-                    },
-                    {
-                        "annotation": {
-                            "tag": "NumericLiteral"
-                        },
-                        "segment": "2"
-                    },
-                    {
-                        "annotation": {
-                            "contents": "##Sequence",
-                            "tag": "TypeReference"
-                        },
-                        "segment": ", "
-                    },
-                    {
-                        "annotation": {
-                            "tag": "NumericLiteral"
-                        },
-                        "segment": "3"
-                    },
-                    {
-                        "annotation": {
-                            "contents": "##Sequence",
-                            "tag": "TypeReference"
-                        },
-                        "segment": "]"
-                    },
-                    {
-                        "annotation": null,
-                        "segment": "\n"
-                    },
-                    {
-                        "annotation": null,
-                        "segment": "  "
-                    },
-                    {
-                        "annotation": {
-                            "contents": "addFinalizer",
-                            "tag": "HashQualifier"
-                        },
-                        "segment": "addFinalizer"
-                    },
-                    {
-                        "annotation": null,
-                        "segment": " "
-                    },
-                    {
-                        "annotation": {
-                            "tag": "Var"
-                        },
-                        "segment": "f"
-                    },
-                    {
-                        "annotation": {
-                            "tag": "BindingEquals"
-                        },
-                        "segment": " ="
-                    },
-                    {
-                        "annotation": null,
-                        "segment": " "
-                    },
-                    {
-                        "annotation": {
-                            "contents": "#a85req9b0u8gkt82fgebosrcu3ba5g1aoqgt1vu5ohd93vpbdlo184e9pf9hgc4nml73aeohru6enhnnpch5oqilutaf0h40uv8dfvg",
-                            "tag": "TermReference"
-                        },
-                        "segment": "fakeRefModify"
-                    },
-                    {
-                        "annotation": null,
-                        "segment": " "
-                    },
-                    {
-                        "annotation": {
-                            "tag": "Var"
-                        },
-                        "segment": "finalizers"
-                    },
-                    {
-                        "annotation": null,
-                        "segment": " "
-                    },
-                    {
-                        "annotation": {
-                            "tag": "Parenthesis"
-                        },
-                        "segment": "("
-                    },
-                    {
-                        "annotation": null,
-                        "segment": "fs"
-                    },
-                    {
-                        "annotation": {
-                            "tag": "ControlKeyword"
-                        },
-                        "segment": " ->"
-                    },
-                    {
-                        "annotation": null,
-                        "segment": " "
-                    }
-                ]
-            },
-            {
-                "diffTag": "new",
-                "elements": [
-                    {
-                        "annotation": {
-                            "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
-                            "tag": "TypeReference"
-                        },
-                        "segment": "("
-                    }
-                ]
-            },
-            {
-                "diffTag": "both",
-                "elements": [
-                    {
-                        "annotation": {
-                            "tag": "Var"
-                        },
-                        "segment": "f"
-                    },
-                    {
-                        "annotation": null,
-                        "segment": " "
-                    },
-                    {
-                        "annotation": {
-                            "contents": "##List.cons",
-                            "tag": "TermReference"
-                        },
-                        "segment": "+:"
-                    },
-                    {
-                        "annotation": null,
-                        "segment": " "
-                    },
-                    {
-                        "annotation": {
-                            "tag": "Var"
-                        },
-                        "segment": "fs"
                     }
                 ]
             },
@@ -3648,130 +3548,6 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=ha
                             "tag": "TypeReference"
                         },
                         "segment": "("
-                    }
-                ]
-            },
-            {
-                "diffTag": "both",
-                "elements": [
-                    {
-                        "annotation": {
-                            "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
-                            "tag": "TypeReference"
-                        },
-                        "segment": ")"
-                    }
-                ]
-            },
-            {
-                "diffTag": "new",
-                "elements": [
-                    {
-                        "annotation": {
-                            "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
-                            "tag": "TypeReference"
-                        },
-                        "segment": ")"
-                    },
-                    {
-                        "annotation": {
-                            "tag": "Parenthesis"
-                        },
-                        "segment": ")"
-                    }
-                ]
-            },
-            {
-                "diffTag": "both",
-                "elements": [
-                    {
-                        "annotation": null,
-                        "segment": "\n"
-                    },
-                    {
-                        "annotation": null,
-                        "segment": "  "
-                    }
-                ]
-            },
-            {
-                "diffTag": "annotationChange",
-                "fromAnnotation": {
-                    "contents": "#bcar3v5qe5466tnl5vc1crcpo13mv0pbspfmtm0g9d9i66pp3og6f75bmk6bhv7ah09igb3un5pmdjdo5ghm0n6krnbne7u2ngi770g",
-                    "tag": "TermReference"
-                },
-                "segment": "foreach",
-                "toAnnotation": {
-                    "contents": "#jb1dd16mkieu352mk4ijml6ksvobs3e31b6q0mt219rrnk9dt6o7rgs87b3kglpfo27nsqmu8ts4q8e55t44e6v894kg9d4361gj4po",
-                    "tag": "TermReference"
-                }
-            },
-            {
-                "diffTag": "both",
-                "elements": [
-                    {
-                        "annotation": null,
-                        "segment": " "
-                    }
-                ]
-            },
-            {
-                "diffTag": "new",
-                "elements": [
-                    {
-                        "annotation": {
-                            "tag": "Var"
-                        },
-                        "segment": "finalizers"
-                    },
-                    {
-                        "annotation": null,
-                        "segment": " "
-                    }
-                ]
-            },
-            {
-                "diffTag": "both",
-                "elements": [
-                    {
-                        "annotation": {
-                            "tag": "Parenthesis"
-                        },
-                        "segment": "("
-                    },
-                    {
-                        "annotation": null,
-                        "segment": "f"
-                    },
-                    {
-                        "annotation": {
-                            "tag": "ControlKeyword"
-                        },
-                        "segment": " ->"
-                    },
-                    {
-                        "annotation": null,
-                        "segment": " "
-                    },
-                    {
-                        "annotation": {
-                            "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
-                            "tag": "TypeReference"
-                        },
-                        "segment": "("
-                    },
-                    {
-                        "annotation": {
-                            "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
-                            "tag": "TypeReference"
-                        },
-                        "segment": ")"
-                    },
-                    {
-                        "annotation": {
-                            "tag": "Parenthesis"
-                        },
-                        "segment": ")"
                     }
                 ]
             },
@@ -3779,14 +3555,40 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=ha
                 "diffTag": "old",
                 "elements": [
                     {
-                        "annotation": null,
-                        "segment": " "
+                        "annotation": {
+                            "tag": "Parenthesis"
+                        },
+                        "segment": ")"
+                    }
+                ]
+            },
+            {
+                "diffTag": "new",
+                "elements": [
+                    {
+                        "annotation": {
+                            "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                            "tag": "TypeReference"
+                        },
+                        "segment": ")"
+                    }
+                ]
+            },
+            {
+                "diffTag": "new",
+                "elements": [
+                    {
+                        "annotation": {
+                            "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                            "tag": "TypeReference"
+                        },
+                        "segment": ")"
                     },
                     {
                         "annotation": {
-                            "tag": "Var"
+                            "tag": "Parenthesis"
                         },
-                        "segment": "finalizers"
+                        "segment": ")"
                     }
                 ]
             }
@@ -3796,12 +3598,55 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=ha
     "diffKind": "diff",
     "newBranchRef": "new",
     "newTerm": {
-        "bestTermName": "handleRequest",
+        "bestTermName": "unitCase",
         "defnTermTag": "Plain",
         "signature": [
             {
+                "annotation": {
+                    "tag": "Var"
+                },
+                "segment": "x"
+            },
+            {
+                "annotation": null,
+                "segment": " "
+            },
+            {
+                "annotation": {
+                    "tag": "TypeOperator"
+                },
+                "segment": "->"
+            },
+            {
+                "annotation": null,
+                "segment": " "
+            },
+            {
                 "annotation": null,
                 "segment": "("
+            },
+            {
+                "annotation": {
+                    "contents": "##Nat",
+                    "tag": "TypeReference"
+                },
+                "segment": "Nat"
+            },
+            {
+                "annotation": null,
+                "segment": ","
+            },
+            {
+                "annotation": null,
+                "segment": " "
+            },
+            {
+                "annotation": null,
+                "segment": "("
+            },
+            {
+                "annotation": null,
+                "segment": ")"
             },
             {
                 "annotation": null,
@@ -3812,10 +3657,10 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=ha
             "contents": [
                 {
                     "annotation": {
-                        "contents": "handleRequest",
+                        "contents": "unitCase",
                         "tag": "HashQualifier"
                     },
-                    "segment": "handleRequest"
+                    "segment": "unitCase"
                 },
                 {
                     "annotation": {
@@ -3828,8 +3673,51 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=ha
                     "segment": " "
                 },
                 {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "x"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "TypeOperator"
+                    },
+                    "segment": "->"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
                     "annotation": null,
                     "segment": "("
+                },
+                {
+                    "annotation": {
+                        "contents": "##Nat",
+                        "tag": "TypeReference"
+                    },
+                    "segment": "Nat"
+                },
+                {
+                    "annotation": null,
+                    "segment": ","
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": null,
+                    "segment": "("
+                },
+                {
+                    "annotation": null,
+                    "segment": ")"
                 },
                 {
                     "annotation": null,
@@ -3841,31 +3729,10 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=ha
                 },
                 {
                     "annotation": {
-                        "contents": "handleRequest",
+                        "contents": "unitCase",
                         "tag": "HashQualifier"
                     },
-                    "segment": "handleRequest"
-                },
-                {
-                    "annotation": {
-                        "tag": "BindingEquals"
-                    },
-                    "segment": " ="
-                },
-                {
-                    "annotation": null,
-                    "segment": "\n"
-                },
-                {
-                    "annotation": null,
-                    "segment": "  "
-                },
-                {
-                    "annotation": {
-                        "contents": "finalizers",
-                        "tag": "HashQualifier"
-                    },
-                    "segment": "finalizers"
+                    "segment": "unitCase"
                 },
                 {
                     "annotation": {
@@ -3879,10 +3746,41 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=ha
                 },
                 {
                     "annotation": {
-                        "contents": "##Sequence",
+                        "contents": "#ttjui80dbufvf3vgaddmcr065dpgl0rtp68i5cdht6tq4t2vk3i2vg60hi77rug368qijgijf8oui27te7o5oq0t0osm6dg65c080i0",
+                        "tag": "TermReference"
+                    },
+                    "segment": "id"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Parenthesis"
+                    },
+                    "segment": "("
+                },
+                {
+                    "annotation": null,
+                    "segment": "x"
+                },
+                {
+                    "annotation": {
+                        "tag": "ControlKeyword"
+                    },
+                    "segment": " ->"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
                         "tag": "TypeReference"
                     },
-                    "segment": "["
+                    "segment": "("
                 },
                 {
                     "annotation": {
@@ -3892,149 +3790,6 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=ha
                 },
                 {
                     "annotation": {
-                        "contents": "##Sequence",
-                        "tag": "TypeReference"
-                    },
-                    "segment": ", "
-                },
-                {
-                    "annotation": {
-                        "tag": "NumericLiteral"
-                    },
-                    "segment": "2"
-                },
-                {
-                    "annotation": {
-                        "contents": "##Sequence",
-                        "tag": "TypeReference"
-                    },
-                    "segment": ", "
-                },
-                {
-                    "annotation": {
-                        "tag": "NumericLiteral"
-                    },
-                    "segment": "3"
-                },
-                {
-                    "annotation": {
-                        "contents": "##Sequence",
-                        "tag": "TypeReference"
-                    },
-                    "segment": "]"
-                },
-                {
-                    "annotation": null,
-                    "segment": "\n"
-                },
-                {
-                    "annotation": null,
-                    "segment": "  "
-                },
-                {
-                    "annotation": {
-                        "contents": "addFinalizer",
-                        "tag": "HashQualifier"
-                    },
-                    "segment": "addFinalizer"
-                },
-                {
-                    "annotation": null,
-                    "segment": " "
-                },
-                {
-                    "annotation": {
-                        "tag": "Var"
-                    },
-                    "segment": "f"
-                },
-                {
-                    "annotation": {
-                        "tag": "BindingEquals"
-                    },
-                    "segment": " ="
-                },
-                {
-                    "annotation": null,
-                    "segment": " "
-                },
-                {
-                    "annotation": {
-                        "contents": "#a85req9b0u8gkt82fgebosrcu3ba5g1aoqgt1vu5ohd93vpbdlo184e9pf9hgc4nml73aeohru6enhnnpch5oqilutaf0h40uv8dfvg",
-                        "tag": "TermReference"
-                    },
-                    "segment": "fakeRefModify"
-                },
-                {
-                    "annotation": null,
-                    "segment": " "
-                },
-                {
-                    "annotation": {
-                        "tag": "Var"
-                    },
-                    "segment": "finalizers"
-                },
-                {
-                    "annotation": null,
-                    "segment": " "
-                },
-                {
-                    "annotation": {
-                        "tag": "Parenthesis"
-                    },
-                    "segment": "("
-                },
-                {
-                    "annotation": null,
-                    "segment": "fs"
-                },
-                {
-                    "annotation": {
-                        "tag": "ControlKeyword"
-                    },
-                    "segment": " ->"
-                },
-                {
-                    "annotation": null,
-                    "segment": " "
-                },
-                {
-                    "annotation": {
-                        "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
-                        "tag": "TypeReference"
-                    },
-                    "segment": "("
-                },
-                {
-                    "annotation": {
-                        "tag": "Var"
-                    },
-                    "segment": "f"
-                },
-                {
-                    "annotation": null,
-                    "segment": " "
-                },
-                {
-                    "annotation": {
-                        "contents": "##List.cons",
-                        "tag": "TermReference"
-                    },
-                    "segment": "+:"
-                },
-                {
-                    "annotation": null,
-                    "segment": " "
-                },
-                {
-                    "annotation": {
-                        "tag": "Var"
-                    },
-                    "segment": "fs"
-                },
-                {
-                    "annotation": {
                         "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
                         "tag": "TypeReference"
                     },
@@ -4053,75 +3808,6 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=ha
                         "tag": "TypeReference"
                     },
                     "segment": ")"
-                },
-                {
-                    "annotation": {
-                        "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
-                        "tag": "TypeReference"
-                    },
-                    "segment": ")"
-                },
-                {
-                    "annotation": {
-                        "tag": "Parenthesis"
-                    },
-                    "segment": ")"
-                },
-                {
-                    "annotation": null,
-                    "segment": "\n"
-                },
-                {
-                    "annotation": null,
-                    "segment": "  "
-                },
-                {
-                    "annotation": {
-                        "contents": "#jb1dd16mkieu352mk4ijml6ksvobs3e31b6q0mt219rrnk9dt6o7rgs87b3kglpfo27nsqmu8ts4q8e55t44e6v894kg9d4361gj4po",
-                        "tag": "TermReference"
-                    },
-                    "segment": "foreach"
-                },
-                {
-                    "annotation": null,
-                    "segment": " "
-                },
-                {
-                    "annotation": {
-                        "tag": "Var"
-                    },
-                    "segment": "finalizers"
-                },
-                {
-                    "annotation": null,
-                    "segment": " "
-                },
-                {
-                    "annotation": {
-                        "tag": "Parenthesis"
-                    },
-                    "segment": "("
-                },
-                {
-                    "annotation": null,
-                    "segment": "f"
-                },
-                {
-                    "annotation": {
-                        "tag": "ControlKeyword"
-                    },
-                    "segment": " ->"
-                },
-                {
-                    "annotation": null,
-                    "segment": " "
-                },
-                {
-                    "annotation": {
-                        "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
-                        "tag": "TypeReference"
-                    },
-                    "segment": "("
                 },
                 {
                     "annotation": {
@@ -4141,31 +3827,50 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=ha
         },
         "termDocs": [],
         "termNames": [
-            "handleRequest"
+            "unitCase"
         ]
     },
     "oldBranchRef": "main",
     "oldTerm": {
-        "bestTermName": "handleRequest",
+        "bestTermName": "unitCase",
         "defnTermTag": "Plain",
         "signature": [
             {
-                "annotation": null,
-                "segment": "("
+                "annotation": {
+                    "tag": "Var"
+                },
+                "segment": "x"
             },
             {
                 "annotation": null,
-                "segment": ")"
+                "segment": " "
+            },
+            {
+                "annotation": {
+                    "tag": "TypeOperator"
+                },
+                "segment": "->"
+            },
+            {
+                "annotation": null,
+                "segment": " "
+            },
+            {
+                "annotation": {
+                    "contents": "##Nat",
+                    "tag": "TypeReference"
+                },
+                "segment": "Nat"
             }
         ],
         "termDefinition": {
             "contents": [
                 {
                     "annotation": {
-                        "contents": "handleRequest",
+                        "contents": "unitCase",
                         "tag": "HashQualifier"
                     },
-                    "segment": "handleRequest"
+                    "segment": "unitCase"
                 },
                 {
                     "annotation": {
@@ -4178,12 +3883,31 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=ha
                     "segment": " "
                 },
                 {
-                    "annotation": null,
-                    "segment": "("
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "x"
                 },
                 {
                     "annotation": null,
-                    "segment": ")"
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "TypeOperator"
+                    },
+                    "segment": "->"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "##Nat",
+                        "tag": "TypeReference"
+                    },
+                    "segment": "Nat"
                 },
                 {
                     "annotation": null,
@@ -4191,31 +3915,10 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=ha
                 },
                 {
                     "annotation": {
-                        "contents": "handleRequest",
+                        "contents": "unitCase",
                         "tag": "HashQualifier"
                     },
-                    "segment": "handleRequest"
-                },
-                {
-                    "annotation": {
-                        "tag": "BindingEquals"
-                    },
-                    "segment": " ="
-                },
-                {
-                    "annotation": null,
-                    "segment": "\n"
-                },
-                {
-                    "annotation": null,
-                    "segment": "  "
-                },
-                {
-                    "annotation": {
-                        "contents": "finalizers",
-                        "tag": "HashQualifier"
-                    },
-                    "segment": "finalizers"
+                    "segment": "unitCase"
                 },
                 {
                     "annotation": {
@@ -4229,10 +3932,34 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=ha
                 },
                 {
                     "annotation": {
-                        "contents": "##Sequence",
-                        "tag": "TypeReference"
+                        "contents": "#ttjui80dbufvf3vgaddmcr065dpgl0rtp68i5cdht6tq4t2vk3i2vg60hi77rug368qijgijf8oui27te7o5oq0t0osm6dg65c080i0",
+                        "tag": "TermReference"
                     },
-                    "segment": "["
+                    "segment": "id"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Parenthesis"
+                    },
+                    "segment": "("
+                },
+                {
+                    "annotation": null,
+                    "segment": "x"
+                },
+                {
+                    "annotation": {
+                        "tag": "ControlKeyword"
+                    },
+                    "segment": " ->"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
                 },
                 {
                     "annotation": {
@@ -4242,221 +3969,16 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=ha
                 },
                 {
                     "annotation": {
-                        "contents": "##Sequence",
-                        "tag": "TypeReference"
-                    },
-                    "segment": ", "
-                },
-                {
-                    "annotation": {
-                        "tag": "NumericLiteral"
-                    },
-                    "segment": "2"
-                },
-                {
-                    "annotation": {
-                        "contents": "##Sequence",
-                        "tag": "TypeReference"
-                    },
-                    "segment": ", "
-                },
-                {
-                    "annotation": {
-                        "tag": "NumericLiteral"
-                    },
-                    "segment": "3"
-                },
-                {
-                    "annotation": {
-                        "contents": "##Sequence",
-                        "tag": "TypeReference"
-                    },
-                    "segment": "]"
-                },
-                {
-                    "annotation": null,
-                    "segment": "\n"
-                },
-                {
-                    "annotation": null,
-                    "segment": "  "
-                },
-                {
-                    "annotation": {
-                        "contents": "addFinalizer",
-                        "tag": "HashQualifier"
-                    },
-                    "segment": "addFinalizer"
-                },
-                {
-                    "annotation": null,
-                    "segment": " "
-                },
-                {
-                    "annotation": {
-                        "tag": "Var"
-                    },
-                    "segment": "f"
-                },
-                {
-                    "annotation": {
-                        "tag": "BindingEquals"
-                    },
-                    "segment": " ="
-                },
-                {
-                    "annotation": null,
-                    "segment": " "
-                },
-                {
-                    "annotation": {
-                        "contents": "#a85req9b0u8gkt82fgebosrcu3ba5g1aoqgt1vu5ohd93vpbdlo184e9pf9hgc4nml73aeohru6enhnnpch5oqilutaf0h40uv8dfvg",
-                        "tag": "TermReference"
-                    },
-                    "segment": "fakeRefModify"
-                },
-                {
-                    "annotation": null,
-                    "segment": " "
-                },
-                {
-                    "annotation": {
-                        "tag": "Var"
-                    },
-                    "segment": "finalizers"
-                },
-                {
-                    "annotation": null,
-                    "segment": " "
-                },
-                {
-                    "annotation": {
-                        "tag": "Parenthesis"
-                    },
-                    "segment": "("
-                },
-                {
-                    "annotation": null,
-                    "segment": "fs"
-                },
-                {
-                    "annotation": {
-                        "tag": "ControlKeyword"
-                    },
-                    "segment": " ->"
-                },
-                {
-                    "annotation": null,
-                    "segment": " "
-                },
-                {
-                    "annotation": {
-                        "tag": "Var"
-                    },
-                    "segment": "f"
-                },
-                {
-                    "annotation": null,
-                    "segment": " "
-                },
-                {
-                    "annotation": {
-                        "contents": "##List.cons",
-                        "tag": "TermReference"
-                    },
-                    "segment": "+:"
-                },
-                {
-                    "annotation": null,
-                    "segment": " "
-                },
-                {
-                    "annotation": {
-                        "tag": "Var"
-                    },
-                    "segment": "fs"
-                },
-                {
-                    "annotation": {
                         "tag": "Parenthesis"
                     },
                     "segment": ")"
-                },
-                {
-                    "annotation": null,
-                    "segment": "\n"
-                },
-                {
-                    "annotation": null,
-                    "segment": "  "
-                },
-                {
-                    "annotation": {
-                        "contents": "#bcar3v5qe5466tnl5vc1crcpo13mv0pbspfmtm0g9d9i66pp3og6f75bmk6bhv7ah09igb3un5pmdjdo5ghm0n6krnbne7u2ngi770g",
-                        "tag": "TermReference"
-                    },
-                    "segment": "foreach"
-                },
-                {
-                    "annotation": null,
-                    "segment": " "
-                },
-                {
-                    "annotation": {
-                        "tag": "Parenthesis"
-                    },
-                    "segment": "("
-                },
-                {
-                    "annotation": null,
-                    "segment": "f"
-                },
-                {
-                    "annotation": {
-                        "tag": "ControlKeyword"
-                    },
-                    "segment": " ->"
-                },
-                {
-                    "annotation": null,
-                    "segment": " "
-                },
-                {
-                    "annotation": {
-                        "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
-                        "tag": "TypeReference"
-                    },
-                    "segment": "("
-                },
-                {
-                    "annotation": {
-                        "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
-                        "tag": "TypeReference"
-                    },
-                    "segment": ")"
-                },
-                {
-                    "annotation": {
-                        "tag": "Parenthesis"
-                    },
-                    "segment": ")"
-                },
-                {
-                    "annotation": null,
-                    "segment": " "
-                },
-                {
-                    "annotation": {
-                        "tag": "Var"
-                    },
-                    "segment": "finalizers"
                 }
             ],
             "tag": "UserObject"
         },
         "termDocs": [],
         "termNames": [
-            "handleRequest"
+            "unitCase"
         ]
     },
     "project": "diffs"

--- a/unison-src/transcripts/definition-diff-api.output.md
+++ b/unison-src/transcripts/definition-diff-api.output.md
@@ -32,6 +32,21 @@ take n s =
                          else None
     { r }  -> Some r
   handle s() with h n
+
+fakeRefModify f g = g []
+
+foreach f xs = match xs with
+    [] -> ()
+    x +: rest -> let
+      f x
+      foreach f rest
+
+handleRequest =
+  use List +:
+  finalizers = [1, 2, 3]
+  addFinalizer f = fakeRefModify finalizers (fs -> f +: fs)
+  foreach (f -> ()) finalizers
+
 ```
 
 ``` ucm
@@ -46,8 +61,11 @@ take n s =
     
       ability Stream a
       type Type
-      take : Nat -> '{g} t ->{g, Stream a} Optional t
-      term : Nat
+      fakeRefModify : f -> ([elem] ->{g} t) ->{g} t
+      foreach       : (i ->{g} ()) -> [i] ->{g} ()
+      handleRequest : ()
+      take          : Nat -> '{g} t ->{g, Stream a} Optional t
+      term          : Nat
 
 ```
 ``` ucm
@@ -57,8 +75,11 @@ diffs/main> add
   
     ability Stream a
     type Type
-    take : Nat -> '{g} t ->{g, Stream a} Optional t
-    term : Nat
+    fakeRefModify : f -> ([elem] ->{g} t) ->{g} t
+    foreach       : (i ->{g} ()) -> [i] ->{g} ()
+    handleRequest : ()
+    take          : Nat -> '{g} t ->{g, Stream a} Optional t
+    term          : Nat
 
 diffs/main> branch.create new
 
@@ -90,6 +111,20 @@ take n s =
   if n > 0
     then handle s () with h (n - 1)
     else None
+
+fakeRefModify2 f g = g []
+
+foreach xs f = match xs with
+    [] -> ()
+    x +: rest -> let
+      f x
+      foreach rest f
+
+handleRequest =
+    use List +:
+    finalizers = [1, 2, 3]
+    addFinalizer f = fakeRefModify2 finalizers (fs -> (f +: fs, ()))
+    foreach finalizers (f -> ())
 ```
 
 ``` ucm
@@ -102,12 +137,19 @@ take n s =
   
     ⊡ Previously added definitions will be ignored: Stream
     
+    ⍟ These new definitions are ok to `add`:
+    
+      fakeRefModify2 : f -> ([elem] ->{g} t) ->{g} t
+        (also named fakeRefModify)
+    
     ⍟ These names already exist. You can `update` them to your
       new definition:
     
       type Type a
-      take : Nat -> '{g} t ->{g, Stream a} Optional t
-      term : Nat
+      foreach       : [t] -> (t ->{g} ()) ->{g} ()
+      handleRequest : ()
+      take          : Nat -> '{g} t ->{g, Stream a} Optional t
+      term          : Nat
 
 ```
 ``` ucm
@@ -3339,6 +3381,1082 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=ta
         "termDocs": [],
         "termNames": [
             "take"
+        ]
+    },
+    "project": "diffs"
+}
+```
+
+Regression test
+
+``` api
+GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=handleRequest&newTerm=handleRequest
+{
+    "diff": {
+        "contents": [
+            {
+                "diffTag": "both",
+                "elements": [
+                    {
+                        "annotation": {
+                            "contents": "handleRequest",
+                            "tag": "HashQualifier"
+                        },
+                        "segment": "handleRequest"
+                    },
+                    {
+                        "annotation": {
+                            "tag": "TypeAscriptionColon"
+                        },
+                        "segment": " :"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "("
+                    },
+                    {
+                        "annotation": null,
+                        "segment": ")"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "\n"
+                    },
+                    {
+                        "annotation": {
+                            "contents": "handleRequest",
+                            "tag": "HashQualifier"
+                        },
+                        "segment": "handleRequest"
+                    },
+                    {
+                        "annotation": {
+                            "tag": "BindingEquals"
+                        },
+                        "segment": " ="
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "\n"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "  "
+                    },
+                    {
+                        "annotation": {
+                            "contents": "finalizers",
+                            "tag": "HashQualifier"
+                        },
+                        "segment": "finalizers"
+                    },
+                    {
+                        "annotation": {
+                            "tag": "BindingEquals"
+                        },
+                        "segment": " ="
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "contents": "##Sequence",
+                            "tag": "TypeReference"
+                        },
+                        "segment": "["
+                    },
+                    {
+                        "annotation": {
+                            "tag": "NumericLiteral"
+                        },
+                        "segment": "1"
+                    },
+                    {
+                        "annotation": {
+                            "contents": "##Sequence",
+                            "tag": "TypeReference"
+                        },
+                        "segment": ", "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "NumericLiteral"
+                        },
+                        "segment": "2"
+                    },
+                    {
+                        "annotation": {
+                            "contents": "##Sequence",
+                            "tag": "TypeReference"
+                        },
+                        "segment": ", "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "NumericLiteral"
+                        },
+                        "segment": "3"
+                    },
+                    {
+                        "annotation": {
+                            "contents": "##Sequence",
+                            "tag": "TypeReference"
+                        },
+                        "segment": "]"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "\n"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "  "
+                    },
+                    {
+                        "annotation": {
+                            "contents": "addFinalizer",
+                            "tag": "HashQualifier"
+                        },
+                        "segment": "addFinalizer"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "Var"
+                        },
+                        "segment": "f"
+                    },
+                    {
+                        "annotation": {
+                            "tag": "BindingEquals"
+                        },
+                        "segment": " ="
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "contents": "#a85req9b0u8gkt82fgebosrcu3ba5g1aoqgt1vu5ohd93vpbdlo184e9pf9hgc4nml73aeohru6enhnnpch5oqilutaf0h40uv8dfvg",
+                            "tag": "TermReference"
+                        },
+                        "segment": "fakeRefModify"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "Var"
+                        },
+                        "segment": "finalizers"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "Parenthesis"
+                        },
+                        "segment": "("
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "fs"
+                    },
+                    {
+                        "annotation": {
+                            "tag": "ControlKeyword"
+                        },
+                        "segment": " ->"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    }
+                ]
+            },
+            {
+                "diffTag": "new",
+                "elements": [
+                    {
+                        "annotation": {
+                            "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                            "tag": "TypeReference"
+                        },
+                        "segment": "("
+                    }
+                ]
+            },
+            {
+                "diffTag": "both",
+                "elements": [
+                    {
+                        "annotation": {
+                            "tag": "Var"
+                        },
+                        "segment": "f"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "contents": "##List.cons",
+                            "tag": "TermReference"
+                        },
+                        "segment": "+:"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "Var"
+                        },
+                        "segment": "fs"
+                    }
+                ]
+            },
+            {
+                "diffTag": "new",
+                "elements": [
+                    {
+                        "annotation": {
+                            "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                            "tag": "TypeReference"
+                        },
+                        "segment": ", "
+                    },
+                    {
+                        "annotation": {
+                            "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                            "tag": "TypeReference"
+                        },
+                        "segment": "("
+                    }
+                ]
+            },
+            {
+                "diffTag": "both",
+                "elements": [
+                    {
+                        "annotation": {
+                            "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                            "tag": "TypeReference"
+                        },
+                        "segment": ")"
+                    }
+                ]
+            },
+            {
+                "diffTag": "new",
+                "elements": [
+                    {
+                        "annotation": {
+                            "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                            "tag": "TypeReference"
+                        },
+                        "segment": ")"
+                    },
+                    {
+                        "annotation": {
+                            "tag": "Parenthesis"
+                        },
+                        "segment": ")"
+                    }
+                ]
+            },
+            {
+                "diffTag": "both",
+                "elements": [
+                    {
+                        "annotation": null,
+                        "segment": "\n"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "  "
+                    }
+                ]
+            },
+            {
+                "diffTag": "annotationChange",
+                "fromAnnotation": {
+                    "contents": "#bcar3v5qe5466tnl5vc1crcpo13mv0pbspfmtm0g9d9i66pp3og6f75bmk6bhv7ah09igb3un5pmdjdo5ghm0n6krnbne7u2ngi770g",
+                    "tag": "TermReference"
+                },
+                "segment": "foreach",
+                "toAnnotation": {
+                    "contents": "#jb1dd16mkieu352mk4ijml6ksvobs3e31b6q0mt219rrnk9dt6o7rgs87b3kglpfo27nsqmu8ts4q8e55t44e6v894kg9d4361gj4po",
+                    "tag": "TermReference"
+                }
+            },
+            {
+                "diffTag": "both",
+                "elements": [
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    }
+                ]
+            },
+            {
+                "diffTag": "new",
+                "elements": [
+                    {
+                        "annotation": {
+                            "tag": "Var"
+                        },
+                        "segment": "finalizers"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    }
+                ]
+            },
+            {
+                "diffTag": "both",
+                "elements": [
+                    {
+                        "annotation": {
+                            "tag": "Parenthesis"
+                        },
+                        "segment": "("
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "f"
+                    },
+                    {
+                        "annotation": {
+                            "tag": "ControlKeyword"
+                        },
+                        "segment": " ->"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                            "tag": "TypeReference"
+                        },
+                        "segment": "("
+                    },
+                    {
+                        "annotation": {
+                            "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                            "tag": "TypeReference"
+                        },
+                        "segment": ")"
+                    },
+                    {
+                        "annotation": {
+                            "tag": "Parenthesis"
+                        },
+                        "segment": ")"
+                    }
+                ]
+            },
+            {
+                "diffTag": "old",
+                "elements": [
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "Var"
+                        },
+                        "segment": "finalizers"
+                    }
+                ]
+            }
+        ],
+        "tag": "UserObject"
+    },
+    "diffKind": "diff",
+    "newBranchRef": "new",
+    "newTerm": {
+        "bestTermName": "handleRequest",
+        "defnTermTag": "Plain",
+        "signature": [
+            {
+                "annotation": null,
+                "segment": "("
+            },
+            {
+                "annotation": null,
+                "segment": ")"
+            }
+        ],
+        "termDefinition": {
+            "contents": [
+                {
+                    "annotation": {
+                        "contents": "handleRequest",
+                        "tag": "HashQualifier"
+                    },
+                    "segment": "handleRequest"
+                },
+                {
+                    "annotation": {
+                        "tag": "TypeAscriptionColon"
+                    },
+                    "segment": " :"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": null,
+                    "segment": "("
+                },
+                {
+                    "annotation": null,
+                    "segment": ")"
+                },
+                {
+                    "annotation": null,
+                    "segment": "\n"
+                },
+                {
+                    "annotation": {
+                        "contents": "handleRequest",
+                        "tag": "HashQualifier"
+                    },
+                    "segment": "handleRequest"
+                },
+                {
+                    "annotation": {
+                        "tag": "BindingEquals"
+                    },
+                    "segment": " ="
+                },
+                {
+                    "annotation": null,
+                    "segment": "\n"
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": {
+                        "contents": "finalizers",
+                        "tag": "HashQualifier"
+                    },
+                    "segment": "finalizers"
+                },
+                {
+                    "annotation": {
+                        "tag": "BindingEquals"
+                    },
+                    "segment": " ="
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "##Sequence",
+                        "tag": "TypeReference"
+                    },
+                    "segment": "["
+                },
+                {
+                    "annotation": {
+                        "tag": "NumericLiteral"
+                    },
+                    "segment": "1"
+                },
+                {
+                    "annotation": {
+                        "contents": "##Sequence",
+                        "tag": "TypeReference"
+                    },
+                    "segment": ", "
+                },
+                {
+                    "annotation": {
+                        "tag": "NumericLiteral"
+                    },
+                    "segment": "2"
+                },
+                {
+                    "annotation": {
+                        "contents": "##Sequence",
+                        "tag": "TypeReference"
+                    },
+                    "segment": ", "
+                },
+                {
+                    "annotation": {
+                        "tag": "NumericLiteral"
+                    },
+                    "segment": "3"
+                },
+                {
+                    "annotation": {
+                        "contents": "##Sequence",
+                        "tag": "TypeReference"
+                    },
+                    "segment": "]"
+                },
+                {
+                    "annotation": null,
+                    "segment": "\n"
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": {
+                        "contents": "addFinalizer",
+                        "tag": "HashQualifier"
+                    },
+                    "segment": "addFinalizer"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "f"
+                },
+                {
+                    "annotation": {
+                        "tag": "BindingEquals"
+                    },
+                    "segment": " ="
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "#a85req9b0u8gkt82fgebosrcu3ba5g1aoqgt1vu5ohd93vpbdlo184e9pf9hgc4nml73aeohru6enhnnpch5oqilutaf0h40uv8dfvg",
+                        "tag": "TermReference"
+                    },
+                    "segment": "fakeRefModify"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "finalizers"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Parenthesis"
+                    },
+                    "segment": "("
+                },
+                {
+                    "annotation": null,
+                    "segment": "fs"
+                },
+                {
+                    "annotation": {
+                        "tag": "ControlKeyword"
+                    },
+                    "segment": " ->"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                        "tag": "TypeReference"
+                    },
+                    "segment": "("
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "f"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "##List.cons",
+                        "tag": "TermReference"
+                    },
+                    "segment": "+:"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "fs"
+                },
+                {
+                    "annotation": {
+                        "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                        "tag": "TypeReference"
+                    },
+                    "segment": ", "
+                },
+                {
+                    "annotation": {
+                        "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                        "tag": "TypeReference"
+                    },
+                    "segment": "("
+                },
+                {
+                    "annotation": {
+                        "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                        "tag": "TypeReference"
+                    },
+                    "segment": ")"
+                },
+                {
+                    "annotation": {
+                        "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                        "tag": "TypeReference"
+                    },
+                    "segment": ")"
+                },
+                {
+                    "annotation": {
+                        "tag": "Parenthesis"
+                    },
+                    "segment": ")"
+                },
+                {
+                    "annotation": null,
+                    "segment": "\n"
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": {
+                        "contents": "#jb1dd16mkieu352mk4ijml6ksvobs3e31b6q0mt219rrnk9dt6o7rgs87b3kglpfo27nsqmu8ts4q8e55t44e6v894kg9d4361gj4po",
+                        "tag": "TermReference"
+                    },
+                    "segment": "foreach"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "finalizers"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Parenthesis"
+                    },
+                    "segment": "("
+                },
+                {
+                    "annotation": null,
+                    "segment": "f"
+                },
+                {
+                    "annotation": {
+                        "tag": "ControlKeyword"
+                    },
+                    "segment": " ->"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                        "tag": "TypeReference"
+                    },
+                    "segment": "("
+                },
+                {
+                    "annotation": {
+                        "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                        "tag": "TypeReference"
+                    },
+                    "segment": ")"
+                },
+                {
+                    "annotation": {
+                        "tag": "Parenthesis"
+                    },
+                    "segment": ")"
+                }
+            ],
+            "tag": "UserObject"
+        },
+        "termDocs": [],
+        "termNames": [
+            "handleRequest"
+        ]
+    },
+    "oldBranchRef": "main",
+    "oldTerm": {
+        "bestTermName": "handleRequest",
+        "defnTermTag": "Plain",
+        "signature": [
+            {
+                "annotation": null,
+                "segment": "("
+            },
+            {
+                "annotation": null,
+                "segment": ")"
+            }
+        ],
+        "termDefinition": {
+            "contents": [
+                {
+                    "annotation": {
+                        "contents": "handleRequest",
+                        "tag": "HashQualifier"
+                    },
+                    "segment": "handleRequest"
+                },
+                {
+                    "annotation": {
+                        "tag": "TypeAscriptionColon"
+                    },
+                    "segment": " :"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": null,
+                    "segment": "("
+                },
+                {
+                    "annotation": null,
+                    "segment": ")"
+                },
+                {
+                    "annotation": null,
+                    "segment": "\n"
+                },
+                {
+                    "annotation": {
+                        "contents": "handleRequest",
+                        "tag": "HashQualifier"
+                    },
+                    "segment": "handleRequest"
+                },
+                {
+                    "annotation": {
+                        "tag": "BindingEquals"
+                    },
+                    "segment": " ="
+                },
+                {
+                    "annotation": null,
+                    "segment": "\n"
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": {
+                        "contents": "finalizers",
+                        "tag": "HashQualifier"
+                    },
+                    "segment": "finalizers"
+                },
+                {
+                    "annotation": {
+                        "tag": "BindingEquals"
+                    },
+                    "segment": " ="
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "##Sequence",
+                        "tag": "TypeReference"
+                    },
+                    "segment": "["
+                },
+                {
+                    "annotation": {
+                        "tag": "NumericLiteral"
+                    },
+                    "segment": "1"
+                },
+                {
+                    "annotation": {
+                        "contents": "##Sequence",
+                        "tag": "TypeReference"
+                    },
+                    "segment": ", "
+                },
+                {
+                    "annotation": {
+                        "tag": "NumericLiteral"
+                    },
+                    "segment": "2"
+                },
+                {
+                    "annotation": {
+                        "contents": "##Sequence",
+                        "tag": "TypeReference"
+                    },
+                    "segment": ", "
+                },
+                {
+                    "annotation": {
+                        "tag": "NumericLiteral"
+                    },
+                    "segment": "3"
+                },
+                {
+                    "annotation": {
+                        "contents": "##Sequence",
+                        "tag": "TypeReference"
+                    },
+                    "segment": "]"
+                },
+                {
+                    "annotation": null,
+                    "segment": "\n"
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": {
+                        "contents": "addFinalizer",
+                        "tag": "HashQualifier"
+                    },
+                    "segment": "addFinalizer"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "f"
+                },
+                {
+                    "annotation": {
+                        "tag": "BindingEquals"
+                    },
+                    "segment": " ="
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "#a85req9b0u8gkt82fgebosrcu3ba5g1aoqgt1vu5ohd93vpbdlo184e9pf9hgc4nml73aeohru6enhnnpch5oqilutaf0h40uv8dfvg",
+                        "tag": "TermReference"
+                    },
+                    "segment": "fakeRefModify"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "finalizers"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Parenthesis"
+                    },
+                    "segment": "("
+                },
+                {
+                    "annotation": null,
+                    "segment": "fs"
+                },
+                {
+                    "annotation": {
+                        "tag": "ControlKeyword"
+                    },
+                    "segment": " ->"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "f"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "##List.cons",
+                        "tag": "TermReference"
+                    },
+                    "segment": "+:"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "fs"
+                },
+                {
+                    "annotation": {
+                        "tag": "Parenthesis"
+                    },
+                    "segment": ")"
+                },
+                {
+                    "annotation": null,
+                    "segment": "\n"
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": {
+                        "contents": "#bcar3v5qe5466tnl5vc1crcpo13mv0pbspfmtm0g9d9i66pp3og6f75bmk6bhv7ah09igb3un5pmdjdo5ghm0n6krnbne7u2ngi770g",
+                        "tag": "TermReference"
+                    },
+                    "segment": "foreach"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Parenthesis"
+                    },
+                    "segment": "("
+                },
+                {
+                    "annotation": null,
+                    "segment": "f"
+                },
+                {
+                    "annotation": {
+                        "tag": "ControlKeyword"
+                    },
+                    "segment": " ->"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                        "tag": "TypeReference"
+                    },
+                    "segment": "("
+                },
+                {
+                    "annotation": {
+                        "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                        "tag": "TypeReference"
+                    },
+                    "segment": ")"
+                },
+                {
+                    "annotation": {
+                        "tag": "Parenthesis"
+                    },
+                    "segment": ")"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "finalizers"
+                }
+            ],
+            "tag": "UserObject"
+        },
+        "termDocs": [],
+        "termNames": [
+            "handleRequest"
         ]
     },
     "project": "diffs"


### PR DESCRIPTION
## Overview

The diff calculator was crashing when there was a change like: `(blah, 1)` -> `(blah, ())` because it thought the `)` from the `()` was related to the ending paren, which was just a syntax element and it didn't know how to create a hash-change annotation from the paren that was just a bracket.

## Implementation notes

I've solved this case by just re-splitting any confusing cases into old and new chunks, which should fix this and any other cases I may have missed.

## Test coverage

Added a regression test for this case.
