### PR TITLE
Remove Stray HasCallStack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ dist-newstyle
 *.hie
 *.prof
 *.prof.html
+*.hp
+*.ps
 /.direnv/
 /.envrc
 

--- a/unison-runtime/src/Unison/Runtime/Machine.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine.hs
@@ -1209,7 +1209,7 @@ uprim1 !stk COMI !i = do
   pure stk
 {-# INLINE uprim1 #-}
 
-uprim2 :: (HasCallStack) => Stack -> UPrim2 -> Int -> Int -> IO Stack
+uprim2 :: Stack -> UPrim2 -> Int -> Int -> IO Stack
 uprim2 !stk ADDI !i !j = do
   m <- upeekOff stk i
   n <- upeekOff stk j


### PR DESCRIPTION
## Overview

HasCallStack can sometimes be expensive, it's just not necessary here, should've been remove after debugging.

## Implementation notes

* Remove the HasCallStack
* Also add some gitignores for some profiliing files.
