### PR TITLE
bugfix: don't consider shortening variables with use statements

### DIFF
--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -1285,7 +1285,6 @@ instance Monoid PrintAnnotation where
 
 suffixCounterTerm :: (Var v) => PrettyPrintEnv -> Set Name -> Set Name -> Term2 v at ap v a -> PrintAnnotation
 suffixCounterTerm n usedTm usedTy = \case
-  Var' v -> countHQ mempty $ HQ.unsafeFromVar v
   Ref' r -> countHQ usedTm $ PrettyPrintEnv.termName n (Referent.Ref r)
   Constructor' r | noImportRefs (r ^. ConstructorReference.reference_) -> mempty
   Constructor' r -> countHQ usedTm $ PrettyPrintEnv.termName n (Referent.Con r CT.Data)

--- a/unison-src/transcripts/fix-5464.md
+++ b/unison-src/transcripts/fix-5464.md
@@ -1,0 +1,37 @@
+```ucm
+scratch/main> builtins.merge lib.builtin
+```
+
+```unison
+foo : Nat
+foo =
+  baz = bar.baz + bar.baz
+  19
+
+bar.baz : Nat
+bar.baz = 20
+
+qux : Nat
+qux = foo + foo
+```
+
+```ucm
+scratch/main> add
+```
+
+```unison
+foo : Nat
+foo =
+  baz = bar.baz + bar.baz
+  20
+
+bar.baz : Nat
+bar.baz = 20
+```
+
+This update should succeed, but it fails because `foo` is incorrectly printed with a `use bar baz` statement, which
+causes references to `bar.baz` to be captured by its locally-bound `baz`.
+
+```ucm:error
+scratch/main> update
+```

--- a/unison-src/transcripts/fix-5464.md
+++ b/unison-src/transcripts/fix-5464.md
@@ -29,9 +29,9 @@ bar.baz : Nat
 bar.baz = 20
 ```
 
-This update should succeed, but it fails because `foo` is incorrectly printed with a `use bar baz` statement, which
-causes references to `bar.baz` to be captured by its locally-bound `baz`.
+This update used to fail because `foo` would incorrectly print with a `use bar baz` statement, which caused references
+to `bar.baz` to be captured by its locally-bound `baz`.
 
-```ucm:error
+```ucm
 scratch/main> update
 ```

--- a/unison-src/transcripts/fix-5464.output.md
+++ b/unison-src/transcripts/fix-5464.output.md
@@ -1,0 +1,107 @@
+``` ucm
+scratch/main> builtins.merge lib.builtin
+
+  Done.
+
+```
+``` unison
+foo : Nat
+foo =
+  baz = bar.baz + bar.baz
+  19
+
+bar.baz : Nat
+bar.baz = 20
+
+qux : Nat
+qux = foo + foo
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      bar.baz : Nat
+      foo     : Nat
+      qux     : Nat
+
+```
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+  
+    bar.baz : Nat
+    foo     : Nat
+    qux     : Nat
+
+```
+``` unison
+foo : Nat
+foo =
+  baz = bar.baz + bar.baz
+  20
+
+bar.baz : Nat
+bar.baz = 20
+```
+
+``` ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⊡ Previously added definitions will be ignored: bar.baz
+    
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      foo : Nat
+
+```
+This update should succeed, but it fails because `foo` is incorrectly printed with a `use bar baz` statement, which
+causes references to `bar.baz` to be captured by its locally-bound `baz`.
+
+``` ucm
+scratch/main> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Typechecking failed. I've updated your scratch file with the
+  definitions that need fixing. Once the file is compiling, try
+  `update` again.
+
+```
+``` unison :added-by-ucm scratch.u
+foo : Nat
+foo =
+  use Nat +
+  use bar baz
+  baz = baz + baz
+  20
+
+bar.baz : Nat
+bar.baz = 20
+
+-- The definitions below no longer typecheck with the changes above.
+-- Please fix the errors and try `update` again.
+
+qux : Nat
+qux =
+  use Nat +
+  foo + foo
+
+```
+

--- a/unison-src/transcripts/fix-5464.output.md
+++ b/unison-src/transcripts/fix-5464.output.md
@@ -68,8 +68,8 @@ bar.baz = 20
       foo : Nat
 
 ```
-This update should succeed, but it fails because `foo` is incorrectly printed with a `use bar baz` statement, which
-causes references to `bar.baz` to be captured by its locally-bound `baz`.
+This update used to fail because `foo` would incorrectly print with a `use bar baz` statement, which caused references
+to `bar.baz` to be captured by its locally-bound `baz`.
 
 ``` ucm
 scratch/main> update
@@ -79,29 +79,8 @@ scratch/main> update
 
   That's done. Now I'm making sure everything typechecks...
 
-  Typechecking failed. I've updated your scratch file with the
-  definitions that need fixing. Once the file is compiling, try
-  `update` again.
+  Everything typechecks, so I'm saving the results...
+
+  Done.
 
 ```
-``` unison :added-by-ucm scratch.u
-foo : Nat
-foo =
-  use Nat +
-  use bar baz
-  baz = baz + baz
-  20
-
-bar.baz : Nat
-bar.baz = 20
-
--- The definitions below no longer typecheck with the changes above.
--- Please fix the errors and try `update` again.
-
-qux : Nat
-qux =
-  use Nat +
-  foo + foo
-
-```
-


### PR DESCRIPTION
## Overview

Fixes #5464 

There was a bug in the logic that considers when/where to place `use` statements that was causing occasional misprinting of code. This PR fixes the bug and adds a regression test.

## Implementation notes

Removed line of code that treated variables as targets for `use`-statement insertion.

For example, we'd previously consider shortening a variable `foo.bar.baz` to `bar.baz` (via a `use foo bar.baz`) or `baz` (via a `use foo.bar baz`). Now, we'll leave variables like `foo.bar.baz` alone.

There may be an even smarter fix that safely inserts `use` to shorten variable names... but perhaps that could be implemented separately from the immediate bugfix. I also think it's probably fine to restrict `use` to shortening names for external references, not local variables (as this PR implements).

## Test coverage

Transcript added, failing in first commit
