### PR TITLE
Run Ormolu 0.7.2.0 across the code base

### DIFF
--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -402,7 +402,6 @@ typeLookupForDependencies codebase s = do
            in depthFirstAccumTypes z (DD.typeDependencies dd)
         Nothing -> pure tl
     goType tl Reference.Builtin {} = pure tl -- codebase isn't consulted for builtins
-
     unseen :: TL.TypeLookup Symbol a -> Reference -> Bool
     unseen tl r =
       isNothing

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -46,9 +46,9 @@ import Unison.Type (Type)
 import Unison.Util.Cache qualified as Cache
 import Unison.WatchKind qualified as UF
 import UnliftIO (finally)
-import UnliftIO.Directory (createDirectoryIfMissing, doesFileExist)
 import UnliftIO qualified as UnliftIO
 import UnliftIO.Concurrent qualified as UnliftIO
+import UnliftIO.Directory (createDirectoryIfMissing, doesFileExist)
 import UnliftIO.STM
 
 debug :: Bool

--- a/parser-typechecker/src/Unison/Typechecker.hs
+++ b/parser-typechecker/src/Unison/Typechecker.hs
@@ -21,7 +21,7 @@ where
 
 import Control.Lens
 import Control.Monad.Fail (fail)
-import Control.Monad.State (StateT, get, modify, execState, State)
+import Control.Monad.State (State, StateT, execState, get, modify)
 import Control.Monad.Writer
 import Data.Foldable
 import Data.Map qualified as Map
@@ -233,7 +233,7 @@ typeDirectedNameResolution ppe oldNotes oldType env = do
     addTypedComponent (Context.TopLevelComponent vtts) =
       for_ vtts \(v, typ, _) ->
         let name = Name.unsafeParseVar (Var.reset v)
-        in #topLevelComponents %= Map.insert name (NamedReference name typ (Context.ReplacementVar v))
+         in #topLevelComponents %= Map.insert name (NamedReference name typ (Context.ReplacementVar v))
     addTypedComponent _ = pure ()
 
     suggest :: [Resolution v loc] -> Result (Notes v loc) ()

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/EditNamespace.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/EditNamespace.hs
@@ -21,13 +21,13 @@ import Unison.HashQualified qualified as HQ
 import Unison.Name (Name)
 import Unison.Names qualified as Names
 import Unison.Prelude
+import Unison.PrettyPrintEnv.Names qualified as PPE
 import Unison.PrettyPrintEnvDecl (PrettyPrintEnvDecl (..))
+import Unison.PrettyPrintEnvDecl.Names qualified as PPED
 import Unison.Referent qualified as Referent
 import Unison.Server.Backend qualified as Backend
 import Unison.Syntax.DeclPrinter qualified as DeclPrinter
 import Unison.Util.Monoid (foldMapM)
-import qualified Unison.PrettyPrintEnv.Names as PPE
-import qualified Unison.PrettyPrintEnvDecl.Names as PPED
 
 handleEditNamespace :: OutputLocation -> [Path] -> Cli ()
 handleEditNamespace outputLoc paths0 = do

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/FindAndReplace.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/FindAndReplace.hs
@@ -1,7 +1,7 @@
 module Unison.Codebase.Editor.HandleInput.FindAndReplace
   ( handleStructuredFindReplaceI,
     handleStructuredFindI,
-    handleTextFindI
+    handleTextFindI,
   )
 where
 
@@ -129,7 +129,8 @@ handleTextFindI allowLib tokens = do
         txts (Term.Float' haystack) = ABT.Found [Text.pack (show haystack)]
         txts (Term.Char' haystack) = ABT.Found [Text.pack [haystack]]
         txts (Term.Match' _ cases) = ABT.Found r
-          where r = join $ Pattern.foldMap' txtPattern . Term.matchPattern <$> cases
+          where
+            r = join $ Pattern.foldMap' txtPattern . Term.matchPattern <$> cases
         txts _ = ABT.Continue
         txtPattern (Pattern.Text _ txt) = [txt]
         txtPattern _ = []

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/RuntimeUtils.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/RuntimeUtils.hs
@@ -4,9 +4,10 @@ module Unison.Codebase.Editor.HandleInput.RuntimeUtils
     evalPureUnison,
     displayDecompileErrors,
     selectRuntime,
-    EvalMode (..)
+    EvalMode (..),
   )
 where
+
 import Control.Lens
 import Control.Monad.Reader (ask)
 import Unison.ABT qualified as ABT
@@ -32,11 +33,12 @@ import Unison.WatchKind qualified as WK
 data EvalMode = Sandboxed | Permissive | Native
 
 selectRuntime :: EvalMode -> Cli (Runtime.Runtime Symbol)
-selectRuntime mode = ask <&> \case
-  Cli.Env { runtime, sandboxedRuntime, nativeRuntime }
-    | Permissive <- mode -> runtime
-    | Sandboxed <- mode -> sandboxedRuntime
-    | Native <- mode -> nativeRuntime
+selectRuntime mode =
+  ask <&> \case
+    Cli.Env {runtime, sandboxedRuntime, nativeRuntime}
+      | Permissive <- mode -> runtime
+      | Sandboxed <- mode -> sandboxedRuntime
+      | Native <- mode -> nativeRuntime
 
 displayDecompileErrors :: [Runtime.Error] -> Cli ()
 displayDecompileErrors errs = Cli.respond (PrintMessage msg)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/RuntimeUtils.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/RuntimeUtils.hs
@@ -34,11 +34,10 @@ data EvalMode = Sandboxed | Permissive | Native
 
 selectRuntime :: EvalMode -> Cli (Runtime.Runtime Symbol)
 selectRuntime mode =
-  ask <&> \case
-    Cli.Env {runtime, sandboxedRuntime, nativeRuntime}
-      | Permissive <- mode -> runtime
-      | Sandboxed <- mode -> sandboxedRuntime
-      | Native <- mode -> nativeRuntime
+  ask <&> \Cli.Env {runtime, sandboxedRuntime, nativeRuntime} -> case mode of
+    Permissive -> runtime
+    Sandboxed -> sandboxedRuntime
+    Native -> nativeRuntime
 
 displayDecompileErrors :: [Runtime.Error] -> Cli ()
 displayDecompileErrors errs = Cli.respond (PrintMessage msg)

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -127,9 +127,10 @@ data Input
   | PullI !PullSourceTarget !PullMode
   | PushRemoteBranchI PushRemoteBranchInput
   | ResetI (BranchId2 {- namespace to reset it to -}) (Maybe UnresolvedProjectBranch {- ProjectBranch to reset -})
-  | -- todo: Q: Does it make sense to publish to not-the-root of a Github repo?
+  | -- | used in Welcome module to give directions to user
+    --
+    -- todo: Q: Does it make sense to publish to not-the-root of a Github repo?
     --          Does it make sense to fork from not-the-root of a Github repo?
-    -- used in Welcome module to give directions to user
     CreateMessage (P.Pretty P.ColorText)
   | -- Change directory.
     SwitchBranchI Path'

--- a/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
+++ b/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
@@ -200,10 +200,9 @@ run isTest verbosity dir codebase runtime sbRuntime nRuntime ucmVersion baseURL 
       outputUcmResult :: Pretty.Pretty Pretty.ColorText -> IO ()
       outputUcmResult line = do
         hide <- hideOutput False
-        unless hide $
+        unless hide . outputUcmLine . UcmOutputLine . Text.pack $
           -- We shorten the terminal width, because "Transcript" manages a 2-space indent for output lines.
-          outputUcmLine . UcmOutputLine . Text.pack $
-            Pretty.toPlain (terminalWidth - 2) line
+          Pretty.toPlain (terminalWidth - 2) line
 
       maybeDieWithMsg :: String -> IO ()
       maybeDieWithMsg msg = do

--- a/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
+++ b/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
@@ -202,7 +202,8 @@ run isTest verbosity dir codebase runtime sbRuntime nRuntime ucmVersion baseURL 
         hide <- hideOutput False
         unless hide $
           -- We shorten the terminal width, because "Transcript" manages a 2-space indent for output lines.
-          outputUcmLine . UcmOutputLine . Text.pack $ Pretty.toPlain (terminalWidth - 2) line
+          outputUcmLine . UcmOutputLine . Text.pack $
+            Pretty.toPlain (terminalWidth - 2) line
 
       maybeDieWithMsg :: String -> IO ()
       maybeDieWithMsg msg = do

--- a/unison-cli/src/Unison/CommandLine/FZFResolvers.hs
+++ b/unison-cli/src/Unison/CommandLine/FZFResolvers.hs
@@ -175,9 +175,9 @@ projectBranchOptions codebase projCtx _searchBranch0 = do
     & foldMap
       ( \(names, projIds) ->
           if projIds.project == projCtx.project.projectId
-            -- If the branch is in the current project, put a shortened version of the branch name first,
+            then -- If the branch is in the current project, put a shortened version of the branch name first,
             -- then the long-form name at the end of the list (in case the user still types the full name)
-            then [(0 :: Int, "/" <> into @Text names.branch), (2, into @Text names)]
+              [(0 :: Int, "/" <> into @Text names.branch), (2, into @Text names)]
             else [(1, into @Text names)]
       )
     -- Put branches in this project first.

--- a/unison-core/src/Unison/ABT/Normalized.hs
+++ b/unison-core/src/Unison/ABT/Normalized.hs
@@ -25,7 +25,7 @@ where
 import Data.Bifoldable
 import Data.Bifunctor
 import Data.Foldable (toList)
-import Data.Functor.Identity (Identity(..))
+import Data.Functor.Identity (Identity (..))
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
@@ -208,10 +208,10 @@ transform phi (TTm body) = TTm . second (transform phi) $ phi body
 transform phi (TAbs u body) = TAbs u $ transform phi body
 
 visit ::
-  Applicative g =>
-  Bifoldable f =>
-  Traversable (f v) =>
-  Var v =>
+  (Applicative g) =>
+  (Bifoldable f) =>
+  (Traversable (f v)) =>
+  (Var v) =>
   (Term f v -> Maybe (g (Term f v))) ->
   Term f v ->
   g (Term f v)
@@ -220,9 +220,10 @@ visit h t = flip fromMaybe (h t) $ case out t of
   Tm body -> TTm <$> traverse (visit h) body
 
 visitPure ::
-  Bifoldable f =>
-  Traversable (f v) =>
-  Var v =>
+  (Bifoldable f) =>
+  (Traversable (f v)) =>
+  (Var v) =>
   (Term f v -> Maybe (Term f v)) ->
-  Term f v -> Term f v
+  Term f v ->
+  Term f v
 visitPure h = runIdentity . visit (fmap pure . h)

--- a/unison-core/src/Unison/ABT/Normalized.hs
+++ b/unison-core/src/Unison/ABT/Normalized.hs
@@ -208,10 +208,7 @@ transform phi (TTm body) = TTm . second (transform phi) $ phi body
 transform phi (TAbs u body) = TAbs u $ transform phi body
 
 visit ::
-  (Applicative g) =>
-  (Bifoldable f) =>
-  (Traversable (f v)) =>
-  (Var v) =>
+  (Applicative g, Bifoldable f, Traversable (f v), Var v) =>
   (Term f v -> Maybe (g (Term f v))) ->
   Term f v ->
   g (Term f v)
@@ -220,9 +217,7 @@ visit h t = flip fromMaybe (h t) $ case out t of
   Tm body -> TTm <$> traverse (visit h) body
 
 visitPure ::
-  (Bifoldable f) =>
-  (Traversable (f v)) =>
-  (Var v) =>
+  (Bifoldable f, Traversable (f v), Var v) =>
   (Term f v -> Maybe (Term f v)) ->
   Term f v ->
   Term f v

--- a/unison-core/src/Unison/Names/ResolutionResult.hs
+++ b/unison-core/src/Unison/Names/ResolutionResult.hs
@@ -6,12 +6,12 @@ module Unison.Names.ResolutionResult
   )
 where
 
+import Unison.HashQualified (HashQualified)
 import Unison.Name (Name)
 import Unison.Names (Names)
 import Unison.Prelude
 import Unison.Reference (TypeReference)
 import Unison.Referent (Referent)
-import Unison.HashQualified (HashQualified)
 
 data ResolutionError ref
   = NotFound

--- a/unison-runtime/src/Unison/Runtime/Builtin.hs
+++ b/unison-runtime/src/Unison/Runtime/Builtin.hs
@@ -522,7 +522,7 @@ dropn :: (Var v) => SuperNormal v
 dropn = binop0 4 $ \[x, y, b, r, tag, n] ->
   TLetD b UN (TPrm LEQN [x, y])
     -- TODO: Can we avoid this work until after the branch?
-  -- Should probably just replace this with an instruction.
+    -- Should probably just replace this with an instruction.
     . TLetD tag UN (TLit $ I $ fromIntegral $ unboxedTypeTagToInt NatTag)
     . TLetD r UN (TPrm SUBN [x, y])
     . TLetD n UN (TPrm CAST [r, tag])
@@ -815,8 +815,8 @@ andb = binop0 0 $ \[p, q] ->
 coerceType :: UnboxedTypeTag -> SuperNormal Symbol
 coerceType destType =
   unop0 1 $ \[v, tag] ->
-      TLetD tag UN (TLit $ I $ fromIntegral $ unboxedTypeTagToInt destType) $
-        TPrm CAST [v, tag]
+    TLetD tag UN (TLit $ I $ fromIntegral $ unboxedTypeTagToInt destType) $
+      TPrm CAST [v, tag]
 
 -- This version of unsafeCoerce is the identity function. It works
 -- only if the two types being coerced between are actually the same,

--- a/unison-runtime/src/Unison/Runtime/Foreign/Function.hs
+++ b/unison-runtime/src/Unison/Runtime/Foreign/Function.hs
@@ -28,8 +28,8 @@ import Network.UDP (UDPSocket)
 import System.IO (BufferMode (..), Handle, IOMode, SeekMode)
 import Unison.Builtin.Decls qualified as Ty
 import Unison.Reference (Reference)
-import Unison.Runtime.Array qualified as PA
 import Unison.Runtime.ANF (Code, PackedTag (..), Value, internalBug)
+import Unison.Runtime.Array qualified as PA
 import Unison.Runtime.Exception
 import Unison.Runtime.Foreign
 import Unison.Runtime.MCode

--- a/unison-runtime/src/Unison/Runtime/MCode/Serialize.hs
+++ b/unison-runtime/src/Unison/Runtime/MCode/Serialize.hs
@@ -17,8 +17,8 @@ import Data.Bytes.VarInt
 import Data.Void (Void)
 import Data.Word (Word64)
 import GHC.Exts (IsList (..))
-import Unison.Runtime.Array (PrimArray)
 import Unison.Runtime.ANF (PackedTag (..))
+import Unison.Runtime.Array (PrimArray)
 import Unison.Runtime.MCode hiding (MatchT)
 import Unison.Runtime.Serialize
 import Unison.Util.Text qualified as Util.Text

--- a/unison-runtime/tests/Unison/Test/Runtime/MCode/Serialization.hs
+++ b/unison-runtime/tests/Unison/Test/Runtime/MCode/Serialization.hs
@@ -16,7 +16,7 @@ import Unison.Prelude
 import Unison.Runtime.Interface
 import Unison.Runtime.MCode (Args (..), BPrim1, BPrim2, Branch, Comb, CombIx (..), GBranch (..), GComb (..), GCombInfo (..), GInstr (..), GRef (..), GSection (..), Instr, MLit (..), Ref, Section, UPrim1, UPrim2)
 import Unison.Runtime.Machine (Combs)
-import Unison.Runtime.TypeTags (PackedTag(..))
+import Unison.Runtime.TypeTags (PackedTag (..))
 import Unison.Test.Gen
 import Unison.Util.EnumContainers (EnumMap, EnumSet)
 import Unison.Util.EnumContainers qualified as EC


### PR DESCRIPTION
## Overview

It seems like some things have gotten a bit out of sync (isn’t Ormolu being run in CI?), so this brings it up-to-date.

When checking my own changes, it was just distracting to get re-formats in files I hadn’t touched.

## Implementation notes

I made a couple other manual changes
- one comment is now Haddock, because in some cases, Ormolu isn’t idempotent on comment positioning
- a couple other tiny cleanups after looking over Ormolu’s changes

## Test coverage

I thought CI handled this, but apparently it’s not right now? Or maybe some modules just get overlooked?
