### PR TITLE
Add structure to UCM command args

### DIFF
--- a/unison-cli-integration/integration-tests/IntegrationTests/transcript.md
+++ b/unison-cli-integration/integration-tests/IntegrationTests/transcript.md
@@ -2,7 +2,7 @@
 
 ``` ucm :hide
 scratch/main> builtins.mergeio lib.builtins
-scratch/main> load ./unison-src/transcripts-using-base/base.u
+scratch/main> load "./unison-src/transcripts-using-base/base.u"
 scratch/main> add
 ```
 

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -712,18 +712,31 @@ loop e = do
             DebugFuzzyOptionsI command args -> do
               Cli.Env {codebase} <- ask
               currentBranch <- Branch.withoutTransitiveLibs <$> Cli.getCurrentBranch0
-              case Map.lookup command InputPatterns.patternMap of
-                Just (IP.InputPattern {args = argTypes}) -> do
-                  zip argTypes args & Monoid.foldMapM \case
-                    ((argName, _, IP.ArgumentType {fzfResolver = Just IP.FZFResolver {getOptions}}), "_") -> do
-                      pp <- Cli.getCurrentProjectPath
-                      results <- liftIO $ getOptions codebase pp currentBranch
-                      Cli.respond (DebugDisplayFuzzyOptions argName (Text.unpack <$> results))
-                    ((_, _, IP.ArgumentType {fzfResolver = Nothing}), "_") -> do
-                      Cli.respond DebugFuzzyOptionsNoResolver
-                    _ -> pure ()
-                Nothing -> do
-                  Cli.respond DebugFuzzyOptionsNoResolver
+              maybe
+                (Cli.respond $ DebugFuzzyOptionsNoCommand command)
+                ( \IP.InputPattern {params} ->
+                    either (Cli.respond . DebugFuzzyOptionsIncorrectArgs) snd $
+                      IP.foldArgs
+                        ( \(paramName, IP.ParameterType {fzfResolver}) arg ->
+                            ( *>
+                                if arg == "_"
+                                  then
+                                    maybe
+                                      (Cli.respond DebugFuzzyOptionsNoResolver)
+                                      ( \IP.FZFResolver {getOptions} -> do
+                                          pp <- Cli.getCurrentProjectPath
+                                          results <- liftIO $ getOptions codebase pp currentBranch
+                                          Cli.respond (DebugDisplayFuzzyOptions paramName (Text.unpack <$> results))
+                                      )
+                                      fzfResolver
+                                  else pure ()
+                            )
+                        )
+                        (pure ())
+                        params
+                        args
+                )
+                $ Map.lookup command InputPatterns.patternMap
             DebugFormatI -> do
               env <- ask
               void $ runMaybeT do

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -355,6 +355,8 @@ data Output
   | DisplayDebugCompletions [Completion.Completion]
   | DisplayDebugLSPNameCompletions [(Text, Name, LabeledDependency)]
   | DebugDisplayFuzzyOptions Text [String {- arg description, options -}]
+  | DebugFuzzyOptionsIncorrectArgs (NonEmpty String)
+  | DebugFuzzyOptionsNoCommand String
   | DebugFuzzyOptionsNoResolver
   | DebugTerm (Bool {- verbose mode -}) (Either (Text {- A builtin hash -}) (Term Symbol Ann))
   | DebugDecl (Either (Text {- A builtin hash -}) (DD.Decl Symbol Ann)) (Maybe ConstructorId {- If 'Just' we're debugging a constructor of the given decl -})
@@ -624,6 +626,8 @@ isFailure o = case o of
   DisplayDebugCompletions {} -> False
   DisplayDebugLSPNameCompletions {} -> False
   DebugDisplayFuzzyOptions {} -> False
+  DebugFuzzyOptionsIncorrectArgs {} -> True
+  DebugFuzzyOptionsNoCommand {} -> True
   DebugFuzzyOptionsNoResolver {} -> True
   DebugTerm {} -> False
   DebugDecl {} -> False

--- a/unison-cli/src/Unison/CommandLine/Completion.hs
+++ b/unison-cli/src/Unison/CommandLine/Completion.hs
@@ -83,8 +83,8 @@ haskelineTabComplete patterns codebase authedHTTPClient ppCtx = Line.completeWor
     case words $ reverse prev of
       h : t -> fromMaybe (pure []) $ do
         p <- Map.lookup h patterns
-        argType <- IP.argType p (length t)
-        pure $ IP.suggestions argType word codebase authedHTTPClient ppCtx
+        paramType <- IP.paramType (IP.params p) (length t)
+        pure $ IP.suggestions paramType word codebase authedHTTPClient ppCtx
       _ -> pure []
 
 -- | Things which we may want to complete for.

--- a/unison-cli/src/Unison/CommandLine/InputPattern.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPattern.hs
@@ -37,6 +37,7 @@ import Unison.Codebase.Editor.StructuredArgument (StructuredArgument)
 import Unison.Codebase.ProjectPath qualified as PP
 import Unison.CommandLine.FZFResolvers (FZFResolver (..))
 import Unison.Prelude
+import Unison.Syntax.Lexer.Unison qualified as Lexer
 import Unison.Util.ColorText qualified as CT
 import Unison.Util.Monoid (foldMapM)
 import Unison.Util.Pretty qualified as P
@@ -48,7 +49,7 @@ data Visibility = Hidden | Visible
 -- needs to be parsed or a numbered argument that doesn’t need to be parsed, as
 -- we’ve preserved its representation (although the numbered argument could
 -- still be of the wrong type, which should result in an error).
-type Argument = Either String StructuredArgument
+type Argument = Either Lexer.Lexeme StructuredArgument
 
 type Arguments = [Argument]
 
@@ -71,7 +72,7 @@ data InputPattern = InputPattern
     --          message, and shouldn’t plan for the context it is being output to (e.g., don’t `P.indentN` the entire
     --          message).
     parse ::
-      -- | This list is always a valid length for the pattern. It may be necessary to have a catch-all case for
+      -- \| This list is always a valid length for the pattern. It may be necessary to have a catch-all case for
       --   coverage, but the implementation can assume that, say, a `OnePlus` parameter will always be provided at least
       --   one argument.
       Arguments ->

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -841,7 +841,7 @@ add =
     "add"
     []
     I.Visible
-    (Parameters [] . Optional [] $ Just ("definition", noCompletionsArg))
+    (Parameters [] . Optional [] $ Just ("definition", exactDefinitionArg))
     ( "`add` adds to the codebase all the definitions from the most recently "
         <> "typechecked file."
     )
@@ -853,7 +853,7 @@ previewAdd =
     "add.preview"
     []
     I.Visible
-    (Parameters [] . Optional [] $ Just ("definition", noCompletionsArg))
+    (Parameters [] . Optional [] $ Just ("definition", exactDefinitionArg))
     ( "`add.preview` previews additions to the codebase from the most recently "
         <> "typechecked file. This command only displays cached typechecking "
         <> "results. Use `load` to reparse & typecheck the file if the context "
@@ -883,7 +883,7 @@ updateOldNoPatch =
     "update.old.nopatch"
     []
     I.Visible
-    (Parameters [] . Optional [] $ Just ("definition", noCompletionsArg))
+    (Parameters [] . Optional [] $ Just ("definition", exactDefinitionArg))
     ( P.wrap
         ( makeExample' updateOldNoPatch
             <> "works like"
@@ -911,7 +911,7 @@ updateOld =
     "update.old"
     []
     I.Visible
-    (Parameters [] . Optional [("patch", patchArg)] $ Just ("definition", noCompletionsArg))
+    (Parameters [] . Optional [("patch", patchArg)] $ Just ("definition", exactDefinitionArg))
     ( P.wrap
         ( makeExample' updateOld
             <> "works like"
@@ -948,7 +948,7 @@ previewUpdate =
     "update.old.preview"
     []
     I.Visible
-    (Parameters [] . Optional [] $ Just ("definition", noCompletionsArg))
+    (Parameters [] . Optional [] $ Just ("definition", exactDefinitionArg))
     ( "`update.old.preview` previews updates to the codebase from the most "
         <> "recently typechecked file. This command only displays cached "
         <> "typechecking results. Use `load` to reparse & typecheck the file if "
@@ -1892,7 +1892,7 @@ debugFuzzyOptions =
     "debug.fuzzy-options"
     []
     I.Hidden
-    (Parameters [] $ OnePlus ("command arguments", noCompletionsArg))
+    (Parameters [("command", commandNameArg)] . Optional [] $ Just ("arguments", noCompletionsArg))
     ( P.lines
         [ P.wrap $ "This command can be used to test and debug ucm's fuzzy-options within transcripts.",
           P.wrap $ "Write a command invocation with _ for any args you'd like to see completion options for.",

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1585,6 +1585,8 @@ notifyUser dir = \case
     pure $
       P.lines
         [P.text (FZFResolvers.fuzzySelectHeader argDesc), P.indentN 2 $ P.bulleted (P.string <$> fuzzyOptions)]
+  DebugFuzzyOptionsIncorrectArgs _ -> pure $ P.string "Too many arguments were provided."
+  DebugFuzzyOptionsNoCommand command -> pure $ "The command “" <> P.string command <> "” doesn’t exist."
   DebugFuzzyOptionsNoResolver -> pure "No resolver found for fuzzy options in this slot."
   ClearScreen -> do
     ANSI.clearScreen

--- a/unison-src/transcripts-manual/benchmarks.md
+++ b/unison-src/transcripts-manual/benchmarks.md
@@ -41,56 +41,56 @@ scratch/main> run prepare
 ## Benchmarks
 
 ``` ucm
-scratch/main> load unison-src/transcripts-manual/benchmarks/each.u
+scratch/main> load "unison-src/transcripts-manual/benchmarks/each.u"
 scratch/main> run main
 ```
 
 ``` ucm
-scratch/main> load unison-src/transcripts-manual/benchmarks/listmap.u
+scratch/main> load "unison-src/transcripts-manual/benchmarks/listmap.u"
 scratch/main> run main
 ```
 
 ``` ucm
-scratch/main> load unison-src/transcripts-manual/benchmarks/listfilter.u
+scratch/main> load "unison-src/transcripts-manual/benchmarks/listfilter.u"
 scratch/main> run main
 ```
 
 ``` ucm
-scratch/main> load unison-src/transcripts-manual/benchmarks/random.u
+scratch/main> load "unison-src/transcripts-manual/benchmarks/random.u"
 scratch/main> run main
 ```
 
 ``` ucm
-scratch/main> load unison-src/transcripts-manual/benchmarks/simpleloop.u
+scratch/main> load "unison-src/transcripts-manual/benchmarks/simpleloop.u"
 scratch/main> run main
 ```
 
 ``` ucm
-scratch/main> load unison-src/transcripts-manual/benchmarks/fibonacci.u
+scratch/main> load "unison-src/transcripts-manual/benchmarks/fibonacci.u"
 scratch/main> run main
 ```
 
 ``` ucm
-scratch/main> load unison-src/transcripts-manual/benchmarks/map.u
+scratch/main> load "unison-src/transcripts-manual/benchmarks/map.u"
 scratch/main> run main
 ```
 
 ``` ucm
-scratch/main> load unison-src/transcripts-manual/benchmarks/natmap.u
+scratch/main> load "unison-src/transcripts-manual/benchmarks/natmap.u"
 scratch/main> run main
 ```
 
 ``` ucm
-scratch/main> load unison-src/transcripts-manual/benchmarks/stm.u
+scratch/main> load "unison-src/transcripts-manual/benchmarks/stm.u"
 scratch/main> run main
 ```
 
 ``` ucm
-scratch/main> load unison-src/transcripts-manual/benchmarks/tmap.u
+scratch/main> load "unison-src/transcripts-manual/benchmarks/tmap.u"
 scratch/main> run main
 ```
 
 ``` ucm
-scratch/main> load unison-src/transcripts-manual/benchmarks/array-sort.u
+scratch/main> load "unison-src/transcripts-manual/benchmarks/array-sort.u"
 scratch/main> run main
 ```

--- a/unison-src/transcripts-manual/rewrites.md
+++ b/unison-src/transcripts-manual/rewrites.md
@@ -1,6 +1,6 @@
 ``` ucm :hide
 scratch/main> builtins.mergeio
-scratch/main> load unison-src/transcripts-using-base/base.u
+scratch/main> load "unison-src/transcripts-using-base/base.u"
 scratch/main> add
 ```
 

--- a/unison-src/transcripts-round-trip/main.md
+++ b/unison-src/transcripts-round-trip/main.md
@@ -7,7 +7,7 @@ scratch/a2> builtins.mergeio lib.builtins
 ```
 
 ``` ucm :hide
-scratch/a1> load unison-src/transcripts-round-trip/reparses-with-same-hash.u
+scratch/a1> load "unison-src/transcripts-round-trip/reparses-with-same-hash.u"
 scratch/a1> add
 ```
 
@@ -48,7 +48,7 @@ Now check that definitions in 'reparses.u' at least parse on round trip:
 
 ``` ucm :hide
 scratch/a3> builtins.mergeio lib.builtins
-scratch/a3> load unison-src/transcripts-round-trip/reparses.u
+scratch/a3> load "unison-src/transcripts-round-trip/reparses.u"
 scratch/a3> add
 ```
 

--- a/unison-src/transcripts-using-base/_base.md
+++ b/unison-src/transcripts-using-base/_base.md
@@ -11,7 +11,7 @@ transcripts which contain less boilerplate.
 
 ``` ucm :hide
 scratch/main> builtins.mergeio
-scratch/main> load unison-src/transcripts-using-base/base.u
+scratch/main> load "unison-src/transcripts-using-base/base.u"
 scratch/main> add
 ```
 

--- a/unison-src/transcripts-using-base/_base.output.md
+++ b/unison-src/transcripts-using-base/_base.output.md
@@ -12,7 +12,7 @@ transcripts which contain less boilerplate.
 ``` ucm :hide
 scratch/main> builtins.mergeio
 
-scratch/main> load unison-src/transcripts-using-base/base.u
+scratch/main> load "unison-src/transcripts-using-base/base.u"
 
 scratch/main> add
 ```

--- a/unison-src/transcripts-using-base/doc.md
+++ b/unison-src/transcripts-using-base/doc.md
@@ -45,7 +45,7 @@ The `docs ImportantConstant` command will look for `ImportantConstant.doc` in th
 First, we'll load the `syntax.u` file which has examples of all the syntax:
 
 ``` ucm
-scratch/main> load ./unison-src/transcripts-using-base/doc.md.files/syntax.u
+scratch/main> load "./unison-src/transcripts-using-base/doc.md.files/syntax.u"
 ```
 
 ``` ucm :hide

--- a/unison-src/transcripts-using-base/doc.output.md
+++ b/unison-src/transcripts-using-base/doc.output.md
@@ -72,7 +72,7 @@ The `docs ImportantConstant` command will look for `ImportantConstant.doc` in th
 First, we'll load the `syntax.u` file which has examples of all the syntax:
 
 ``` ucm
-scratch/main> load ./unison-src/transcripts-using-base/doc.md.files/syntax.u
+scratch/main> load "./unison-src/transcripts-using-base/doc.md.files/syntax.u"
 
   Loading changes detected in
   ./unison-src/transcripts-using-base/doc.md.files/syntax.u.

--- a/unison-src/transcripts/idempotent/any-extract.md
+++ b/unison-src/transcripts/idempotent/any-extract.md
@@ -3,7 +3,7 @@
 ``` ucm :hide
 scratch/main> builtins.mergeio
 
-scratch/main> load unison-src/transcripts-using-base/base.u
+scratch/main> load "unison-src/transcripts-using-base/base.u"
 
 scratch/main> add
 ```

--- a/unison-src/transcripts/idempotent/api-list-projects-branches.md
+++ b/unison-src/transcripts/idempotent/api-list-projects-branches.md
@@ -1,17 +1,17 @@
 # List Projects And Branches Test
 
 ``` ucm :hide
-scratch/main> project.create-empty project-one
+scratch/main> project.create-empty "project-one"
 
-scratch/main> project.create-empty project-two
+scratch/main> project.create-empty "project-two"
 
-scratch/main> project.create-empty project-three
+scratch/main> project.create-empty "project-three"
 
-project-one/main> branch branch-one
+project-one/main> branch "branch-one"
 
-project-one/main> branch branch-two
+project-one/main> branch "branch-two"
 
-project-one/main> branch branch-three
+project-one/main> branch "branch-three"
 ```
 
 ``` api

--- a/unison-src/transcripts/idempotent/branch-command.md
+++ b/unison-src/transcripts/idempotent/branch-command.md
@@ -37,14 +37,14 @@ foo/main> branch topic1
   Tip: To merge your work back into the main branch, first
        `switch /main` then `merge /topic1`.
 
-foo/main> branch /topic2
+foo/main> branch "/topic2"
 
   Done. I've created the topic2 branch based off of main.
 
   Tip: To merge your work back into the main branch, first
        `switch /main` then `merge /topic2`.
 
-foo/main> branch foo/topic3
+foo/main> branch "foo/topic3"
 
   Done. I've created the topic3 branch based off of main.
 
@@ -58,75 +58,75 @@ foo/main> branch main topic4
   Tip: To merge your work back into the main branch, first
        `switch /main` then `merge /topic4`.
 
-foo/main> branch main /topic5
+foo/main> branch main "/topic5"
 
   Done. I've created the topic5 branch based off of main.
 
   Tip: To merge your work back into the main branch, first
        `switch /main` then `merge /topic5`.
 
-foo/main> branch main foo/topic6
+foo/main> branch main "foo/topic6"
 
   Done. I've created the topic6 branch based off of main.
 
   Tip: To merge your work back into the main branch, first
        `switch /main` then `merge /topic6`.
 
-foo/main> branch /main topic7
+foo/main> branch "/main" topic7
 
   Done. I've created the topic7 branch based off of main.
 
   Tip: To merge your work back into the main branch, first
        `switch /main` then `merge /topic7`.
 
-foo/main> branch /main /topic8
+foo/main> branch "/main" "/topic8"
 
   Done. I've created the topic8 branch based off of main.
 
   Tip: To merge your work back into the main branch, first
        `switch /main` then `merge /topic8`.
 
-foo/main> branch /main foo/topic9
+foo/main> branch "/main" "foo/topic9"
 
   Done. I've created the topic9 branch based off of main.
 
   Tip: To merge your work back into the main branch, first
        `switch /main` then `merge /topic9`.
 
-foo/main> branch foo/main topic10
+foo/main> branch "foo/main" topic10
 
   Done. I've created the topic10 branch based off of main.
 
   Tip: To merge your work back into the main branch, first
        `switch /main` then `merge /topic10`.
 
-foo/main> branch foo/main /topic11
+foo/main> branch "foo/main" "/topic11"
 
   Done. I've created the topic11 branch based off of main.
 
   Tip: To merge your work back into the main branch, first
        `switch /main` then `merge /topic11`.
 
-scratch/main> branch foo/main foo/topic12
+scratch/main> branch "foo/main" "foo/topic12"
 
   Done. I've created the topic12 branch based off of main.
 
   Tip: To merge your work back into the main branch, first
        `switch /main` then `merge /topic12`.
 
-foo/main> branch bar/topic
+foo/main> branch "bar/topic"
 
   Done. I've created the bar/topic branch based off foo/main.
 
-bar/main> branch foo/main topic2
+bar/main> branch "foo/main" topic2
 
   Done. I've created the bar/topic2 branch based off foo/main.
 
-bar/main> branch foo/main /topic3
+bar/main> branch "foo/main" "/topic3"
 
   Done. I've created the bar/topic3 branch based off foo/main.
 
-scratch/main> branch foo/main bar/topic4
+scratch/main> branch "foo/main" "bar/topic4"
 
   Done. I've created the bar/topic4 branch based off foo/main.
 
@@ -136,19 +136,19 @@ foo/main> branch.empty empty1
 
   Tip: Use `merge /somebranch` to initialize this branch.
 
-foo/main> branch.empty /empty2
+foo/main> branch.empty "/empty2"
 
   Done. I've created an empty branch foo/empty2.
 
   Tip: Use `merge /somebranch` to initialize this branch.
 
-foo/main> branch.empty foo/empty3
+foo/main> branch.empty "foo/empty3"
 
   Done. I've created an empty branch foo/empty3.
 
   Tip: Use `merge /somebranch` to initialize this branch.
 
-scratch/main> branch.empty foo/empty4
+scratch/main> branch.empty "foo/empty4"
 
   Done. I've created an empty branch foo/empty4.
 
@@ -158,7 +158,7 @@ scratch/main> branch.empty foo/empty4
 The `branch` command can create branches named `releases/drafts/*` (because why not).
 
 ``` ucm
-foo/main> branch releases/drafts/1.2.3
+foo/main> branch "releases/drafts/1.2.3"
 
   Done. I've created the releases/drafts/1.2.3 branch based off
   of main.
@@ -166,13 +166,13 @@ foo/main> branch releases/drafts/1.2.3
   Tip: To merge your work back into the main branch, first
        `switch /main` then `merge /releases/drafts/1.2.3`.
 
-foo/main> switch /releases/drafts/1.2.3
+foo/main> switch "/releases/drafts/1.2.3"
 ```
 
 The `branch` command can't create branches named `releases/*` nor `releases/drafts/*`.
 
 ``` ucm :error
-foo/main> branch releases/1.2.3
+foo/main> branch "releases/1.2.3"
 
   Branch names like releases/1.2.3 are reserved for releases.
 
@@ -181,7 +181,7 @@ foo/main> branch releases/1.2.3
 
   Tip: to draft a new release, try `release.draft 1.2.3`.
 
-foo/main> switch /releases/1.2.3
+foo/main> switch "/releases/1.2.3"
 
   foo/releases/1.2.3 does not exist.
 ```

--- a/unison-src/transcripts/idempotent/branch-relative-path.md
+++ b/unison-src/transcripts/idempotent/branch-relative-path.md
@@ -53,7 +53,7 @@ p1/main> add
     bonk      : ##Nat
     donk.bonk : ##Nat
 
-p1/main> fork p0/main: zzz
+p1/main> fork "p0/main:" zzz
 
   Done.
 
@@ -62,7 +62,7 @@ p1/main> find zzz
   1. zzz.foo : ##Nat
   2. zzz.foo.bar : ##Nat
 
-p1/main> fork p0/main:foo yyy
+p1/main> fork "p0/main:foo" yyy
 
   Done.
 
@@ -70,7 +70,7 @@ p1/main> find yyy
 
   1. yyy.bar : ##Nat
 
-p0/main> fork p1/main: p0/main:p1
+p0/main> fork "p1/main:" "p0/main:p1"
 
   Done.
 

--- a/unison-src/transcripts/idempotent/bug-strange-closure.md
+++ b/unison-src/transcripts/idempotent/bug-strange-closure.md
@@ -1,7 +1,7 @@
 ``` ucm :hide
 scratch/main> builtins.mergeio lib.builtins
 
-scratch/main> load unison-src/transcripts-using-base/doc.md.files/syntax.u
+scratch/main> load "unison-src/transcripts-using-base/doc.md.files/syntax.u"
 ```
 
 We can display the guide before and after adding it to the codebase:

--- a/unison-src/transcripts/idempotent/builtins.md
+++ b/unison-src/transcripts/idempotent/builtins.md
@@ -3,7 +3,7 @@
 ``` ucm :hide
 scratch/main> builtins.mergeio
 
-scratch/main> load unison-src/transcripts-using-base/base.u
+scratch/main> load "unison-src/transcripts-using-base/base.u"
 
 scratch/main> add
 ```

--- a/unison-src/transcripts/idempotent/deep-names.md
+++ b/unison-src/transcripts/idempotent/deep-names.md
@@ -15,9 +15,9 @@ http.z = 8
 ``` ucm :hide
 scratch/main> add
 
-scratch/main> branch /app1
+scratch/main> branch "/app1"
 
-scratch/main> branch /app2
+scratch/main> branch "/app2"
 ```
 
 Our `app1` project includes the text library twice and the http library twice as direct dependencies.

--- a/unison-src/transcripts/idempotent/delete-namespace-dependents-check.md
+++ b/unison-src/transcripts/idempotent/delete-namespace-dependents-check.md
@@ -35,7 +35,7 @@ myproject/main> add
     dependent      : Nat
     sub.dependency : Nat
 
-myproject/main> branch /new
+myproject/main> branch "/new"
 
   Done. I've created the new branch based off of main.
 

--- a/unison-src/transcripts/idempotent/delete-project-branch.md
+++ b/unison-src/transcripts/idempotent/delete-project-branch.md
@@ -9,7 +9,7 @@ foo/main> branch topic
   Tip: To merge your work back into the main branch, first
        `switch /main` then `merge /topic`.
 
-foo/topic> delete.branch /topic
+foo/topic> delete.branch "/topic"
 ```
 
 A branch need not be preceded by a forward slash.
@@ -35,19 +35,19 @@ foo/main> branch topic
   Tip: To merge your work back into the main branch, first
        `switch /main` then `merge /topic`.
 
-scratch/main> delete.branch foo/topic
+scratch/main> delete.branch "foo/topic"
 ```
 
 You can delete the only branch in a project.
 
 ``` ucm
-foo/main> delete.branch /main
+foo/main> delete.branch "/main"
 ```
 
 You can delete the last branch in the project, a new one will be created.
 
 ``` ucm
-scratch/main> delete.branch scratch/main
+scratch/main> delete.branch "scratch/main"
 
 scratch/main> branches
 
@@ -59,9 +59,9 @@ scratch/main> branches
 If the the last branch isn't /main, then /main will be created.
 
 ``` ucm
-scratch/main2> delete.branch /main
+scratch/main2> delete.branch "/main"
 
-scratch/main2> delete.branch /main2
+scratch/main2> delete.branch "/main2"
 
 scratch/other> branches
 

--- a/unison-src/transcripts/idempotent/diff-namespace.md
+++ b/unison-src/transcripts/idempotent/diff-namespace.md
@@ -45,7 +45,7 @@ scratch/b1> debug.alias.term.force .x .fslkdjflskdjflksjdf
 ```
 
 ``` ucm
-scratch/main> diff.namespace /b1: /b2:
+scratch/main> diff.namespace "/b1:" "/b2:"
 
   Resolved name conflicts:
 
@@ -105,7 +105,7 @@ scratch/ns1> alias.term helloWorld helloWorld2
 
   Done.
 
-scratch/ns1> branch /ns2
+scratch/ns1> branch "/ns2"
 
   Done. I've created the ns2 branch based off of ns1.
 
@@ -116,7 +116,7 @@ scratch/ns1> branch /ns2
 Here's what we've done so far:
 
 ``` ucm :error
-scratch/main> diff.namespace .nothing /ns1:
+scratch/main> diff.namespace .nothing "/ns1:"
 
   ⚠️
 
@@ -124,7 +124,7 @@ scratch/main> diff.namespace .nothing /ns1:
 ```
 
 ``` ucm :error
-scratch/main> diff.namespace /ns1: /ns2:
+scratch/main> diff.namespace "/ns1:" "/ns2:"
 
   The namespaces are identical.
 ```
@@ -170,7 +170,7 @@ scratch/ns2> update
 
   Done.
 
-scratch/main> diff.namespace /ns1: /ns2:
+scratch/main> diff.namespace "/ns1:" "/ns2:"
 
   Resolved name conflicts:
 
@@ -223,7 +223,7 @@ scratch/ns2> alias.term X.x X'.x
 
   Done.
 
-scratch/main> diff.namespace /ns1: /ns2:
+scratch/main> diff.namespace "/ns1:" "/ns2:"
 
   Resolved name conflicts:
 
@@ -281,7 +281,7 @@ scratch/ns2> alias.term A'.A A''.A
 
   Done.
 
-scratch/ns2> branch /ns3
+scratch/ns2> branch "/ns3"
 
   Done. I've created the ns3 branch based off of ns2.
 
@@ -303,7 +303,7 @@ scratch/ns2> delete.term.verbose fromJust'
   Tip: You can use `undo` or use a hash from `reflog` to undo
        this change.
 
-scratch/main> diff.namespace /ns3: /ns2:
+scratch/main> diff.namespace "/ns3:" "/ns2:"
 
   Name changes:
 
@@ -324,7 +324,7 @@ scratch/ns3> update
 
   Done.
 
-scratch/main> diff.namespace /ns2: /ns3:
+scratch/main> diff.namespace "/ns2:" "/ns3:"
 
   Updates:
 
@@ -360,14 +360,14 @@ scratch/nsx> add
     b            : Nat
     forconflicts : Nat
 
-scratch/nsx> branch /nsy
+scratch/nsx> branch "/nsy"
 
   Done. I've created the nsy branch based off of nsx.
 
   Tip: To merge your work back into the nsx branch, first
        `switch /nsx` then `merge /nsy`.
 
-scratch/nsx> branch /nsz
+scratch/nsx> branch "/nsz"
 
   Done. I've created the nsz branch based off of nsx.
 
@@ -408,7 +408,7 @@ scratch/nsz> update
 
   Done.
 
-scratch/nsy> branch /nsw
+scratch/nsy> branch "/nsw"
 
   Done. I've created the nsw branch based off of nsy.
 
@@ -425,7 +425,7 @@ scratch/nsw> debug.alias.term.force .forconflicts .b
 ```
 
 ``` ucm
-scratch/main> diff.namespace /nsx: /nsw:
+scratch/main> diff.namespace "/nsx:" "/nsw:"
 
   New name conflicts:
 

--- a/unison-src/transcripts/idempotent/fix-5326.md
+++ b/unison-src/transcripts/idempotent/fix-5326.md
@@ -189,7 +189,7 @@ D - C - B - A
 ```
 
 ``` ucm
-scratch/main> merge /foo
+scratch/main> merge "/foo"
 
   I merged scratch/foo into scratch/main.
 ```
@@ -207,7 +207,7 @@ F - D - C - B - A
 ```
 
 ``` ucm
-scratch/main> merge /bar
+scratch/main> merge "/bar"
 
   😶
 

--- a/unison-src/transcripts/idempotent/fix1327.md
+++ b/unison-src/transcripts/idempotent/fix1327.md
@@ -34,7 +34,7 @@ scratch/main> ls
   1. bar (##Nat)
   2. foo (##Nat)
 
-scratch/main> alias.many 1-2 .ns1_nohistory
+scratch/main> alias.many "1-2" .ns1_nohistory
 
   Here's what changed in .ns1_nohistory :
 

--- a/unison-src/transcripts/idempotent/fix2254.md
+++ b/unison-src/transcripts/idempotent/fix2254.md
@@ -48,7 +48,7 @@ scratch/a> add
     f3 : NeedsA Nat Nat -> Nat
     g  : A Nat Nat Nat Nat -> Nat
 
-scratch/a> branch /a2
+scratch/a> branch "/a2"
 
   Done. I've created the a2 branch based off of a.
 

--- a/unison-src/transcripts/idempotent/io.md
+++ b/unison-src/transcripts/idempotent/io.md
@@ -5,7 +5,7 @@ scratch/main> builtins.merge
 
 scratch/main> builtins.mergeio
 
-scratch/main> load unison-src/transcripts-using-base/base.u
+scratch/main> load "unison-src/transcripts-using-base/base.u"
 
 scratch/main> add
 ```

--- a/unison-src/transcripts/idempotent/numbered-args.md
+++ b/unison-src/transcripts/idempotent/numbered-args.md
@@ -117,7 +117,7 @@ scratch/main> find
   6. qux : Text
   7. builtin type Text
 
-scratch/main> view 2-4
+scratch/main> view "2-4"
 
   baz : Text
   baz = "baz"
@@ -142,7 +142,7 @@ scratch/main> find
   6. qux : Text
   7. builtin type Text
 
-scratch/main> view 1-3 4 5-6
+scratch/main> view "1-3" 4 "5-6"
 
   bar : Text
   bar = "bar"

--- a/unison-src/transcripts/idempotent/pull-errors.md
+++ b/unison-src/transcripts/idempotent/pull-errors.md
@@ -1,5 +1,5 @@
 ``` ucm :error
-test/main> pull @aryairani/test-almost-empty/main lib.base_latest
+test/main> pull "@aryairani/test-almost-empty/main" lib.base_latest
 
   The use of `pull` to install libraries is now deprecated.
   Going forward, you can use
@@ -10,7 +10,7 @@ test/main> pull @aryairani/test-almost-empty/main lib.base_latest
   I installed @aryairani/test-almost-empty/main as
   aryairani_test_almost_empty_main.
 
-test/main> pull @aryairani/test-almost-empty/main a.b
+test/main> pull "@aryairani/test-almost-empty/main" a.b
 
   ⚠️
 
@@ -22,13 +22,13 @@ test/main> pull @aryairani/test-almost-empty/main a.b
 
   You can run `help pull` for more information on using `pull`.
 
-test/main> pull @aryairani/test-almost-empty/main a
+test/main> pull "@aryairani/test-almost-empty/main" a
 
   I think you want to merge @aryairani/test-almost-empty/main
   into the a branch, but it doesn't exist. If you want, you can
   create it with `branch.empty a`, and then `pull` again.
 
-test/main> pull @aryairani/test-almost-empty/main .a
+test/main> pull "@aryairani/test-almost-empty/main" .a
 
   ⚠️
 

--- a/unison-src/transcripts/idempotent/records.md
+++ b/unison-src/transcripts/idempotent/records.md
@@ -3,7 +3,7 @@ Ensure that Records keep their syntax after being added to the codebase
 ``` ucm :hide
 scratch/main> builtins.merge
 
-scratch/main> load unison-src/transcripts-using-base/base.u
+scratch/main> load "unison-src/transcripts-using-base/base.u"
 ```
 
 ## Record with 1 field

--- a/unison-src/transcripts/idempotent/reflog.md
+++ b/unison-src/transcripts/idempotent/reflog.md
@@ -51,7 +51,7 @@ scratch/main> add
 
     y : Nat
 
-scratch/main> branch /other
+scratch/main> branch "/other"
 
   Done. I've created the other branch based off of main.
 

--- a/unison-src/transcripts/idempotent/release-draft-command.md
+++ b/unison-src/transcripts/idempotent/release-draft-command.md
@@ -35,7 +35,7 @@ Now, the `release.draft` demo:
 `release.draft` accepts a single semver argument.
 
 ``` ucm
-foo/main> release.draft 1.2.3
+foo/main> release.draft "1.2.3"
 
   😎 Great! I've created a draft release for you at
   /releases/drafts/1.2.3.
@@ -55,7 +55,7 @@ foo/main> release.draft 1.2.3
 It's an error to try to create a `releases/drafts/x.y.z` branch that already exists.
 
 ``` ucm :error
-foo/main> release.draft 1.2.3
+foo/main> release.draft "1.2.3"
 
   foo/releases/drafts/1.2.3 already exists. You can switch to it
   with `switch foo/releases/drafts/1.2.3`.

--- a/unison-src/transcripts/idempotent/reset.md
+++ b/unison-src/transcripts/idempotent/reset.md
@@ -153,7 +153,7 @@ foo/main> update
 
   Done.
 
-foo/empty> reset /main:
+foo/empty> reset "/main:"
 
   Done.
 

--- a/unison-src/transcripts/idempotent/switch-command.md
+++ b/unison-src/transcripts/idempotent/switch-command.md
@@ -53,13 +53,13 @@ forward slash (which makes it unambiguous).
 ``` ucm
 scratch/main> switch foo
 
-scratch/main> switch foo/topic
+scratch/main> switch "foo/topic"
 
 foo/main> switch topic
 
-foo/main> switch /topic
+foo/main> switch "/topic"
 
-foo/main> switch bar/
+foo/main> switch "bar/"
 ```
 
 It's an error to try to switch to something ambiguous.
@@ -79,20 +79,20 @@ foo/main> switch bar
 It's an error to try to switch to something that doesn't exist, of course.
 
 ``` ucm :error
-scratch/main> switch foo/no-such-branch
+scratch/main> switch "foo/no-such-branch"
 
   foo/no-such-branch does not exist.
 ```
 
 ``` ucm :error
-scratch/main> switch no-such-project
+scratch/main> switch "no-such-project"
 
   Neither project no-such-project nor branch /no-such-project
   exists.
 ```
 
 ``` ucm :error
-foo/main> switch no-such-project-or-branch
+foo/main> switch "no-such-project-or-branch"
 
   Neither project no-such-project-or-branch nor branch
   /no-such-project-or-branch exists.

--- a/unison-src/transcripts/idempotent/tab-completion.md
+++ b/unison-src/transcripts/idempotent/tab-completion.md
@@ -180,7 +180,7 @@ scratch/main> update.old
     type Foo
     add : a -> a
 
-scratch/main> debug.tab-complete delete.type Foo
+scratch/main> debug.tab-complete "delete.type" Foo
 
   * Foo
     Foo.

--- a/unison-src/transcripts/idempotent/textfind.md
+++ b/unison-src/transcripts/idempotent/textfind.md
@@ -113,7 +113,7 @@ scratch/main> text.find.all hi
   Tip: Try `edit 1` or `edit 1-2` to bring these into your
        scratch file.
 
-scratch/main> view 1-5
+scratch/main> view "1-5"
 
   bar : Nat
   bar = match "well hi there" with
@@ -154,7 +154,7 @@ scratch/main> grep quaffle
 
   Tip: Try `edit 1` to bring this into your scratch file.
 
-scratch/main> view 1-5
+scratch/main> view "1-5"
 
   baz : [Text]
   baz = ["an", "quaffle", "tres"]
@@ -169,7 +169,7 @@ scratch/main> text.find "interesting const"
 
   Tip: Try `edit 1` to bring this into your scratch file.
 
-scratch/main> view 1-5
+scratch/main> view "1-5"
 
   foo : Nat
   foo =

--- a/unison-src/transcripts/merge.md
+++ b/unison-src/transcripts/merge.md
@@ -43,7 +43,7 @@ scratch/bob> add
 ```
 Merge result:
 ``` ucm
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 scratch/alice> view foo bar
 ```
 
@@ -84,7 +84,7 @@ scratch/bob> add
 ```
 Merge result:
 ``` ucm
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 scratch/alice> view foo bar
 ```
 
@@ -136,7 +136,7 @@ scratch/bob> add
 ```
 Merge result:
 ``` ucm
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 scratch/alice> view foo bar
 scratch/alice> display bar
 ```
@@ -202,7 +202,7 @@ scratch/bob> display foo
 ```
 Merge result:
 ``` ucm
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 scratch/alice> view foo bar baz
 scratch/alice> display foo
 ```
@@ -272,7 +272,7 @@ scratch/bob> display foo
 
 Merge result:
 ``` ucm
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 scratch/alice> view foo bar baz
 scratch/alice> display foo
 ```
@@ -318,7 +318,7 @@ scratch/bob> delete.term foo
 
 Merge result:
 ``` ucm
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 scratch/alice> view foo
 ```
 
@@ -393,7 +393,7 @@ scratch/main> builtins.mergeio lib.builtins
 ``` ucm
 scratch/main> branch alice
 scratch/main> branch bob
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 ```
 
 ``` ucm :hide
@@ -421,7 +421,7 @@ foo = "foo"
 
 ``` ucm
 scratch/alice> add
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 ```
 
 ``` ucm :hide
@@ -449,7 +449,7 @@ foo = "foo"
 
 ``` ucm
 scratch/bob> add
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 ```
 
 ``` ucm :hide
@@ -460,7 +460,7 @@ scratch/main> project.delete scratch
 
 ``` ucm
 scratch/main> branch topic
-scratch/main> merge /topic
+scratch/main> merge "/topic"
 ```
 
 ``` ucm :hide
@@ -505,7 +505,7 @@ bar = foo ++ " - " ++ foo
 
 ``` ucm :error
 scratch/bob> add
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 ```
 
 ``` ucm :hide
@@ -555,7 +555,7 @@ scratch/bob> update
 ```
 
 ``` ucm :error
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 ```
 
 ``` ucm :hide
@@ -616,7 +616,7 @@ baz = "bobs baz"
 scratch/bob> update
 ```
 ``` ucm :error
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 ```
 
 ``` ucm
@@ -663,7 +663,7 @@ unique type Foo = MkFoo Nat Text
 scratch/bob> update
 ```
 ``` ucm :error
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 ```
 
 ``` ucm :hide
@@ -703,7 +703,7 @@ Bob's renames `Qux` to `BobQux`:
 scratch/bob> move.term Foo.Qux Foo.BobQux
 ```
 ``` ucm :error
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 ```
 
 ``` ucm :hide
@@ -1006,7 +1006,7 @@ Attempt to merge:
 scratch/bob> update
 ```
 ``` ucm :error
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 ```
 
 Resolve conflicts and commit:
@@ -1099,7 +1099,7 @@ scratch/bob> add
 ```
 
 ``` ucm :error
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 ```
 
 ``` ucm :hide
@@ -1140,7 +1140,7 @@ scratch/bob> add
 ```
 
 ``` ucm :error
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 ```
 
 ``` ucm :hide
@@ -1186,7 +1186,7 @@ scratch/bob> add
 ```
 
 ``` ucm :error
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 ```
 
 ``` ucm :hide
@@ -1220,7 +1220,7 @@ scratch/alice> delete.term Foo.Bar
 
 Bob's branch:
 ``` ucm :hide
-scratch/main> branch /bob
+scratch/main> branch "/bob"
 ```
 
 ``` unison :hide
@@ -1233,7 +1233,7 @@ scratch/bob> add
 ```
 
 ``` ucm :error
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 ```
 
 ``` ucm :hide
@@ -1281,7 +1281,7 @@ scratch/bob> add
 ```
 
 ``` ucm :error
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 ```
 
 ``` ucm :hide
@@ -1366,7 +1366,7 @@ scratch/bob> add
 ```
 
 ``` ucm :error
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 ```
 
 ``` ucm :hide
@@ -1432,7 +1432,7 @@ scratch/bob> add
 Now we merge:
 
 ``` ucm
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 ```
 
 ``` ucm :hide
@@ -1477,7 +1477,7 @@ scratch/bob> add
 ```
 
 ``` ucm
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 ```
 
 ``` ucm :hide
@@ -1581,7 +1581,7 @@ When we try to merge Bob into Alice, we should see both versions of `baz`, with 
 the underlying namespace.
 
 ``` ucm :error
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 ```
 
 But `bar` was put into the scratch file instead.
@@ -1636,8 +1636,8 @@ b = 2
 
 ``` ucm
 scratch/carol> add
-scratch/bob> merge /alice
-scratch/carol> merge /bob
+scratch/bob> merge "/alice"
+scratch/carol> merge "/bob"
 scratch/carol> history
 ```
 
@@ -1696,7 +1696,7 @@ scratch/alice> update
 ```
 
 ``` ucm
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 ```
 
 ``` ucm :hide
@@ -1726,7 +1726,7 @@ scratch/bob> move.term Foo.Lca Foo.Bob
 ```
 
 ``` ucm :error
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 ```
 
 ``` ucm
@@ -1789,7 +1789,7 @@ scratch/bob> update
 Note Bob's `hello` references `foo` (Alice's name), not `bar` (Bob's name).
 
 ``` ucm :error
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 ```
 
 ``` ucm :hide

--- a/unison-src/transcripts/merge.output.md
+++ b/unison-src/transcripts/merge.output.md
@@ -64,7 +64,7 @@ scratch/bob> add
 Merge result:
 
 ``` ucm
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 
   I merged scratch/bob into scratch/alice.
 
@@ -121,7 +121,7 @@ scratch/bob> add
 Merge result:
 
 ``` ucm
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 
   I merged scratch/bob into scratch/alice.
 
@@ -192,7 +192,7 @@ scratch/bob> add
 Merge result:
 
 ``` ucm
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 
   I merged scratch/bob into scratch/alice.
 
@@ -285,7 +285,7 @@ scratch/bob> display foo
 Merge result:
 
 ``` ucm
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 
   I merged scratch/bob into scratch/alice.
 
@@ -387,7 +387,7 @@ scratch/bob> display foo
 Merge result:
 
 ``` ucm
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 
   I merged scratch/bob into scratch/alice.
 
@@ -460,7 +460,7 @@ scratch/bob> delete.term foo
 Merge result:
 
 ``` ucm
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 
   I merged scratch/bob into scratch/alice.
 
@@ -576,7 +576,7 @@ scratch/main> branch bob
   Tip: To merge your work back into the main branch, first
        `switch /main` then `merge /bob`.
 
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 
   😶
 
@@ -625,7 +625,7 @@ scratch/alice> add
 
     foo : Text
 
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 
   😶
 
@@ -674,7 +674,7 @@ scratch/bob> add
 
     foo : Text
 
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 
   I fast-forward merged scratch/bob into scratch/alice.
 ```
@@ -693,7 +693,7 @@ scratch/main> branch topic
   Tip: To merge your work back into the main branch, first
        `switch /main` then `merge /topic`.
 
-scratch/main> merge /topic
+scratch/main> merge "/topic"
 
   😶
 
@@ -755,7 +755,7 @@ scratch/bob> add
 
     bar : Text
 
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 
   I couldn't automatically merge scratch/bob into scratch/alice.
   However, I've added the definitions that need attention to the
@@ -834,7 +834,7 @@ scratch/bob> update
 ```
 
 ``` ucm :error
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 
   I couldn't automatically merge scratch/bob into scratch/alice.
   However, I've added the definitions that need attention to the
@@ -924,7 +924,7 @@ scratch/bob> update
 ```
 
 ``` ucm :error
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 
   I couldn't automatically merge scratch/bob into scratch/alice.
   However, I've added the definitions that need attention to the
@@ -1019,7 +1019,7 @@ scratch/bob> update
 ```
 
 ``` ucm :error
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 
   I couldn't automatically merge scratch/bob into scratch/alice.
   However, I've added the definitions that need attention to the
@@ -1092,7 +1092,7 @@ scratch/bob> move.term Foo.Qux Foo.BobQux
 ```
 
 ``` ucm :error
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 
   I couldn't automatically merge scratch/bob into scratch/alice.
   However, I've added the definitions that need attention to the
@@ -1602,7 +1602,7 @@ scratch/bob> update
 ```
 
 ``` ucm :error
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 
   I couldn't automatically merge scratch/bob into scratch/alice.
   However, I've added the definitions that need attention to the
@@ -1765,7 +1765,7 @@ scratch/bob> add
 ```
 
 ``` ucm :error
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 
   Sorry, I wasn't able to perform the merge:
 
@@ -1827,7 +1827,7 @@ scratch/bob> add
 ```
 
 ``` ucm :error
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 
   Sorry, I wasn't able to perform the merge:
 
@@ -1888,7 +1888,7 @@ scratch/bob> add
 ```
 
 ``` ucm :error
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 
   Sorry, I wasn't able to perform the merge:
 
@@ -1937,7 +1937,7 @@ scratch/alice> delete.term Foo.Bar
 Bob's branch:
 
 ``` ucm :hide
-scratch/main> branch /bob
+scratch/main> branch "/bob"
 ```
 
 ``` unison :hide
@@ -1950,7 +1950,7 @@ scratch/bob> add
 ```
 
 ``` ucm :error
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 
   Sorry, I wasn't able to perform the merge:
 
@@ -2013,7 +2013,7 @@ scratch/bob> add
 ```
 
 ``` ucm :error
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 
   On scratch/alice, the type A.inner.X is an alias of A. I'm not
   able to perform a merge when a type exists nested under an
@@ -2119,7 +2119,7 @@ scratch/bob> add
 ```
 
 ``` ucm :error
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 
   Sorry, I wasn't able to perform the merge:
 
@@ -2266,7 +2266,7 @@ scratch/bob> add
 Now we merge:
 
 ``` ucm
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 
   I merged scratch/bob into scratch/alice.
 ```
@@ -2379,7 +2379,7 @@ scratch/bob> add
 ```
 
 ``` ucm
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 
   I merged scratch/bob into scratch/alice.
 ```
@@ -2611,7 +2611,7 @@ When we try to merge Bob into Alice, we should see both versions of `baz`, with 
 the underlying namespace.
 
 ``` ucm :error
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 
   I couldn't automatically merge scratch/bob into scratch/alice.
   However, I've added the definitions that need attention to the
@@ -2773,11 +2773,11 @@ scratch/carol> add
     a : ##Nat
     b : ##Nat
 
-scratch/bob> merge /alice
+scratch/bob> merge "/alice"
 
   I merged scratch/alice into scratch/bob.
 
-scratch/carol> merge /bob
+scratch/carol> merge "/bob"
 
   I merged scratch/bob into scratch/carol.
 
@@ -2919,7 +2919,7 @@ scratch/alice> update
 ```
 
 ``` ucm
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 
   I merged scratch/bob into scratch/alice.
 ```
@@ -2987,7 +2987,7 @@ scratch/bob> move.term Foo.Lca Foo.Bob
 ```
 
 ``` ucm :error
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 
   I couldn't automatically merge scratch/bob into scratch/alice.
   However, I've added the definitions that need attention to the
@@ -3024,6 +3024,7 @@ type Bar
 ```
 
 ``` ucm
+scratch/merge-bob-into-alice> 
 ```
 
 ``` unison
@@ -3176,7 +3177,7 @@ scratch/bob> update
 Note Bob's `hello` references `foo` (Alice's name), not `bar` (Bob's name).
 
 ``` ucm :error
-scratch/alice> merge /bob
+scratch/alice> merge "/bob"
 
   I couldn't automatically merge scratch/bob into scratch/alice.
   However, I've added the definitions that need attention to the


### PR DESCRIPTION
## Overview

This changes the UCM command parser quite a bit.

### The args now have to match the parameter definitions

First, this renames some things to make the distinction between parameters and arguments provided to those parameters clearer. This is most apparent in the `InputPattern.args` to `InputPattern.params` change.

Previously, there were a lot of commands which omitted or had incorrect parameter definitions. This prevented completion from working for those, and just allowed things to get a bit out of sync. This is no longer possible. They now have to match.

But an `InputPattern`’s `Parameters` are now used to determine whether an argument is “structured” or not. Structured args have numbered arg substitution applied, while unstructured args do not. So the arguments to `run` are unstructured, meaning numbers can be passed as arguments now.

Also, the arguments are lexed with Unison’s lexer, which (among other things) handles quoted strings consistently. This now allows for file paths containing spaces, and arguments to other functions (`run`, `create.author`, etc. now consistently allow quoted strings)

Fixes #2805 and #5193.

## Implementation notes

It creates a more rigid `Parameters` structure is then folded alongside a list of arguments. As each argument is processed, it is optionally (based on the individual `Parameter`) passed through numeric expansion. That can cause an argument to be replaced with multiple arguments (because of ranges), which then cascade to the later parameters.

The result of the fold is a pair of remaining parameters and the expanded arguments that have been processed. If there are unsatisfied required parameters, then it its handed off to fuzzy completion.

## Interesting/controversial decisions

This uses the existing Unison lexer. It seems like a better approach might be to use some of the lexing functions in a new (simpler) lexer that also supports lexemes for projects, branches, etc.

## Test coverage

The transcripts check a lot of this.

## Loose ends

This is still a WIP. It mostly works, but there are a couple remaining rough edges, and the code needs to be cleaned up.

Right now, I think it requires quoting strings a bit more often than would be ideal (basically, anything that doesn’t form a valid Unison lexeme, so `"@project/branch"`, versions like `"1.2.3"`, and a couple other cases). The error reporting needs to be improved as well.

I mentioned having a more specific lexer for this as one bit of further work (which would eliminate the extra quoting). Alternatively, we could lex incrementally – with each `ParameterType` specifying whether the next argument should be lexed or just taken to the next space.

Another good change would be to move the argument handling functions from the individual command parsers to the `ParameterType` structure.