### PR TITLE
`run` should use the `TypeLookup` from the file too

### DIFF
--- a/parser-typechecker/src/Unison/UnisonFile.hs
+++ b/parser-typechecker/src/Unison/UnisonFile.hs
@@ -33,6 +33,7 @@ module Unison.UnisonFile
     nonEmpty,
     termSignatureExternalLabeledDependencies,
     topLevelComponents,
+    typecheckedToTypeLookup,
     typecheckedUnisonFile,
     Unison.UnisonFile.rewrite,
     prepareRewrite,
@@ -365,6 +366,15 @@ declsToTypeLookup uf =
     mempty
     (wrangle (dataDeclarations uf))
     (wrangle (effectDeclarations uf))
+  where
+    wrangle = Map.fromList . Map.elems
+
+typecheckedToTypeLookup :: TypecheckedUnisonFile v a -> TL.TypeLookup v a
+typecheckedToTypeLookup tuf =
+  TL.TypeLookup
+    mempty
+    (wrangle (dataDeclarations' tuf))
+    (wrangle (effectDeclarations' tuf))
   where
     wrangle = Map.fromList . Map.elems
 

--- a/unison-src/transcripts/idempotent/fix5448.md
+++ b/unison-src/transcripts/idempotent/fix5448.md
@@ -1,0 +1,12 @@
+``` unison :hide
+type NewType = NewType
+main = do NewType
+```
+
+You shouldn't have to `add` a type before using it with `run`.
+
+``` ucm
+scratch/main> run main
+
+  NewType
+```


### PR DESCRIPTION
`run` checks the type of the argument to make sure that it's runnable; but in type checking, it doesn't know about types from the scratch file, which sometimes led to an ugly crash.

fixes #5448
