### PR TITLE
Simplify Stack usage in Nix

### DIFF
--- a/.github/workflows/bundle-ucm.yaml
+++ b/.github/workflows/bundle-ucm.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: install stack
         uses: unisonweb/actions/stack/install@main
         with:
-          stack-version: 2.15.5
+          stack-version: 2.15.7
 
       - name: build
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,7 +110,7 @@ jobs:
         if: steps.cache-ucm-binaries.outputs.cache-hit != 'true'
         uses: unisonweb/actions/stack/install@main
         with:
-          stack-version: 2.15.5
+          stack-version: 2.15.7
 
       # Build deps, then build local code. Splitting it into two steps just allows us to see how much time each step
       # takes.

--- a/.github/workflows/haddocks.yaml
+++ b/.github/workflows/haddocks.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: install stack
         uses: unisonweb/actions/stack/install@main
         with:
-          stack-version: 2.15.5
+          stack-version: 2.15.7
 
       - name: build with haddocks
         working-directory: unison

--- a/.github/workflows/update-transcripts.yaml
+++ b/.github/workflows/update-transcripts.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: install stack
         uses: unisonweb/actions/stack/install@main
         with:
-          stack-version: 2.15.5
+          stack-version: 2.15.7
 
       # One of the transcripts fails if the user's git name hasn't been set.
       - name: set git user info

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "haskell.toolchain": {
     "cabal": "3.10.3.0",
-    "hls": "2.8.0.0",
+    "hls": "2.9.0.0",
     "stack": "2.15.7"
   }
 }

--- a/flake.lock
+++ b/flake.lock
@@ -667,6 +667,10 @@
         "nixpkgs": [
           "haskellNix",
           "nixpkgs-2405"
+        ],
+        "systems": [
+          "flake-utils",
+          "systems"
         ]
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -105,11 +105,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -138,11 +138,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1719535035,
-        "narHash": "sha256-kCCfZytGgkRYlsiNe/dwLAnpNOvfywpjVl61hO/8l2M=",
+        "lastModified": 1733445020,
+        "narHash": "sha256-KnEbmqy2yX0316kZkgG63unxtpxpXre9z581DRQg9TM=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "66f23365685f71610460f3c2c0dfa91f96c532ac",
+        "rev": "3e12b545e3f597e48989811cc9d4f4f4a353921d",
         "type": "github"
       },
       "original": {
@@ -170,6 +170,7 @@
         "hls-2.6": "hls-2.6",
         "hls-2.7": "hls-2.7",
         "hls-2.8": "hls-2.8",
+        "hls-2.9": "hls-2.9",
         "hpc-coveralls": "hpc-coveralls",
         "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",
@@ -184,16 +185,17 @@
         "nixpkgs-2211": "nixpkgs-2211",
         "nixpkgs-2305": "nixpkgs-2305",
         "nixpkgs-2311": "nixpkgs-2311",
+        "nixpkgs-2405": "nixpkgs-2405",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1719535822,
-        "narHash": "sha256-IteIKK4+GEZI2nHqCz0zRVgQ3aqs/WXKTOt2sbHJmGk=",
+        "lastModified": 1733464032,
+        "narHash": "sha256-92Cc7s1DDX9jPpm8TvXBHUCegOUNfiit+ezOqk0kCEc=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "72bc84d0a4e8d0536505628040d96fd0a9e16c70",
+        "rev": "47ee8a2c90975aef07ca3188dc4918de417e1bc7",
         "type": "github"
       },
       "original": {
@@ -351,6 +353,23 @@
       "original": {
         "owner": "haskell",
         "ref": "2.8.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.9": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1720003792,
+        "narHash": "sha256-qnDx8Pk0UxtoPr7BimEsAZh9g2WuTuMB/kGqnmdryKs=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "0c1817cb2babef0765e4e72dd297c013e8e3d12b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.9.0.1",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -546,11 +565,11 @@
     },
     "nixpkgs-2305": {
       "locked": {
-        "lastModified": 1701362232,
-        "narHash": "sha256-GVdzxL0lhEadqs3hfRLuj+L1OJFGiL/L7gCcelgBlsw=",
+        "lastModified": 1705033721,
+        "narHash": "sha256-K5eJHmL1/kev6WuqyqqbS1cdNnSidIZ3jeqJ7GbrYnQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d2332963662edffacfddfad59ff4f709dde80ffe",
+        "rev": "a1982c92d8980a0114372973cbdfe0a307f1bdea",
         "type": "github"
       },
       "original": {
@@ -562,16 +581,32 @@
     },
     "nixpkgs-2311": {
       "locked": {
-        "lastModified": 1701386440,
-        "narHash": "sha256-xI0uQ9E7JbmEy/v8kR9ZQan6389rHug+zOtZeZFiDJk=",
+        "lastModified": 1719957072,
+        "narHash": "sha256-gvFhEf5nszouwLAkT9nWsDzocUTqLWHuL++dvNjMp9I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "293822e55ec1872f715a66d0eda9e592dc14419f",
+        "rev": "7144d6241f02d171d25fba3edeaf15e0f2592105",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-23.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2405": {
+      "locked": {
+        "lastModified": 1729242558,
+        "narHash": "sha256-VgcLDu4igNT0eYua6OAl9pWCI0cYXhDbR+pWP44tte0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4a3f2d3195b60d07530574988df92e049372c10e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -592,35 +627,19 @@
         "type": "github"
       }
     },
-    "nixpkgs-release": {
-      "locked": {
-        "lastModified": 1719520878,
-        "narHash": "sha256-5BXzNOl2RVHcfS/oxaZDKOi7gVuTyWPibQG0DHd5sSc=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "a44bedbb48c367f0476e6a3a27bf28f6330faf23",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "release-24.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1694822471,
-        "narHash": "sha256-6fSDCj++lZVMZlyqOe9SIOL8tYSBz1bI8acwovRwoX8=",
+        "lastModified": 1729980323,
+        "narHash": "sha256-eWPRZAlhf446bKSmzw6x7RWEE4IuZgAp8NW3eXZwRAY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
+        "rev": "86e78d3d2084ff87688da662cf78c2af085d8e73",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
-        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
         "type": "github"
       }
     },
@@ -645,21 +664,20 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "haskellNix": "haskellNix",
-        "nixpkgs-haskellNix": [
+        "nixpkgs": [
           "haskellNix",
-          "nixpkgs-unstable"
-        ],
-        "nixpkgs-release": "nixpkgs-release"
+          "nixpkgs-2405"
+        ]
       }
     },
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1719102283,
-        "narHash": "sha256-pon+cXgMWPlCiBx9GlRcjsjTHbCc8fDVgOGb3Z7qhRM=",
+        "lastModified": 1733443946,
+        "narHash": "sha256-xz8bzbXm5vE3TWdvU+/7CdRSm43D9P8XftYUSVp58Ck=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "7df45e0bd9852810d8070f9c5257f8e7a4677b91",
+        "rev": "2e2aba31ade325ca2c6ab0f4564f568cac2110bd",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -7,22 +7,20 @@
   };
 
   inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
     haskellNix.url = "github:input-output-hk/haskell.nix";
     nixpkgs.follows = "haskellNix/nixpkgs-2405";
-    flake-utils.url = "github:numtide/flake-utils";
+    systems.follows = "flake-utils/systems";
   };
 
   outputs = {
-    self,
+    flake-utils,
     haskellNix,
     nixpkgs,
-    flake-utils,
+    self,
+    systems,
   }:
-    flake-utils.lib.eachSystem [
-      "x86_64-linux"
-      "x86_64-darwin"
-      "aarch64-darwin"
-    ]
+    flake-utils.lib.eachSystem (import systems)
     (system: let
       ## It’s much easier to read from a JSON file than to have JSON import from some other file, so we extract some
       ## configuration from the VS Code settings to avoid duplication.

--- a/nix/dependencies.nix
+++ b/nix/dependencies.nix
@@ -1,21 +1,13 @@
-{nixpkgs-release}: final: prev: let
-  pinned-pkgs = import nixpkgs-release {inherit (final) system;};
-in {
-  stack = pinned-pkgs.stack;
-
+final: prev: {
   ## See https://docs.haskellstack.org/en/stable/nix_integration/#supporting-both-nix-and-non-nix-developers for an
-  ## explanation of this package.
-  stack-wrapped = final.symlinkJoin {
-    name = "stack"; # will be available as the usual `stack` in terminal
-    paths = [final.stack];
+  ## explanation of this derivation.
+  stack = final.symlinkJoin {
+    inherit (prev.stack) version;
+    name = "stack";
+    paths = [prev.stack];
     buildInputs = [final.makeWrapper];
     postBuild = ''
-      wrapProgram $out/bin/stack \
-        --add-flags "\
-          --no-nix \
-          --system-ghc \
-          --no-install-ghc \
-        "
+      wrapProgram $out/bin/stack --add-flags "--no-nix --system-ghc --no-install-ghc"
     '';
   };
 }

--- a/nix/haskell-nix-flake.nix
+++ b/nix/haskell-nix-flake.nix
@@ -35,7 +35,7 @@
           pkgs.gettext # for envsubst, used by unison-src/builtin-tests/interpreter-tests.sh
           pkgs.hpack
           pkgs.pkg-config
-          pkgs.stack-wrapped
+          pkgs.stack
         ];
       # workaround for https://gitlab.haskell.org/ghc/ghc/-/issues/11042
       shellHook = ''
@@ -44,8 +44,7 @@
       tools =
         (args.tools or {})
         // {
-          cabal = {version = versions.cabal;};
-          ormolu = {version = versions.ormolu;};
+          cabal.version = versions.cabal;
           haskell-language-server = {
             version = versions.hls;
             modules = [
@@ -64,6 +63,7 @@
               constraints: ormolu == ${versions.ormolu}
             '';
           };
+          ormolu.version = versions.ormolu;
         };
     };
 

--- a/nix/haskell-nix-flake.nix
+++ b/nix/haskell-nix-flake.nix
@@ -91,18 +91,8 @@ in
     defaultPackage = haskell-nix-flake.packages."unison-cli-main:exe:unison";
 
     devShells = let
-      mkDevShell = pkg:
-        shellFor {
-          packages = _hpkgs: [pkg];
-          ## Enabling Hoogle causes us to rebuild GHC.
-          withHoogle = false;
-        };
+      mkDevShell = pkg: shellFor {packages = _hpkgs: [pkg];};
     in
-      {
-        local = shellFor {
-          packages = _hpkgs: builtins.attrValues localPackages;
-          withHoogle = false;
-        };
-      }
+      {local = shellFor {packages = _hpkgs: builtins.attrValues localPackages;};}
       // pkgs.lib.mapAttrs (_name: mkDevShell) localPackages;
   }

--- a/nix/haskell-nix-flake.nix
+++ b/nix/haskell-nix-flake.nix
@@ -37,10 +37,6 @@
           pkgs.pkg-config
           pkgs.stack
         ];
-      # workaround for https://gitlab.haskell.org/ghc/ghc/-/issues/11042
-      shellHook = ''
-        export LD_LIBRARY_PATH=${pkgs.zlib}/lib:$LD_LIBRARY_PATH
-      '';
       tools =
         (args.tools or {})
         // {

--- a/nix/haskell-nix-flake.nix
+++ b/nix/haskell-nix-flake.nix
@@ -34,6 +34,7 @@
           pkgs.cachix
           pkgs.gettext # for envsubst, used by unison-src/builtin-tests/interpreter-tests.sh
           pkgs.hpack
+          pkgs.jq
           pkgs.pkg-config
           pkgs.stack
         ];

--- a/stack.yaml
+++ b/stack.yaml
@@ -50,7 +50,7 @@ packages:
   - unison-syntax
   - yaks/easytest
 
-resolver: lts-22.26
+resolver: lts-22.43
 
 extra-deps:
   # This custom Haskeline alters ANSI rendering on Windows.

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -59,7 +59,7 @@ packages:
     hackage: network-udp-0.0.0@sha256:408d2d4fa1a25e49e95752ee124cca641993404bb133ae10fb81daef22d876ae,1075
 snapshots:
 - completed:
-    sha256: 8e7996960d864443a66eb4105338bbdd6830377b9f6f99cd5527ef73c10c01e7
-    size: 719128
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/26.yaml
-  original: lts-22.26
+    sha256: 08bd13ce621b41a8f5e51456b38d5b46d7783ce114a50ab604d6bbab0d002146
+    size: 720271
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/43.yaml
+  original: lts-22.43


### PR DESCRIPTION
The particular Stack build was the only reason we had two Nixpkgs dependencies. This removes the custom stack dependency, and instead sets the versions for the haskell.nix `tools`.

It also bumps hpack to 0.36.0, because it turns out that’s the minimum required by our pinned version of Stack anyway.