### PR TITLE
cleanup: generate unique type guids only when necessary

### DIFF
--- a/unison-src/transcripts-manual/rewrites.output.md
+++ b/unison-src/transcripts-manual/rewrites.output.md
@@ -81,7 +81,7 @@ rule1 f x =
     term x + 1 ==> Nat.increment x
     term a -> f a ==> f
 
-type Optional2 a = Some2 a | None2
+type Optional2 a = None2 | Some2 a
 
 rule2 x = @rewrite signature Optional ==> Optional2
 ```
@@ -111,7 +111,7 @@ rule1 f x =
     term x + 1 ==> Nat.increment x
     term a -> f a ==> f
 
-type Optional2 a = Some2 a | None2
+type Optional2 a = None2 | Some2 a
 
 rule2 x = @rewrite signature Optional ==> Optional2
 ```

--- a/unison-src/transcripts/idempotent/ability-order-doesnt-affect-hash.md
+++ b/unison-src/transcripts/idempotent/ability-order-doesnt-affect-hash.md
@@ -27,6 +27,6 @@ scratch/main> add
 scratch/main> names term1
 
   Term
-  Hash:   #8hum58rlih
+  Hash:   #42m1ui9g56
   Names:  term1 term2
 ```

--- a/unison-src/transcripts/idempotent/find-by-type.md
+++ b/unison-src/transcripts/idempotent/find-by-type.md
@@ -48,7 +48,7 @@ scratch/main> find : Text
   I couldn't find exact type matches, resorting to fuzzy
   matching...
 
-  1. bar : Text -> A
-  2. baz : A -> Text
+  1. baz : A -> Text
+  2. bar : Text -> A
   3. A.A : Text -> A
 ```

--- a/unison-src/transcripts/idempotent/fix2254.md
+++ b/unison-src/transcripts/idempotent/fix2254.md
@@ -84,15 +84,15 @@ scratch/a2> update
 scratch/a2> view A NeedsA f f2 f3 g
 
   type A a b c d
-    = A a
-    | D d
-    | E a d
+    = E a d
     | B b
+    | A a
+    | D d
     | C c
 
   structural type NeedsA a b
-    = NeedsA (A a b Nat Nat)
-    | Zoink Text
+    = Zoink Text
+    | NeedsA (A a b Nat Nat)
 
   f : A Nat Nat Nat Nat -> Nat
   f = cases

--- a/unison-src/transcripts/idempotent/kind-inference.md
+++ b/unison-src/transcripts/idempotent/kind-inference.md
@@ -31,9 +31,10 @@ unique type T a
   Loading changes detected in scratch.u.
 
   Kind mismatch arising from
-        3 |   | StarStar (a Nat)
+        2 |   = Star a
     
-    a doesn't expect an argument; however, it is applied to Nat.
+    The arrow type (->) expects arguments of kind Type; however,
+    it is applied to a which has kind: Type -> Type.
 ```
 
 ## Kinds are inferred by decl component

--- a/unison-src/transcripts/idempotent/move-all.md
+++ b/unison-src/transcripts/idempotent/move-all.md
@@ -96,7 +96,7 @@ scratch/main> history Bar
   Note: The most recent namespace hash is immediately below this
         message.
 
-  ⊙ 1. #o7vuviel4c
+  ⊙ 1. #hk3a3lsc2e
 
     + Adds / updates:
     
@@ -106,7 +106,7 @@ scratch/main> history Bar
     
       T.T
 
-  □ 2. #c5cggiaumo (start of history)
+  □ 2. #vqc50q3b3v (start of history)
 ```
 
 ## Happy Path - Just term

--- a/unison-src/transcripts/idempotent/move-namespace.md
+++ b/unison-src/transcripts/idempotent/move-namespace.md
@@ -185,7 +185,7 @@ scratch/happy> history b
   Note: The most recent namespace hash is immediately below this
         message.
 
-  ⊙ 1. #rkvfe5p8fu
+  ⊙ 1. #ugqniosnp0
 
     + Adds / updates:
     
@@ -195,7 +195,7 @@ scratch/happy> history b
     
       T.T
 
-  □ 2. #avlnmh0erc (start of history)
+  □ 2. #a7r726o5ut (start of history)
 ```
 
 ## Namespace history

--- a/unison-src/transcripts/idempotent/pattern-match-coverage.md
+++ b/unison-src/transcripts/idempotent/pattern-match-coverage.md
@@ -1286,5 +1286,5 @@ result f =
     
       ability GiveA a
       ability GiveB a
-      result : '{e, GiveA V, GiveB V} r ->{e} r
+      result : '{e, GiveB V, GiveA V} r ->{e} r
 ```

--- a/unison-src/transcripts/idempotent/propagate.md
+++ b/unison-src/transcripts/idempotent/propagate.md
@@ -38,13 +38,13 @@ scratch/main> add
 
 scratch/main> find.verbose
 
-  1. -- #uj8oalgadr2f52qloufah6t8vsvbc76oqijkotek87vooih7aqu44k20hrs34kartusapghp4jmfv6g1409peklv3r6a527qpk52soo
+  1. -- #j743idicb1sf7udts85812agaml4rkfi3iss6lstvmvgufibd40blq5qtmoh9ndrtkvkaqkurn7npgc61ob8j2louj04j8slkppsl90
      type Foo
      
-  2. -- #uj8oalgadr2f52qloufah6t8vsvbc76oqijkotek87vooih7aqu44k20hrs34kartusapghp4jmfv6g1409peklv3r6a527qpk52soo#0
+  2. -- #j743idicb1sf7udts85812agaml4rkfi3iss6lstvmvgufibd40blq5qtmoh9ndrtkvkaqkurn7npgc61ob8j2louj04j8slkppsl90#0
      Foo.Foo : Foo
      
-  3. -- #j6hbm1gc2ak4f46b6705q90ld4bmhoi8etq2q45j081i9jgn95fvk3p6tjg67e7sm0021035i8qikmk4p6k845l5d00u26cos5731to
+  3. -- #sd7apvqbpk3vl2aassq4gcckovohqrs05ne1g9ol0fb6gd227bp388osj7bg40kttt2o9f1kit9avlb94ep8q1ho3g284ursrplb4l0
      fooToInt : Foo -> Int
      
 

--- a/unison-src/transcripts/idempotent/unique-type-churn.md
+++ b/unison-src/transcripts/idempotent/unique-type-churn.md
@@ -52,11 +52,11 @@ If the name stays the same, the churn is even prevented if the type is updated a
 scratch/main> names A
 
   Type
-  Hash:  #uj8oalgadr
+  Hash:  #j743idicb1
   Names: A
 
   Term
-  Hash:   #uj8oalgadr#0
+  Hash:   #j743idicb1#0
   Names:  A.A
 ```
 
@@ -88,11 +88,11 @@ scratch/main> update
 scratch/main> names A
 
   Type
-  Hash:  #ufo5tuc7ho
+  Hash:  #186m0i6upt
   Names: A
 
   Term
-  Hash:   #ufo5tuc7ho#0
+  Hash:   #186m0i6upt#0
   Names:  A.A
 ```
 
@@ -126,10 +126,10 @@ scratch/main> update
 scratch/main> names A
 
   Type
-  Hash:  #uj8oalgadr
+  Hash:  #j743idicb1
   Names: A
 
   Term
-  Hash:   #uj8oalgadr#0
+  Hash:   #j743idicb1#0
   Names:  A.A
 ```

--- a/unison-src/transcripts/idempotent/update-type-add-constructor.md
+++ b/unison-src/transcripts/idempotent/update-type-add-constructor.md
@@ -56,17 +56,17 @@ scratch/main> update
 
 scratch/main> view Foo
 
-  type Foo = Bar Nat | Baz Nat Nat
+  type Foo = Baz Nat Nat | Bar Nat
 
 scratch/main> find.verbose
 
-  1. -- #2sffq4apsq1cts53njcunj63fa8ohov4eqn77q14s77ajicajh4g28sq5s5ai33f2k6oh6o67aarnlpu7u7s4la07ag2er33epalsog
+  1. -- #id3p6do8f7ssln9npa3gs3c2i8uors25ffts92pr4nsh9k9bn3no50e4d1b053c2d0vei64pbtcpdld9gk6drsvptnpfqr6tp8v4qh0
      type Foo
      
-  2. -- #2sffq4apsq1cts53njcunj63fa8ohov4eqn77q14s77ajicajh4g28sq5s5ai33f2k6oh6o67aarnlpu7u7s4la07ag2er33epalsog#0
+  2. -- #id3p6do8f7ssln9npa3gs3c2i8uors25ffts92pr4nsh9k9bn3no50e4d1b053c2d0vei64pbtcpdld9gk6drsvptnpfqr6tp8v4qh0#1
      Foo.Bar : Nat -> Foo
      
-  3. -- #2sffq4apsq1cts53njcunj63fa8ohov4eqn77q14s77ajicajh4g28sq5s5ai33f2k6oh6o67aarnlpu7u7s4la07ag2er33epalsog#1
+  3. -- #id3p6do8f7ssln9npa3gs3c2i8uors25ffts92pr4nsh9k9bn3no50e4d1b053c2d0vei64pbtcpdld9gk6drsvptnpfqr6tp8v4qh0#0
      Foo.Baz : Nat -> Nat -> Foo
      
 ```

--- a/unison-src/transcripts/idempotent/update-type-add-field.md
+++ b/unison-src/transcripts/idempotent/update-type-add-field.md
@@ -57,10 +57,10 @@ scratch/main> view Foo
 
 scratch/main> find.verbose
 
-  1. -- #8fk6k0j208th1ia4vnjtoc5fomd6le540prec255svg71bcfga9dofrvoq1d7v6010d6b6em4q51p8st5c5juhrev72cnnel8ko3o1g
+  1. -- #hlhjq1lf1cvfevkvb9d441kkubn0f6s43gvrd4gcff0r739vomehjnov4b3qe8506fb5bm8m5ba0sol9mbljgkk3gb2qt2u02v6i2vo
      type Foo
      
-  2. -- #8fk6k0j208th1ia4vnjtoc5fomd6le540prec255svg71bcfga9dofrvoq1d7v6010d6b6em4q51p8st5c5juhrev72cnnel8ko3o1g#0
+  2. -- #hlhjq1lf1cvfevkvb9d441kkubn0f6s43gvrd4gcff0r739vomehjnov4b3qe8506fb5bm8m5ba0sol9mbljgkk3gb2qt2u02v6i2vo#0
      Foo.Bar : Nat -> Nat -> Foo
      
 ```

--- a/unison-src/transcripts/idempotent/update-type-add-record-field.md
+++ b/unison-src/transcripts/idempotent/update-type-add-record-field.md
@@ -72,28 +72,28 @@ scratch/main> view Foo
 
 scratch/main> find.verbose
 
-  1. -- #05gh1dur4778dauh9slaofprc5356n47qpove0c1jl0birt2fcu301js8auu5vfr5bjfga9j8ikuk07ll9fu1gj3ehrp3basguhsd58
+  1. -- #m0tpa159pbsdld5ea0marnq9614dnmjjc72n1evi4bsk45a1hl84qprt6vdvejuuiuc3f5o23olc1t19tk1dt8mjobmr0chqc3svij8
      type Foo
      
-  2. -- #77mi33dv8ac2s90852khi35km5gsamhnpada8mai0k36obbttgg17qld719ospcs1ht9ctolg3pjsqs6qjnl3hfmu493rgsher73sc0
+  2. -- #16o21u2lli7rd8f3h4epnblpfk3h68gag99d5gicihcpk15dkv4m9601picg37ncsbg2e8j63tu7ebs40jrcoifs7f6nqrus3qnfgv0
      Foo.bar : Foo -> Nat
      
-  3. -- #7m1n2178r5u12jdnb6crcmanu2gm961kdvbjul5m6hta1s57avibsvk6p5g9efut8sennpgstbb8kf97eujbbuiplsoloa4cael7t90
+  3. -- #64v4pv4rvmnts82gbsb1u2dvgdu4eqq8leq37anqjrkq8s9c7ogrjahdotc36nrodva6ok1rs4ah5k09i7sb0clvcap2773k1t7thb8
      Foo.bar.modify : (Nat ->{g} Nat) -> Foo ->{g} Foo
      
-  4. -- #ghuqoel4pao6v8e7un238i3e86vv7a7pnvgaq8m9s32edm1upgv35gri2iu32ipn9r4poli56r5kr3vtjfrltem696grfl75al4jkgg
+  4. -- #bkfjhnu5jqv2m49hosd8g6m4e5u9ju4b1du90cji8s8hnaendvnep2a5cd085ejtu27c4lm3u7slamk52p86rubp211jc5c0qcut2l0
      Foo.bar.set : Nat -> Foo -> Foo
      
-  5. -- #p8emkm2s09n3nsd8ne5f6fro0vsldk8pn7n6rcf417anuvvun43qrk1ioofs6pdq4537eosao17c7ibvktktr3lfqglmj26gmbulmj0
+  5. -- #u394ule3vr1ab8q5nit6miktgpki9gj4nft5jfjsho6cflg94kf953mdhjj8s18e9j1525iv8l5ebjhebnuc01q51fl8ni5n9j0gs28
      Foo.baz : Foo -> Int
      
-  6. -- #0il9pl29jpe3fh6vp3qeqai73915k3qffhf4bgttrgsj000b9fgs3bqoj8ugjop6kdr04acc34m1bj7lf417tslfeva7dmmoqdu5hug
+  6. -- #cbbi7mqcaqdlcl41uajb608b8fi5dfvc654rmd47mk9okpn1t3jltrf8psnn3g2tnr1ftctj753fjhco3ku1oapc664upo1h6eodfrg
      Foo.baz.modify : (Int ->{g} Int) -> Foo ->{g} Foo
      
-  7. -- #87rjeqltvvd4adffsheqae62eefoge8p78pvnjdkc9q1stq20lhubvtpos0io4v3vhnol8nn2uollup97l4orq1fh2h12b0imeuuc58
+  7. -- #hhi45ik1245qq3g93586f998di8j5afvjamqr2m08auqq8ogqt4d01rejrse4qsl27381vnqnt8uffhgvnc0nk22o5uabimjhji4868
      Foo.baz.set : Int -> Foo -> Foo
      
-  8. -- #05gh1dur4778dauh9slaofprc5356n47qpove0c1jl0birt2fcu301js8auu5vfr5bjfga9j8ikuk07ll9fu1gj3ehrp3basguhsd58#0
+  8. -- #m0tpa159pbsdld5ea0marnq9614dnmjjc72n1evi4bsk45a1hl84qprt6vdvejuuiuc3f5o23olc1t19tk1dt8mjobmr0chqc3svij8#0
      Foo.Foo : Nat -> Int -> Foo
      
 ```

--- a/unison-src/transcripts/idempotent/update-type-delete-constructor.md
+++ b/unison-src/transcripts/idempotent/update-type-delete-constructor.md
@@ -60,10 +60,10 @@ scratch/main> view Foo
 
 scratch/main> find.verbose
 
-  1. -- #b509v3eg4kehsg29g6pvrogeb71ue32nm2fj9284n4i7lprsr7u9a7g6s695d09du0fsfti6rrsk1s62q5thpr1jjkqb3us3s0lrd60
+  1. -- #h88o5sirfn0a8f4o81sb012p2rha5h8r73n8bloc8qq94kqmltjq94iiep2e6dj7ppuulc8jce2f0vmddqp76nm0hqs9jh53s502v4g
      type Foo
      
-  2. -- #b509v3eg4kehsg29g6pvrogeb71ue32nm2fj9284n4i7lprsr7u9a7g6s695d09du0fsfti6rrsk1s62q5thpr1jjkqb3us3s0lrd60#0
+  2. -- #h88o5sirfn0a8f4o81sb012p2rha5h8r73n8bloc8qq94kqmltjq94iiep2e6dj7ppuulc8jce2f0vmddqp76nm0hqs9jh53s502v4g#0
      Foo.Bar : Nat -> Foo
      
 ```

--- a/unison-src/transcripts/idempotent/update-type-delete-record-field.md
+++ b/unison-src/transcripts/idempotent/update-type-delete-record-field.md
@@ -78,28 +78,28 @@ scratch/main> view Foo
 
 scratch/main> find.verbose
 
-  1. -- #05gh1dur4778dauh9slaofprc5356n47qpove0c1jl0birt2fcu301js8auu5vfr5bjfga9j8ikuk07ll9fu1gj3ehrp3basguhsd58
+  1. -- #m0tpa159pbsdld5ea0marnq9614dnmjjc72n1evi4bsk45a1hl84qprt6vdvejuuiuc3f5o23olc1t19tk1dt8mjobmr0chqc3svij8
      type Foo
      
-  2. -- #77mi33dv8ac2s90852khi35km5gsamhnpada8mai0k36obbttgg17qld719ospcs1ht9ctolg3pjsqs6qjnl3hfmu493rgsher73sc0
+  2. -- #16o21u2lli7rd8f3h4epnblpfk3h68gag99d5gicihcpk15dkv4m9601picg37ncsbg2e8j63tu7ebs40jrcoifs7f6nqrus3qnfgv0
      Foo.bar : Foo -> Nat
      
-  3. -- #7m1n2178r5u12jdnb6crcmanu2gm961kdvbjul5m6hta1s57avibsvk6p5g9efut8sennpgstbb8kf97eujbbuiplsoloa4cael7t90
+  3. -- #64v4pv4rvmnts82gbsb1u2dvgdu4eqq8leq37anqjrkq8s9c7ogrjahdotc36nrodva6ok1rs4ah5k09i7sb0clvcap2773k1t7thb8
      Foo.bar.modify : (Nat ->{g} Nat) -> Foo ->{g} Foo
      
-  4. -- #ghuqoel4pao6v8e7un238i3e86vv7a7pnvgaq8m9s32edm1upgv35gri2iu32ipn9r4poli56r5kr3vtjfrltem696grfl75al4jkgg
+  4. -- #bkfjhnu5jqv2m49hosd8g6m4e5u9ju4b1du90cji8s8hnaendvnep2a5cd085ejtu27c4lm3u7slamk52p86rubp211jc5c0qcut2l0
      Foo.bar.set : Nat -> Foo -> Foo
      
-  5. -- #p8emkm2s09n3nsd8ne5f6fro0vsldk8pn7n6rcf417anuvvun43qrk1ioofs6pdq4537eosao17c7ibvktktr3lfqglmj26gmbulmj0
+  5. -- #u394ule3vr1ab8q5nit6miktgpki9gj4nft5jfjsho6cflg94kf953mdhjj8s18e9j1525iv8l5ebjhebnuc01q51fl8ni5n9j0gs28
      Foo.baz : Foo -> Int
      
-  6. -- #0il9pl29jpe3fh6vp3qeqai73915k3qffhf4bgttrgsj000b9fgs3bqoj8ugjop6kdr04acc34m1bj7lf417tslfeva7dmmoqdu5hug
+  6. -- #cbbi7mqcaqdlcl41uajb608b8fi5dfvc654rmd47mk9okpn1t3jltrf8psnn3g2tnr1ftctj753fjhco3ku1oapc664upo1h6eodfrg
      Foo.baz.modify : (Int ->{g} Int) -> Foo ->{g} Foo
      
-  7. -- #87rjeqltvvd4adffsheqae62eefoge8p78pvnjdkc9q1stq20lhubvtpos0io4v3vhnol8nn2uollup97l4orq1fh2h12b0imeuuc58
+  7. -- #hhi45ik1245qq3g93586f998di8j5afvjamqr2m08auqq8ogqt4d01rejrse4qsl27381vnqnt8uffhgvnc0nk22o5uabimjhji4868
      Foo.baz.set : Int -> Foo -> Foo
      
-  8. -- #05gh1dur4778dauh9slaofprc5356n47qpove0c1jl0birt2fcu301js8auu5vfr5bjfga9j8ikuk07ll9fu1gj3ehrp3basguhsd58#0
+  8. -- #m0tpa159pbsdld5ea0marnq9614dnmjjc72n1evi4bsk45a1hl84qprt6vdvejuuiuc3f5o23olc1t19tk1dt8mjobmr0chqc3svij8#0
      Foo.Foo : Nat -> Int -> Foo
      
 ```

--- a/unison-src/transcripts/idempotent/update-type-missing-constructor.md
+++ b/unison-src/transcripts/idempotent/update-type-missing-constructor.md
@@ -52,7 +52,7 @@ unique type Foo = Bar Nat Nat
 ``` ucm :error
 scratch/main> view Foo
 
-  type Foo = #b509v3eg4k#0 Nat
+  type Foo = #5mod0n8ps2#0 Nat
 
 scratch/main> update
 

--- a/unison-src/transcripts/idempotent/update-type-turn-constructor-into-smart-constructor.md
+++ b/unison-src/transcripts/idempotent/update-type-turn-constructor-into-smart-constructor.md
@@ -70,16 +70,16 @@ scratch/main> view Foo
 
 scratch/main> find.verbose
 
-  1. -- #b509v3eg4kehsg29g6pvrogeb71ue32nm2fj9284n4i7lprsr7u9a7g6s695d09du0fsfti6rrsk1s62q5thpr1jjkqb3us3s0lrd60
+  1. -- #oebc8v8v9lob5bnq7go1pjhfjbtnh8dmfhontua90t3mji0cl91t1dqaece9quofrk1vsbq6g0ukfigoi0vmvc01v8roceppejlgbs8
      type Foo
      
-  2. -- #36rn6jqt1k5jccb3c7vagp3jam74dngr92kgcntqhs6dbkua54verfert2i6hsku6uitt9s2jvt1msric0tgemal52d5apav6akn25o
+  2. -- #gl18p1lnbeari67ohdt9n46usnvsl59a6up1lhd9r808pqb7tt5edsf65o98bqcvb529mfm7q631ciuv2t5nqnde1i7b9t5mlu1drto
      Foo.Bar : Nat -> Foo
      
-  3. -- #b509v3eg4kehsg29g6pvrogeb71ue32nm2fj9284n4i7lprsr7u9a7g6s695d09du0fsfti6rrsk1s62q5thpr1jjkqb3us3s0lrd60#0
+  3. -- #oebc8v8v9lob5bnq7go1pjhfjbtnh8dmfhontua90t3mji0cl91t1dqaece9quofrk1vsbq6g0ukfigoi0vmvc01v8roceppejlgbs8#0
      Foo.internal.Bar : Nat -> Foo
      
-  4. -- #204frdcl0iid1ujkkfbkc6b3v7cgqp56h1q3duc46i5md6qb4m6am1fqbceb335u87l05gkdnaa7fjn4alj1diukgme63e41lh072l8
+  4. -- #td96hudai64mf0qgtusc70ehv98krs10jghdipjluc6cp4j8ac65msrt3tji18enpm2tm8d8h2qcf3parke19g7s17ipkd925m3061g
      makeFoo : Nat -> Foo
      
 ```

--- a/unison-src/transcripts/idempotent/update-type-turn-non-record-into-record.md
+++ b/unison-src/transcripts/idempotent/update-type-turn-non-record-into-record.md
@@ -63,19 +63,19 @@ scratch/main> view Foo
 
 scratch/main> find.verbose
 
-  1. -- #b509v3eg4kehsg29g6pvrogeb71ue32nm2fj9284n4i7lprsr7u9a7g6s695d09du0fsfti6rrsk1s62q5thpr1jjkqb3us3s0lrd60
+  1. -- #5mod0n8ps2emue478fdroo6adp4ovt41qogtmduta8vgv1v8mi8ep2ho0rc1mg699j1feojmv0oe9ndbul5t64menchhnklpgji45o0
      type Foo
      
-  2. -- #ovhevqfin94qhq5fu0mujfi20mbpvg5mh4vsfklrohp84cch4lhvrn5p29cnbsqfm92l7bt8c1vpjooh72a0psbddvvten4gq2sipag
+  2. -- #pshsb3s03nqe194ks3ap3kid0gpb13d68u83gss8vtmbfqma97f84b4vqf362r8gieulqnbfidvh9idkgp6k7mllmss92bh9ebqmolo
      Foo.bar : Foo -> Nat
      
-  3. -- #as72md2u70e0u9s2ig2ug7jvlbrk1mubo8qlfokpuvgusg35svh05r7nsj27sqo5edeghjnk8g8259fi4ismse736v4n5ojrb3o2le8
+  3. -- #184mc2vauvn8197ecedvus5ubj787dgav6cjkvqqnohej8f997ku7iicurnkvlcqtlv29mjad0mjr3td241q7b0b0kg0i9v4n3qq7vo
      Foo.bar.modify : (Nat ->{g} Nat) -> Foo ->{g} Foo
      
-  4. -- #5cbctoor75nbtn4ppp10qm1i25gqt2lgth3itqa0lloib32je4ijfj2n3qcdfhmdcnbgum2jg46opntlohv7ladun3dmefl1ucgobeg
+  4. -- #sc08708c9s5mhtg6r1obh2mckvjhc5pf2e83lafrkrjrpkikh9kn09vag7kbugcnit50ak8vgr1100am6iqo4ln75uq4dck9pasvnv8
      Foo.bar.set : Nat -> Foo -> Foo
      
-  5. -- #b509v3eg4kehsg29g6pvrogeb71ue32nm2fj9284n4i7lprsr7u9a7g6s695d09du0fsfti6rrsk1s62q5thpr1jjkqb3us3s0lrd60#0
+  5. -- #5mod0n8ps2emue478fdroo6adp4ovt41qogtmduta8vgv1v8mi8ep2ho0rc1mg699j1feojmv0oe9ndbul5t64menchhnklpgji45o0#0
      Foo.Foo : Nat -> Foo
      
 ```

--- a/unison-src/transcripts/idempotent/update-type-with-dependent-type.md
+++ b/unison-src/transcripts/idempotent/update-type-with-dependent-type.md
@@ -68,16 +68,16 @@ scratch/main> view Baz
 
 scratch/main> find.verbose
 
-  1. -- #34msh9satlfog576493eo9pkjn6aj7d8fj6jfheglvgr5s39iptb81649bpkad1lqraheqb8em9ms551k01oternhknc4m7jicgtk08
+  1. -- #1uosg6rv85ql7rbohtfvqqacgjl5pp2faj0t3k3dkrtn0t3jqdh2m2om8earv0jh8m8j86vv6bv1h17jl8a2lfa857pm6n27hnisi1g
      type Baz
      
-  2. -- #34msh9satlfog576493eo9pkjn6aj7d8fj6jfheglvgr5s39iptb81649bpkad1lqraheqb8em9ms551k01oternhknc4m7jicgtk08#0
+  2. -- #1uosg6rv85ql7rbohtfvqqacgjl5pp2faj0t3k3dkrtn0t3jqdh2m2om8earv0jh8m8j86vv6bv1h17jl8a2lfa857pm6n27hnisi1g#0
      Baz.Qux : Foo -> Baz
      
-  3. -- #8fk6k0j208th1ia4vnjtoc5fomd6le540prec255svg71bcfga9dofrvoq1d7v6010d6b6em4q51p8st5c5juhrev72cnnel8ko3o1g
+  3. -- #hlhjq1lf1cvfevkvb9d441kkubn0f6s43gvrd4gcff0r739vomehjnov4b3qe8506fb5bm8m5ba0sol9mbljgkk3gb2qt2u02v6i2vo
      type Foo
      
-  4. -- #8fk6k0j208th1ia4vnjtoc5fomd6le540prec255svg71bcfga9dofrvoq1d7v6010d6b6em4q51p8st5c5juhrev72cnnel8ko3o1g#0
+  4. -- #hlhjq1lf1cvfevkvb9d441kkubn0f6s43gvrd4gcff0r739vomehjnov4b3qe8506fb5bm8m5ba0sol9mbljgkk3gb2qt2u02v6i2vo#0
      Foo.Bar : Nat -> Nat -> Foo
      
 ```

--- a/unison-src/transcripts/merge.output.md
+++ b/unison-src/transcripts/merge.output.md
@@ -1588,7 +1588,7 @@ scratch/bob> move.term Foo.Bar.Qux Foo.Bar.Hello
 ``` ucm
 scratch/bob> view Foo.Bar
 
-  type Foo.Bar = Baz Nat | Hello Nat Nat
+  type Foo.Bar = Hello Nat Nat | Baz Nat
 ```
 
 At this point, Bob and alice have both updated the name `Foo.Bar.Hello` in different ways, so that's a conflict. Therefore, Bob's entire type (`Foo.Bar` with constructors `Foo.Bar.Baz` and `Foo.Bar.Hello`) gets rendered into the scratch file.
@@ -1635,7 +1635,7 @@ Foo.Bar.Hello : Nat
 Foo.Bar.Hello = 18
 
 -- scratch/bob
-type Foo.Bar = Baz Nat | Hello Nat Nat
+type Foo.Bar = Hello Nat Nat | Baz Nat
 
 ```
 


### PR DESCRIPTION
## Overview

While investigating #5489 I discovered some tech debt – we had been generating unique type guids that might not be needed, just to prevent transcript churn in the original PR. This PR follows up on that by deleting some logic and churning the transcripts' unique type guids.