### PR TITLE
Reduce allocations by optimizing branching and black holes

### DIFF
--- a/unison-runtime/src/Unison/Runtime/MCode.hs
+++ b/unison-runtime/src/Unison/Runtime/MCode.hs
@@ -730,9 +730,16 @@ data GBranch comb
       !(M.Map Text (GSection comb))
   deriving stock (Show, Eq, Ord, Functor, Foldable, Traversable)
 
+branchToEnumMap :: GBranch comb -> Maybe ((GSection comb), EnumMap Word64 (GSection comb))
+branchToEnumMap = \case
+  (Test1 k t d) -> Just (d, EC.mapSingleton k t)
+  (Test2 k1 s1 k2 s2 d) -> Just (d, EC.mapFromList [(k1, s1), (k2, s2)])
+  (TestW d m) -> Just (d, m)
+  _ -> Nothing
+
 -- Convenience patterns for matches used in the algorithms below.
 pattern MatchW :: Int -> (GSection comb) -> EnumMap Word64 (GSection comb) -> (GSection comb)
-pattern MatchW i d cs <- Match i (TestW d cs)
+pattern MatchW i d cs <- Match i (branchToEnumMap -> Just (d, cs))
   where
     MatchW i d cs = Match i (mkBranch d cs)
 
@@ -741,7 +748,7 @@ pattern MatchT i d cs = Match i (TestT d cs)
 
 pattern NMatchW ::
   Maybe Reference -> Int -> (GSection comb) -> EnumMap Word64 (GSection comb) -> (GSection comb)
-pattern NMatchW r i d cs <- NMatch r i (TestW d cs)
+pattern NMatchW r i d cs <- NMatch r i (branchToEnumMap -> Just (d, cs))
   where
     NMatchW r i d cs = NMatch r i $ mkBranch d cs
 

--- a/unison-runtime/src/Unison/Runtime/Machine.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine.hs
@@ -2125,8 +2125,10 @@ codeValidate tml cc = do
       ntys = M.fromList $ zip (S.toList ntys0) [fty ..]
       rty = ntys <> rty0
   ftm <- readTVarIO (freshTm cc)
-  rtm <- readTVarIO (refTm cc)
-  let rns = RN (refLookup "ty" rty) (refLookup "tm" rtm) (const Nothing)
+  rtm0 <- readTVarIO (refTm cc)
+  let rs = fst <$> tml
+      rtm = rtm0 `M.union` M.fromList (zip rs [ftm ..])
+      rns = RN (refLookup "ty" rty) (refLookup "tm" rtm) (const Nothing)
       combinate (n, (r, g)) = evaluate $ emitCombs rns r n g
   (Nothing <$ traverse_ combinate (zip [ftm ..] tml))
     `catch` \(CE cs perr) ->

--- a/unison-runtime/src/Unison/Runtime/Machine.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine.hs
@@ -2125,10 +2125,8 @@ codeValidate tml cc = do
       ntys = M.fromList $ zip (S.toList ntys0) [fty ..]
       rty = ntys <> rty0
   ftm <- readTVarIO (freshTm cc)
-  rtm0 <- readTVarIO (refTm cc)
-  let rs = fst <$> tml
-      rtm = rtm0 `M.withoutKeys` S.fromList rs
-      rns = RN (refLookup "ty" rty) (refLookup "tm" rtm) (const Nothing)
+  rtm <- readTVarIO (refTm cc)
+  let rns = RN (refLookup "ty" rty) (refLookup "tm" rtm) (const Nothing)
       combinate (n, (r, g)) = evaluate $ emitCombs rns r n g
   (Nothing <$ traverse_ combinate (zip [ftm ..] tml))
     `catch` \(CE cs perr) ->

--- a/unison-runtime/src/Unison/Runtime/Stack.hs
+++ b/unison-runtime/src/Unison/Runtime/Stack.hs
@@ -160,9 +160,6 @@ import Prelude hiding (words)
 
 {- ORMOLU_DISABLE -}
 #ifdef STACK_CHECK
-import Data.Text.IO (hPutStrLn)
-import UnliftIO (stderr, throwIO)
-import GHC.Stack (CallStack, callStack)
 
 type DebugCallStack = (HasCallStack :: Constraint)
 

--- a/unison-runtime/src/Unison/Runtime/Stack.hs
+++ b/unison-runtime/src/Unison/Runtime/Stack.hs
@@ -279,6 +279,11 @@ data GClosure comb
   deriving stock (Show, Functor, Foldable, Traversable)
 {- ORMOLU_ENABLE -}
 
+-- Singleton black hole value to avoid allocation.
+blackHole :: Closure
+blackHole = Closure GBlackHole
+{-# NOINLINE blackHole #-}
+
 pattern PAp :: CombIx -> GCombInfo (RComb Val) -> Seg -> Closure
 pattern PAp cix comb seg = Closure (GPAp cix comb seg)
 
@@ -295,7 +300,9 @@ pattern Captured k a seg = Closure (GCaptured k a seg)
 
 pattern Foreign x = Closure (GForeign x)
 
-pattern BlackHole = Closure GBlackHole
+pattern BlackHole <- Closure GBlackHole
+  where
+    BlackHole = blackHole
 
 pattern UnboxedTypeTag t <- Closure (GUnboxedTypeTag t)
   where


### PR DESCRIPTION
## Overview

We've long had optimized Branch enums for one-branch and two-branch cases, but just never emitted them in code-gen.

Cutting down on allocations helps performance a bit by avoiding GCs

## Implementation notes

This changes code-gen to use these optimized cases which skips an EnumMap lookup and more importantly, avoids superfluous allocations.

It also NOINLINE's a single black hole value so we're not dynamically allocating those.

Fixes an oversight in codeValidate which caused it to fail on recursive functions.
Dan and I think the failure was always there, but after this change things are stricter Test1 and Test2 are strict in their branches whereas TestW isn't.

## Test coverage

Benchmarks:

```
trunk -> better-branches

fib1
326.288µs -> 314.807µs

fib2
2.308349ms -> 2.259432ms

fib3
2.724128ms -> 2.646835ms

Decode Nat
349ns -> 337ns

Generate 100 random numbers
210.259µs -> 207.108µs

List.foldLeft
2.137183ms -> 2.025939ms

Count to 1 million
128.04945ms -> 124.7779ms

Json parsing (per document)
268.95µs -> 261.794µs

Count to N (per element)
192ns -> 188ns

Count to 1000
193.911µs -> 188.466µs

Mutate a Ref 1000 times
321.721µs -> 314.031µs

CAS an IO.ref 1000 times
430.627µs -> 425.158µs

List.range (per element)
338ns -> 325ns

List.range 0 1000
351.001µs -> 345.243µs

Set.fromList (range 0 1000)
1.679125ms -> 1.592714ms

Map.fromList (range 0 1000)
1.270356ms -> 1.173887ms

NatMap.fromList (range 0 1000)
5.025834ms -> 4.871296ms

Map.lookup (1k element map)
2.633µs -> 2.546µs

Map.insert (1k element map)
7.1µs -> 6.888µs

List.at (1k element list)
299ns -> 277ns

Text.split /
33.074µs -> 32.688µs
```
