### PR TITLE
bugfix: don't omit leading dot in certain term references

### DIFF
--- a/parser-typechecker/package.yaml
+++ b/parser-typechecker/package.yaml
@@ -103,6 +103,7 @@ default-extensions:
   - ApplicativeDo
   - BangPatterns
   - BlockArguments
+  - ConstraintKinds
   - DeriveAnyClass
   - DeriveFunctor
   - DeriveGeneric

--- a/parser-typechecker/src/Unison/PrettyPrintEnv/MonadPretty.hs
+++ b/parser-typechecker/src/Unison/PrettyPrintEnv/MonadPretty.hs
@@ -1,38 +1,31 @@
-{-# LANGUAGE ConstraintKinds #-}
+module Unison.PrettyPrintEnv.MonadPretty
+  ( MonadPretty,
+    Env (..),
+    runPretty,
+    addTypeVars,
+    willCaptureType,
+  )
+where
 
-module Unison.PrettyPrintEnv.MonadPretty where
-
-import Control.Lens (views, _1, _2)
+import Control.Lens (views)
 import Control.Monad.Reader (MonadReader, Reader, local, runReader)
 import Data.Set qualified as Set
 import Unison.Prelude
 import Unison.PrettyPrintEnv (PrettyPrintEnv)
+import Unison.Util.Set qualified as Set
 import Unison.Var (Var)
 
-type MonadPretty v m = (Var v, MonadReader (PrettyPrintEnv, Set v) m)
+type MonadPretty v m = (Var v, MonadReader (Env v) m)
 
-getPPE :: (MonadPretty v m) => m PrettyPrintEnv
-getPPE = view _1
-
--- | Run a computation with a modified PrettyPrintEnv, restoring the original
-withPPE :: (MonadPretty v m) => PrettyPrintEnv -> m a -> m a
-withPPE p = local (set _1 p)
-
-applyPPE :: (MonadPretty v m) => (PrettyPrintEnv -> a) -> m a
-applyPPE = views _1
-
-applyPPE2 :: (MonadPretty v m) => (PrettyPrintEnv -> a -> b) -> a -> m b
-applyPPE2 f a = views _1 (`f` a)
-
-applyPPE3 :: (MonadPretty v m) => (PrettyPrintEnv -> a -> b -> c) -> a -> b -> m c
-applyPPE3 f a b = views _1 (\ppe -> f ppe a b)
-
--- | Run a computation with a modified PrettyPrintEnv, restoring the original
-modifyPPE :: (MonadPretty v m) => (PrettyPrintEnv -> PrettyPrintEnv) -> m a -> m a
-modifyPPE = local . over _1
+data Env v = Env
+  { boundTerms :: !(Set v),
+    boundTypes :: !(Set v),
+    ppe :: !PrettyPrintEnv
+  }
+  deriving stock (Generic)
 
 modifyTypeVars :: (MonadPretty v m) => (Set v -> Set v) -> m a -> m a
-modifyTypeVars = local . over _2
+modifyTypeVars = local . over #boundTypes
 
 -- | Add type variables to the set of variables that need to be avoided
 addTypeVars :: (MonadPretty v m) => [v] -> m a -> m a
@@ -40,8 +33,15 @@ addTypeVars = modifyTypeVars . Set.union . Set.fromList
 
 -- | Check if a list of type variables contains any variables that need to be
 -- avoided
-willCapture :: (MonadPretty v m) => [v] -> m Bool
-willCapture vs = views _2 (not . Set.null . Set.intersection (Set.fromList vs))
+willCaptureType :: (MonadPretty v m) => [v] -> m Bool
+willCaptureType vs = views #boundTypes (Set.intersects (Set.fromList vs))
 
-runPretty :: (Var v) => PrettyPrintEnv -> Reader (PrettyPrintEnv, Set v) a -> a
-runPretty ppe m = runReader m (ppe, mempty)
+runPretty :: (Var v) => PrettyPrintEnv -> Reader (Env v) a -> a
+runPretty ppe m =
+  runReader
+    m
+    Env
+      { boundTerms = Set.empty,
+        boundTypes = Set.empty,
+        ppe
+      }

--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -675,7 +675,7 @@ printLetBinding :: (MonadPretty v m) => AmbientContext -> (v, Term3 v PrintAnnot
 printLetBinding context (v, binding) =
   if Var.isAction v
     then pretty0 context binding
-    else renderPrettyBinding <$> prettyBinding0' context (HQ.unsafeFromVar v) binding
+    else renderPrettyBinding <$> prettyBinding0' context (HQ.unsafeFromVar (Var.reset v)) binding
 
 prettyPattern ::
   forall v loc.
@@ -1317,7 +1317,7 @@ printAnnotate n tm =
       Set.fromList [n | v <- ABT.allVars tm, n <- varToName v]
     usedTypeNames =
       Set.fromList [n | Ann' _ ty <- ABT.subterms tm, v <- ABT.allVars ty, n <- varToName v]
-    varToName v = toList (Name.parseText (Var.name v))
+    varToName = toList . Name.parseText . Var.name . Var.reset
     go :: (Ord v) => Term2 v at ap v b -> Term2 v () () v b
     go = extraMap' id (const ()) (const ())
 
@@ -2213,7 +2213,7 @@ avoidShadowing tm (PrettyPrintEnv terms types) =
            in (HQ'.NameOnly fullName, HQ'.NameOnly resuffixifiedName)
     tweak _ p = p
     varToName :: (Var v) => v -> [Name]
-    varToName = toList . Name.parseText . Var.name
+    varToName = toList . Name.parseText . Var.name . Var.reset
 
 isLeaf :: Term2 vt at ap v a -> Bool
 isLeaf (Var' {}) = True

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -165,6 +165,7 @@ library
       ApplicativeDo
       BangPatterns
       BlockArguments
+      ConstraintKinds
       DeriveAnyClass
       DeriveFunctor
       DeriveGeneric
@@ -285,6 +286,7 @@ test-suite parser-typechecker-tests
       ApplicativeDo
       BangPatterns
       BlockArguments
+      ConstraintKinds
       DeriveAnyClass
       DeriveFunctor
       DeriveGeneric

--- a/unison-src/transcripts/idempotent/fix-5427.md
+++ b/unison-src/transcripts/idempotent/fix-5427.md
@@ -1,3 +1,60 @@
+# Issue 1
+
+``` ucm
+scratch/main> builtins.merge lib.builtin
+
+  Done.
+```
+
+``` unison
+foo : Nat
+foo = 17
+
+bar : Nat
+bar =
+  foo _ =
+    _ = foo
+    .foo
+  foo()
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+
+    ⍟ These new definitions are ok to `add`:
+
+      bar : Nat
+      foo : Nat
+```
+
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+
+    bar : Nat
+    foo : Nat
+
+scratch/main> view bar
+
+  bar : Nat
+  bar =
+    foo1 _ =
+      _ = foo
+      foo
+    foo()
+```
+
+``` ucm :hide
+scratch/main> delete.project scratch
+```
+
+# Issue 2
+
 ``` ucm
 scratch/main> builtins.merge lib.builtin
 
@@ -25,7 +82,7 @@ baz = foo + foo
   change:
 
     ⍟ These new definitions are ok to `add`:
-    
+
       bar : Nat
       baz : Nat
       foo : Nat
@@ -60,7 +117,7 @@ bar =
 
     ⍟ These names already exist. You can `update` them to your
       new definition:
-    
+
       bar : Nat
       foo : Nat
 ```

--- a/unison-src/transcripts/idempotent/fix-5427.md
+++ b/unison-src/transcripts/idempotent/fix-5427.md
@@ -26,7 +26,7 @@ bar =
   change:
 
     ⍟ These new definitions are ok to `add`:
-
+    
       bar : Nat
       foo : Nat
 ```
@@ -43,9 +43,9 @@ scratch/main> view bar
 
   bar : Nat
   bar =
-    foo1 _ =
+    foo _ =
       _ = foo
-      foo
+      .foo
     foo()
 ```
 
@@ -82,7 +82,7 @@ baz = foo + foo
   change:
 
     ⍟ These new definitions are ok to `add`:
-
+    
       bar : Nat
       baz : Nat
       foo : Nat
@@ -117,7 +117,7 @@ bar =
 
     ⍟ These names already exist. You can `update` them to your
       new definition:
-
+    
       bar : Nat
       foo : Nat
 ```

--- a/unison-src/transcripts/idempotent/fix-5427.md
+++ b/unison-src/transcripts/idempotent/fix-5427.md
@@ -122,9 +122,9 @@ bar =
       foo : Nat
 ```
 
-This should succeed, but `bar` gets printed incorrectly\!
+Previously, `bar` would incorrectly print with a `foo = foo` line. Now, it works.
 
-``` ucm :error
+``` ucm
 scratch/main> update
 
   Okay, I'm searching the branch for code that needs to be
@@ -132,26 +132,14 @@ scratch/main> update
 
   That's done. Now I'm making sure everything typechecks...
 
-  Typechecking failed. I've updated your scratch file with the
-  definitions that need fixing. Once the file is compiling, try
-  `update` again.
-```
+  Everything typechecks, so I'm saving the results...
 
-``` unison :added-by-ucm scratch.u
-foo : Nat
-foo = 18
+  Done.
 
-bar : Nat
-bar =
-  foo = foo
-  foo
+scratch/main> view bar
 
--- The definitions below no longer typecheck with the changes above.
--- Please fix the errors and try `update` again.
-
-baz : Nat
-baz =
-  use Nat +
-  foo + foo
-
+  bar : Nat
+  bar =
+    foo = .foo
+    foo
 ```

--- a/unison-src/transcripts/idempotent/fix-5427.md
+++ b/unison-src/transcripts/idempotent/fix-5427.md
@@ -1,0 +1,100 @@
+``` ucm
+scratch/main> builtins.merge lib.builtin
+
+  Done.
+```
+
+``` unison
+foo : Nat
+foo = 17
+
+bar : Nat
+bar =
+  foo = .foo
+  foo
+
+baz : Nat
+baz = foo + foo
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+
+    ⍟ These new definitions are ok to `add`:
+    
+      bar : Nat
+      baz : Nat
+      foo : Nat
+```
+
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+
+    bar : Nat
+    baz : Nat
+    foo : Nat
+```
+
+``` unison
+foo : Nat
+foo = 18
+
+bar : Nat
+bar =
+  foo = .foo
+  foo
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      bar : Nat
+      foo : Nat
+```
+
+This should succeed, but `bar` gets printed incorrectly\!
+
+``` ucm :error
+scratch/main> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Typechecking failed. I've updated your scratch file with the
+  definitions that need fixing. Once the file is compiling, try
+  `update` again.
+```
+
+``` unison :added-by-ucm scratch.u
+foo : Nat
+foo = 18
+
+bar : Nat
+bar =
+  foo = foo
+  foo
+
+-- The definitions below no longer typecheck with the changes above.
+-- Please fix the errors and try `update` again.
+
+baz : Nat
+baz =
+  use Nat +
+  foo + foo
+
+```


### PR DESCRIPTION
## Overview

Fixes #5427 

This PR fixes a couple issues related to rendering terms with overlapping local variable and reference names. I've added a transcript to demonstrate the fixes.

There were basically three issues; the first two are related to the fact that a term's variables may not always have id 0.

1. Rendering let bindings didn't reset the var name, so sometimes we'd render the wrong binding name (e.g. `foo1 = ...` when it should be `foo = ...`)
2. The "avoid shadowing" preprocessor step didn't reset var names, so sometimes we'd erroneously capture a variable (as in the #5427 bug report).
3. The non-recursive let-printing logic wasn't smart enough to avoid variable capture in all cases.

## Test coverage

I've added a transcript that demonstrates and fixes the issues.