### PR TITLE
Add missing INLINE's on EnumContainers

### DIFF
--- a/parser-typechecker/src/Unison/Util/EnumContainers.hs
+++ b/parser-typechecker/src/Unison/Util/EnumContainers.hs
@@ -43,11 +43,15 @@ class EnumKey k where
   intToKey :: Int -> k
 
 instance EnumKey Word64 where
+  {-# INLINE keyToInt #-}
   keyToInt e = fromIntegral e
+  {-# INLINE intToKey #-}
   intToKey i = fromIntegral i
 
 instance EnumKey Word16 where
+  {-# INLINE keyToInt #-}
   keyToInt e = fromIntegral e
+  {-# INLINE intToKey #-}
   intToKey i = fromIntegral i
 
 newtype EnumMap k a = EM (IM.IntMap a)
@@ -77,24 +81,31 @@ newtype EnumSet k = ES IS.IntSet
       Semigroup
     )
 
+{-# INLINE mapFromList #-}
 mapFromList :: (EnumKey k) => [(k, a)] -> EnumMap k a
 mapFromList = EM . IM.fromList . fmap (first keyToInt)
 
+{-# INLINE setFromList #-}
 setFromList :: (EnumKey k) => [k] -> EnumSet k
 setFromList = ES . IS.fromList . fmap keyToInt
 
+{-# INLINE setToList #-}
 setToList :: (EnumKey k) => EnumSet k -> [k]
 setToList (ES s) = intToKey <$> IS.toList s
 
+{-# INLINE mapSingleton #-}
 mapSingleton :: (EnumKey k) => k -> a -> EnumMap k a
 mapSingleton e a = EM $ IM.singleton (keyToInt e) a
 
+{-# INLINE setSingleton #-}
 setSingleton :: (EnumKey k) => k -> EnumSet k
 setSingleton e = ES . IS.singleton $ keyToInt e
 
+{-# INLINE mapInsert #-}
 mapInsert :: (EnumKey k) => k -> a -> EnumMap k a -> EnumMap k a
 mapInsert e x (EM m) = EM $ IM.insert (keyToInt e) x m
 
+{-# INLINE unionWith #-}
 unionWith ::
   (EnumKey k) =>
   (a -> a -> a) ->
@@ -103,6 +114,7 @@ unionWith ::
   EnumMap k a
 unionWith f (EM l) (EM r) = EM $ IM.unionWith f l r
 
+{-# INLINE intersectionWith #-}
 intersectionWith ::
   (a -> b -> c) ->
   EnumMap k a ->
@@ -110,53 +122,69 @@ intersectionWith ::
   EnumMap k c
 intersectionWith f (EM l) (EM r) = EM $ IM.intersectionWith f l r
 
+{-# INLINE keys #-}
 keys :: (EnumKey k) => EnumMap k a -> [k]
 keys (EM m) = fmap intToKey . IM.keys $ m
 
+{-# INLINE keysSet #-}
 keysSet :: (EnumKey k) => EnumMap k a -> EnumSet k
 keysSet (EM m) = ES (IM.keysSet m)
 
+{-# INLINE restrictKeys #-}
 restrictKeys :: (EnumKey k) => EnumMap k a -> EnumSet k -> EnumMap k a
 restrictKeys (EM m) (ES s) = EM $ IM.restrictKeys m s
 
+{-# INLINE withoutKeys #-}
 withoutKeys :: (EnumKey k) => EnumMap k a -> EnumSet k -> EnumMap k a
 withoutKeys (EM m) (ES s) = EM $ IM.withoutKeys m s
 
+{-# INLINE mapDifference #-}
 mapDifference :: (EnumKey k) => EnumMap k a -> EnumMap k b -> EnumMap k a
 mapDifference (EM l) (EM r) = EM $ IM.difference l r
 
+{-# INLINE member #-}
 member :: (EnumKey k) => k -> EnumSet k -> Bool
 member e (ES s) = IS.member (keyToInt e) s
 
+{-# INLINE hasKey #-}
 hasKey :: (EnumKey k) => k -> EnumMap k a -> Bool
 hasKey k (EM m) = IM.member (keyToInt k) m
 
+{-# INLINE lookup #-}
 lookup :: (EnumKey k) => k -> EnumMap k a -> Maybe a
 lookup e (EM m) = IM.lookup (keyToInt e) m
 
+{-# INLINE lookupWithDefault #-}
 lookupWithDefault :: (EnumKey k) => a -> k -> EnumMap k a -> a
 lookupWithDefault d e (EM m) = IM.findWithDefault d (keyToInt e) m
 
+{-# INLINE mapWithKey #-}
 mapWithKey :: (EnumKey k) => (k -> a -> b) -> EnumMap k a -> EnumMap k b
 mapWithKey f (EM m) = EM $ IM.mapWithKey (f . intToKey) m
 
+{-# INLINE foldMapWithKey #-}
 foldMapWithKey :: (EnumKey k) => (Monoid m) => (k -> a -> m) -> EnumMap k a -> m
 foldMapWithKey f (EM m) = IM.foldMapWithKey (f . intToKey) m
 
+{-# INLINE mapToList #-}
 mapToList :: (EnumKey k) => EnumMap k a -> [(k, a)]
 mapToList (EM m) = first intToKey <$> IM.toList m
 
+{-# INLINE (!) #-}
 (!) :: (EnumKey k) => EnumMap k a -> k -> a
 (!) (EM m) e = m IM.! keyToInt e
 
+{-# INLINE findMin #-}
 findMin :: (EnumKey k) => EnumSet k -> k
 findMin (ES s) = intToKey $ IS.findMin s
 
+{-# INLINE traverseSet_ #-}
 traverseSet_ ::
   (Applicative f) => (EnumKey k) => (k -> f ()) -> EnumSet k -> f ()
 traverseSet_ f (ES s) =
   IS.foldr (\i r -> f (intToKey i) *> r) (pure ()) s
 
+{-# INLINE interverse #-}
 interverse ::
   (Applicative f) =>
   (a -> b -> f c) ->
@@ -166,6 +194,7 @@ interverse ::
 interverse f (EM l) (EM r) =
   fmap EM . traverse id $ IM.intersectionWith f l r
 
+{-# INLINE traverseWithKey #-}
 traverseWithKey ::
   (Applicative f) =>
   (EnumKey k) =>
@@ -174,5 +203,6 @@ traverseWithKey ::
   f (EnumMap k b)
 traverseWithKey f (EM m) = EM <$> IM.traverseWithKey (f . intToKey) m
 
+{-# INLINE setSize #-}
 setSize :: EnumSet k -> Int
 setSize (ES s) = IS.size s


### PR DESCRIPTION
## Overview

I was partaking in my now daily ritual ritual of staring into the void (a.k.a. GHC Core) guess what I found!

The difference here is _substantial_ and implies that the places we're still using Enum Containers probably require another look, or at least I should re-examine the core again to explain how there's _this_ much of a speed difference.

It's really important to be careful about INLINE pragmas when helper methods are in a different module than they're used in, since GHC won't typically inline across modules unless asked to.

## Implementation notes

Just add a bunch of INLINE annotations to EnumMap methods


Benchmarks:

trunk -> new

```
fib1
313.5µs -> 206.985µs

fib2
2.241831ms -> 1.820296ms

fib3
2.651751ms -> 2.060708ms

Decode Nat
341ns -> 245ns

Generate 100 random numbers
207.506µs -> 146.037µs

List.foldLeft
2.020392ms -> 1.538192ms

Count to 1 million
124.85875ms -> 80.50275ms

Json parsing (per document)
258.366µs -> 214.227µs

Count to N (per element)
190ns -> 119ns

Count to 1000
191.382µs -> 119.902µs

Mutate a Ref 1000 times
316.96µs -> 204.624µs

CAS an IO.ref 1000 times
426.228µs -> 287.614µs

List.range (per element)
326ns -> 244ns

List.range 0 1000
345.768µs -> 255.853µs

Set.fromList (range 0 1000)
1.584278ms -> 1.194793ms

Map.fromList (range 0 1000)
1.160257ms -> 845.532µs

NatMap.fromList (range 0 1000)
4.869621ms -> 3.453725ms

Map.lookup (1k element map)
2.539µs -> 1.709µs

Map.insert (1k element map)
6.829µs -> 4.899µs

List.at (1k element list)
286ns -> 188ns

Text.split /
35.598µs -> 26.241µs
```