### PR TITLE
Do reference-based pruning for ucm compile, turn back on inlining

### DIFF
--- a/unison-runtime/src/Unison/Runtime/Machine.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine.hs
@@ -2207,10 +2207,11 @@ cacheAdd0 ntys0 termSuperGroups sands cc = do
     rtm <- updateMap (M.fromList $ zip rs [ntm ..]) (refTm cc)
     -- check for missing references
     let arities = fmap (head . ANF.arities) int <> builtinArities
+        inlinfo = ANF.buildInlineMap int <> builtinInlineInfo
         rns = RN (refLookup "ty" rty) (refLookup "tm" rtm) (flip M.lookup arities)
         combinate :: Word64 -> (Reference, SuperGroup Symbol) -> (Word64, EnumMap Word64 Comb)
         combinate n (r, g) =
-          (n, emitCombs rns r n g)
+          (n, emitCombs rns r n $ ANF.inline inlinfo g)
     let combRefUpdates = (mapFromList $ zip [ntm ..] rs)
     let combIdFromRefMap = (M.fromList $ zip rs [ntm ..])
     let newCacheableCombs =


### PR DESCRIPTION
The interpreter state pruning was causing problems with compiled programs when inlining was on, because it would prune based on the inlined code. The inlined code may have certain intermediate combinators omitted, but those are still necessary to have a full picture of the source code. Since `compile` was using the `MCode` numbering and backing out which `References` are necessary from that, it would throw away the source code for these intermediate definitions. This then caused problems when e.g. cloud (running from a compiled build) would try to send code to other environments. It wouldn't have the intermediate terms necessary for the remote environment to do its own
intermediate->interpreter step.

This new approach does all the 'necessary terms' tracing at the intermediate level, and then instead determines which `MCode` level defintions are necessary from that. This means that the pruning is no longer sensitive to the inlining. So, it should be safe to turn inlining back on.

@ceedubs This fixes my local test, which is just looking up recursive dependencies of something in base in a compiled program (i.e. it works fine doing `run` in ucm, because everything is loaded, but not in `run.compiled` because some of the recursive dependencies have been pruned away). Let me know if it solves the cloud issues.