### PR TITLE
bugfix: make namespace directive not churn unique types

### DIFF
--- a/parser-typechecker/src/Unison/Syntax/DeclParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/DeclParser.hs
@@ -1,17 +1,18 @@
 module Unison.Syntax.DeclParser
-  ( declarations,
+  ( synDeclsP,
+    SynDecl (..),
+    synDeclConstructors,
+    synDeclName,
+    SynDataDecl (..),
+    SynEffectDecl (..),
+    UnresolvedModifier (..),
   )
 where
 
 import Control.Lens
-import Control.Monad.Reader (MonadReader (..))
 import Data.List.NonEmpty (pattern (:|))
 import Data.List.NonEmpty qualified as NonEmpty
-import Data.Map qualified as Map
-import Text.Megaparsec qualified as P
 import Unison.ABT qualified as ABT
-import Unison.DataDeclaration (DataDeclaration, EffectDeclaration)
-import Unison.DataDeclaration qualified as DD
 import Unison.Name qualified as Name
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
@@ -27,45 +28,47 @@ import Unison.Var (Var)
 import Unison.Var qualified as Var (name, named)
 import Prelude hiding (readFile)
 
--- The parsed form of record accessors, as in:
---
--- type Additive a = { zero : a, (+) : a -> a -> a }
---
--- The `Token v` is the variable name and location (here `zero` and `(+)`) of
--- each field, and the type is the type of that field
-type Accessors v = [(L.Token v, [(L.Token v, Type v Ann)])]
+data SynDecl v
+  = SynDecl'Data !(SynDataDecl v)
+  | SynDecl'Effect !(SynEffectDecl v)
 
-declarations ::
-  (Monad m, Var v) =>
-  P
-    v
-    m
-    ( Map v (DataDeclaration v Ann),
-      Map v (EffectDeclaration v Ann),
-      Accessors v
-    )
-declarations = do
-  declarations <- many $ declaration <* optional semi
-  let (dataDecls0, effectDecls) = partitionEithers declarations
-      dataDecls = [(a, b) | (a, b, _) <- dataDecls0]
-      multimap :: (Ord k) => [(k, v)] -> Map k [v]
-      multimap = foldl' mi Map.empty
-      mi m (k, v) = Map.insertWith (++) k [v] m
-      mds = multimap dataDecls
-      mes = multimap effectDecls
-      mdsBad = Map.filter (\xs -> length xs /= 1) mds
-      mesBad = Map.filter (\xs -> length xs /= 1) mes
-  if Map.null mdsBad && Map.null mesBad
-    then
-      pure
-        ( Map.fromList dataDecls,
-          Map.fromList effectDecls,
-          join . map (view _3) $ dataDecls0
-        )
-    else
-      P.customFailure . DuplicateTypeNames $
-        [(v, DD.annotation <$> ds) | (v, ds) <- Map.toList mdsBad]
-          <> [(v, DD.annotation . DD.toDataDecl <$> es) | (v, es) <- Map.toList mesBad]
+instance Annotated (SynDecl v) where
+  ann = \case
+    SynDecl'Data decl -> decl.annotation
+    SynDecl'Effect decl -> decl.annotation
+
+synDeclConstructors :: SynDecl v -> [(Ann, v, Type v Ann)]
+synDeclConstructors = \case
+  SynDecl'Data decl -> decl.constructors
+  SynDecl'Effect decl -> decl.constructors
+
+synDeclName :: SynDecl v -> L.Token v
+synDeclName = \case
+  SynDecl'Data decl -> decl.name
+  SynDecl'Effect decl -> decl.name
+
+data SynDataDecl v = SynDataDecl
+  { annotation :: !Ann,
+    constructors :: ![(Ann, v, Type v Ann)],
+    fields :: !(Maybe [(L.Token v, Type v Ann)]),
+    modifier :: !(Maybe (L.Token UnresolvedModifier)),
+    name :: !(L.Token v),
+    tyvars :: ![v]
+  }
+  deriving stock (Generic)
+
+data SynEffectDecl v = SynEffectDecl
+  { annotation :: !Ann,
+    constructors :: ![(Ann, v, Type v Ann)],
+    modifier :: !(Maybe (L.Token UnresolvedModifier)),
+    name :: !(L.Token v),
+    tyvars :: ![v]
+  }
+  deriving stock (Generic)
+
+synDeclsP :: (Monad m, Var v) => P v m [SynDecl v]
+synDeclsP =
+  many (synDeclP <* optional semi)
 
 -- | When we first walk over the modifier, it may be a `unique`, in which case we want to use a function in the parsing
 -- environment to map the type's name (which we haven't parsed yet) to a GUID to reuse (if any).
@@ -77,27 +80,9 @@ data UnresolvedModifier
   | UnresolvedModifier'UniqueWithGuid !Text
   | UnresolvedModifier'UniqueWithoutGuid
 
-resolveUnresolvedModifier :: (Monad m, Var v) => L.Token UnresolvedModifier -> v -> P v m (L.Token DD.Modifier)
-resolveUnresolvedModifier unresolvedModifier var =
-  case L.payload unresolvedModifier of
-    UnresolvedModifier'Structural -> pure (DD.Structural <$ unresolvedModifier)
-    UnresolvedModifier'UniqueWithGuid guid -> pure (DD.Unique guid <$ unresolvedModifier)
-    UnresolvedModifier'UniqueWithoutGuid -> do
-      unique <- resolveUniqueModifier var
-      pure $ unique <$ unresolvedModifier
-
-resolveUniqueModifier :: (Monad m, Var v) => v -> P v m DD.Modifier
-resolveUniqueModifier var = do
-  env <- ask
-  guid <-
-    lift (lift (env.uniqueTypeGuid (Name.unsafeParseVar var))) >>= \case
-      Nothing -> uniqueName 32
-      Just guid -> pure guid
-  pure (DD.Unique guid)
-
 -- unique[someguid] type Blah = ...
-modifier :: (Monad m, Var v) => P v m (Maybe (L.Token UnresolvedModifier))
-modifier = do
+modifierP :: (Monad m, Var v) => P v m (Maybe (L.Token UnresolvedModifier))
+modifierP = do
   optional (unique <|> structural)
   where
     unique = do
@@ -109,31 +94,16 @@ modifier = do
       tok <- openBlockWith "structural"
       pure (UnresolvedModifier'Structural <$ tok)
 
-declaration ::
-  (Monad m, Var v) =>
-  P
-    v
-    m
-    ( Either
-        (v, DataDeclaration v Ann, Accessors v)
-        (v, EffectDeclaration v Ann)
-    )
-declaration = do
-  mod <- modifier
-  fmap Right (effectDeclaration mod) <|> fmap Left (dataDeclaration mod)
+synDeclP :: (Monad m, Var v) => P v m (SynDecl v)
+synDeclP = do
+  modifier <- modifierP
+  SynDecl'Effect <$> synEffectDeclP modifier <|> SynDecl'Data <$> synDataDeclP modifier
 
-dataDeclaration ::
-  forall m v.
-  (Monad m, Var v) =>
-  Maybe (L.Token UnresolvedModifier) ->
-  P v m (v, DataDeclaration v Ann, Accessors v)
-dataDeclaration maybeUnresolvedModifier = do
+synDataDeclP :: forall m v. (Monad m, Var v) => Maybe (L.Token UnresolvedModifier) -> P v m (SynDataDecl v)
+synDataDeclP modifier = do
   typeToken <- fmap void (reserved "type") <|> openBlockWith "type"
-  (name, typeArgs) <-
-    (,)
-      <$> TermParser.verifyRelativeVarName prefixDefinitionName
-      <*> many (TermParser.verifyRelativeVarName prefixDefinitionName)
-  let typeArgVs = L.payload <$> typeArgs
+  (name, typeArgs) <- (,) <$> prefixVar <*> many prefixVar
+  let tyvars = L.payload <$> typeArgs
   eq <- reserved "="
   let -- go gives the type of the constructor, given the types of
       -- the constructor arguments, e.g. Cons becomes forall a . a -> List a -> List a
@@ -146,127 +116,104 @@ dataDeclaration maybeUnresolvedModifier = do
             -- ctorType e.g. `a -> Optional a`
             --    or just `Optional a` in the case of `None`
             ctorType = foldr arrow ctorReturnType ctorArgs
-            ctorAnn = ann ctorName <> maybe (ann ctorName) ann (lastMay ctorArgs)
+            ctorAnn = ann ctorName <> maybe mempty ann (lastMay ctorArgs)
          in ( ctorAnn,
               ( ann ctorName,
                 Var.namespaced (L.payload name :| [L.payload ctorName]),
-                Type.foralls ctorAnn typeArgVs ctorType
+                Type.foralls ctorAnn tyvars ctorType
               )
             )
-      prefixVar = TermParser.verifyRelativeVarName prefixDefinitionName
-      dataConstructor :: P v m (Ann, (Ann, v, Type v Ann))
-      dataConstructor = go <$> prefixVar <*> many TypeParser.valueTypeLeaf
-      record :: P v m ([(Ann, (Ann, v, Type v Ann))], [(L.Token v, [(L.Token v, Type v Ann)])], Ann)
+      record :: P v m ((Ann, v, Type v Ann), Maybe [(L.Token v, Type v Ann)], Ann)
       record = do
         _ <- openBlockWith "{"
         let field :: P v m [(L.Token v, Type v Ann)]
             field = do
               f <- liftA2 (,) (prefixVar <* reserved ":") TypeParser.valueType
-              optional (reserved ",")
-                >>= ( \case
-                        Nothing -> pure [f]
-                        Just _ -> maybe [f] (f :) <$> (optional semi *> optional field)
-                    )
+              optional (reserved ",") >>= \case
+                Nothing -> pure [f]
+                Just _ -> maybe [f] (f :) <$> (optional semi *> optional field)
         fields <- field
         closingToken <- closeBlock
         let lastSegment = name <&> (\v -> Var.named (Name.toText $ Name.unqualified (Name.unsafeParseVar v)))
-        pure ([go lastSegment (snd <$> fields)], [(name, fields)], ann closingToken)
-  (constructors, accessors, closingAnn) <-
-    msum [Left <$> record, Right <$> sepBy (reserved "|") dataConstructor] <&> \case
-      Left (constructors, accessors, closingAnn) -> (constructors, accessors, closingAnn)
-      Right constructors -> do
-        let closingAnn :: Ann
-            closingAnn = NonEmpty.last (ann eq NonEmpty.:| ((\(constrSpanAnn, _) -> constrSpanAnn) <$> constructors))
-         in (constructors, [], closingAnn)
-  _ <- closeBlock
-  case maybeUnresolvedModifier of
+        pure (snd (go lastSegment (snd <$> fields)), Just fields, ann closingToken)
+  optional record >>= \case
     Nothing -> do
-      modifier <- resolveUniqueModifier (L.payload name)
-      -- ann spanning the whole Decl.
-      let declSpanAnn = ann typeToken <> closingAnn
+      constructors <- sepBy (reserved "|") (go <$> prefixVar <*> many TypeParser.valueTypeLeaf)
+      _ <- closeBlock
+      let closingAnn :: Ann
+          closingAnn = NonEmpty.last (ann eq NonEmpty.:| ((\(constrSpanAnn, _) -> constrSpanAnn) <$> constructors))
       pure
-        ( L.payload name,
-          DD.mkDataDecl' modifier declSpanAnn typeArgVs (snd <$> constructors),
-          accessors
-        )
-    Just unresolvedModifier -> do
-      modifier <- resolveUnresolvedModifier unresolvedModifier (L.payload name)
-      -- ann spanning the whole Decl.
-      -- Technically the typeToken is redundant here, but this is more future proof.
-      let declSpanAnn = ann typeToken <> ann modifier <> closingAnn
+        SynDataDecl
+          { annotation = maybe (ann typeToken) ann modifier <> closingAnn,
+            constructors = snd <$> constructors,
+            fields = Nothing,
+            modifier,
+            name,
+            tyvars
+          }
+    Just (constructor, fields, closingAnn) -> do
+      _ <- closeBlock
       pure
-        ( L.payload name,
-          DD.mkDataDecl' (L.payload modifier) declSpanAnn typeArgVs (snd <$> constructors),
-          accessors
-        )
+        SynDataDecl
+          { annotation = maybe (ann typeToken) ann modifier <> closingAnn,
+            constructors = [constructor],
+            fields,
+            modifier,
+            name,
+            tyvars
+          }
+  where
+    prefixVar :: P v m (L.Token v)
+    prefixVar =
+      TermParser.verifyRelativeVarName prefixDefinitionName
 
-effectDeclaration ::
-  forall m v.
-  (Monad m, Var v) =>
-  Maybe (L.Token UnresolvedModifier) ->
-  P v m (v, EffectDeclaration v Ann)
-effectDeclaration maybeUnresolvedModifier = do
+synEffectDeclP :: forall m v. (Monad m, Var v) => Maybe (L.Token UnresolvedModifier) -> P v m (SynEffectDecl v)
+synEffectDeclP modifier = do
   abilityToken <- fmap void (reserved "ability") <|> openBlockWith "ability"
   name <- TermParser.verifyRelativeVarName prefixDefinitionName
   typeArgs <- many (TermParser.verifyRelativeVarName prefixDefinitionName)
-  let typeArgVs = L.payload <$> typeArgs
   blockStart <- openBlockWith "where"
-  constructors <- sepBy semi (constructor typeArgs name)
+  constructors <- sepBy semi (effectConstructorP typeArgs name)
   -- `ability` opens a block, as does `where`
   _ <- closeBlock <* closeBlock
   let closingAnn =
         last $ ann blockStart : ((\(_, _, t) -> ann t) <$> constructors)
+  pure
+    SynEffectDecl
+      { annotation = maybe (ann abilityToken) ann modifier <> closingAnn,
+        constructors,
+        modifier,
+        name,
+        tyvars = L.payload <$> typeArgs
+      }
 
-  case maybeUnresolvedModifier of
-    Nothing -> do
-      modifier <- resolveUniqueModifier (L.payload name)
-      -- ann spanning the whole ability declaration.
-      let abilitySpanAnn = ann abilityToken <> closingAnn
-      pure
-        ( L.payload name,
-          DD.mkEffectDecl' modifier abilitySpanAnn typeArgVs constructors
-        )
-    Just unresolvedModifier -> do
-      modifier <- resolveUnresolvedModifier unresolvedModifier (L.payload name)
-      -- ann spanning the whole ability declaration.
-      -- Technically the abilityToken is redundant here, but this is more future proof.
-      let abilitySpanAnn = ann abilityToken <> ann modifier <> closingAnn
-      pure
-        ( L.payload name,
-          DD.mkEffectDecl'
-            (L.payload modifier)
-            abilitySpanAnn
-            typeArgVs
-            constructors
+effectConstructorP :: (Monad m, Var v) => [L.Token v] -> L.Token v -> P v m (Ann, v, Type v Ann)
+effectConstructorP typeArgs name =
+  explodeToken
+    <$> TermParser.verifyRelativeVarName prefixDefinitionName
+    <* reserved ":"
+    <*> ( Type.generalizeLowercase mempty
+            . ensureEffect
+            <$> TypeParser.computationType
         )
   where
-    constructor :: [L.Token v] -> L.Token v -> P v m (Ann, v, Type v Ann)
-    constructor typeArgs name =
-      explodeToken
-        <$> TermParser.verifyRelativeVarName prefixDefinitionName
-        <* reserved ":"
-        <*> ( Type.generalizeLowercase mempty
-                . ensureEffect
-                <$> TypeParser.computationType
-            )
-      where
-        explodeToken v t = (ann v, Var.namespaced (L.payload name :| [L.payload v]), t)
-        -- If the effect is not syntactically present in the constructor types,
-        -- add them after parsing.
-        ensureEffect t = case t of
-          Type.Effect' _ _ -> modEffect t
-          x -> Type.editFunctionResult modEffect x
-        modEffect t = case t of
-          Type.Effect' es t -> go es t
-          t -> go [] t
-        toTypeVar t = Type.av' (ann t) (Var.name $ L.payload t)
-        headIs t v = case t of
-          Type.Apps' (Type.Var' x) _ -> x == v
-          Type.Var' x -> x == v
-          _ -> False
-        go es t =
-          let es' =
-                if any (`headIs` L.payload name) es
-                  then es
-                  else Type.apps' (toTypeVar name) (toTypeVar <$> typeArgs) : es
-           in Type.cleanupAbilityLists $ Type.effect (ABT.annotation t) es' t
+    explodeToken v t = (ann v, Var.namespaced (L.payload name :| [L.payload v]), t)
+    -- If the effect is not syntactically present in the constructor types,
+    -- add them after parsing.
+    ensureEffect t = case t of
+      Type.Effect' _ _ -> modEffect t
+      x -> Type.editFunctionResult modEffect x
+    modEffect t = case t of
+      Type.Effect' es t -> go es t
+      t -> go [] t
+    toTypeVar t = Type.av' (ann t) (Var.name $ L.payload t)
+    headIs t v = case t of
+      Type.Apps' (Type.Var' x) _ -> x == v
+      Type.Var' x -> x == v
+      _ -> False
+    go es t =
+      let es' =
+            if any (`headIs` L.payload name) es
+              then es
+              else Type.apps' (toTypeVar name) (toTypeVar <$> typeArgs) : es
+       in Type.cleanupAbilityLists $ Type.effect (ABT.annotation t) es' t

--- a/parser-typechecker/src/Unison/Syntax/FileParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/FileParser.hs
@@ -5,14 +5,14 @@ where
 
 import Control.Lens
 import Control.Monad.Reader (asks, local)
+import Data.Foldable (foldlM)
 import Data.List qualified as List
 import Data.Map qualified as Map
 import Data.Set qualified as Set
 import Data.Text qualified as Text
 import Text.Megaparsec qualified as P
 import Unison.ABT qualified as ABT
-import Unison.DataDeclaration (DataDeclaration, EffectDeclaration)
-import Unison.DataDeclaration qualified as DD
+import Unison.DataDeclaration (DataDeclaration (..), EffectDeclaration)
 import Unison.DataDeclaration qualified as DataDeclaration
 import Unison.DataDeclaration.Records (generateRecordAccessors)
 import Unison.Name qualified as Name
@@ -23,7 +23,7 @@ import Unison.Parser.Ann (Ann)
 import Unison.Parser.Ann qualified as Ann
 import Unison.Prelude
 import Unison.Reference (TypeReferenceId)
-import Unison.Syntax.DeclParser (declarations)
+import Unison.Syntax.DeclParser (SynDataDecl (..), SynDecl (..), SynEffectDecl (..), UnresolvedModifier (..), synDeclName, synDeclsP, synDeclConstructors)
 import Unison.Syntax.Lexer qualified as L
 import Unison.Syntax.Name qualified as Name (toText, toVar, unsafeParseVar)
 import Unison.Syntax.Parser
@@ -57,62 +57,74 @@ file = do
       Just _ -> do
         namespace <- importWordyId <|> importSymbolyId
         void (optional semi)
-        pure (Just (L.payload namespace))
+        pure (Just namespace.payload)
   let maybeNamespaceVar = Name.toVar <$> maybeNamespace
 
   -- The file may optionally contain top-level imports,
   -- which are parsed and applied to the type decls and term stanzas
   (namesStart, imports) <- TermParser.imports <* optional semi
-  (dataDecls, effectDecls, parsedAccessors) <- declarations
 
-  env <-
-    let applyNamespaceToDecls :: forall decl. Iso' decl (DataDeclaration v Ann) -> Map v decl -> Map v decl
-        applyNamespaceToDecls dataDeclL =
-          case maybeNamespaceVar of
-            Nothing -> id
-            Just namespace -> Map.fromList . map f . Map.toList
-              where
-                f :: (v, decl) -> (v, decl)
-                f (declName, decl) =
-                  ( Var.namespaced2 namespace declName,
-                    review dataDeclL (applyNamespaceToDataDecl namespace unNamespacedTypeNames (view dataDeclL decl))
-                  )
+  -- Parse all syn decls
+  unNamespacedSynDecls <- synDeclsP
 
-                unNamespacedTypeNames :: Set v
-                unNamespacedTypeNames =
-                  Set.union (Map.keysSet dataDecls) (Map.keysSet effectDecls)
+  -- Sanity check: bail if there's a duplicate name among them
+  unNamespacedSynDecls
+    & List.map (\decl -> (L.payload (synDeclName decl), decl))
+    & List.multimap
+    & Map.toList
+    & mapMaybe \case
+      (name, decls@(_ : _ : _)) -> Just (name, map ann decls)
+      _ -> Nothing
+    & \case
+      [] -> pure ()
+      dupes -> P.customFailure (DuplicateTypeNames dupes)
 
-        dataDecls1 = applyNamespaceToDecls id dataDecls
-        effectDecls1 = applyNamespaceToDecls DataDeclaration.asDataDecl_ effectDecls
-     in case UFN.environmentFor namesStart dataDecls1 effectDecls1 of
-          Right (Right env) -> pure env
-          Right (Left es) -> P.customFailure $ TypeDeclarationErrors es
-          Left es -> resolutionFailures (toList es)
+  -- Apply the namespace directive (if there is one) to the decls
+  let synDecls = maybe id applyNamespaceToSynDecls maybeNamespaceVar unNamespacedSynDecls
+
+  -- Compute an environment from the decls that we use to parse terms
+  env <- do
+    -- Make real data/effect decls from the "syntactic" ones
+    (dataDecls, effectDecls) <- synDeclsToDecls synDecls
+    result <- UFN.environmentFor namesStart dataDecls effectDecls & onLeft \errs -> resolutionFailures (toList errs)
+    result & onLeft \errs -> P.customFailure (TypeDeclarationErrors errs)
+
+  -- Generate the record accessors with *un-namespaced* names (passing `typ` rather than `typ1`) below, because we need
+  -- to know these names in order to perform rewriting. As an example,
+  --
+  --   namespace foo
+  --   type Bar = { baz : Nat }
+  --   term = ... Bar.baz ...
+  --
+  -- we want to rename `Bar.baz` to `foo.Bar.baz`, and it seems easier to first generate un-namespaced accessors like
+  -- `Bar.baz`, rather than rip off the namespace from accessors like `foo.Bar.baz` (though not by much).
   let unNamespacedAccessors :: [(v, Ann, Term v Ann)]
-      unNamespacedAccessors = do
-        (typ, fields) <- parsedAccessors
-        -- The parsed accessor has an un-namespaced type, so apply the namespace directive (if necessary) before
-        -- looking up in the environment computed by `environmentFor`.
-        let typ1 = maybe id Var.namespaced2 maybeNamespaceVar (L.payload typ)
-        Just (r, _) <- [Map.lookup typ1 (UF.datas env)]
-        -- Generate the record accessors with *un-namespaced* names (passing `typ` rather than `typ1`) below, because we
-        -- need to know these names in order to perform rewriting. As an example,
-        --
-        --   namespace foo
-        --   type Bar = { baz : Nat }
-        --   term = ... Bar.baz ...
-        --
-        -- we want to rename `Bar.baz` to `foo.Bar.baz`, and it seems easier to first generate un-namespaced accessors
-        -- like `Bar.baz`, rather than rip off the namespace from accessors like `foo.Bar.baz` (though not by much).
-        generateRecordAccessors Var.namespaced Ann.GeneratedFrom (toPair <$> fields) (L.payload typ) r
+      unNamespacedAccessors =
+        foldMap
+          ( \case
+              -- N.B. the fields themselves were not namespaced by `applyNamespaceToSynDecls`
+              SynDecl'Data decl
+                | Just fields <- decl.fields,
+                  Just (ref, _) <- Map.lookup decl.name.payload (UF.datas env) ->
+                    generateRecordAccessors
+                      Var.namespaced
+                      Ann.GeneratedFrom
+                      (toPair <$> fields)
+                      decl.name.payload
+                      ref
+              _ -> []
+          )
+          synDecls
         where
-          toPair (tok, typ) = (L.payload tok, ann tok <> ann typ)
+          toPair (tok, typ) = (tok.payload, ann tok <> ann typ)
+
   let accessors :: [(v, Ann, Term v Ann)]
       accessors =
         unNamespacedAccessors
           & case maybeNamespaceVar of
             Nothing -> id
             Just namespace -> over (mapped . _1) (Var.namespaced2 namespace)
+
   -- At this stage of the file parser, we've parsed all the type and ability
   -- declarations.
   let updateEnvForTermParsing e =
@@ -137,8 +149,7 @@ file = do
                       [ -- The vars parsed from the stanzas themselves (before applying namespace directive)
                         Set.fromList (unNamespacedStanzas >>= getVars),
                         -- The un-namespaced constructor names (from the *originally-parsed* data and effect decls)
-                        foldMap (Set.fromList . DataDeclaration.constructorVars) dataDecls,
-                        foldMap (Set.fromList . DataDeclaration.constructorVars . DataDeclaration.toDataDecl) effectDecls,
+                        foldMap (Set.fromList . map (view _2) . synDeclConstructors) unNamespacedSynDecls,
                         -- The un-namespaced accessors
                         Set.fromList (map (view _1) unNamespacedAccessors)
                       ]
@@ -175,17 +186,84 @@ file = do
       (terms <> accessors)
       (List.multimap watches)
 
-applyNamespaceToDataDecl :: forall a v. (Var v) => v -> Set v -> DataDeclaration v a -> DataDeclaration v a
-applyNamespaceToDataDecl namespace locallyBoundTypes =
-  over (DataDeclaration.constructors_ . mapped) \(ann, conName, conTy) ->
-    (ann, Var.namespaced2 namespace conName, ABT.substsInheritAnnotation replacements conTy)
+-- | Suppose a data declaration `Foo` has a constructor `A` with fields `B` and `C`, where `B` is locally-bound and `C`
+-- is not:
+--
+-- @
+-- type B
+--
+-- type Foo
+-- constructor Foo.A : B -> C -> Foo
+-- @
+--
+-- Then, this function applies a namespace "namespace" to the data declaration `Foo` by prefixing each of its
+-- constructors and references to locally-bound types with "namespace":
+--
+-- @
+-- type Foo
+-- constructor namespace.Foo.A : namespace.B -> C -> foo.Foo
+--             ^^^^^^^^^^        ^^^^^^^^^^          ^^^^
+-- @
+--
+-- (note that the name for the data declaration itself is not prefixed within this function, because a data declaration
+-- does not contain its own name).
+applyNamespaceToSynDecls :: forall v. (Var v) => v -> [SynDecl v] -> [SynDecl v]
+applyNamespaceToSynDecls namespace decls =
+  map
+    ( \case
+        SynDecl'Data decl ->
+          SynDecl'Data
+            ( decl
+                & over (#constructors . mapped) applyToConstructor
+                & over (#name . mapped) (Var.namespaced2 namespace)
+            )
+        SynDecl'Effect decl ->
+          SynDecl'Effect
+            ( decl
+                & over (#constructors . mapped) applyToConstructor
+                & over (#name . mapped) (Var.namespaced2 namespace)
+            )
+    )
+    decls
   where
+    applyToConstructor :: (Ann, v, Type v Ann) -> (Ann, v, Type v Ann)
+    applyToConstructor (ann, name, typ) =
+      ( ann,
+        Var.namespaced2 namespace name,
+        ABT.substsInheritAnnotation typeReplacements typ
+      )
+
     -- Replace var "Foo" with var "namespace.Foo"
-    replacements :: [(v, Type v ())]
-    replacements =
-      locallyBoundTypes
+    typeReplacements :: [(v, Type v ())]
+    typeReplacements =
+      decls
+        & List.foldl' (\acc decl -> Set.insert (L.payload (synDeclName decl)) acc) Set.empty
         & Set.toList
         & map (\v -> (v, Type.var () (Var.namespaced2 namespace v)))
+
+synDeclsToDecls :: (Monad m, Var v) => [SynDecl v] -> P v m (Map v (DataDeclaration v Ann), Map v (EffectDeclaration v Ann))
+synDeclsToDecls = do
+  foldlM
+    ( \(datas, effects) -> \case
+        SynDecl'Data decl -> do
+          modifier <- resolveModifier decl.name decl.modifier
+          let decl1 = DataDeclaration modifier decl.annotation decl.tyvars decl.constructors
+          let !datas1 = Map.insert decl.name.payload decl1 datas
+          pure (datas1, effects)
+        SynDecl'Effect decl -> do
+          modifier <- resolveModifier decl.name decl.modifier
+          let decl1 = DataDeclaration.mkEffectDecl' modifier decl.annotation decl.tyvars decl.constructors
+          let !effects1 = Map.insert decl.name.payload decl1 effects
+          pure (datas, effects1)
+    )
+    (Map.empty, Map.empty)
+  where
+    resolveModifier name modifier =
+      case L.payload <$> modifier of
+        Just UnresolvedModifier'Structural -> pure DataDeclaration.Structural
+        Just (UnresolvedModifier'UniqueWithGuid guid) -> pure (DataDeclaration.Unique guid)
+        Just UnresolvedModifier'UniqueWithoutGuid -> resolveUniqueTypeGuid name.payload
+        Nothing -> resolveUniqueTypeGuid name.payload
 
 applyNamespaceToStanza ::
   forall a v.
@@ -253,13 +331,13 @@ checkForDuplicateTermsAndConstructors datas effects terms watches = do
       }
   where
     effectDecls :: [DataDeclaration v Ann]
-    effectDecls = Map.elems . fmap (DD.toDataDecl . snd) $ effects
+    effectDecls = Map.elems . fmap (DataDeclaration.toDataDecl . snd) $ effects
     dataDecls :: [DataDeclaration v Ann]
     dataDecls = fmap snd $ Map.elems datas
     allConstructors :: [(v, Ann)]
     allConstructors =
       (dataDecls <> effectDecls)
-        & foldMap DD.constructors'
+        & foldMap DataDeclaration.constructors'
         & fmap (\(ann, v, _typ) -> (v, ann))
     allTerms :: [(v, Ann)]
     allTerms =

--- a/parser-typechecker/src/Unison/Syntax/FileParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/FileParser.hs
@@ -89,8 +89,8 @@ file = do
     result <- UFN.environmentFor namesStart dataDecls effectDecls & onLeft \errs -> resolutionFailures (toList errs)
     result & onLeft \errs -> P.customFailure (TypeDeclarationErrors errs)
 
-  -- Generate the record accessors with *un-namespaced* names (passing `typ` rather than `typ1`) below, because we need
-  -- to know these names in order to perform rewriting. As an example,
+  -- Generate the record accessors with *un-namespaced* names below, because we need to know these names in order to
+  -- perform rewriting. As an example,
   --
   --   namespace foo
   --   type Bar = { baz : Nat }
@@ -102,10 +102,10 @@ file = do
       unNamespacedAccessors =
         foldMap
           ( \case
-              -- N.B. the fields themselves were not namespaced by `applyNamespaceToSynDecls`
               SynDecl'Data decl
                 | Just fields <- decl.fields,
-                  Just (ref, _) <- Map.lookup decl.name.payload (UF.datas env) ->
+                  Just (ref, _) <-
+                    Map.lookup (maybe id Var.namespaced2 maybeNamespaceVar decl.name.payload) (UF.datas env) ->
                     generateRecordAccessors
                       Var.namespaced
                       Ann.GeneratedFrom
@@ -114,7 +114,7 @@ file = do
                       ref
               _ -> []
           )
-          synDecls
+          unNamespacedSynDecls
         where
           toPair (tok, typ) = (tok.payload, ann tok <> ann typ)
 

--- a/unison-src/transcripts/idempotent/duplicate-names.md
+++ b/unison-src/transcripts/idempotent/duplicate-names.md
@@ -58,7 +58,7 @@ structural ability X where
 ``` ucm :added-by-ucm
   Loading changes detected in scratch.u.
 
-  I found two types called X:
+  I found multiple types with the name X:
 
       1 | structural type X = x
       2 | structural ability X where

--- a/unison-src/transcripts/idempotent/fix-5489.md
+++ b/unison-src/transcripts/idempotent/fix-5489.md
@@ -11,7 +11,7 @@ type Foo = Foo
   change:
 
     ⍟ These new definitions are ok to `add`:
-
+    
       type foo.Foo
 ```
 
@@ -31,12 +31,6 @@ type Foo = Foo
 ``` ucm :added-by-ucm
   Loading changes detected in scratch.u.
 
-  I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
-
-    ⍟ These names already exist. You can `update` them to your
-      new definition:
-
-      type foo.Foo
+  I found and typechecked the definitions in scratch.u. This
+  file has been previously added to the codebase.
 ```

--- a/unison-src/transcripts/idempotent/fix-5489.md
+++ b/unison-src/transcripts/idempotent/fix-5489.md
@@ -1,0 +1,42 @@
+``` unison
+namespace foo
+type Foo = Foo
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+
+    ⍟ These new definitions are ok to `add`:
+
+      type foo.Foo
+```
+
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+
+    type foo.Foo
+```
+
+``` unison
+namespace foo
+type Foo = Foo
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+
+      type foo.Foo
+```


### PR DESCRIPTION
## Overview

Fixes #5489 

This PR tweaks decl parsing to delay assigning a unique type guid until after the namespace pragma is applied. Previously (as seen in first transcript commit), one could accidentally be assigned a new unique type guid in the presence of a namespace directive.

## Test coverage

I've added a transcript that demonstrates the fix.