### PR TITLE
add shell-based regression-tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -273,6 +273,10 @@ jobs:
           ${{env.transcripts}}
           # Fail if any transcripts cause git diffs.
           git diff --ignore-cr-at-eol --exit-code unison-src/transcripts
+      - name: shell-based regression tests
+        if: steps.cache-transcript-test-results.outputs.cache-hit != 'true' && runner.os == 'linux'
+        run: |
+          unison-src/tests/fix5507.sh ${{env.ucm}}
       - name: docs.to-html
         if: steps.cache-transcript-test-results.outputs.cache-hit != 'true'
         run: |

--- a/unison-src/tests/fix5507.md
+++ b/unison-src/tests/fix5507.md
@@ -1,0 +1,28 @@
+```ucm :hide
+scratch/main> builtins.merge lib.builtin
+```
+
+```unison :hide
+Nat.toBytesLittleEndian : Nat -> Bytes
+Nat.toBytesLittleEndian = encodeNat64le
+```
+
+```ucm :hide
+scratch/main> add
+```
+
+`Nat.toBytesLittleEndian` gets inlined, but it should still be found in the code cache when this is compiled and re-loaded.
+
+```unison :hide
+main : '{IO} ()
+main = do
+  _ = Nat.toBytesLittleEndian 3
+  match Code.lookup (termLink Nat.toBytesLittleEndian) with
+    Some _code -> ()
+    None -> bug "code cache was empty"
+```
+
+```ucm :hide
+scratch/main> add
+scratch/main> compile main fix5507
+```

--- a/unison-src/tests/fix5507.sh
+++ b/unison-src/tests/fix5507.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+set -ex
+
+# the first arg is the path to the unison executable
+if [ -z "$1" ]; then
+  echo "Usage: $0 <path-to-ucm>"
+  exit 1
+fi
+
+# call unison with all its args quoted
+"$@" transcript unison-src/tests/fix5507.md \
+  && "$@" run.compiled fix5507.uc


### PR DESCRIPTION
The issue in #5507 involves the `compile` command, and testing the resulting executable, which we can't currently do from a transcript alone.  This PR adds a scripts section to CI and a script to test this.