### PR TITLE
add runOnly support for unison-syntax tests

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -89,3 +89,4 @@ The format for this list: name, GitHub handle
 * Eduard Nicodei (@neduard)
 * Brian McKenna (@puffnfresh)
 * Ruslan Simchuk (@SimaDovakin)
+* Brandon Barker (@bbarker)

--- a/unison-syntax/test/Main.hs
+++ b/unison-syntax/test/Main.hs
@@ -7,9 +7,6 @@ import System.IO.CodePage (withCP65001)
 import Unison.Test.Doc qualified as Doc
 import Unison.Test.Unison qualified as Unison
 
--- main :: IO ()
--- main = withCP65001 . run $ tests [Unison.test, Doc.test]
-
 test :: Test ()
 test =
   tests

--- a/unison-syntax/test/Main.hs
+++ b/unison-syntax/test/Main.hs
@@ -1,9 +1,28 @@
 module Main (main) where
 
 import EasyTest
+import System.Environment (getArgs)
+import System.IO
 import System.IO.CodePage (withCP65001)
 import Unison.Test.Doc qualified as Doc
 import Unison.Test.Unison qualified as Unison
 
+-- main :: IO ()
+-- main = withCP65001 . run $ tests [Unison.test, Doc.test]
+
+test :: Test ()
+test =
+  tests
+    [ Doc.test,
+      Unison.test
+    ]
+
 main :: IO ()
-main = withCP65001 . run $ tests [Unison.test, Doc.test]
+main = withCP65001 do
+  args <- getArgs
+  mapM_ (`hSetEncoding` utf8) [stdout, stdin, stderr]
+  case args of
+    [] -> runOnly "" test
+    [prefix] -> runOnly prefix test
+    [seed, prefix] -> rerunOnly (read seed) prefix test
+    _ -> error "expected no args, a prefix, or a seed and a prefix"

--- a/unison-syntax/test/Unison/Test/Doc.hs
+++ b/unison-syntax/test/Unison/Test/Doc.hs
@@ -15,7 +15,7 @@ import Unison.Util.Recursion
 
 test :: Test ()
 test =
-  scope "Doc parser" . tests $
+  scope "DocParser" . tests $
     [ t "# Hello" [Doc.Section (Doc.Paragraph $ docWord "Hello" :| []) []],
       t
         ( unlines


### PR DESCRIPTION
## Overview

What does this change accomplish and why?

This makes it easier to run specific Unison in `unison-syntax`, e.g., we can now do:

```
stack test --fast unison-syntax --ta "DocParser.@typecheck"
```