### PR TITLE
making it a bit easier to run individual tests in Doc.hs

### DIFF
--- a/unison-syntax/package.yaml
+++ b/unison-syntax/package.yaml
@@ -41,6 +41,7 @@ tests:
       - easytest
       - free
       - megaparsec
+      - safe
       - unison-core1
       - unison-prelude
       - unison-syntax

--- a/unison-syntax/test/Unison/Test/Doc.hs
+++ b/unison-syntax/test/Unison/Test/Doc.hs
@@ -2,7 +2,9 @@ module Unison.Test.Doc (test) where
 
 import Control.Comonad.Trans.Cofree (CofreeF ((:<)))
 import Data.Bifunctor (first)
+import Data.Char (isAlphaNum)
 import Data.List.NonEmpty (NonEmpty ((:|)))
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import EasyTest
 import Text.Megaparsec qualified as P
@@ -12,6 +14,7 @@ import Unison.Syntax.Name qualified as Name
 import Unison.Syntax.Parser.Doc qualified as DP
 import Unison.Syntax.Parser.Doc.Data qualified as Doc
 import Unison.Util.Recursion
+import Safe (headMay)
 
 test :: Test ()
 test =
@@ -133,7 +136,7 @@ t ::
   [Doc.Top String (Fix (Doc.Leaf Text String)) (Fix (Doc.Top String (Fix (Doc.Leaf Text String))))] ->
   Test ()
 t s expected =
-  scope s
+  scope simpleScope $ scope s
     . either
       (crash . P.errorBundlePretty)
       ( \actual ->
@@ -147,6 +150,8 @@ t s expected =
                   crash "actual != expected"
       )
     $ P.runParser (DP.doc (Name.toText . HQ'.toName . snd <$> typeOrTerm) (P.manyTill P.anySingle) P.eof) "test case" s
+  where
+    simpleScope = fromMaybe "default" $ headMay $ words $ filter isAlphaNum s
 
 -- * Helper functions to make it easier to read the examples.
 

--- a/unison-syntax/unison-syntax.cabal
+++ b/unison-syntax/unison-syntax.cabal
@@ -132,6 +132,7 @@ test-suite syntax-tests
     , easytest
     , free
     , megaparsec
+    , safe
     , text
     , unison-core1
     , unison-prelude


### PR DESCRIPTION
## Overview

Previously, running e.g. `stack test --fast unison-syntax --ta "DocParser.Hello"`

Would result in:

```
Randomness seed for this run is 5876492311547008607
Raw test output to follow ...
------------------------------------------------------------
------------------------------------------------------------


😶  hmm ... no test results recorded
Tip: use `ok`, `expect`, or `crash` to record results
Tip: if running via `runOnly` or `rerunOnly`, check for typos
```

Now with this change we get:

```
🦄  DocParser.Hello.# Hello
🦄  DocParser.HelloAgain.# Hello
## Again

🦄  DocParser.HelloAgain.## Hello
# Again
```

I'm not sure this is the best solution, but maybe it is something to start with.