### PR TITLE
CLI names command can search for multiple names

### DIFF
--- a/lib/unison-pretty-printer/src/Unison/Util/Pretty.hs
+++ b/lib/unison-pretty-printer/src/Unison/Util/Pretty.hs
@@ -695,8 +695,8 @@ column2UnzippedM bottomPadding left right =
 column3sep ::
   (LL.ListLike s Char, IsString s) => Pretty s -> [(Pretty s, Pretty s, Pretty s)] -> Pretty s
 column3sep sep rows =
-  let bc = align [(b, sep <> c) | (_, b, c) <- rows]
-      abc = group <$> align [(a, sep <> bc) | ((a, _, _), bc) <- rows `zip` bc]
+  let bc = align $ [(b, indent sep c) | (_, b, c) <- rows]
+      abc = group <$> align [(a, indent sep bc) | ((a, _, _), bc) <- rows `zip` bc]
    in lines abc
 
 -- | Creates an aligned table with an arbitrary number of columns separated by `sep`

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -59,8 +59,8 @@ import Unison.Codebase.Editor.HandleInput.DeleteBranch (handleDeleteBranch)
 import Unison.Codebase.Editor.HandleInput.DeleteNamespace (getEndangeredDependents, handleDeleteNamespace)
 import Unison.Codebase.Editor.HandleInput.DeleteProject (handleDeleteProject)
 import Unison.Codebase.Editor.HandleInput.Dependents (handleDependents)
-import Unison.Codebase.Editor.HandleInput.EditNamespace (handleEditNamespace)
 import Unison.Codebase.Editor.HandleInput.EditDependents (handleEditDependents)
+import Unison.Codebase.Editor.HandleInput.EditNamespace (handleEditNamespace)
 import Unison.Codebase.Editor.HandleInput.FindAndReplace (handleStructuredFindI, handleStructuredFindReplaceI, handleTextFindI)
 import Unison.Codebase.Editor.HandleInput.FormatFile qualified as Format
 import Unison.Codebase.Editor.HandleInput.Global qualified as Global
@@ -73,6 +73,7 @@ import Unison.Codebase.Editor.HandleInput.MoveAll (handleMoveAll)
 import Unison.Codebase.Editor.HandleInput.MoveBranch (doMoveBranch)
 import Unison.Codebase.Editor.HandleInput.MoveTerm (doMoveTerm)
 import Unison.Codebase.Editor.HandleInput.MoveType (doMoveType)
+import Unison.Codebase.Editor.HandleInput.Names (handleNames)
 import Unison.Codebase.Editor.HandleInput.NamespaceDependencies (handleNamespaceDependencies)
 import Unison.Codebase.Editor.HandleInput.NamespaceDiffUtils (diffHelper)
 import Unison.Codebase.Editor.HandleInput.ProjectClone (handleClone)
@@ -497,29 +498,8 @@ loop e = do
 
                 fixupOutput :: Path.HQSplit -> HQ.HashQualified Name
                 fixupOutput = HQ'.toHQ . Path.nameFromHQSplit
-            NamesI global query -> do
-              hqLength <- Cli.runTransaction Codebase.hashLength
-              let searchNames names = do
-                    let pped = PPED.makePPED (PPE.hqNamer 10 names) (PPE.suffixifyByHash names)
-                        unsuffixifiedPPE = PPED.unsuffixifiedPPE pped
-                        terms = Names.lookupHQTerm Names.IncludeSuffixes query names
-                        types = Names.lookupHQType Names.IncludeSuffixes query names
-                        terms' :: [(Referent, [HQ'.HashQualified Name])]
-                        terms' = map (\r -> (r, PPE.allTermNames unsuffixifiedPPE r)) (Set.toList terms)
-                        types' :: [(Reference, [HQ'.HashQualified Name])]
-                        types' = map (\r -> (r, PPE.allTypeNames unsuffixifiedPPE r)) (Set.toList types)
-                    pure (terms', types')
-              if global
-                then do
-                  Global.forAllProjectBranches \(projBranchNames, _ids) branch -> do
-                    let names = Branch.toNames . Branch.head $ branch
-                    (terms, types) <- searchNames names
-                    when (not (null terms) || not (null types)) do
-                      Cli.respond $ GlobalListNames projBranchNames hqLength types terms
-                else do
-                  names <- Cli.currentNames
-                  (terms, types) <- searchNames names
-                  Cli.respond $ ListNames hqLength types terms
+            NamesI global queries -> do
+              mapM_ (handleNames global) queries
             DocsI srcs -> do
               for_ srcs docsI
             CreateAuthorI authorNameSegment authorFullName -> do

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Names.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Names.hs
@@ -1,0 +1,70 @@
+module Unison.Codebase.Editor.HandleInput.Names (handleNames) where
+
+import Control.Monad (when)
+import Data.Set qualified as Set
+import Unison.Cli.Monad (Cli)
+import Unison.Cli.Monad qualified as Cli
+import Unison.Cli.NamesUtils qualified as Cli
+import Unison.Codebase qualified as Codebase
+import Unison.Codebase.Branch qualified as Branch
+import Unison.Codebase.Branch.Names qualified as Branch
+import Unison.Codebase.Editor.HandleInput.Global qualified as Global
+import Unison.Codebase.Editor.Input (ErrorMessageOrName, RawQuery)
+import Unison.Codebase.Editor.Output (Output (..))
+import Unison.HashQualifiedPrime qualified as HQ'
+import Unison.Name (Name)
+import Unison.NamesWithHistory qualified as Names
+import Unison.PrettyPrintEnv qualified as PPE
+import Unison.PrettyPrintEnv.Names qualified as PPE
+import Unison.PrettyPrintEnvDecl qualified as PPED
+import Unison.PrettyPrintEnvDecl.Names qualified as PPED
+import Unison.Reference (Reference)
+import Unison.Referent (Referent)
+import Unison.Util.Pretty qualified as P
+
+-- | Handles a single @NamesI@ input query returning terms that match a given name.
+--
+-- Parameters:
+--
+-- * @global :: Bool@
+-- ** If @True@, search all projects and branches.
+-- ** If @False@, search only the current branch.
+--
+-- * @query :: (RawQuery, ErrorMessageOrName)@
+-- ** The first member is the raw @nameQuery@ being handled.
+-- ** The second member is the parsed @nameQuery@ that is either an error message
+--    to be printed or a name that can be looked up in the codebase.
+handleNames ::
+  Bool ->
+  (RawQuery, ErrorMessageOrName) ->
+  Cli ()
+handleNames _ (nameQuery, Left errMsg) = do
+  Cli.respond $
+    PrintMessage $
+      P.lines [prettyNameQuery, errMsg]
+  where
+    prettyNameQuery =
+      P.red (P.bold $ P.string nameQuery) <> ":"
+handleNames global (nameQuery, Right query) = do
+  hqLength <- Cli.runTransaction Codebase.hashLength
+  let searchNames names = do
+        let pped = PPED.makePPED (PPE.hqNamer 10 names) (PPE.suffixifyByHash names)
+            unsuffixifiedPPE = PPED.unsuffixifiedPPE pped
+            terms = Names.lookupHQTerm Names.IncludeSuffixes query names
+            types = Names.lookupHQType Names.IncludeSuffixes query names
+            terms' :: [(Referent, [HQ'.HashQualified Name])]
+            terms' = map (\r -> (r, PPE.allTermNames unsuffixifiedPPE r)) (Set.toList terms)
+            types' :: [(Reference, [HQ'.HashQualified Name])]
+            types' = map (\r -> (r, PPE.allTypeNames unsuffixifiedPPE r)) (Set.toList types)
+        pure (terms', types')
+  if global
+    then do
+      Global.forAllProjectBranches \(projBranchNames, _ids) branch -> do
+        let names = Branch.toNames . Branch.head $ branch
+        (terms, types) <- searchNames names
+        when (not (null terms) || not (null types)) do
+          Cli.respond $ GlobalListNames nameQuery projBranchNames hqLength types terms
+    else do
+      names <- Cli.currentNames
+      (terms, types) <- searchNames names
+      Cli.respond $ ListNames nameQuery hqLength types terms

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -27,6 +27,10 @@ module Unison.Codebase.Editor.Input
     IsGlobal,
     DeleteOutput (..),
     DeleteTarget (..),
+
+    -- * Type aliases
+    ErrorMessageOrName,
+    RawQuery,
   )
 where
 
@@ -60,6 +64,12 @@ type Source = Text -- "id x = x\nconst a b = a"
 type SourceName = Text -- "foo.u" or "buffer 7"
 
 type PatchPath = Path.Split'
+
+type ErrorMessageOrValue a = Either (P.Pretty P.ColorText) a
+
+type ErrorMessageOrName = ErrorMessageOrValue (HQ.HashQualified Name)
+
+type RawQuery = String
 
 data OptionalPatch = NoPatch | DefaultPatch | UsePatch PatchPath
   deriving (Eq, Ord, Show)
@@ -141,7 +151,8 @@ data Input
     -- > names .foo.bar
     -- > names .foo.bar#asdflkjsdf
     -- > names #sdflkjsdfhsdf
-    NamesI IsGlobal (HQ.HashQualified Name)
+    -- > names foo.bar foo.baz #sdflkjsdfhsdf
+    NamesI IsGlobal [(RawQuery, ErrorMessageOrName)]
   | AliasTermI !Bool HashOrHQSplit' Path.Split' -- bool = force?
   | AliasTypeI !Bool HashOrHQSplit' Path.Split' -- bool = force?
   | AliasManyI [Path.HQSplit] Path'

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -264,10 +264,12 @@ data Output
   | MovedOverExistingBranch Path'
   | DeletedEverything
   | ListNames
+      String -- input namesQuery for which this output is being produced
       Int -- hq length to print References
       [(Reference, [HQ'.HashQualified Name])] -- type match, type names
       [(Referent, [HQ'.HashQualified Name])] -- term match, term names
   | GlobalListNames
+      String -- input namesQuery for which this output is being produced
       (ProjectAndBranch ProjectName ProjectBranchName)
       Int -- hq length to print References
       [(Reference, [HQ'.HashQualified Name])] -- type match, type names
@@ -547,7 +549,7 @@ isFailure o = case o of
   MoveRootBranchConfirmation -> False
   MovedOverExistingBranch {} -> False
   DeletedEverything -> False
-  ListNames _ tys tms -> null tms && null tys
+  ListNames _ _ tys tms -> null tms && null tys
   GlobalListNames {} -> False
   ListOfDefinitions _ _ _ ds -> null ds
   GlobalFindBranchResults _ _ _ _ -> False

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -74,6 +74,7 @@ library
       Unison.Codebase.Editor.HandleInput.MoveBranch
       Unison.Codebase.Editor.HandleInput.MoveTerm
       Unison.Codebase.Editor.HandleInput.MoveType
+      Unison.Codebase.Editor.HandleInput.Names
       Unison.Codebase.Editor.HandleInput.NamespaceDependencies
       Unison.Codebase.Editor.HandleInput.NamespaceDiffUtils
       Unison.Codebase.Editor.HandleInput.ProjectClone

--- a/unison-src/transcripts/idempotent/ability-order-doesnt-affect-hash.md
+++ b/unison-src/transcripts/idempotent/ability-order-doesnt-affect-hash.md
@@ -26,7 +26,7 @@ scratch/main> add
 
 scratch/main> names term1
 
-  Term
-  Hash:   #42m1ui9g56
-  Names:  term1 term2
+  'term1':
+  Hash          Kind   Names
+  #42m1ui9g56   Term   term1, term2
 ```

--- a/unison-src/transcripts/idempotent/deep-names.md
+++ b/unison-src/transcripts/idempotent/deep-names.md
@@ -53,15 +53,15 @@ As such, we see two copies of `a` and two copies of `x` via these direct depende
 ``` ucm
 scratch/app1> names a
 
-  Term
-  Hash:   #gjmq673r1v
-  Names:  lib.text_v1.a lib.text_v2.a
+  'a':
+  Hash          Kind   Names
+  #gjmq673r1v   Term   lib.text_v1.a, lib.text_v2.a
 
 scratch/app1> names x
 
-  Term
-  Hash:   #nsmc4p1ra4
-  Names:  lib.http_v3.x lib.http_v4.x
+  'x':
+  Hash          Kind   Names
+  #nsmc4p1ra4   Term   lib.http_v3.x, lib.http_v4.x
 ```
 
 Our `app2` project includes the `http` library twice as direct dependencies, and once as an indirect dependency via `webutil`.
@@ -103,13 +103,13 @@ We see neither the second indirect copy of `a` nor the indirect copy of `x` via 
 ``` ucm
 scratch/app2> names a
 
-  Term
-  Hash:   #gjmq673r1v
-  Names:  lib.webutil.lib.text_v1.a
+  'a':
+  Hash          Kind   Names
+  #gjmq673r1v   Term   lib.webutil.lib.text_v1.a
 
 scratch/app2> names x
 
-  Term
-  Hash:   #nsmc4p1ra4
-  Names:  lib.http_v1.x lib.http_v2.x
+  'x':
+  Hash          Kind   Names
+  #nsmc4p1ra4   Term   lib.http_v1.x, lib.http_v2.x
 ```

--- a/unison-src/transcripts/idempotent/help.md
+++ b/unison-src/transcripts/idempotent/help.md
@@ -152,10 +152,13 @@ scratch/main> help
                                    operation.
 
   debug.names.global
-  `debug.names.global foo` Iteratively search across all
-  projects and branches for names matching `foo`. Note that this
-  is expected to be quite slow and is primarily for debugging
-  issues with your codebase.
+  Iteratively search names or hashes across all projects and branches.
+  `debug.names.global foo` List all known names for `foo`.
+  `debug.names.global foo #bar` List all known names for the
+  name `foo` and for the hash `#bar`.
+  `debug.names.global` without arguments invokes a search to
+  select names/hashes to list, which requires that `fzf` can be
+  found within your PATH.
 
   debug.numberedArgs
   Dump the contents of the numbered args state.
@@ -553,8 +556,13 @@ scratch/main> help
   `move.type foo bar` renames `foo` to `bar`.
 
   names
-  `names foo` List all known names for `foo` in the current
-  branch.
+  Search names or hashes in the current branch.
+  `names foo` List all known names for `foo`.
+  `names foo #bar` List all known names for the name `foo` and
+  for the hash `#bar`.
+  `names` without arguments invokes a search to select
+  names/hashes to list, which requires that `fzf` can be found
+  within your PATH.
 
   namespace.dependencies
   List the external dependencies of the specified namespace.

--- a/unison-src/transcripts/idempotent/names.md
+++ b/unison-src/transcripts/idempotent/names.md
@@ -16,6 +16,24 @@ some.otherplace.x = 10
 somewhere.z = 1
 -- Some similar name with a different value
 somewhere.y = 2
+
+another.Boolean = true
+
+dd.baz = true
+aa.baz = true
+bb.baz = true
+cc.baz = true
+
+d.baz = 100
+a.baz = 100
+b.baz = 100
+c.baz = 100
+
+type a.baz = Boolean
+type z.baz = Boolean
+
+
+xyz.baz = 100.1
 ```
 
 ``` ucm :added-by-ucm
@@ -27,11 +45,23 @@ somewhere.y = 2
 
     ⍟ These new definitions are ok to `add`:
     
+      type a.baz
+      type z.baz
+      a.baz             : Nat
+      aa.baz            : Boolean
+      another.Boolean   : Boolean
+      b.baz             : Nat
+      bb.baz            : Boolean
+      c.baz             : Nat
+      cc.baz            : Boolean
+      d.baz             : Nat
+      dd.baz            : Boolean
       some.otherplace.x : Nat
       some.otherplace.y : Nat
       some.place.x      : Nat
       somewhere.y       : Nat
       somewhere.z       : Nat
+      xyz.baz           : Float
 ```
 
 ``` ucm
@@ -39,11 +69,23 @@ scratch/main> add
 
   ⍟ I've added these definitions:
 
+    type a.baz
+    type z.baz
+    a.baz             : Nat
+    aa.baz            : Boolean
+    another.Boolean   : Boolean
+    b.baz             : Nat
+    bb.baz            : Boolean
+    c.baz             : Nat
+    cc.baz            : Boolean
+    d.baz             : Nat
+    dd.baz            : Boolean
     some.otherplace.x : Nat
     some.otherplace.y : Nat
     some.place.x      : Nat
     somewhere.y       : Nat
     somewhere.z       : Nat
+    xyz.baz           : Float
 ```
 
 `names` searches relative to the current path.
@@ -53,45 +95,76 @@ scratch/main> add
 
 scratch/main> names x
 
-  Terms
-  Hash:   #gjmq673r1v
-  Names:  some.otherplace.y some.place.x somewhere.z
+  'x':
+  Hash          Kind   Names
+  #pi25gcdv0o   Term   some.otherplace.x
+  #gjmq673r1v   Term   some.otherplace.y,
+                       some.place.x,
+                       somewhere.z
 
-  Hash:   #pi25gcdv0o
-  Names:  some.otherplace.x
+-- We can search for multiple names in one command
+
+scratch/main> names x y
+
+  'x':
+  Hash          Kind   Names
+  #pi25gcdv0o   Term   some.otherplace.x
+  #gjmq673r1v   Term   some.otherplace.y,
+                       some.place.x,
+                       somewhere.z
+
+  'y':
+  Hash          Kind   Names
+  #gjmq673r1v   Term   some.otherplace.y,
+                       some.place.x,
+                       somewhere.z
+  #dcgdua2lj6   Term   somewhere.y
 
 -- We can search by hash, and see all aliases of that hash
 
 scratch/main> names #gjmq673r1v
 
-  Term
-  Hash:   #gjmq673r1v
-  Names:  some.otherplace.y some.place.x somewhere.z
+  '#gjmq673r1v':
+  Hash          Kind   Names
+  #gjmq673r1v   Term   some.otherplace.y,
+                       some.place.x,
+                       somewhere.z
 
 -- Works with absolute names too
 
 scratch/main> names .some.place.x
 
-  Term
-  Hash:   #gjmq673r1v
-  Names:  some.otherplace.y some.place.x somewhere.z
+  '.some.place.x':
+  Hash          Kind   Names
+  #gjmq673r1v   Term   some.otherplace.y,
+                       some.place.x,
+                       somewhere.z
 ```
 
 `debug.names.global` searches from the root, and absolutely qualifies results
 
 ``` ucm
--- We can search from a different branch and find all names in the codebase named 'x', and each of their aliases respectively.
+-- We can search from a different branch and find all names in the codebase named 'x' and those named 'y', and each of their aliases respectively.
 
-scratch/other> debug.names.global x
+scratch/other> debug.names.global x y
 
   Found results in scratch/main
 
-  Terms
-  Hash:   #gjmq673r1v
-  Names:  some.otherplace.y some.place.x somewhere.z
+  'x':
+  Hash          Kind   Names
+  #pi25gcdv0o   Term   some.otherplace.x
+  #gjmq673r1v   Term   some.otherplace.y,
+                       some.place.x,
+                       somewhere.z
 
-  Hash:   #pi25gcdv0o
-  Names:  some.otherplace.x
+  Found results in scratch/main
+
+  'y':
+  Hash          Kind   Names
+  #gjmq673r1v   Term   some.otherplace.y,
+                       some.place.x,
+                       somewhere.z
+  #dcgdua2lj6   Term   somewhere.y
 
 -- We can search by hash, and see all aliases of that hash in the codebase
 
@@ -99,9 +172,11 @@ scratch/other> debug.names.global #gjmq673r1v
 
   Found results in scratch/main
 
-  Term
-  Hash:   #gjmq673r1v
-  Names:  some.otherplace.y some.place.x somewhere.z
+  '#gjmq673r1v':
+  Hash          Kind   Names
+  #gjmq673r1v   Term   some.otherplace.y,
+                       some.place.x,
+                       somewhere.z
 
 -- We can search using an absolute name
 
@@ -109,7 +184,70 @@ scratch/other> debug.names.global .some.place.x
 
   Found results in scratch/main
 
-  Term
-  Hash:   #gjmq673r1v
-  Names:  some.otherplace.y some.place.x somewhere.z
+  '.some.place.x':
+  Hash          Kind   Names
+  #gjmq673r1v   Term   some.otherplace.y,
+                       some.place.x,
+                       somewhere.z
+```
+
+``` ucm :error
+-- We can handle many name queries, some of which fail and some of which succeed
+
+-- The names command is considered to have failed because there are 1 or more query failures
+
+-- We can display hashes that are references to types and to terms
+
+-- Each list of names in the Names column is sorted alphabetically
+
+-- Each row is sorted by the Names column, alphabetically by name and then by the length of the list
+
+scratch/main> names max /invalid1 /invalid2 + Boolean foo baz
+
+  'max':
+  Hash          Kind   Names
+  ##Float.max   Term   lib.builtins.Float.max
+
+  /invalid1:
+  /invalid1 is not a well-formed name, hash, or hash-qualified
+  name. I expected something like `foo`, `#abc123`, or
+  `foo#abc123`.
+
+  /invalid2:
+  /invalid2 is not a well-formed name, hash, or hash-qualified
+  name. I expected something like `foo`, `#abc123`, or
+  `foo#abc123`.
+
+  '+':
+  Hash        Kind   Names
+  ##Float.+   Term   lib.builtins.Float.+
+  ##Int.+     Term   lib.builtins.Int.+
+  ##Nat.+     Term   lib.builtins.Nat.+
+
+  'Boolean':
+  Hash            Kind   Names
+  #idl63c82kf#0   Term   a.baz.Boolean
+  #56fi1cmq3u     Term   aa.baz,
+                         another.Boolean,
+                         bb.baz,
+                         cc.baz,
+                         dd.baz
+  ##Boolean       Type   lib.builtins.Boolean
+  #cmihlkoddu#0   Term   z.baz.Boolean
+
+  'foo':
+  😶
+  I couldn't find anything by that name.
+
+  'baz':
+  Hash          Kind   Names
+  #idl63c82kf   Type   a.baz
+  #u1qsl3nk5t   Term   a.baz, b.baz, c.baz, d.baz
+  #56fi1cmq3u   Term   aa.baz,
+                       another.Boolean,
+                       bb.baz,
+                       cc.baz,
+                       dd.baz
+  #00kr10tpqr   Term   xyz.baz
+  #cmihlkoddu   Type   z.baz
 ```

--- a/unison-src/transcripts/idempotent/suffixes.md
+++ b/unison-src/transcripts/idempotent/suffixes.md
@@ -161,7 +161,7 @@ scratch/main> view distributed.abra.cadabra
 
 scratch/main> names distributed.lib.baz.qux
 
-  Term
-  Hash:   #nhup096n2s
-  Names:  lib.distributed.lib.baz.qux
+  'distributed.lib.baz.qux':
+  Hash          Kind   Names
+  #nhup096n2s   Term   lib.distributed.lib.baz.qux
 ```

--- a/unison-src/transcripts/idempotent/unique-type-churn.md
+++ b/unison-src/transcripts/idempotent/unique-type-churn.md
@@ -51,13 +51,10 @@ If the name stays the same, the churn is even prevented if the type is updated a
 ``` ucm
 scratch/main> names A
 
-  Type
-  Hash:  #j743idicb1
-  Names: A
-
-  Term
-  Hash:   #j743idicb1#0
-  Names:  A.A
+  'A':
+  Hash            Kind   Names
+  #j743idicb1     Type   A
+  #j743idicb1#0   Term   A.A
 ```
 
 ``` unison
@@ -87,13 +84,10 @@ scratch/main> update
 
 scratch/main> names A
 
-  Type
-  Hash:  #186m0i6upt
-  Names: A
-
-  Term
-  Hash:   #186m0i6upt#0
-  Names:  A.A
+  'A':
+  Hash            Kind   Names
+  #186m0i6upt     Type   A
+  #186m0i6upt#0   Term   A.A
 ```
 
 ``` unison
@@ -125,11 +119,8 @@ scratch/main> update
 
 scratch/main> names A
 
-  Type
-  Hash:  #j743idicb1
-  Names: A
-
-  Term
-  Hash:   #j743idicb1#0
-  Names:  A.A
+  'A':
+  Hash            Kind   Names
+  #j743idicb1     Type   A
+  #j743idicb1#0   Term   A.A
 ```

--- a/unison-src/transcripts/idempotent/update-ignores-lib-namespace.md
+++ b/unison-src/transcripts/idempotent/update-ignores-lib-namespace.md
@@ -61,7 +61,7 @@ scratch/main> update
 
 scratch/main> names foo
 
-  Term
-  Hash:   #9ntnotdp87
-  Names:  foo
+  'foo':
+  Hash          Kind   Names
+  #9ntnotdp87   Term   foo
 ```

--- a/unison-src/transcripts/merge.output.md
+++ b/unison-src/transcripts/merge.output.md
@@ -2206,9 +2206,9 @@ scratch/alice> add
 ``` ucm
 scratch/alice> names A
 
-  Type
-  Hash:  #65mdg7015r
-  Names: A A.inner.X
+  'A':
+  Hash          Kind   Names
+  #65mdg7015r   Type   A, A.inner.X
 ```
 
 Bob's branch:
@@ -3364,15 +3364,15 @@ scratch/merge-bob-into-alice> update
 
 scratch/merge-bob-into-alice> names Bar
 
-  Type
-  Hash:  #h3af39sae7
-  Names: Bar
+  'Bar':
+  Hash          Kind   Names
+  #h3af39sae7   Type   Bar
 
 scratch/alice> names Bar
 
-  Type
-  Hash:  #h3af39sae7
-  Names: Bar
+  'Bar':
+  Hash          Kind   Names
+  #h3af39sae7   Type   Bar
 ```
 
 ``` ucm :hide


### PR DESCRIPTION
## Overview

This change allows the `names` CLI command to take multiple name/hash arguments to be looked up in the codebase for matching terms.

After this change, the output of names given multiple arguments looks like the following:

```
scratch/main> names max /invalid1 /invalid2 + Boolean foo baz

  'max':
  Hash          Kind   Names
  ##Float.max   Term   lib.builtins.Float.max

  /invalid1:
  /invalid1 is not a well-formed name, hash, or hash-qualified
  name. I expected something like `foo`, `#abc123`, or
  `foo#abc123`.

  /invalid2:
  /invalid2 is not a well-formed name, hash, or hash-qualified
  name. I expected something like `foo`, `#abc123`, or
  `foo#abc123`.

  '+':
  Hash        Kind   Names
  ##Float.+   Term   lib.builtins.Float.+
  ##Int.+     Term   lib.builtins.Int.+
  ##Nat.+     Term   lib.builtins.Nat.+

  'Boolean':
  Hash            Kind   Names
  #idl63c82kf#0   Term   a.baz.Boolean
  #56fi1cmq3u     Term   aa.baz,
                         another.Boolean,
                         bb.baz,
                         cc.baz,
                         dd.baz
  ##Boolean       Type   lib.builtins.Boolean
  #cmihlkoddu#0   Term   z.baz.Boolean

  'foo':
  😶
  I couldn't find anything by that name.

  'baz':
  Hash          Kind   Names
  #idl63c82kf   Type   a.baz
  #u1qsl3nk5t   Term   a.baz, b.baz, c.baz, d.baz
  #56fi1cmq3u   Term   aa.baz,
                       another.Boolean,
                       bb.baz,
                       cc.baz,
                       dd.baz
  #00kr10tpqr   Term   xyz.baz
  #cmihlkoddu   Type   z.baz

```

Note that due to partial failure (some name queries are invalid or unknown/empty), the entire names command is considered a failure.

The output is coloured to show success/failure of each name query at a glance

![image](https://github.com/user-attachments/assets/4590d16e-0778-4f25-9869-5ed91137f1a7)


Closes #3557.

## Implementation notes

In `Unison.Codebase.Editor.Input`, changes  `Input` constructor `NamesI IsGlobal (HQ.HashQualified Name)` to `NamesI IsGlobal [(RawQuery, ErrorMessageOrName)]` where the following type aliases are defined:

```haskell
type ErrorMessageOrValue a = Either (P.Pretty P.ColorText) a
type ErrorMessageOrName = ErrorMessageOrValue (HQ.HashQualified Name)
type RawQuery = String
```
This change is required so that a batch of names can be handled with the original raw query string available to be printed as headings in the final output and so error messages in parsing a raw query/arg can be printed if necessary for each query.

Updates `Unison.CommandLine.InputPatterns` to take multiple names and produce the modified `NamesI`.

Updates `Unison.Codebase.Editor.HandleInput` to handle the modified `NamesI` by mapping over each name/hash query in the batch. 

Updates `Output` type in `Unison.Codebase.Editor.Output` so that the `ListNames` and `GlobalListnames` constructors take an additional `String` value that is the name query for printing headers.

Updates function `listOfNames` in `Unison.CommandLine.OutputMessage` to print a compact table of hashes, hash kinds, and names. Sorts the names column alphabetically and orders rows by the names column.

## Interesting/controversial decisions

Include anything that you thought twice about, debated, chose arbitrarily, etc.
What could have been done differently, but wasn't? And why?

### 1
When a single name is queried, the output of `names` still includes a heading for the raw name query:

```
scratch/main> names max

  '+':
  Hash              Kind        Names
  builtin.Float.+   ##Float.+   Term
  builtin.Int.+     ##Int.+     Term
  builtin.Nat.+     ##Nat.+     Term
```

### 2

The Kind column shows whether the hash refers to a term or a type. Kind may be an overloaded word here, but I wasn't aware of a better word.

## Test coverage

Existing transcript tests cover `names` and `debug.names.global` queries for single argument cases. Cases for handling multiple arguments were added to these tests. Cases exercising the sorting of the tabular output were also added. Existing transcript tests also cover the help output when using e.g. `? names`.

## Loose ends

I want to cover adding multiple args support to `list`/`ls` in a new issue (to be created).

During design discussion we wanted to put the Names column first, but because of an outstanding pretty printing bug we decided to defer this. See https://github.com/unisonweb/unison/issues/5550.

## Evolution

Originally, the output of names remained similar to the original format but with headers for the name queries. This was changed to provide a more compact table-oriented format after design discussion. 

Additionally, new Output constructors were initially added (BatchedOutput and IndentedOutput) to enable adding such headers without touching the original Output constructor signatures. This was changed to reduce the complexity overhead from the new constructors.
