### PR TITLE
Error Messages: on name resolution failure, suggest similar names

### DIFF
--- a/parser-typechecker/src/Unison/DataDeclaration/Dependencies.hs
+++ b/parser-typechecker/src/Unison/DataDeclaration/Dependencies.hs
@@ -122,5 +122,6 @@ hashFieldAccessors ppe declName vars declRef dd = do
                 effectDecls = mempty
               },
           termsByShortname = mempty,
+          freeNameToFuzzyTermsByShortName = Map.empty,
           topLevelComponents = Map.empty
         }

--- a/parser-typechecker/src/Unison/FileParsers.hs
+++ b/parser-typechecker/src/Unison/FileParsers.hs
@@ -110,7 +110,13 @@ computeTypecheckingEnvironment shouldUseTndr ambientAbilities typeLookupf uf =
               localNames
 
           localNames = Set.map Name.unsafeParseVar (UF.toTermAndWatchNames uf)
-          globalNamesShadowed = Names.shadowing (UF.toNames uf) (Parser.names parsingEnv)
+          -- We exclude names from indirect dependencies for fuzzy searching during name resolution,
+          -- that is dependencies under lib.*.lib for performance
+          -- TODO: We may consider exposing user configuration to enable searching through indirect dependencies
+          globalNamesShadowed = excludeNamesFromIndirectDeps $ Names.shadowing (UF.toNames uf) (Parser.names parsingEnv)
+            where
+              excludeNamesFromIndirectDeps = Names.filter (Name.classifyNameLocation >>> excludeIndirectDeps)
+              excludeIndirectDeps = (\case Name.NameLocation'IndirectDep -> False; _otherwise -> True)
 
           freeNames :: [Name]
           freeNames =

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -685,7 +685,7 @@ renderTypeError e env src = case e of
         Type.Var' (TypeVar.Existential {}) -> mempty
         _ -> Pr.wrap $ "It should be of type " <> Pr.group (style Type1 (renderType' env expectedType) <> ".")
   UnknownTerm {..} ->
-    let (correct, rightNameWrongTypes, wrongNameRightTypes, similarNameRightTypes, similarNameWrongTypes) =
+    let (suggestionsRightNameRightType, suggestionsRightNameWrongType, suggestionsWrongNameRightType, suggestionsSimilarNameRightType, suggestionsSimilarNameWrongType) =
           foldr
             sep
             id
@@ -700,16 +700,15 @@ renderTypeError e env src = case e of
             C.SimilarNameWrongType -> (_5 %~ (s :)) . r
         undefinedSymbolHelp =
           mconcat
-            [ ( case expectedType of
-                  Type.Var' (TypeVar.Existential {}) ->
-                    Pr.wrap "I also don't know what type it should be."
-                  _ ->
-                    mconcat
-                      [ Pr.wrap "I think its type should be:",
-                        "\n\n",
-                        Pr.indentN 4 (style Type1 (renderType' env expectedType))
-                      ]
-              ),
+            [ case expectedType of
+                Type.Var' (TypeVar.Existential {}) ->
+                  Pr.wrap "I also don't know what type it should be."
+                _ ->
+                  mconcat
+                    [ Pr.wrap "I think its type should be:",
+                      "\n\n",
+                      Pr.indentN 4 (style Type1 (renderType' env expectedType))
+                    ],
               "\n\n",
               Pr.hang
                 "Some common causes of this error include:"
@@ -720,89 +719,83 @@ renderTypeError e env src = case e of
                     ]
                 )
             ]
+
+        -- Handle various types of transitions
+        -- The suggestions should be ordered such that handling the first set of suggestions that is non-empty is sufficient
+        handleSuggestions (suggestionsRightNameRightType, _, _, _, _)
+          | not $ null suggestionsRightNameRightType =
+              mconcat
+                [ Pr.wrap
+                    ( mconcat
+                        [ mconcat
+                            [ "The name ",
+                              style Identifier (Var.nameStr unknownTermV),
+                              " is ambiguous. "
+                            ],
+                          case expectedType of
+                            Type.Var' (TypeVar.Existential {}) -> "I couldn't narrow it down by type, as any type would work here."
+                            _ ->
+                              "Its type should be:\n\n"
+                                <> Pr.indentN 4 (style Type1 (renderType' env expectedType))
+                        ]
+                    ),
+                  "\n\n",
+                  Pr.wrap "I found some terms in scope that have matching names and types. Maybe you meant one of these:",
+                  "\n\n",
+                  intercalateMap "\n" (renderSuggestion env) suggestionsRightNameRightType
+                ]
+        handleSuggestions (_, suggestionsRightNameWrongType, _, _, _)
+          | not $ null suggestionsRightNameWrongType =
+              let helpMeOut =
+                    Pr.wrap
+                      ( mconcat
+                          [ "Help me out by",
+                            Pr.bold "using a more specific name here",
+                            "or",
+                            Pr.bold "adding a type annotation."
+                          ]
+                      )
+               in Pr.wrap
+                    ( "The name "
+                        <> style Identifier (Var.nameStr unknownTermV)
+                        <> " is ambiguous. I tried to resolve it by type but"
+                    )
+                    <> " "
+                    <> case expectedType of
+                      Type.Var' (TypeVar.Existential {}) -> Pr.wrap ("its type could be anything." <> helpMeOut) <> "\n"
+                      _ ->
+                        mconcat
+                          [ Pr.wrap $
+                              mconcat
+                                [ "no term with that name would pass typechecking.",
+                                  "I think its type should be:"
+                                ],
+                            "\n\n",
+                            Pr.indentN 4 (style Type1 (renderType' env expectedType)),
+                            "\n\n",
+                            Pr.wrap
+                              ( mconcat
+                                  [ "If that's not what you expected, you may have a type error somewhere else in your code.",
+                                    helpMeOut
+                                  ]
+                              )
+                          ]
+                    <> "\n\n"
+                    <> formatWrongs preambleRightNameWrongType suggestionsRightNameWrongType
+        handleSuggestions (_, _, suggestionsSimilarNameRightType, _, _)
+          | not $ null suggestionsSimilarNameRightType =
+              formatWrongs preambleSimilarNameRightType suggestionsSimilarNameRightType
+        handleSuggestions (_, _, _, suggestionsWrongNameRightType, suggestionsSimilarNameWrongType)
+          | not $ null (suggestionsSimilarNameWrongType ++ suggestionsWrongNameRightType) =
+              formatWrongs preambleDifferentNameWrongType (suggestionsSimilarNameWrongType ++ suggestionsWrongNameRightType)
+        handleSuggestions (_, _, _, _, _) = undefinedSymbolHelp
      in mconcat
           [ "I couldn't figure out what ",
             style ErrorSite (Var.nameStr unknownTermV),
             " refers to here:\n\n",
             annotatedAsErrorSite src termSite,
             "\n",
-            case correct of
-              [] -> case rightNameWrongTypes of
-                [] -> case similarNameRightTypes of
-                  [] ->
-                    -- If available, show any 'WrongNameRightType' or 'SimilarNameWrongType' suggestions
-                    -- Otherwise if no suggestions are available show 'undefinedSymbolHelp'
-                    if null wrongNameRightTypes && null similarNameWrongTypes
-                      then undefinedSymbolHelp
-                      else
-                        mconcat
-                          [ if null similarNameWrongTypes
-                              then ""
-                              else formatWrongs similarNameWrongTypeText similarNameWrongTypes,
-                            if null wrongNameRightTypes
-                              then ""
-                              else formatWrongs wrongNameRightTypeText wrongNameRightTypes
-                          ]
-                  similarNameRightTypes -> formatWrongs similarNameRightTypeText similarNameRightTypes
-                rightNameWrongTypes ->
-                  let helpMeOut =
-                        Pr.wrap
-                          ( mconcat
-                              [ "Help me out by",
-                                Pr.bold "using a more specific name here",
-                                "or",
-                                Pr.bold "adding a type annotation."
-                              ]
-                          )
-                   in Pr.wrap
-                        ( "The name "
-                            <> style Identifier (Var.nameStr unknownTermV)
-                            <> " is ambiguous. I tried to resolve it by type but"
-                        )
-                        <> " "
-                        <> case expectedType of
-                          Type.Var' (TypeVar.Existential {}) -> Pr.wrap ("its type could be anything." <> helpMeOut) <> "\n"
-                          _ ->
-                            mconcat
-                              [ ( Pr.wrap $
-                                    mconcat
-                                      [ "no term with that name would pass typechecking.",
-                                        "I think its type should be:"
-                                      ]
-                                ),
-                                "\n\n",
-                                Pr.indentN 4 (style Type1 (renderType' env expectedType)),
-                                "\n\n",
-                                Pr.wrap
-                                  ( mconcat
-                                      [ "If that's not what you expected, you may have a type error somewhere else in your code.",
-                                        helpMeOut
-                                      ]
-                                  )
-                              ]
-                        <> "\n\n"
-                        <> formatWrongs rightNameWrongTypeText rightNameWrongTypes
-              suggs ->
-                mconcat
-                  [ Pr.wrap
-                      ( mconcat
-                          [ mconcat
-                              [ "The name ",
-                                style Identifier (Var.nameStr unknownTermV),
-                                " is ambiguous. "
-                              ],
-                            case expectedType of
-                              Type.Var' (TypeVar.Existential {}) -> "I couldn't narrow it down by type, as any type would work here."
-                              _ ->
-                                "Its type should be:\n\n"
-                                  <> Pr.indentN 4 (style Type1 (renderType' env expectedType))
-                          ]
-                      ),
-                    "\n\n",
-                    Pr.wrap "I found some terms in scope that have matching names and types. Maybe you meant one of these:",
-                    "\n\n",
-                    intercalateMap "\n" (renderSuggestion env) suggs
-                  ]
+            handleSuggestions (suggestionsRightNameRightType, suggestionsRightNameWrongType, suggestionsWrongNameRightType, suggestionsSimilarNameRightType, suggestionsSimilarNameWrongType)
           ]
   DuplicateDefinitions {..} ->
     mconcat
@@ -862,46 +855,64 @@ renderTypeError e env src = case e of
         summary note
       ]
   where
-    rightNameWrongTypeText _ =
-      mconcat
-        [ "I found one or more terms in scope with the ",
-          Pr.bold "right names ",
-          "but the ",
-          Pr.bold "wrong types.",
-          "\n",
-          "If you meant to use one of these, try using it with its full name and then adjusting types",
-          ":\n\n"
-        ]
-    similarNameRightTypeText _ =
-      mconcat
-        [ "I found one or more terms in scope with ",
-          Pr.bold "similar names ",
-          "and the ",
-          Pr.bold "right types.",
-          "\n",
-          "If you meant to use one of these, try using it instead",
-          ":\n\n"
-        ]
-    similarNameWrongTypeText _ =
-      mconcat
-        [ "I found one or more terms in scope with ",
-          Pr.bold "similar names ",
-          "but the ",
-          Pr.bold "wrong types.",
-          "\n",
-          "If you meant to use one of these, try using it instead and then adjusting types",
-          ":\n\n"
-        ]
-    wrongNameRightTypeText _ =
-      mconcat
-        [ "I found one or more terms in scope with the ",
-          Pr.bold "wrong names ",
-          "but the ",
-          Pr.bold "right types.",
-          "\n",
-          "If you meant to use one of these, try using it instead",
-          ":\n\n"
-        ]
+    preambleRightNameWrongType pl =
+      Pr.paragraphyText
+        ( mconcat
+            [ "I found ",
+              pl "a term" "some terms",
+              " in scope with ",
+              pl "a " "",
+              "matching name",
+              pl "" "s",
+              " but ",
+              pl "a " "",
+              "different type",
+              pl "" "s",
+              ". ",
+              "If ",
+              pl "this" "one of these",
+              " is what you meant, try using its full name:"
+            ]
+        )
+        <> "\n\n"
+    preambleSimilarNameRightType pl =
+      Pr.paragraphyText
+        ( mconcat
+            [ "I found ",
+              pl "a term" "some terms",
+              " in scope with ",
+              pl "a " "",
+              "matching type",
+              pl "" "s",
+              " but ",
+              pl "a " "",
+              "different name",
+              pl "" "s",
+              ". ",
+              "Maybe you meant ",
+              pl "this" "one of these",
+              ":\n\n"
+            ]
+        )
+    preambleDifferentNameWrongType pl =
+      Pr.paragraphyText
+        ( mconcat
+            [ "I found ",
+              pl "a term" "some terms",
+              " in scope with ",
+              pl "a " "",
+              "similar name",
+              pl "" "s",
+              " but ",
+              pl "a " "",
+              "different type",
+              pl "" "s",
+              ". ",
+              "Maybe you meant ",
+              pl "this" "one of these",
+              ":\n\n"
+            ]
+        )
     formatWrongs txt wrongs =
       let sz = length wrongs
           pl a b = if sz == 1 then a else b

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -15,7 +15,7 @@ module Unison.PrintError
   )
 where
 
-import Control.Lens.Tuple (_1, _2, _3)
+import Control.Lens.Tuple (_1, _2, _3, _4, _5)
 import Data.Foldable qualified as Foldable
 import Data.Function (on)
 import Data.List (find, intersperse, sortBy)
@@ -685,17 +685,19 @@ renderTypeError e env src = case e of
         Type.Var' (TypeVar.Existential {}) -> mempty
         _ -> Pr.wrap $ "It should be of type " <> Pr.group (style Type1 (renderType' env expectedType) <> ".")
   UnknownTerm {..} ->
-    let (correct, wrongTypes, wrongNames) =
+    let (correct, rightNameWrongTypes, wrongNameRightTypes, similarNameRightTypes, similarNameWrongTypes) =
           foldr
             sep
             id
             (sortBy (comparing length <> compare `on` (Name.segments . C.suggestionName)) suggestions)
-            ([], [], [])
+            ([], [], [], [], [])
         sep s@(C.Suggestion _ _ _ match) r =
           case match of
             C.Exact -> (_1 %~ (s :)) . r
-            C.WrongType -> (_2 %~ (s :)) . r
-            C.WrongName -> (_3 %~ (s :)) . r
+            C.RightNameWrongType -> (_2 %~ (s :)) . r
+            C.WrongNameRightType -> (_3 %~ (s :)) . r
+            C.SimilarNameRightType -> (_4 %~ (s :)) . r
+            C.SimilarNameWrongType -> (_5 %~ (s :)) . r
         undefinedSymbolHelp =
           mconcat
             [ ( case expectedType of
@@ -725,11 +727,24 @@ renderTypeError e env src = case e of
             annotatedAsErrorSite src termSite,
             "\n",
             case correct of
-              [] -> case wrongTypes of
-                [] -> case wrongNames of
-                  [] -> undefinedSymbolHelp
-                  wrongs -> formatWrongs wrongNameText wrongs
-                wrongs ->
+              [] -> case rightNameWrongTypes of
+                [] -> case similarNameRightTypes of
+                  [] ->
+                    -- If available, show any 'WrongNameRightType' or 'SimilarNameWrongType' suggestions
+                    -- Otherwise if no suggestions are available show 'undefinedSymbolHelp'
+                    if null wrongNameRightTypes && null similarNameWrongTypes
+                      then undefinedSymbolHelp
+                      else
+                        mconcat
+                          [ if null similarNameWrongTypes
+                              then ""
+                              else formatWrongs similarNameWrongTypeText similarNameWrongTypes,
+                            if null wrongNameRightTypes
+                              then ""
+                              else formatWrongs wrongNameRightTypeText wrongNameRightTypes
+                          ]
+                  similarNameRightTypes -> formatWrongs similarNameRightTypeText similarNameRightTypes
+                rightNameWrongTypes ->
                   let helpMeOut =
                         Pr.wrap
                           ( mconcat
@@ -766,7 +781,7 @@ renderTypeError e env src = case e of
                                   )
                               ]
                         <> "\n\n"
-                        <> formatWrongs wrongTypeText wrongs
+                        <> formatWrongs rightNameWrongTypeText rightNameWrongTypes
               suggs ->
                 mconcat
                   [ Pr.wrap
@@ -847,45 +862,46 @@ renderTypeError e env src = case e of
         summary note
       ]
   where
-    wrongTypeText pl =
-      Pr.paragraphyText
-        ( mconcat
-            [ "I found ",
-              pl "a term" "some terms",
-              " in scope with ",
-              pl "a " "",
-              "matching name",
-              pl "" "s",
-              " but ",
-              pl "a " "",
-              "different type",
-              pl "" "s",
-              ". ",
-              "If ",
-              pl "this" "one of these",
-              " is what you meant, try using its full name:"
-            ]
-        )
-        <> "\n\n"
-    wrongNameText pl =
-      Pr.paragraphyText
-        ( mconcat
-            [ "I found ",
-              pl "a term" "some terms",
-              " in scope with ",
-              pl "a " "",
-              "matching type",
-              pl "" "s",
-              " but ",
-              pl "a " "",
-              "different name",
-              pl "" "s",
-              ". ",
-              "Maybe you meant ",
-              pl "this" "one of these",
-              ":\n\n"
-            ]
-        )
+    rightNameWrongTypeText _ =
+      mconcat
+        [ "I found one or more terms in scope with the ",
+          Pr.bold "right names ",
+          "but the ",
+          Pr.bold "wrong types.",
+          "\n",
+          "If you meant to use one of these, try using it with its full name and then adjusting types",
+          ":\n\n"
+        ]
+    similarNameRightTypeText _ =
+      mconcat
+        [ "I found one or more terms in scope with ",
+          Pr.bold "similar names ",
+          "and the ",
+          Pr.bold "right types.",
+          "\n",
+          "If you meant to use one of these, try using it instead",
+          ":\n\n"
+        ]
+    similarNameWrongTypeText _ =
+      mconcat
+        [ "I found one or more terms in scope with ",
+          Pr.bold "similar names ",
+          "but the ",
+          Pr.bold "wrong types.",
+          "\n",
+          "If you meant to use one of these, try using it instead and then adjusting types",
+          ":\n\n"
+        ]
+    wrongNameRightTypeText _ =
+      mconcat
+        [ "I found one or more terms in scope with the ",
+          Pr.bold "wrong names ",
+          "but the ",
+          Pr.bold "right types.",
+          "\n",
+          "If you meant to use one of these, try using it instead",
+          ":\n\n"
+        ]
     formatWrongs txt wrongs =
       let sz = length wrongs
           pl a b = if sz == 1 then a else b

--- a/parser-typechecker/src/Unison/Typechecker.hs
+++ b/parser-typechecker/src/Unison/Typechecker.hs
@@ -388,10 +388,8 @@ typeDirectedNameResolution ppe oldNotes oldType env = do
                   (TypeVar.liftType foundType)
                   replace
                   if not fuzzyNameMatch
-                    then
-                      if typeMatches then Context.Exact else Context.RightNameWrongType
-                    else
-                      if typeMatches then Context.SimilarNameRightType else Context.SimilarNameWrongType
+                    then if typeMatches then Context.Exact else Context.RightNameWrongType
+                    else if typeMatches then Context.SimilarNameRightType else Context.SimilarNameWrongType
 
 -- | Check whether a term matches a type, using a
 -- function to resolve the type of @Ref@ constructors

--- a/parser-typechecker/src/Unison/Typechecker.hs
+++ b/parser-typechecker/src/Unison/Typechecker.hs
@@ -80,7 +80,7 @@ data NamedReference v loc = NamedReference
 data Env v loc = Env
   { ambientAbilities :: [Type v loc],
     typeLookup :: TL.TypeLookup v loc,
-    -- TDNR environment - maps short names like `+` to fully-qualified
+    -- | TDNR environment - maps short names like `+` to fully-qualified
     -- lists of named references whose full name matches the short name
     -- Example: `+` maps to [Nat.+, Float.+, Int.+]
     --
@@ -91,6 +91,12 @@ data Env v loc = Env
     -- - Right means a term/constructor in the namespace, or a constructor in the file (for which we do have a type
     --   before typechecking)
     termsByShortname :: Map Name.Name [Either Name.Name (NamedReference v loc)],
+    -- | This mapping is populated before typechecking with the top N fuzzy matches
+    -- to provide suggestions to the user for each free name that could not be resolved
+    -- with an exact match.
+    --
+    -- For each free name, a separate mapping with the same type as termsByShortname is provided.
+    freeNameToFuzzyTermsByShortName :: Map Name.Name (Map Name.Name [Either Name.Name (NamedReference v loc)]),
     topLevelComponents :: Map Name.Name (NamedReference v loc)
   }
   deriving stock (Generic)
@@ -261,6 +267,10 @@ typeDirectedNameResolution ppe oldNotes oldType env = do
         Var.MissingResult -> v
         _ -> Var.named name
 
+    dedupe :: [Context.Suggestion v loc] -> [Context.Suggestion v loc]
+    dedupe =
+      uniqueBy Context.suggestionReplacement
+
     extractSubstitution :: [Context.Suggestion v loc] -> Maybe (Context.Replacement v)
     extractSubstitution suggestions =
       let groupedByName :: [([Name.Name], Context.Replacement v)] =
@@ -309,20 +319,23 @@ typeDirectedNameResolution ppe oldNotes oldType env = do
       Context.InfoNote v loc ->
       Result (Notes v loc) (Maybe (Resolution v loc))
     resolveNote env = \case
-      Context.SolvedBlank (B.Resolve loc str) v it -> do
-        let shortname = Name.unsafeParseText (Text.pack str)
-            matches =
-              env.termsByShortname
-                & Map.findWithDefault [] shortname
-                & mapMaybe \case
-                  Left longname -> Map.lookup longname env.topLevelComponents
-                  Right namedRef -> Just namedRef
-        suggestions <- wither (resolve it) matches
+      Context.SolvedBlank (B.Resolve loc str) v inferredType -> do
+        let resolvedName = Text.pack str
+        let shortname = Name.unsafeParseText resolvedName
+
+        let matches = findExactMatches env shortname
+        suggestionsExact <- wither (resolveExact inferredType) matches
+
+        let fuzzyMatches = findFuzzyMatches env shortname
+        suggestionsFuzzy <- wither (resolveFuzzy inferredType) fuzzyMatches
+
+        let suggestions = suggestionsExact ++ suggestionsFuzzy
+
         pure $
           Just
             Resolution
-              { resolvedName = Text.pack str,
-                inferredType = it,
+              { resolvedName,
+                inferredType,
                 resolvedLoc = loc,
                 v,
                 suggestions
@@ -334,27 +347,51 @@ typeDirectedNameResolution ppe oldNotes oldType env = do
       note -> do
         btw note
         pure Nothing
+      where
+        findExactMatches :: Env v loc -> Name.Name -> [NamedReference v loc]
+        findExactMatches env name = do
+          env.termsByShortname
+            & Map.findWithDefault [] name
+            & lookupName
 
-    dedupe :: [Context.Suggestion v loc] -> [Context.Suggestion v loc]
-    dedupe =
-      uniqueBy Context.suggestionReplacement
+        findFuzzyMatches :: Env v loc -> Name.Name -> [NamedReference v loc]
+        findFuzzyMatches env name = do
+          env.freeNameToFuzzyTermsByShortName
+            & Map.findWithDefault Map.empty name
+            -- Keep only names that are not exact matches, assuming they are instead fuzzy matches.
+            & Map.filterWithKey (\key _ -> key /= name)
+            & Map.elems
+            & join
+            & lookupName
 
-    resolve ::
-      Context.Type v loc ->
-      NamedReference v loc ->
-      Result (Notes v loc) (Maybe (Context.Suggestion v loc))
-    resolve inferredType (NamedReference fqn foundType replace) =
-      -- We found a name that matches. See if the type matches too.
-      case Context.isSubtype (TypeVar.liftType foundType) (Context.relax inferredType) of
-        Left bug -> Nothing <$ compilerBug bug
-        -- Suggest the import if the type matches.
-        Right b ->
-          pure . Just $
-            Context.Suggestion
-              fqn
-              (TypeVar.liftType foundType)
-              replace
-              (if b then Context.Exact else Context.WrongType)
+        lookupName = mapMaybe \case
+          Left longname -> Map.lookup longname env.topLevelComponents
+          Right namedRef -> Just namedRef
+
+        resolveExact = resolve False
+        resolveFuzzy = resolve True
+
+        resolve ::
+          Bool ->
+          Context.Type v loc ->
+          NamedReference v loc ->
+          Result (Notes v loc) (Maybe (Context.Suggestion v loc))
+        resolve fuzzyNameMatch inferredType (NamedReference fqn foundType replace) =
+          -- We found a name that matches or is similar. Check the type matches too.
+          case Context.isSubtype (TypeVar.liftType foundType) (Context.relax inferredType) of
+            Left bug -> Nothing <$ compilerBug bug
+            -- Create a suggestion based on name and type similarity.
+            Right typeMatches ->
+              pure . Just $
+                Context.Suggestion
+                  fqn
+                  (TypeVar.liftType foundType)
+                  replace
+                  if not fuzzyNameMatch
+                    then
+                      if typeMatches then Context.Exact else Context.RightNameWrongType
+                    else
+                      if typeMatches then Context.SimilarNameRightType else Context.SimilarNameWrongType
 
 -- | Check whether a term matches a type, using a
 -- function to resolve the type of @Ref@ constructors

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -339,7 +339,12 @@ type ExpectedArgCount = Int
 
 type ActualArgCount = Int
 
-data SuggestionMatch = Exact | WrongType | WrongName
+data SuggestionMatch
+  = Exact
+  | RightNameWrongType
+  | WrongNameRightType
+  | SimilarNameRightType
+  | SimilarNameWrongType
   deriving (Ord, Eq, Show)
 
 data Suggestion v loc = Suggestion

--- a/parser-typechecker/src/Unison/UnisonFile.hs
+++ b/parser-typechecker/src/Unison/UnisonFile.hs
@@ -140,7 +140,7 @@ definitionLocation v uf =
     <|> dataDeclarations uf ^? ix v . _2 . to DD.annotation
     <|> effectDeclarations uf ^? ix v . _2 . to (DD.annotation . DD.toDataDecl)
 
--- Converts a file to a single let rec with a body of `()`, for
+-- | Converts a file to a single let rec with a body of `()`, for
 -- purposes of typechecking.
 typecheckingTerm :: (Var v, Monoid a) => UnisonFile v a -> Term v a
 typecheckingTerm uf =

--- a/parser-typechecker/tests/Unison/Test/Typechecker/TypeError.hs
+++ b/parser-typechecker/tests/Unison/Test/Typechecker/TypeError.hs
@@ -17,7 +17,7 @@ import Unison.Typechecker.TypeError qualified as Err
 
 test :: Test ()
 test =
-  scope "> extractor" . tests $
+  scope "extractor" . tests $
     [ y "> true && 3" Err.and,
       y "> true || 3" Err.or,
       y "> if 3 then 1 else 2" Err.cond,
@@ -54,7 +54,7 @@ noYieldsError s ex = not $ yieldsError s ex
 
 yieldsError :: forall a. String -> ErrorExtractor Symbol Ann a -> Bool
 yieldsError s ex =
-  case Common.parseAndSynthesizeAsFile [] "> test" s of
+  case Common.parseAndSynthesizeAsFile [] "> test_path" s of
     Result notes (Just _) ->
       let notes' :: [C.ErrorNote Symbol Ann]
           notes' = [n | Result.TypeError n <- toList notes]

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 

--- a/unison-cli/src/Unison/Cli/TypeCheck.hs
+++ b/unison-cli/src/Unison/Cli/TypeCheck.hs
@@ -50,6 +50,7 @@ typecheckTerm codebase tm = do
           { ambientAbilities = [],
             typeLookup,
             termsByShortname = Map.empty,
+            freeNameToFuzzyTermsByShortName = Map.empty,
             topLevelComponents = Map.empty
           }
   pure $ fmap extract $ FileParsers.synthesizeFile typecheckingEnv file

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Run.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Run.hs
@@ -172,6 +172,7 @@ synthesizeForce tl typeOfFunc = do
           { ambientAbilities = [DD.exceptionType External, Type.builtinIO External],
             typeLookup = mempty {TypeLookup.typeOfTerms = Map.singleton ref typeOfFunc} <> tl,
             termsByShortname = Map.empty,
+            freeNameToFuzzyTermsByShortName = Map.empty,
             topLevelComponents = Map.empty
           }
   case Result.runResultT

--- a/unison-cli/src/Unison/LSP/FileAnalysis.hs
+++ b/unison-cli/src/Unison/LSP/FileAnalysis.hs
@@ -415,8 +415,10 @@ analyseNotes fileUri ppe src notes = do
 
     nameResolutionSuggestionPriority (Context.Suggestion {suggestionMatch, suggestionName}) = case suggestionMatch of
       Context.Exact -> (0 :: Int, suggestionName)
-      Context.WrongType -> (1, suggestionName)
-      Context.WrongName -> (2, suggestionName)
+      Context.RightNameWrongType -> (1, suggestionName)
+      Context.SimilarNameRightType -> (2, suggestionName)
+      Context.SimilarNameWrongType -> (3, suggestionName)
+      Context.WrongNameRightType -> (4, suggestionName)
 
     -- typeHoleReplacementCodeActions :: Symbol -> _ -> Lsp [a]
     typeHoleReplacementCodeActions diags v typ

--- a/unison-core/package.yaml
+++ b/unison-core/package.yaml
@@ -9,6 +9,7 @@ library:
   source-dirs: src
   ghc-options: -Wall -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -funbox-strict-fields
   dependencies:
+    - edit-distance
     - base
     - bytestring
     - containers >= 0.6.3

--- a/unison-core/src/Unison/Name.hs
+++ b/unison-core/src/Unison/Name.hs
@@ -25,6 +25,10 @@ module Unison.Name
     suffixes,
     lastSegment,
 
+    -- * Location Queries
+    classifyNameLocation,
+    NameLocation (..),
+
     -- * Basic manipulation
     makeAbsolute,
     makeRelative,

--- a/unison-core/src/Unison/Names.hs
+++ b/unison-core/src/Unison/Names.hs
@@ -19,6 +19,8 @@ module Unison.Names
     makeAbsolute,
     makeRelative,
     fuzzyFind,
+    queryEditDistances,
+    queryEditDistances',
     hqName,
     hqTermName,
     hqTypeName,
@@ -65,6 +67,7 @@ import Data.Semialign (alignWith)
 import Data.Set qualified as Set
 import Data.Text qualified as Text
 import Data.These (These (..))
+import Text.EditDistance
 import Text.FuzzyFind qualified as FZF
 import Unison.ConstructorReference (GConstructorReference (..))
 import Unison.ConstructorType qualified as CT
@@ -146,7 +149,7 @@ makeAbsolute = map Name.makeAbsolute
 makeRelative :: Names -> Names
 makeRelative = map Name.makeRelative
 
--- Finds names that are supersequences of all the given strings, ordered by
+-- | Finds names that are supersequences of all the given strings, ordered by
 -- score and grouped by name.
 fuzzyFind ::
   (Name -> Text) ->
@@ -187,6 +190,51 @@ fuzzyFind nameToText query names =
                       (Just mempty)
                       query
             )
+
+-- | Computes edit distances between a name query and each name in names.
+--
+-- Searches both terms and types in names.
+queryEditDistances ::
+  (Name -> Text) ->
+  String ->
+  Names ->
+  [(Int, Name, Maybe (Set (Either Referent TypeReference)))]
+queryEditDistances nameToText query names = do
+  let namedReferences =
+        (Set.mapMonotonic Left <$> R.toMultimap names.terms)
+          <> (Set.mapMonotonic Right <$> R.toMultimap names.types)
+          & Map.toList
+  let nameToString = Text.unpack . nameToText
+  let fuzzyMatches =
+        fmap
+          ( \(name, reference) ->
+              (editDistance query (nameToString name), name, Just reference)
+          )
+          namedReferences
+
+  fuzzyMatches
+
+-- | Computes edit distances between a name query and each name in names.
+--
+-- Searches over a set of names.
+queryEditDistances' ::
+  (Name -> Text) ->
+  String ->
+  Set Name ->
+  [(Int, Name, Maybe (Set (Either Referent TypeReference)))]
+queryEditDistances' nameToText query names = do
+  let nameToString = Text.unpack . nameToText
+  let fuzzyMatches =
+        Set.map
+          ( \name ->
+              (editDistance query (nameToString name), name, Nothing)
+          )
+          names
+
+  Set.toList fuzzyMatches
+
+editDistance :: String -> String -> Int
+editDistance = restrictedDamerauLevenshteinDistance defaultEditCosts
 
 -- | Get all (untagged) term/type references ids in a @Names@.
 referenceIds :: Names -> Set Reference.Id

--- a/unison-core/unison-core1.cabal
+++ b/unison-core/unison-core1.cabal
@@ -100,6 +100,7 @@ library
     , bytestring
     , containers >=0.6.3
     , cryptonite
+    , edit-distance
     , extra
     , fuzzyfind
     , generic-lens

--- a/unison-merge/src/Unison/Merge/Mergeblob5.hs
+++ b/unison-merge/src/Unison/Merge/Mergeblob5.hs
@@ -26,6 +26,7 @@ makeMergeblob5 blob typeLookup =
           { ambientAbilities = [],
             termsByShortname = Map.empty,
             typeLookup,
+            freeNameToFuzzyTermsByShortName = Map.empty,
             topLevelComponents = Map.empty
           }
    in case runIdentity (Result.runResultT (FileParsers.synthesizeFile typecheckingEnv blob.file)) of

--- a/unison-src/transcripts-manual/rewrites.output.md
+++ b/unison-src/transcripts-manual/rewrites.output.md
@@ -338,14 +338,10 @@ scratch/main> load
 
      19 |   bar21
 
-  I also don't know what type it should be.
+  I found one or more terms in scope with similar names and the right types.
+  If you meant to use one of these, try using it instead:
 
-  Some common causes of this error include:
-    * Your current namespace is too deep to contain the
-      definition in its subtree
-    * The definition is part of a library which hasn't been
-      added to this project
-    * You have a typo in the name
+  bar1 : Nat
 ```
 
 In this example, the `a` is locally bound by the rule, so it shouldn't capture the `a = 39494` binding which is in scope at the point of the replacement:
@@ -395,14 +391,12 @@ scratch/main> load
 
       6 |   a1
 
-  I also don't know what type it should be.
+  I found one or more terms in scope with similar names and the right types.
+  If you meant to use one of these, try using it instead:
 
-  Some common causes of this error include:
-    * Your current namespace is too deep to contain the
-      definition in its subtree
-    * The definition is part of a library which hasn't been
-      added to this project
-    * You have a typo in the name
+  (<|) : (i ->{g} o) -> i ->{g} o
+  Bytes.at : Nat -> Bytes -> Optional Nat
+  List.at : Nat -> [a] -> Optional a
 ```
 
 ## Structural find

--- a/unison-src/transcripts-manual/rewrites.output.md
+++ b/unison-src/transcripts-manual/rewrites.output.md
@@ -338,8 +338,8 @@ scratch/main> load
 
      19 |   bar21
 
-  I found one or more terms in scope with similar names and the right types.
-  If you meant to use one of these, try using it instead:
+  I found a term in scope with a similar name but a different 
+  type. Maybe you meant this:
 
   bar1 : Nat
 ```
@@ -391,8 +391,8 @@ scratch/main> load
 
       6 |   a1
 
-  I found one or more terms in scope with similar names and the right types.
-  If you meant to use one of these, try using it instead:
+  I found some terms in scope with similar names but different 
+  types. Maybe you meant one of these:
 
   (<|) : (i ->{g} o) -> i ->{g} o
   Bytes.at : Nat -> Bytes -> Optional Nat

--- a/unison-src/transcripts/idempotent/destructuring-binds.md
+++ b/unison-src/transcripts/idempotent/destructuring-binds.md
@@ -89,16 +89,12 @@ ex4 =
 
       2 |   (a,b) = (a Nat.+ b, 19)
 
-  I think its type should be:
+  I found one or more terms in scope with similar names but the wrong types.
+  If you meant to use one of these, try using it instead and then adjusting types:
 
-      Nat
-
-  Some common causes of this error include:
-    * Your current namespace is too deep to contain the
-      definition in its subtree
-    * The definition is part of a library which hasn't been
-      added to this project
-    * You have a typo in the name
+  (Float.*) : Float -> Float -> Float
+  (Int.*) : Int -> Int -> Int
+  (Nat.*) : Nat -> Nat -> Nat
 ```
 
 Even though the parser accepts any pattern on the LHS of a bind, it looks pretty weird to see things like `12 = x`, so we avoid showing a destructuring bind when the LHS is a "literal" pattern (like `42` or "hi"). Again these examples wouldn't compile with coverage checking.

--- a/unison-src/transcripts/idempotent/destructuring-binds.md
+++ b/unison-src/transcripts/idempotent/destructuring-binds.md
@@ -89,8 +89,8 @@ ex4 =
 
       2 |   (a,b) = (a Nat.+ b, 19)
 
-  I found one or more terms in scope with similar names but the wrong types.
-  If you meant to use one of these, try using it instead and then adjusting types:
+  I found some terms in scope with similar names but different 
+  types. Maybe you meant one of these:
 
   (Float.*) : Float -> Float -> Float
   (Int.*) : Int -> Int -> Int

--- a/unison-src/transcripts/idempotent/fix845.md
+++ b/unison-src/transcripts/idempotent/fix845.md
@@ -42,16 +42,10 @@ Now, typecheck a file with a reference to `Blah.zonk` (which doesn't exist in th
 
       2 | > Blah.zonk [1,2,3]
 
-  I think its type should be:
+  I found one or more terms in scope with similar names and the right types.
+  If you meant to use one of these, try using it instead:
 
-      [Nat] -> o
-
-  Some common causes of this error include:
-    * Your current namespace is too deep to contain the
-      definition in its subtree
-    * The definition is part of a library which hasn't been
-      added to this project
-    * You have a typo in the name
+  List.zonk : [a] -> [a]
 ```
 
 Here's another example, just checking that TDNR works for definitions in the same file:

--- a/unison-src/transcripts/idempotent/fix845.md
+++ b/unison-src/transcripts/idempotent/fix845.md
@@ -42,9 +42,10 @@ Now, typecheck a file with a reference to `Blah.zonk` (which doesn't exist in th
 
       2 | > Blah.zonk [1,2,3]
 
-  I found one or more terms in scope with similar names and the right types.
-  If you meant to use one of these, try using it instead:
+  I found some terms in scope with similar names but different 
+  types. Maybe you meant one of these:
 
+  Text.zonk : Text -> Text
   List.zonk : [a] -> [a]
 ```
 

--- a/unison-src/transcripts/idempotent/formatter.md
+++ b/unison-src/transcripts/idempotent/formatter.md
@@ -194,9 +194,8 @@ brokenDoc = {{ hello }} + 1
   Help me out by using a more specific name here or adding a
   type annotation.
 
-  I found some terms in scope with matching names but different 
-  types. If one of these is what you meant, try using its full 
-  name:
+  I found one or more terms in scope with the right names but the wrong types.
+  If you meant to use one of these, try using it with its full name and then adjusting types:
 
   (Float.+) : Float -> Float -> Float
   (Int.+) : Int -> Int -> Int

--- a/unison-src/transcripts/idempotent/formatter.md
+++ b/unison-src/transcripts/idempotent/formatter.md
@@ -194,8 +194,9 @@ brokenDoc = {{ hello }} + 1
   Help me out by using a more specific name here or adding a
   type annotation.
 
-  I found one or more terms in scope with the right names but the wrong types.
-  If you meant to use one of these, try using it with its full name and then adjusting types:
+  I found some terms in scope with matching names but different 
+  types. If one of these is what you meant, try using its full 
+  name:
 
   (Float.+) : Float -> Float -> Float
   (Int.+) : Int -> Int -> Int

--- a/unison-src/transcripts/idempotent/name-resolution-fuzzy.md
+++ b/unison-src/transcripts/idempotent/name-resolution-fuzzy.md
@@ -1,0 +1,252 @@
+# Check outputs produced during fuzzy name resolution failures
+
+## Setup
+
+``` ucm :hide
+scratch/main> builtins.merge
+```
+
+## When given a term with the right name and the right type
+
+### Then I successfully typecheck the term and allow it to be added
+
+``` unison
+myFunction : Float -> Int
+myFunction = truncate
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+
+    ⍟ These new definitions are ok to `add`:
+    
+      myFunction : Float -> Int
+```
+
+## When given a term with the right name but wrong type
+
+### Then I get a type mismatch error
+
+``` unison :error
+-- TODO: Can we exercise suggestions for right name wrong type without encountering type mismatch errors?
+myFunction : Float -> Nat
+myFunction = truncate
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I found a value  of type:  Int
+  where I expected to find:  Nat
+
+      2 | myFunction : Float -> Nat
+      3 | myFunction = truncate
+```
+
+## When given a term that matches with terms with similar names and the right type
+
+### Then I get a name resolution error with suggestions to use one of the similar names
+
+``` unison :error
+-- This should be Float -> Float but it seems the stdlib is old
+-- should match only truncate
+myFunction : Float -> Int
+myFunction = TRuncate
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I couldn't figure out what TRuncate refers to here:
+
+      4 | myFunction = TRuncate
+
+  I found one or more terms in scope with similar names and the right types.
+  If you meant to use one of these, try using it instead:
+
+  truncate : Float -> Int
+```
+
+``` unison :error
+-- Works with fully-qualified names
+-- should match only builtin.io2.Ref.cas
+myFunction : Ref {IO} a1 -> Ticket a1 -> a1 ->{IO} Boolean
+myFunction = builtin.io2.Ref.ca1
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I couldn't figure out what builtin.io2.Ref.ca1 refers to here:
+
+      4 | myFunction = builtin.io2.Ref.ca1
+
+  I found one or more terms in scope with similar names and the right types.
+  If you meant to use one of these, try using it instead:
+
+  cas : Ref {IO} a -> Ticket a -> a ->{IO} Boolean
+```
+
+``` unison :hide
+-- Works with definitions added to the code base interactively
+byz.byte : Boolean
+byz.byte = true
+
+long.fully.qualified.name.foo.bar.biz.bite : Nat
+long.fully.qualified.name.foo.bar.biz.bite = 123
+```
+
+``` ucm :hide
+scratch/main> add
+```
+
+``` unison :error
+-- Long fully-qualified names are still suggested when in scope
+x = biz.bete
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I couldn't figure out what biz.bete refers to here:
+
+      2 | x = biz.bete
+
+  I found one or more terms in scope with similar names and the right types.
+  If you meant to use one of these, try using it instead:
+
+  byte : Boolean
+  bite : Nat
+```
+
+## When given a term that matches with terms with similar names but the wrong type
+
+### Then I get a name resolution error with suggestions to use one of the similar names and adjust the type
+
+``` unison :error
+-- Should match truncate and truncate0 though they have different types
+myFunction : Float -> Nat
+myFunction = Flat.TRuncate2x4
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I couldn't figure out what Flat.TRuncate2x4 refers to here:
+
+      3 | myFunction = Flat.TRuncate2x4
+
+  I found one or more terms in scope with similar names but the wrong types.
+  If you meant to use one of these, try using it instead and then adjusting types:
+
+  truncate : Float -> Int
+  truncate0 : Int -> Nat
+```
+
+``` unison :error
+-- Works with short names
+-- Should match short name * in Float/Int/Nat
+myFunction : Int -> Int -> Boolean
+myFunction = X
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I couldn't figure out what X refers to here:
+
+      4 | myFunction = X
+
+  I found one or more terms in scope with similar names but the wrong types.
+  If you meant to use one of these, try using it instead and then adjusting types:
+
+  (Float.*) : Float -> Float -> Float
+  (Int.*) : Int -> Int -> Int
+  (Nat.*) : Nat -> Nat -> Nat
+```
+
+``` unison :error
+-- Works with qualified short names
+-- Should only match short names Int
+myFunction : Int -> Int -> Boolean
+myFunction = In.X
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I couldn't figure out what In.X refers to here:
+
+      4 | myFunction = In.X
+
+  I found one or more terms in scope with similar names but the wrong types.
+  If you meant to use one of these, try using it instead and then adjusting types:
+
+  (Int.*) : Int -> Int -> Int
+  (Int.+) : Int -> Int -> Int
+  (Int.-) : Int -> Int -> Int
+```
+
+## When given a term that matches local terms not yet added to the code base
+
+### Then I get a name resolution error with suggestions to use a similar name
+
+``` unison :error
+a : Boolean
+a = 1 == 2
+
+xyzlmno : Boolean
+xyzlmno = 1 == 2
+
+-- Should only match with local name a with the right type Boolean
+f : ()
+f =
+  if A then xYzlmno else ()
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I couldn't figure out what A refers to here:
+
+     10 |   if A then xYzlmno else ()
+
+  I found one or more terms in scope with similar names and the right types.
+  If you meant to use one of these, try using it instead:
+
+  a : Boolean
+```
+
+``` unison :error
+a : Boolean
+a = 1 == 2
+
+L.xyzlmno : Int
+L.xyzlmno = +1
+
+-- Should only match with local name L.xyzlmno although the type doesn't match
+f : ()
+f =
+  if R.xYzlmno then A else ()
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I couldn't figure out what R.xYzlmno refers to here:
+
+     10 |   if R.xYzlmno then A else ()
+
+  I found one or more terms in scope with similar names but the wrong types.
+  If you meant to use one of these, try using it instead and then adjusting types:
+
+  L.xyzlmno : Int
+```
+
+## Notes
+
+There is another case where the term matches with terms with the wrong name but the right type. This case was not added here because it is unclear how to produce a concrete example. This kind of suggestion does not seem to be produced in the code paths in Unison.TypeChecker

--- a/unison-src/transcripts/idempotent/name-resolution-fuzzy.md
+++ b/unison-src/transcripts/idempotent/name-resolution-fuzzy.md
@@ -19,10 +19,9 @@ myFunction = truncate
   Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
+  do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `add`:
+    ⍟ These new definitions are ok to `update`:
     
       myFunction : Float -> Int
 ```

--- a/unison-src/transcripts/idempotent/name-resolution-fuzzy.md
+++ b/unison-src/transcripts/idempotent/name-resolution-fuzzy.md
@@ -64,9 +64,10 @@ myFunction = TRuncate
 
       4 | myFunction = TRuncate
 
-  I found one or more terms in scope with similar names and the right types.
-  If you meant to use one of these, try using it instead:
+  I found some terms in scope with similar names but different 
+  types. Maybe you meant one of these:
 
+  truncate0 : Int -> Nat
   truncate : Float -> Int
 ```
 
@@ -84,8 +85,8 @@ myFunction = builtin.io2.Ref.ca1
 
       4 | myFunction = builtin.io2.Ref.ca1
 
-  I found one or more terms in scope with similar names and the right types.
-  If you meant to use one of these, try using it instead:
+  I found a term in scope with a similar name but a different 
+  type. Maybe you meant this:
 
   cas : Ref {IO} a -> Ticket a -> a ->{IO} Boolean
 ```
@@ -115,8 +116,8 @@ x = biz.bete
 
       2 | x = biz.bete
 
-  I found one or more terms in scope with similar names and the right types.
-  If you meant to use one of these, try using it instead:
+  I found some terms in scope with similar names but different 
+  types. Maybe you meant one of these:
 
   byte : Boolean
   bite : Nat
@@ -139,8 +140,8 @@ myFunction = Flat.TRuncate2x4
 
       3 | myFunction = Flat.TRuncate2x4
 
-  I found one or more terms in scope with similar names but the wrong types.
-  If you meant to use one of these, try using it instead and then adjusting types:
+  I found some terms in scope with similar names but different 
+  types. Maybe you meant one of these:
 
   truncate : Float -> Int
   truncate0 : Int -> Nat
@@ -160,8 +161,8 @@ myFunction = X
 
       4 | myFunction = X
 
-  I found one or more terms in scope with similar names but the wrong types.
-  If you meant to use one of these, try using it instead and then adjusting types:
+  I found some terms in scope with similar names but different 
+  types. Maybe you meant one of these:
 
   (Float.*) : Float -> Float -> Float
   (Int.*) : Int -> Int -> Int
@@ -182,8 +183,8 @@ myFunction = In.X
 
       4 | myFunction = In.X
 
-  I found one or more terms in scope with similar names but the wrong types.
-  If you meant to use one of these, try using it instead and then adjusting types:
+  I found some terms in scope with similar names but different 
+  types. Maybe you meant one of these:
 
   (Int.*) : Int -> Int -> Int
   (Int.+) : Int -> Int -> Int
@@ -214,9 +215,11 @@ f =
 
      10 |   if A then xYzlmno else ()
 
-  I found one or more terms in scope with similar names and the right types.
-  If you meant to use one of these, try using it instead:
+  I found some terms in scope with similar names but different 
+  types. Maybe you meant one of these:
 
+  (Float.*) : Float -> Float -> Float
+  (Int.*) : Int -> Int -> Int
   a : Boolean
 ```
 
@@ -240,8 +243,8 @@ f =
 
      10 |   if R.xYzlmno then A else ()
 
-  I found one or more terms in scope with similar names but the wrong types.
-  If you meant to use one of these, try using it instead and then adjusting types:
+  I found a term in scope with a similar name but a different 
+  type. Maybe you meant this:
 
   L.xyzlmno : Int
 ```


### PR DESCRIPTION
## Overview

This change improves error messages when the user provides a name in Unison source code files that does not exactly match a known name in the codebase or within the file. Specifically, it suggests that the user try one of the top 3 closest name matches by Levenshtein edit distance. This is intended to aid users in more quickly resolving typos and similar errors.

The PR introduces a few new suggestion categories that align with this fuzzy matching behaviour. Suggestions for matches with a **similar name** and the **right type** are presented first if possible. Otherwise, suggestions for **similar name** but **wrong type** are presented.

For example,

``` unison :error
-- Should match truncate and truncate0 though they have different types
myFunction : Float -> Nat
myFunction = Flat.TRuncate2x4
```

``` ucm :added-by-ucm
  Loading changes detected in scratch.u.

  I couldn't figure out what Flat.TRuncate2x4 refers to here:

      3 | myFunction = Flat.TRuncate2x4

  I found one or more terms in scope with similar names but the wrong types.
  If you meant to use one these, try using it instead and then adjusting types:

  truncate : Float -> Int
  truncate0 : Int -> Nat
```

### Changes to Error Message Preambles

Additionally, suggestions in error messages on name resolution failure now use plurality-agnostic messages for simplicity and consistency. For example we now have,

```txt
  I found one or more terms in scope with similar names and the right types.
  If you meant to use one of these, try using it instead:
```

For example, this simplifies some of the error message code from:

```haskell
    wrongTypeText pl =
      Pr.paragraphyText
        ( mconcat
            [ "I found ",
              pl "a term" "some terms",
              " in scope with ",
              pl "a " "",
              "matching name",
              pl "" "s",
              " but ",
              pl "a " "",
              "different type",
              pl "" "s",
              ". ",
              "If ",
              pl "this" "one of these",
              " is what you meant, try using its full name:"
            ]
        )
        <> "\n\n"
```

to

```haskell
  rightNameWrongTypeText _ =
    mconcat
      [ "I found one or more terms in scope with the ",
        Pr.bold "right names ",
        "but the ",
        Pr.bold "wrong types.",
        "\n",
        "If you meant to use one of these, try using it with its full name and then adjusting types",
        ":\n\n"
      ]
```

### Relevant Issues

Partially addresses #713.

## Implementation notes

How does it accomplish it, in broad strokes? i.e. How does it change the Haskell codebase?

1. Updates `Unison.FileParsers`, function `computeTypecheckingEnvironment`, to produce a `Typechecker.Env` with a new field `freeNameToFuzzyTermsByShortName`.
	1. The field `freeNameToFuzzyTermsByShortName` is a mapping from the free names in the Unison file that needs to be type-checked to a mapping from short names to terms (similar to the field `termsByShortname`).
		- We need to group the terms by free name so that we don't mix fuzzy matches between one free name and another giving poor suggestions.
	2. Adds function `fuzzyFindByEditDistanceRanked ` used to produce fuzzy matches ranked by edit distance. This function uses two new functions in ` Unison.Names`, `queryEditDistances ` and `queryEditDistances'` that search through `Names` and `Set Name` respectively to get edit distnaces.
2.  Updates `Unison.Typechecker` such that the `resolve` function used by `resolveNote` and in turn by `typeDirectedNameResolution` to produce and append fuzzy match suggestions to the `Resolution` data type.
	- Suggestion types were expanded in `Unison.Typechecker.Context` to include the `SimilarNameRightType` and `SimilarNameWrongType` cases.
3. Updates `Unison.PrintError` to handle printing of the new suggestion types.

## Interesting/controversial decisions

### 1

I chose fuzzy matching by edit distance because it is usually more appropriate than FZF-style fuzzy finding for suggesting typos or other user errors. I tried FZF-style matching initially since existing code used it, but it would sometimes produce strange matches. Additionally, the FZF-style matching code is significantly slower and currently includes a prefilter that restricts matching to substrings and is not as useful.

### 2

A tricky piece of improving fuzzy match results was preprocessing names in the search space to the last N name segments where N is the number of name segments in the free name the user provided. This helped reduce edit distance bias towards shorter, fully-qualified names. For example, a deeply nested name like `foo.bar.biz.bite` would be deprioritized compared to a name like `byz.byte` if the user tried to use `bete` or `baz.bete` despite the edit distance being the same when considering only the last N segments. This could perhaps be improved by also considering aliases and qualified imports, but the adjustment here proved relatively simple and effective.

This behaviour is covered by one of the transcript tests.

### 3

Somewhat arbitrarily, I chose to show only the top 3 matches by edit distance.

Additionally, I decided to filter out matches with large edit distance. Here I made the decision after some manual testing to go with the following max score formula:

```haskell
    -- Expect edit distances (number of typos) to be about half the length of the name being queried
    -- But clamp max edit distance to work well with very short names
    -- and keep ranking reasonably fast when a verbose name is queried
    maxScore = clamp (3, 16) $ Text.length (nameToText name) `ceilingDiv` 2
```



### 4

There may be some unintended impact to the dependence of some transcript tests to the global namespace. When the global namespace changes, fuzzy matching results could change and this may change transcript test outputs. This will usually change in ucm transcripts with the `:error` directive so the change should be automatically captured, but needs to be reviewed.

## Test coverage

Some existing transcript tests cover name resolution failure error messages.

A new transcript `name-resolution-fuzzy.md` was added to more thoroughly cover all fuzzy name resolution scenarios.

As noted in this transcript, there is another case where the term matches with terms with the wrong name but the right type. This case was not added here because it is unclear how to produce a concrete example. This kind of suggestion does not seem to be produced in the code paths in `Unison.TypeChecker`.

## Loose ends

### 1

It would be nice to have LSP code actions for accepting suggestions. This should be a separate ticket, and the design here hopefully doesn't conflict with that goal, but I don't have enough experience in the codebase to know.

### 2

It would be nice if LSP error reporting did not stop on the first error in the file. Although in the UCM it may be overwhelming to print all errors, it is useful while working on source code to be able to see all error hints so the user can work through errors in an order that works for them.

### 3

When name resolution fails it normally prints

```
  I also don't know what type it should be.

  Some common causes of this error include:
    * Your current namespace is too deep to contain the
      definition in its subtree
    * The definition is part of a library which hasn't been
      added to this project
    * You have a typo in the name
```

However, when suggestions are available this isn't printed. If none of the suggestions make sense, then it might be good to for the user to be shown more general guidance, perhaps after the suggestions.

### 4

This PR addresses some of the situations documented by @seagreen in #713, but not all of them.

#### Example 1 - Local Name Resolution (Directly Addressed)

```
aaaaa : Boolean
aaaaa = true

f : ()
f =
  if aaaaA then () else ()
```

Now gives the more helpful suggestions:

```
  I couldn't figure out what aaaaA refers to here:

      6 |   if aaaaA then () else ()

  I found one or more terms in scope with similar names and the right types.
  If you meant to use one of these, try using it instead:

  aaaaa : Boolean
```

#### Example 2 - Type Symbol Resolution (Not Addressed)

The following case where the name of the type is wrong (`Bool` instead of `Boolean`) is not addressed here as type symbol resolution seems to occur before term resolution and needs additional work.

```
x : Bool
x = true
```

#### Example 3 - Global Name Resolution (Partially Addressed)
Unfortunately, some builtins like `true` don't seem to be readily found in the parsing environment and global namespace so the following provides some awkward suggestions:

```
x : Boolean
x = True
```

```
  I found one or more terms in scope with similar names but the wrong types.
  If you meant to use one of these, try using it instead and then adjusting types:

  Type : Type -> Link
  Pattern.run : Pattern a -> a -> Optional ([a], a)
  Scope.run : (Unit ->{Scope s, g} r) ->{g} r
```

However, many other global names can be found and this scenario usually works. See the example above with `truncate` in the overview.
