### PR TITLE
`gh workflow run` seems to want the file extension in v2.55.0

### DIFF
--- a/scripts/make-release.sh
+++ b/scripts/make-release.sh
@@ -52,16 +52,16 @@ echo "Kicking off release workflow in unisonweb/unison"
 git fetch origin trunk
 git tag "${tag}" "${src}"
 git push origin "${tag}"
-gh workflow run release --repo unisonweb/unison \
+gh workflow run release.yaml --repo unisonweb/unison \
   --ref "${tag}" \
   --field "version=${version}"
 
 echo "Kicking off Homebrew update task"
-gh workflow run release --repo unisonweb/homebrew-unison --field "version=${version}"
+gh workflow run release.yaml --repo unisonweb/homebrew-unison --field "version=${version}"
 
 echo "Opening relevant workflows in browser"
-gh workflow view release --web --repo unisonweb/homebrew-unison || true
-gh workflow view release --web --repo unisonweb/unison || true
+gh workflow view release.yaml --web --repo unisonweb/homebrew-unison || true
+gh workflow view release.yaml --web --repo unisonweb/unison || true
 
 echo "Okay! All the work has been kicked off, it may take several hours to complete."
 echo "Run '$0 --status' to see job status."


### PR DESCRIPTION
```
arya@MacBookAir trunk % scripts/make-release.sh 0.5.30
Creating release in unison-local-ui.
https://github.com/unisonweb/unison-local-ui/releases/tag/release/0.5.30
Kicking off release workflow in unisonweb/unison
From github.com:unisonweb/unison
 * branch                trunk      -> FETCH_HEAD
Total 0 (delta 0), reused 0 (delta 0), pack-reused 0
To github.com:unisonweb/unison
 * [new tag]             release/0.5.30 -> release/0.5.30
could not find any workflows named release
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ???
```