### PR TITLE
bugfix: make `view Float.mod.doc` not crash

### DIFF
--- a/unison-core/src/Unison/Name.hs
+++ b/unison-core/src/Unison/Name.hs
@@ -453,11 +453,14 @@ sortNames toText =
 -- /Precondition/: the name is relative.
 splits :: (HasCallStack) => Name -> [([NameSegment], Name)]
 splits (Name p ss0) =
-  ss0
-    & List.NonEmpty.toList
-    & reverse
-    & splits0
-    & over (mapped . _2) (Name p . List.NonEmpty.reverse)
+  case p of
+    Absolute -> error (reportBug "E243149" ("Name.splits called with an absolute name: " ++ show ss0))
+    Relative ->
+      ss0
+        & List.NonEmpty.toList
+        & reverse
+        & splits0
+        & over (mapped . _2) (Name p . List.NonEmpty.reverse)
   where
     -- splits a.b.c
     -- ([], a.b.c) : over (mapped . _1) (a.) (splits b.c)


### PR DESCRIPTION
## Overview

Fixes #5520 

This is a weird one. `view Float.mod.doc` caused UCM to crash, ultimately because we were calling `Name.splits` on an absolute name, which you aren't supposed to do.

The fix implemented here is to simply not call `Name.splits` on absolute names. This seems fine, because we are only calling `Name.splits` on names in order to count their uses, for the purpose of possibly inserting a `use` clause to clean some stuff up. So, a consequence of this particular fix is we won't ever (say) shorten something like

```
.foo.bar + .foo.bar + .foo.bar
```

to

```
use .foo bar
bar + bar + bar
```

Given how incredibly fragile this particular part of term parsing and printing is, with respect to variable capture, I think that's an ok compromise.

On to the root cause: I think there is an issue in the doc parser. Take a look at a rendering of part of `Float.mod.doc`:

<img width="658" alt="Screen Shot 2025-01-13 at 1 46 45 PM" src="https://github.com/user-attachments/assets/b13b5a75-6752-4952-8609-270d1dc1ec23" />

Notice that `Float.-` is a clickable thing, but none of `Float.floor`, `Float./`, or `Float.*` are. Why is that?

Simplifying the example a bit,

```
{{ ``x Float.* floor y`` }}
```

this comes out of the doc parser as

```
Paragraph
  [ Special 
      (  Example
          3 
          ( Term.Term 
              ( Any (do x Float.floor y -> x Float.* Float.floor y) )
          )
      )
  ]
```

Note that `Float.*` is free, but `Float.floor` is _bound_ for some reason (which is especially curious since I originally wrote the expression as `floor` and let TDNR resolve it to `Float.floor`). That ultimately explains why the "avoid shadowing" logic in our term printer kicks in and has to render some `Float.*` with a leading dot, due to the (overly-conservative) logic that only cares whether a variable is bound anywhere in a term.

## Test coverage

I've only tested this manually, but could add a transcript that tries to distill down the problem and solution. I'm hesitant to do that, though, because I suspect a fix to the doc parser would essentially make that transcript not really test anything important. So, it's plausible (to me) that a manual test is fine for this one.