### PR TITLE
bugfix: call lspCheckForChanges in more places, such as after a failed merge

### DIFF
--- a/unison-cli/src/Unison/Cli/Monad.hs
+++ b/unison-cli/src/Unison/Cli/Monad.hs
@@ -50,9 +50,6 @@ module Unison.Cli.Monad
     runTransactionWithRollback,
     runTransactionWithRollback2,
 
-    -- * Internal
-    setMostRecentProjectPath,
-
     -- * Misc types
     LoadSourceResult (..),
   )
@@ -169,6 +166,8 @@ data Env = Env
     generateUniqueName :: IO Parser.UniqueName,
     -- | How to load source code.
     loadSource :: SourceName -> IO LoadSourceResult,
+    -- | Notify the LSP that this ProjectPathIds might be different from the last (e.g. on branch update, switch, etc).
+    lspCheckForChanges :: PP.ProjectPathIds -> IO (),
     -- | How to write source code. Bool = make new fold?
     writeSource :: SourceName -> Text -> Bool -> IO (),
     -- | What to do with output for the user.
@@ -388,19 +387,24 @@ getProjectPathIds = do
 
 cd :: Path.Absolute -> Cli ()
 cd path = do
+  env <- ask
   pp <- getProjectPathIds
   let newPP = pp & PP.absPath_ .~ path
-  setMostRecentProjectPath newPP
+  runTransaction (Codebase.setCurrentProjectPath newPP)
   #projectPathStack %= NonEmpty.cons newPP
+  liftIO (env.lspCheckForChanges newPP)
 
 switchProject :: ProjectAndBranch ProjectId ProjectBranchId -> Cli ()
 switchProject pab@(ProjectAndBranch projectId branchId) = do
-  Env {codebase} <- ask
+  env <- ask
   let newPP = PP.ProjectPath projectId branchId Path.absoluteEmpty
   #projectPathStack %= NonEmpty.cons newPP
-  runTransaction $ do Q.setMostRecentBranch projectId branchId
-  setMostRecentProjectPath newPP
-  liftIO $ Codebase.preloadProjectBranch codebase pab
+  runTransaction do
+    Q.setMostRecentBranch projectId branchId
+    Codebase.setCurrentProjectPath newPP
+  liftIO do
+    Codebase.preloadProjectBranch env.codebase pab
+    env.lspCheckForChanges newPP
 
 -- | Pop the latest path off the stack, if it's not the only path in the stack.
 --
@@ -411,13 +415,12 @@ popd = do
   case List.NonEmpty.uncons (projectPathStack state) of
     (_, Nothing) -> pure False
     (_, Just paths) -> do
-      setMostRecentProjectPath (List.NonEmpty.head paths)
+      let path = List.NonEmpty.head paths
+      runTransaction (Codebase.setCurrentProjectPath path)
       State.put state {projectPathStack = paths}
+      env <- ask
+      liftIO (env.lspCheckForChanges path)
       pure True
-
-setMostRecentProjectPath :: PP.ProjectPathIds -> Cli ()
-setMostRecentProjectPath loc =
-  runTransaction $ Codebase.setCurrentProjectPath loc
 
 respond :: Output -> Cli ()
 respond output = do

--- a/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
+++ b/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
@@ -487,6 +487,7 @@ run isTest verbosity dir codebase runtime sbRuntime nRuntime ucmVersion baseURL 
               i <- atomicModifyIORef' seedRef \i -> let !i' = i + 1 in (i', i)
               pure (Parser.uniqueBase32Namegen (Random.drgNewSeed (Random.seedFromInteger (fromIntegral i)))),
             loadSource = loadPreviousUnisonBlock,
+            lspCheckForChanges = \_ -> pure (),
             writeSource,
             notify = print,
             notifyNumbered = printNumbered,

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -232,6 +232,7 @@ main dir welcome ppIds initialInputs runtime sbRuntime nRuntime codebase serverB
             codebase,
             credentialManager,
             loadSource = loadSourceFile,
+            lspCheckForChanges,
             writeSource,
             generateUniqueName = Parser.uniqueBase32Namegen <$> Random.getSystemDRG,
             notify,
@@ -252,9 +253,6 @@ main dir welcome ppIds initialInputs runtime sbRuntime nRuntime codebase serverB
     -- Handle inputs until @HaltRepl@, staying in the loop on Ctrl+C or synchronous exception.
     let loop0 :: Cli.LoopState -> IO ()
         loop0 s0 = do
-          -- It's always possible the previous command changed the branch head, so tell the LSP to check if the current
-          -- path or project has changed.
-          lspCheckForChanges (NEL.head $ Cli.projectPathStack s0)
           let step = do
                 input <- awaitInput s0
                 (!result, resultState) <- Cli.runCli env s0 (HandleInput.loop input)

--- a/unison-cli/src/Unison/Main.hs
+++ b/unison-cli/src/Unison/Main.hs
@@ -306,7 +306,7 @@ main version = do
               currentPP <- Codebase.runTransaction theCodebase do
                 PP.toIds <$> Codebase.expectCurrentProjectPath
               changeSignal <- Signal.newSignalIO (Just currentPP)
-              let lspCheckForChanges pp = Signal.writeSignalIO changeSignal pp
+              let lspCheckForChanges = Signal.writeSignalIO changeSignal
               -- Unfortunately, the windows IO manager on GHC 8.* is prone to just hanging forever
               -- when waiting for input on handles, so if we listen for LSP connections it will
               -- prevent UCM from shutting down properly. Hopefully we can re-enable LSP on


### PR DESCRIPTION
# Overview

Fixes LSP for in-progress merges. I couldn't find a ticket for this issue, but basically, LSP wouldn't properly refresh on merge failure.

Now, it does. I've tested this change manually by setting up the following merge:

LCA
```
foo = 17
bar = foo + foo
```

Alice
```
foo = 18 -- conflicts with bob
```

Bob
```
foo = 19 -- conflicts with alice
bar = foo + baz
baz = 200
```

When merging bob into alice, we end up with a file that looks like

```
-- alice
foo = 18
-- bob
foo = 19

-- dependents
bar = foo + baz
```

where `baz` is in the underlying namespace, because it was an unconflicted add.

Prior to this PR, LSP would complain that `baz` is out of scope.