### PR TITLE
Bump `@unison/runtime-tests` to version `0.0.3`

### DIFF
--- a/.github/workflows/ci-test-jit.yaml
+++ b/.github/workflows/ci-test-jit.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
 
 env:
-  runtime_tests_version: "@unison/runtime-tests/releases/0.0.1"
+  runtime_tests_version: "@unison/runtime-tests/releases/0.0.3"
   # for best results, this should match the path in ci.yaml too; but GH doesn't make it easy to share them.
   runtime_tests_codebase: "~/.cache/unisonlanguage/runtime-tests.unison"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ env:
   ## Some version numbers that are used during CI
   ormolu_version: 0.7.2.0
   jit_version: "@unison/internal/releases/0.0.25"
-  runtime_tests_version: "@unison/runtime-tests/releases/0.0.1"
+  runtime_tests_version: "@unison/runtime-tests/releases/0.0.3"
 
   ## Some cached directories
   # a temp path for caching a built `ucm`

--- a/unison-src/builtin-tests/interpreter-tests.output.md
+++ b/unison-src/builtin-tests/interpreter-tests.output.md
@@ -13,7 +13,7 @@ scratch/main> delete.project runtime-tests
 ```
 
 ``` ucm :hide
-scratch/main> clone @unison/runtime-tests/releases/0.0.1 runtime-tests/selected
+scratch/main> clone @unison/runtime-tests/releases/0.0.3 runtime-tests/selected
 ```
 
 ``` ucm

--- a/unison-src/builtin-tests/interpreter-tests.sh
+++ b/unison-src/builtin-tests/interpreter-tests.sh
@@ -7,7 +7,7 @@ else
   ucm="$1"
 fi
 
-runtime_tests_version="@unison/runtime-tests/releases/0.0.1"
+runtime_tests_version="@unison/runtime-tests/releases/0.0.3"
 
 codebase=${XDG_CACHE_HOME:-"$HOME/.cache"}/unisonlanguage/runtime-tests.unison
 

--- a/unison-src/builtin-tests/jit-tests.output.md
+++ b/unison-src/builtin-tests/jit-tests.output.md
@@ -13,7 +13,7 @@ scratch/main> delete.project runtime-tests
 ```
 
 ``` ucm :hide
-scratch/main> clone @unison/runtime-tests/releases/0.0.1 runtime-tests/selected
+scratch/main> clone @unison/runtime-tests/releases/0.0.3 runtime-tests/selected
 ```
 
 ``` ucm

--- a/unison-src/builtin-tests/jit-tests.sh
+++ b/unison-src/builtin-tests/jit-tests.sh
@@ -8,7 +8,7 @@ if [ -z "$1" ]; then
   exit 1
 fi
 
-runtime_tests_version="@unison/runtime-tests/releases/0.0.1"
+runtime_tests_version="@unison/runtime-tests/releases/0.0.3"
 echo $runtime_tests_version
 
 codebase=${XDG_CACHE_HOME:-"$HOME/.cache"}/unisonlanguage/runtime-tests.unison


### PR DESCRIPTION
This upgrades the interpreter and jit tests to release 0.0.3 on share.

The primary motivation for this change is that the function that was checking byte arrays was incorrect. It was looping through the array, but used one of the array values to calculate the index in the recursive call.

I also took the opportunity to clean up and merge some other stuff I'd worked on before. It pulls all the serialization tests in as codebase values, so that running the tests no longer depends on being in the appropriate location of a unison checkout. It seems I added some additional test cases of this sort, too, but I don't exactly recall what they are. :)