### PR TITLE
Project List API updates for UCM Desktop

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -2279,32 +2279,6 @@ globEscape =
     ']' -> "[]]"
     c -> Text.singleton c
 
--- | Escape special characters for "LIKE" matches.
---
--- Prepared statements prevent sql injection, but it's still possible some user
--- may be able to craft a query using a fake "hash" that would let them see more than they
--- ought to.
---
--- You still need to provide the escape char in the sql query, E.g.
---
--- @@
---   SELECT * FROM table
---     WHERE txt LIKE ? ESCAPE '\'
--- @@
---
--- >>> likeEscape '\\' "Nat.%"
--- "Nat.\%"
-likeEscape :: Char -> Text -> Text
-likeEscape '%' _ = error "Can't use % or _ as escape characters"
-likeEscape '_' _ = error "Can't use % or _ as escape characters"
-likeEscape escapeChar pat =
-  flip Text.concatMap pat \case
-    '%' -> Text.pack [escapeChar, '%']
-    '_' -> Text.pack [escapeChar, '_']
-    c
-      | c == escapeChar -> Text.pack [escapeChar, escapeChar]
-      | otherwise -> Text.singleton c
-
 -- | NOTE: requires that the codebase has an up-to-date name lookup index. As of writing, this
 -- is only true on Share.
 --

--- a/codebase2/codebase-sqlite/sql/015-add-project-branch-last-accessed.sql
+++ b/codebase2/codebase-sqlite/sql/015-add-project-branch-last-accessed.sql
@@ -1,0 +1,3 @@
+-- Add a new column to the project_branch table to store the last time that project branch was accessed.
+-- This column is stored as a unix epoch time.
+ALTER TABLE project_branch ADD COLUMN last_accessed INTEGER NOT NULL DEFAULT (strftime('%s', 'now'));

--- a/codebase2/codebase-sqlite/sql/015-add-project-branch-last-accessed.sql
+++ b/codebase2/codebase-sqlite/sql/015-add-project-branch-last-accessed.sql
@@ -1,3 +1,3 @@
 -- Add a new column to the project_branch table to store the last time that project branch was accessed.
 -- This column is stored as a unix epoch time.
-ALTER TABLE project_branch ADD COLUMN last_accessed INTEGER NOT NULL DEFAULT (strftime('%s', 'now'));
+ALTER TABLE project_branch ADD COLUMN last_accessed INTEGER NULL;

--- a/codebase2/codebase-sqlite/unison-codebase-sqlite.cabal
+++ b/codebase2/codebase-sqlite/unison-codebase-sqlite.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -24,6 +24,7 @@ extra-source-files:
     sql/012-add-current-project-path-table.sql
     sql/013-add-project-branch-reflog-table.sql
     sql/014-add-project-branch-causal-hash-id.sql
+    sql/015-add-project-branch-last-accessed.sql
     sql/create.sql
 
 source-repository head

--- a/lib/unison-sqlite/src/Unison/Sqlite.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite.hs
@@ -55,6 +55,9 @@ module Unison.Sqlite
     queryOneRowCheck,
     queryOneColCheck,
 
+    -- * Utilities
+    likeEscape,
+
     -- * Rows modified
     rowsModified,
 
@@ -118,6 +121,7 @@ import Unison.Sqlite.Exception
 import Unison.Sqlite.JournalMode (JournalMode (..), SetJournalModeException (..), trySetJournalMode)
 import Unison.Sqlite.Sql (Sql, sql)
 import Unison.Sqlite.Transaction
+import Unison.Sqlite.Utils (likeEscape)
 
 -- $query-naming-convention
 --

--- a/lib/unison-sqlite/src/Unison/Sqlite/Utils.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite/Utils.hs
@@ -1,0 +1,30 @@
+module Unison.Sqlite.Utils (likeEscape) where
+
+import Data.Text (Text)
+import Data.Text qualified as Text
+
+-- | Escape special characters for "LIKE" matches.
+--
+-- Prepared statements prevent sql injection, but it's still possible some user
+-- may be able to craft a query using a fake "hash" that would let them see more than they
+-- ought to.
+--
+-- You still need to provide the escape char in the sql query, E.g.
+--
+-- @@
+--   SELECT * FROM table
+--     WHERE txt LIKE ? ESCAPE '\'
+-- @@
+--
+-- >>> likeEscape '\\' "Nat.%"
+-- "Nat.\%"
+likeEscape :: Char -> Text -> Text
+likeEscape '%' _ = error "Can't use % or _ as escape characters"
+likeEscape '_' _ = error "Can't use % or _ as escape characters"
+likeEscape escapeChar pat =
+  flip Text.concatMap pat \case
+    '%' -> Text.pack [escapeChar, '%']
+    '_' -> Text.pack [escapeChar, '_']
+    c
+      | c == escapeChar -> Text.pack [escapeChar, escapeChar]
+      | otherwise -> Text.singleton c

--- a/lib/unison-sqlite/unison-sqlite.cabal
+++ b/lib/unison-sqlite/unison-sqlite.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -27,6 +27,7 @@ library
       Unison.Sqlite.Exception
       Unison.Sqlite.JournalMode
       Unison.Sqlite.Sql
+      Unison.Sqlite.Utils
   hs-source-dirs:
       src
   default-extensions:

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations.hs
@@ -84,7 +84,8 @@ migrations regionVar getDeclType termBuffer declBuffer rootCodebasePath =
       sqlMigration 14 Q.addSquashResultTable,
       sqlMigration 15 Q.addSquashResultTableIfNotExists,
       sqlMigration 16 Q.cdToProjectRoot,
-      (17 {- This migration takes a raw sqlite connection -}, \conn -> migrateSchema16To17 conn)
+      (17 {- This migration takes a raw sqlite connection -}, \conn -> migrateSchema16To17 conn),
+      sqlMigration 18 Q.addProjectBranchLastAccessedColumn
     ]
   where
     runT :: Sqlite.Transaction () -> Sqlite.Connection -> IO ()

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
@@ -96,6 +96,7 @@ createSchema = do
   Q.addCurrentProjectPathTable
   Q.addProjectBranchReflogTable
   Q.addProjectBranchCausalHashIdColumn
+  Q.addProjectBranchLastAccessedColumn
   (_, emptyCausalHashId) <- emptyCausalHash
   (_, ProjectBranch {projectId, branchId}) <- insertProjectAndBranch scratchProjectName scratchBranchName emptyCausalHashId
   Q.setCurrentProjectPath projectId branchId []

--- a/unison-share-api/package.yaml
+++ b/unison-share-api/package.yaml
@@ -95,3 +95,4 @@ default-extensions:
   - TypeOperators
   - ViewPatterns
   - ImportQualifiedPost
+  - QuasiQuotes

--- a/unison-share-api/src/Unison/Server/Local/Endpoints/Projects.hs
+++ b/unison-share-api/src/Unison/Server/Local/Endpoints/Projects.hs
@@ -11,9 +11,7 @@ module Unison.Server.Local.Endpoints.Projects
   )
 where
 
-import Data.Aeson (ToJSON (..))
-import Data.Aeson qualified as Aeson
-import Data.OpenApi (ToParamSchema, ToSchema)
+import Data.OpenApi (ToParamSchema)
 import GHC.Generics ()
 import Servant
 import Servant.Docs
@@ -22,44 +20,16 @@ import U.Codebase.Sqlite.Project qualified as SqliteProject
 import U.Codebase.Sqlite.Queries qualified as Q
 import Unison.Codebase (Codebase)
 import Unison.Codebase qualified as Codebase
-import Unison.Core.Project (ProjectBranchName (UnsafeProjectBranchName), ProjectName (UnsafeProjectName))
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
+import Unison.Project (ProjectName)
 import Unison.Server.Backend (Backend)
+import Unison.Server.Local.Endpoints.Projects.Queries qualified as PQ
+import Unison.Server.Local.Endpoints.Projects.Types
 import Unison.Symbol (Symbol)
 
-data ProjectListing = ProjectListing
-  { projectName :: ProjectName
-  }
-  deriving stock (Show, Generic)
-
-instance ToSchema ProjectListing
-
-instance ToJSON ProjectListing where
-  toJSON ProjectListing {projectName} =
-    Aeson.object ["projectName" Aeson..= projectName]
-
-instance ToSample ProjectListing where
-  toSamples _ =
-    singleSample $ ProjectListing (UnsafeProjectName "my-project")
-
-data ProjectBranchListing = ProjectBranchListing
-  { branchName :: ProjectBranchName
-  }
-  deriving stock (Show, Generic)
-
-instance ToSchema ProjectBranchListing
-
-instance ToJSON ProjectBranchListing where
-  toJSON ProjectBranchListing {branchName} =
-    Aeson.object ["branchName" Aeson..= branchName]
-
-instance ToSample ProjectBranchListing where
-  toSamples _ =
-    singleSample $ ProjectBranchListing (UnsafeProjectBranchName "my-branch")
-
 type ListProjectsEndpoint =
-  QueryParam "prefix" PrefixFilter
+  QueryParam "query" Query
     :> Get '[JSON] [ProjectListing]
 
 type ListProjectBranchesEndpoint =
@@ -86,13 +56,33 @@ instance Docs.ToSample PrefixFilter where
   toSamples _ =
     singleSample $ PrefixFilter "my-proj"
 
+newtype Query = Query
+  { getQuery :: Text
+  }
+  deriving stock (Show, Generic)
+  deriving newtype (FromHttpApiData)
+
+instance ToParamSchema Query
+
+instance ToParam (QueryParam "query" Query) where
+  toParam _ =
+    DocQueryParam
+      "query"
+      ["my-proj"]
+      "Filter for results containing the given text."
+      Normal
+
+instance Docs.ToSample Query where
+  toSamples _ =
+    singleSample $ Query "my-proj"
+
 projectListingEndpoint ::
   Codebase IO Symbol Ann ->
-  Maybe PrefixFilter ->
+  -- Infix Query
+  Maybe Query ->
   Backend IO [ProjectListing]
-projectListingEndpoint codebase mayPrefix = liftIO . Codebase.runTransaction codebase $ do
-  projects <- Q.loadAllProjectsBeginningWith (prefix <$> mayPrefix)
-  pure $ ProjectListing . SqliteProject.name <$> projects
+projectListingEndpoint codebase mayQuery = liftIO . Codebase.runTransaction codebase $ do
+  PQ.listProjects (getQuery <$> mayQuery)
 
 projectBranchListingEndpoint ::
   Codebase IO Symbol Ann ->

--- a/unison-share-api/src/Unison/Server/Local/Endpoints/Projects/Queries.hs
+++ b/unison-share-api/src/Unison/Server/Local/Endpoints/Projects/Queries.hs
@@ -1,0 +1,20 @@
+module Unison.Server.Local.Endpoints.Projects.Queries (listProjects) where
+
+import Data.Text (Text)
+import Unison.Server.Local.Endpoints.Projects.Types
+import Unison.Sqlite
+
+-- | Load all project listings, optionally requiring an infix match with a query.
+listProjects :: Maybe Text -> Transaction [ProjectListing]
+listProjects mayQuery =
+  queryListRow
+    [sql|
+      SELECT project.name, branch.name
+      FROM project
+        LEFT JOIN most_recent_branch mrb
+          ON project.id = mrb.project_id
+        LEFT JOIN project_branch branch
+          ON mrb.branch_id = branch.branch_id
+        WHERE (:mayQuery IS NULL OR project.name LIKE '%' || :mayQuery || '%')
+      ORDER BY name ASC
+    |]

--- a/unison-share-api/src/Unison/Server/Local/Endpoints/Projects/Queries.hs
+++ b/unison-share-api/src/Unison/Server/Local/Endpoints/Projects/Queries.hs
@@ -16,5 +16,5 @@ listProjects mayQuery =
         LEFT JOIN project_branch branch
           ON mrb.branch_id = branch.branch_id
         WHERE (:mayQuery IS NULL OR project.name LIKE '%' || :mayQuery || '%')
-      ORDER BY name ASC
+      ORDER BY branch.last_accessed DESC, project.name ASC
     |]

--- a/unison-share-api/src/Unison/Server/Local/Endpoints/Projects/Queries.hs
+++ b/unison-share-api/src/Unison/Server/Local/Endpoints/Projects/Queries.hs
@@ -6,7 +6,8 @@ import Unison.Sqlite
 
 -- | Load all project listings, optionally requiring an infix match with a query.
 listProjects :: Maybe Text -> Transaction [ProjectListing]
-listProjects mayQuery =
+listProjects mayUnsafeQuery = do
+  let mayQuery = fmap (likeEscape '\\') mayUnsafeQuery
   queryListRow
     [sql|
       SELECT project.name, branch.name
@@ -15,6 +16,6 @@ listProjects mayQuery =
           ON project.id = mrb.project_id
         LEFT JOIN project_branch branch
           ON mrb.branch_id = branch.branch_id
-        WHERE (:mayQuery IS NULL OR project.name LIKE '%' || :mayQuery || '%')
+        WHERE (:mayQuery IS NULL OR project.name LIKE '%' || :mayQuery || '%' ESCAPE '\')
       ORDER BY branch.last_accessed DESC, project.name ASC
     |]

--- a/unison-share-api/src/Unison/Server/Local/Endpoints/Projects/Queries.hs
+++ b/unison-share-api/src/Unison/Server/Local/Endpoints/Projects/Queries.hs
@@ -17,5 +17,5 @@ listProjects mayUnsafeQuery = do
         LEFT JOIN project_branch branch
           ON mrb.branch_id = branch.branch_id
         WHERE (:mayQuery IS NULL OR project.name LIKE '%' || :mayQuery || '%' ESCAPE '\')
-      ORDER BY branch.last_accessed DESC, project.name ASC
+      ORDER BY branch.last_accessed DESC NULLS LAST, project.name ASC
     |]

--- a/unison-share-api/src/Unison/Server/Local/Endpoints/Projects/Types.hs
+++ b/unison-share-api/src/Unison/Server/Local/Endpoints/Projects/Types.hs
@@ -41,6 +41,9 @@ data ProjectBranchListing = ProjectBranchListing
   }
   deriving stock (Show, Generic)
 
+instance FromRow ProjectBranchListing where
+  fromRow = ProjectBranchListing <$> field
+
 instance ToSchema ProjectBranchListing
 
 instance ToJSON ProjectBranchListing where

--- a/unison-share-api/src/Unison/Server/Local/Endpoints/Projects/Types.hs
+++ b/unison-share-api/src/Unison/Server/Local/Endpoints/Projects/Types.hs
@@ -1,0 +1,52 @@
+module Unison.Server.Local.Endpoints.Projects.Types
+  ( ProjectListing (..),
+    ProjectBranchListing (..),
+  )
+where
+
+import Data.Aeson (ToJSON (..))
+import Data.Aeson qualified as Aeson
+import Data.OpenApi
+import GHC.Generics ()
+import Servant.Docs
+import Unison.Core.Project (ProjectBranchName (UnsafeProjectBranchName), ProjectName (UnsafeProjectName))
+import Unison.Prelude
+import Unison.Server.Orphans ()
+import Unison.Sqlite (FromRow (..), field)
+
+data ProjectListing = ProjectListing
+  { projectName :: ProjectName,
+    mostRecentActiveBranch :: Maybe ProjectBranchName
+  }
+  deriving stock (Show, Generic)
+
+instance FromRow ProjectListing where
+  fromRow = ProjectListing <$> field <*> field
+
+instance ToSchema ProjectListing
+
+instance ToJSON ProjectListing where
+  toJSON (ProjectListing projectName mostRecentActiveBranch) =
+    Aeson.object
+      [ "projectName" Aeson..= projectName,
+        "activeBranchRef" Aeson..= mostRecentActiveBranch
+      ]
+
+instance ToSample ProjectListing where
+  toSamples _ =
+    singleSample $ ProjectListing (UnsafeProjectName "my-project") Nothing
+
+data ProjectBranchListing = ProjectBranchListing
+  { branchName :: ProjectBranchName
+  }
+  deriving stock (Show, Generic)
+
+instance ToSchema ProjectBranchListing
+
+instance ToJSON ProjectBranchListing where
+  toJSON ProjectBranchListing {branchName} =
+    Aeson.object ["branchName" Aeson..= branchName]
+
+instance ToSample ProjectBranchListing where
+  toSamples _ =
+    singleSample $ ProjectBranchListing (UnsafeProjectBranchName "my-branch")

--- a/unison-share-api/src/Unison/Server/Orphans.hs
+++ b/unison-share-api/src/Unison/Server/Orphans.hs
@@ -36,6 +36,7 @@ import Unison.Reference qualified as Reference
 import Unison.Referent qualified as Referent
 import Unison.ShortHash (ShortHash)
 import Unison.ShortHash qualified as SH
+import Unison.Sqlite qualified as Sqlite
 import Unison.Syntax.HashQualified qualified as HQ (parseText)
 import Unison.Syntax.HashQualifiedPrime qualified as HQ' (parseText)
 import Unison.Syntax.Name qualified as Name (parseTextEither, toText)
@@ -387,6 +388,8 @@ deriving anyclass instance (ToSchema n) => ToSchema (HQ.HashQualified n)
 
 deriving anyclass instance (ToSchema n) => ToSchema (HQ'.HashQualified n)
 
+deriving via Text instance Sqlite.FromField ProjectName
+
 instance FromHttpApiData ProjectName where
   parseQueryParam = mapLeft tShow . tryInto @ProjectName
 
@@ -405,6 +408,8 @@ instance ToCapture (Capture "project-name" ProjectName) where
 instance ToSchema ProjectName
 
 deriving via Text instance ToJSON ProjectName
+
+deriving via Text instance Sqlite.FromField ProjectBranchName
 
 instance FromHttpApiData ProjectBranchName where
   parseQueryParam = mapLeft tShow . tryInto @ProjectBranchName

--- a/unison-share-api/unison-share-api.cabal
+++ b/unison-share-api/unison-share-api.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -34,6 +34,8 @@ library
       Unison.Server.Local.Endpoints.NamespaceDetails
       Unison.Server.Local.Endpoints.NamespaceListing
       Unison.Server.Local.Endpoints.Projects
+      Unison.Server.Local.Endpoints.Projects.Queries
+      Unison.Server.Local.Endpoints.Projects.Types
       Unison.Server.Local.Endpoints.UCM
       Unison.Server.NameSearch
       Unison.Server.NameSearch.FromNames
@@ -81,6 +83,7 @@ library
       TypeOperators
       ViewPatterns
       ImportQualifiedPost
+      QuasiQuotes
   ghc-options: -Wall
   build-depends:
       Diff

--- a/unison-src/transcripts/idempotent/api-list-projects-branches.md
+++ b/unison-src/transcripts/idempotent/api-list-projects-branches.md
@@ -19,26 +19,28 @@ project-one/main> branch branch-three
 GET /api/projects
   [
       {
+          "activeBranchRef": "branch-three",
           "projectName": "project-one"
       },
       {
+          "activeBranchRef": "main",
           "projectName": "project-three"
       },
       {
+          "activeBranchRef": "main",
           "projectName": "project-two"
       },
       {
+          "activeBranchRef": "main",
           "projectName": "scratch"
       }
   ]
--- Should list projects starting with project-t
-GET /api/projects?prefix=project-t
+-- Can query for some infix of the project name
+GET /api/projects?query=thre
   [
       {
+          "activeBranchRef": "main",
           "projectName": "project-three"
-      },
-      {
-          "projectName": "project-two"
       }
   ]
 -- Should list all branches

--- a/unison-src/transcripts/idempotent/api-list-projects-branches.md
+++ b/unison-src/transcripts/idempotent/api-list-projects-branches.md
@@ -1,17 +1,24 @@
 # List Projects And Branches Test
 
+I create projects and branches in reverse alphabetical order, and starting with `z`
+to place them after `main` alphabetically.
+This is because the results from the listing endpoints is sorted by (timestamp, name); but
+the default sqlite timestamp only has second-level precision and the transcript will sometimes
+lump many of those together. Doing it this way ensures both the creation timestamp and name sort
+the same direction so we don't end up with flaky non-deterministic tests.
+
 ``` ucm :hide
-scratch/main> project.create-empty project-apple
+scratch/main> project.create-empty project-cherry
 
 scratch/main> project.create-empty project-banana
 
-scratch/main> project.create-empty project-cherry
+scratch/main> project.create-empty project-apple
 
-project-apple/main> branch branch-apple
+project-apple/main> branch z-branch-cherry
 
-project-apple/main> branch branch-banana
+project-apple/main> branch z-branch-banana
 
-project-apple/main> branch branch-cherry
+project-apple/main> branch z-branch-apple
 ```
 
 ``` api
@@ -19,7 +26,7 @@ project-apple/main> branch branch-cherry
 GET /api/projects
   [
       {
-          "activeBranchRef": "branch-cherry",
+          "activeBranchRef": "z-branch-apple",
           "projectName": "project-apple"
       },
       {
@@ -47,23 +54,23 @@ GET /api/projects?query=bana
 GET /api/projects/project-apple/branches
   [
       {
-          "branchName": "branch-apple"
-      },
-      {
-          "branchName": "branch-banana"
-      },
-      {
-          "branchName": "branch-cherry"
-      },
-      {
           "branchName": "main"
+      },
+      {
+          "branchName": "z-branch-apple"
+      },
+      {
+          "branchName": "z-branch-banana"
+      },
+      {
+          "branchName": "z-branch-cherry"
       }
   ]
 -- Can query for some  infix of the project name
 GET /api/projects/project-apple/branches?query=bana
   [
       {
-          "branchName": "branch-banana"
+          "branchName": "z-branch-banana"
       }
   ]
 ```

--- a/unison-src/transcripts/idempotent/api-list-projects-branches.md
+++ b/unison-src/transcripts/idempotent/api-list-projects-branches.md
@@ -1,17 +1,17 @@
 # List Projects And Branches Test
 
 ``` ucm :hide
-scratch/main> project.create-empty project-one
+scratch/main> project.create-empty project-apple
 
-scratch/main> project.create-empty project-two
+scratch/main> project.create-empty project-banana
 
-scratch/main> project.create-empty project-three
+scratch/main> project.create-empty project-cherry
 
-project-one/main> branch branch-one
+project-apple/main> branch branch-apple
 
-project-one/main> branch branch-two
+project-apple/main> branch branch-banana
 
-project-one/main> branch branch-three
+project-apple/main> branch branch-cherry
 ```
 
 ``` api
@@ -19,16 +19,16 @@ project-one/main> branch branch-three
 GET /api/projects
   [
       {
-          "activeBranchRef": "branch-three",
-          "projectName": "project-one"
+          "activeBranchRef": "branch-cherry",
+          "projectName": "project-apple"
       },
       {
           "activeBranchRef": "main",
-          "projectName": "project-three"
+          "projectName": "project-banana"
       },
       {
           "activeBranchRef": "main",
-          "projectName": "project-two"
+          "projectName": "project-cherry"
       },
       {
           "activeBranchRef": "main",
@@ -36,37 +36,34 @@ GET /api/projects
       }
   ]
 -- Can query for some infix of the project name
-GET /api/projects?query=thre
+GET /api/projects?query=bana
   [
       {
           "activeBranchRef": "main",
-          "projectName": "project-three"
+          "projectName": "project-banana"
       }
   ]
 -- Should list all branches
-GET /api/projects/project-one/branches
+GET /api/projects/project-apple/branches
   [
       {
-          "branchName": "branch-one"
+          "branchName": "branch-apple"
       },
       {
-          "branchName": "branch-three"
+          "branchName": "branch-banana"
       },
       {
-          "branchName": "branch-two"
+          "branchName": "branch-cherry"
       },
       {
           "branchName": "main"
       }
   ]
--- Should list all branches beginning with branch-t
-GET /api/projects/project-one/branches?prefix=branch-t
+-- Can query for some  infix of the project name
+GET /api/projects/project-apple/branches?query=bana
   [
       {
-          "branchName": "branch-three"
-      },
-      {
-          "branchName": "branch-two"
+          "branchName": "branch-banana"
       }
   ]
 ```


### PR DESCRIPTION
## Overview

Resolves:
* https://linear.app/unison/issue/UX-498/include-last-active-branch-in-projects-endpoint

Handles:
* https://linear.app/unison/issue/UX-525/sort-projects-and-branches-by-recency
* https://linear.app/unison/issue/UX-524/better-search-support-for-branches-and-projects

## Implementation notes

* **ADDS A SCHEMA MIGRATION** to add a `last_accessed` unix epoch column to the`project_branch` which is set when `setCurrentProjectPath` is called (which is whenever the user `switch`es).
* Splits of a Utils module in SQLite and moves `likeEscape` there.
* I made a new Query module in `unison-share-api` for UCM local queries, since these will likely be pretty different than UCM's internal queries over time. If we'd really prefer ALL queries be in the same module I can move it.
* Allows filtering project or branch listings by an infix query rather than JUST a prefix one.
* Made a new query for project listings which includes the last active branch name and sorts by that branch's most recently accessed time.

## Interesting/controversial decisions

How do we want to organize query modules and things for UCM Desktop?

## Test coverage

Updated api transcript tests.