### PR TITLE
List fzf options for switch by recency

### DIFF
--- a/unison-src/transcripts/idempotent/api-list-projects-branches.md
+++ b/unison-src/transcripts/idempotent/api-list-projects-branches.md
@@ -1,17 +1,23 @@
 # List Projects And Branches Test
 
+I create projects and branches in reverse alphabetical order,
+this is because the results from the listing endpoints is sorted by (timestamp, name); but
+the default sqlite timestamp only has second-level precision and the transcript will sometimes
+lump many of those together. Doing it this way ensures both the creation timestamp and name sort
+the same direction so we don't end up with flaky non-deterministic tests.
+
 ``` ucm :hide
-scratch/main> project.create-empty project-apple
+scratch/main> project.create-empty project-cherry
 
 scratch/main> project.create-empty project-banana
 
-scratch/main> project.create-empty project-cherry
+scratch/main> project.create-empty project-apple
 
-project-apple/main> branch branch-apple
+project-apple/main> branch branch-cherry
 
 project-apple/main> branch branch-banana
 
-project-apple/main> branch branch-cherry
+project-apple/main> branch branch-apple
 ```
 
 ``` api
@@ -19,7 +25,7 @@ project-apple/main> branch branch-cherry
 GET /api/projects
   [
       {
-          "activeBranchRef": "branch-cherry",
+          "activeBranchRef": "branch-apple",
           "projectName": "project-apple"
       },
       {

--- a/unison-src/transcripts/idempotent/fuzzy-options.md
+++ b/unison-src/transcripts/idempotent/fuzzy-options.md
@@ -71,12 +71,9 @@ myproject/main> branch mybranch
 scratch/main> debug.fuzzy-options switch _
 
   Select a project or branch to switch to:
-    * /empty
-    * /main
     * myproject/main
     * myproject/mybranch
     * scratch/empty
-    * scratch/main
     * myproject
     * scratch
 ```


### PR DESCRIPTION
* [ ] Merge #5553  first

## Overview

With  the addition of #5553  it's now possible to list projects and branches by which were most recently visited.

This change lists project branches putting most recently accessed first.

## Implementation notes

* Sort fzf completion list so it goes: 
  * project branches in order of most recently accessed,
  * then the  list of all projects

## Interesting/controversial decisions

I  removed the `/` prefixing thing since it didn't really make sense to include names twice like I was when sorting in this new way, you'd always see the shortcut name next to the full name, and I think it's important to keep the full name in  case the user types the project name and expects to find it that way.

## Test coverage

See fzf  transcript

## Loose ends

Maybe we'll want to tweak it after trying it out a bit.