### PR TITLE
Sort switch fzf by recency

### DIFF
--- a/unison-src/transcripts/idempotent/api-list-projects-branches.md
+++ b/unison-src/transcripts/idempotent/api-list-projects-branches.md
@@ -14,11 +14,11 @@ scratch/main> project.create-empty project-banana
 
 scratch/main> project.create-empty project-apple
 
-project-apple/main> branch z-branch-cherry
+project-apple/main> branch a-branch-cherry
 
-project-apple/main> branch z-branch-banana
+project-apple/main> branch a-branch-banana
 
-project-apple/main> branch z-branch-apple
+project-apple/main> branch a-branch-apple
 ```
 
 ``` api
@@ -26,7 +26,7 @@ project-apple/main> branch z-branch-apple
 GET /api/projects
   [
       {
-          "activeBranchRef": "z-branch-apple",
+          "activeBranchRef": "a-branch-apple",
           "projectName": "project-apple"
       },
       {
@@ -54,23 +54,23 @@ GET /api/projects?query=bana
 GET /api/projects/project-apple/branches
   [
       {
+          "branchName": "a-branch-apple"
+      },
+      {
+          "branchName": "a-branch-banana"
+      },
+      {
+          "branchName": "a-branch-cherry"
+      },
+      {
           "branchName": "main"
-      },
-      {
-          "branchName": "z-branch-apple"
-      },
-      {
-          "branchName": "z-branch-banana"
-      },
-      {
-          "branchName": "z-branch-cherry"
       }
   ]
 -- Can query for some  infix of the project name
 GET /api/projects/project-apple/branches?query=bana
   [
       {
-          "branchName": "z-branch-banana"
+          "branchName": "a-branch-banana"
       }
   ]
 ```

--- a/unison-src/transcripts/idempotent/fuzzy-options.md
+++ b/unison-src/transcripts/idempotent/fuzzy-options.md
@@ -71,12 +71,9 @@ myproject/main> branch mybranch
 scratch/main> debug.fuzzy-options switch _
 
   Select a project or branch to switch to:
-    * /empty
-    * /main
     * myproject/main
     * myproject/mybranch
     * scratch/empty
-    * scratch/main
     * myproject
     * scratch
 ```


### PR DESCRIPTION
* [x] Merge #5553  first

## Overview

With  the addition of #5553  it's now possible to list projects and branches by which were most recently visited.

This change lists project branches putting most recently accessed first.

## Implementation notes

* Sort fzf completion list so it goes: 
  * project branches in order of most recently accessed,
  * then the  list of all projects

## Interesting/controversial decisions

I  removed the `/` prefixing thing since it didn't really make sense to include names twice like I was when sorting in this new way, you'd always see the shortcut name next to the full name, and I think it's important to keep the full name in  case the user types the project name and expects to find it that way.

## Test coverage

See fzf  transcript

## Loose ends

Maybe we'll want to tweak it after trying it out a bit.