### PR TITLE
Rework data pattern matching to use default cases

### DIFF
--- a/unison-runtime/src/Unison/Runtime/Pattern.hs
+++ b/unison-runtime/src/Unison/Runtime/Pattern.hs
@@ -13,7 +13,8 @@ module Unison.Runtime.Pattern
 where
 
 import Control.Monad.State (State, evalState, modify, runState, state)
-import Data.List (nub, transpose)
+import Data.Containers.ListUtils (nubOrd)
+import Data.List (transpose)
 import Data.Map.Strict
   ( fromListWith,
     insertWith,
@@ -662,7 +663,7 @@ compile spec ctx m@(PM (r : rs))
 -- Calculates the data constructors—with their arities—that should be
 -- matched on when splitting a matrix on a given variable. This
 -- includes
-relevantConstructors :: Eq v => PatternMatrix v -> v -> [(Int, Int)]
+relevantConstructors :: Ord v => PatternMatrix v -> v -> [(Int, Int)]
 relevantConstructors (PM rows) v = search [] rows
   where
     search acc (row : rows)
@@ -677,7 +678,7 @@ relevantConstructors (PM rows) v = search [] rows
           -- so contributes no relevant constructor.
           _ -> search acc rows
     -- irrefutable row, or no rows left
-    search acc _ = nub $ reverse acc
+    search acc _ = nubOrd $ reverse acc
 
 buildCaseBuiltin ::
   (Var v) =>

--- a/unison-runtime/src/Unison/Runtime/Stack.hs
+++ b/unison-runtime/src/Unison/Runtime/Stack.hs
@@ -22,6 +22,7 @@ module Unison.Runtime.Stack
         BlackHole,
         UnboxedTypeTag
       ),
+    closureTag,
     UnboxedTypeTag (..),
     unboxedTypeTagToInt,
     unboxedTypeTagFromInt,
@@ -153,7 +154,7 @@ module Unison.Runtime.Stack
   )
 where
 
-import Control.Exception (throwIO)
+import Control.Exception (throw, throwIO)
 import Control.Monad.Primitive
 import Data.Char qualified as Char
 import Data.IORef (IORef)
@@ -370,6 +371,14 @@ splitData = \case
   (Data2 r t i j) -> Just (r, t, [i, j])
   (DataG r t seg) -> Just (r, t, segToList seg)
   _ -> Nothing
+
+closureTag :: Closure -> PackedTag
+closureTag (Enum _ t) = t
+closureTag (Data1 _ t _) = t
+closureTag (Data2 _ t _ _) = t
+closureTag (DataG _ t _) = t
+closureTag c =
+  throw $ Panic "closureTag: unexpected closure" (Just $ BoxedVal c)
 
 -- | Converts a list of integers representing an unboxed segment back into the
 -- appropriate segment. Segments are stored backwards in the runtime, so this

--- a/unison-runtime/src/Unison/Runtime/Stack.hs
+++ b/unison-runtime/src/Unison/Runtime/Stack.hs
@@ -379,6 +379,7 @@ closureTag (Data2 _ t _ _) = t
 closureTag (DataG _ t _) = t
 closureTag c =
   throw $ Panic "closureTag: unexpected closure" (Just $ BoxedVal c)
+{-# inline closureTag #-}
 
 -- | Converts a list of integers representing an unboxed segment back into the
 -- appropriate segment. Segments are stored backwards in the runtime, so this


### PR DESCRIPTION
Previously, we were always expanding data type matching to explicitly match against every case. This was necessary because we would eagerly dump the entire data contents to the stack and analyze the tag from there. Different constructors with different numbrs of arguments would result in a different stack layout, so default cases could not be uniform.

However, a while ago we started analyzing data type tags directly, to avoid putting them on the stack. This change goes the final step. It selects the branch before deciding to dump the data type to the stack, and only does so in specific case branches. Nothing is added to the stack in default branches, so they can be shared among all constructors.

On the other end, the pattern matching compiler has been changed to preserve default cases when possible. When splitting on a data type, the actual constructors matched in the source are used as the explicit branches, and a default case is used if it exists in the source. The translation will still sometimes duplicate branches, but not nearly as much as before (and mainly due to complicated pattern matching).

Passed base tests, unison tests, unison transcripts and runtime tests.