### PR TITLE
Fix a variable capture during pattern desugaring

### DIFF
--- a/unison-src/transcripts/idempotent/fix-pattern-capture.md
+++ b/unison-src/transcripts/idempotent/fix-pattern-capture.md
@@ -1,0 +1,63 @@
+``` ucm :hide
+scratch/main> builtins.merge
+```
+
+Checks a case that was resulting in variable capture when compiling
+pattern matching. `y` was evidently getting captured by the variable
+introduced for `confuser decoy`
+
+``` unison
+type NatBox = NatBox Nat
+type Decoy a = { confuser : Tres }
+
+type Tres = One | Two | Three
+
+xyzzy : NatBox -> Decoy a -> Nat
+xyzzy box decoy =
+      (NatBox y) = box
+      (natty) =  -- Note that these parentheses are required
+        match confuser decoy with
+          Tres.One -> y
+          Two -> y + 1
+          Three -> 11
+      natty
+
+> xyzzy (NatBox 1) (Decoy One)
+> xyzzy (NatBox 1) (Decoy Two)
+> xyzzy (NatBox 1) (Decoy Three)
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+
+    ⍟ These new definitions are ok to `add`:
+
+      type Decoy a
+      type NatBox
+      type Tres
+      Decoy.confuser        : Decoy a -> Tres
+      Decoy.confuser.modify : (Tres ->{g} Tres)
+                              -> Decoy a1
+                              ->{g} Decoy a
+      Decoy.confuser.set    : Tres -> Decoy a1 -> Decoy a
+      xyzzy                 : NatBox -> Decoy a -> Nat
+
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    16 | > xyzzy (NatBox 1) (Decoy One)
+           ⧩
+           1
+
+    17 | > xyzzy (NatBox 1) (Decoy Two)
+           ⧩
+           2
+
+    18 | > xyzzy (NatBox 1) (Decoy Three)
+           ⧩
+           11
+```

--- a/unison-src/transcripts/idempotent/fix-pattern-capture.md
+++ b/unison-src/transcripts/idempotent/fix-pattern-capture.md
@@ -35,7 +35,7 @@ xyzzy box decoy =
   change:
 
     ⍟ These new definitions are ok to `add`:
-
+    
       type Decoy a
       type NatBox
       type Tres


### PR DESCRIPTION
This fixes a variable capture issue that @stew found. I think it would only occur when you have code that is internally a case inside the scrutinee of a case.

I didn't try to find the exact spot that the variable capture occurs, and add calls to freshen variables. The capture was occurring on variables that are introduced by the pattern compiler. Before each stage of compilation would make up new variables like this starting from 0. Instead, I threaded the 'fresh number' through the whole process, so that variables made up are unique to the whole definition, and there's no need to worry about capture and re-freshening. This was pretty easy because it just involved tweaking how the `visit` function is used to rewrite the expression.

I added Stew's example as a transcript test case as well.