### PR TITLE
Add SyncV2 Causal Negotiation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,6 +10,7 @@
     * [`UNISON_SHARE_ACCESS_TOKEN`](#unison_share_access_token)
     * [`UNISON_READONLY`](#unison_readonly)
     * [`UNISON_ENTITY_VALIDATION`](#unison_entity_validation)
+    * [`UNISON_SYNC_VERSION`](#unison_sync_version)
     * [Local Codebase Server](#local-codebase-server)
 * [Codebase Configuration](#codebase-configuration)
 
@@ -17,7 +18,7 @@
 
 ### `UNISON_DEBUG`
 
-Enable debugging output for various portions of the application. 
+Enable debugging output for various portions of the application.
 See `lib/unison-prelude/src/Unison/Debug.hs` for the full list of supported flags.
 
 E.g.
@@ -62,7 +63,7 @@ Note for Windows users: Due to an outstanding issue with GHC's IO manager on Win
 Enabling the LSP on windows can cause UCM to hang on exit and may require the process to be killed by the operating system or via Ctrl-C.
 Note that this doesn't pose any risk of codebase corruption or cause any known issues, it's simply an annoyance.
 
-If you accept this annoyance, you can enable the LSP server on Windows by exporting the `UNISON_LSP_ENABLED=true` environment variable. 
+If you accept this annoyance, you can enable the LSP server on Windows by exporting the `UNISON_LSP_ENABLED=true` environment variable.
 
 You can set this persistently in powershell using:
 
@@ -115,6 +116,14 @@ Defaults to enabled.
 
 ```sh
 $ UNISON_ENTITY_VALIDATION="false" ucm
+```
+
+### `UNISON_SYNC_VERSION`
+
+Allows enabling the experimental Sync Version 2 protocol when downloading code from Share.
+
+```sh
+$ UNISON_ENTITY_VALIDATION="2" ucm
 ```
 
 ### `UNISON_PULL_WORKERS`

--- a/unison-cli/src/Unison/Cli/DownloadUtils.hs
+++ b/unison-cli/src/Unison/Cli/DownloadUtils.hs
@@ -11,7 +11,6 @@ where
 import Control.Concurrent.STM (atomically)
 import Control.Concurrent.STM.TVar (modifyTVar', newTVarIO, readTVar, readTVarIO)
 import Data.List.NonEmpty (pattern (:|))
-import Data.Set qualified as Set
 import System.Console.Regions qualified as Console.Regions
 import U.Codebase.HashTags (CausalHash)
 import U.Codebase.Sqlite.Queries qualified as Queries
@@ -67,11 +66,9 @@ downloadProjectBranchFromShare syncVersion useSquashed branch =
             Cli.respond (Output.DownloadedEntities numDownloaded)
         SyncV2 -> do
           let branchRef = SyncV2.BranchRef (into @Text (ProjectAndBranch branch.projectName remoteProjectBranchName))
-          -- TODO: Fill this in.
-          let knownHashes = Set.empty
           let downloadedCallback = \_ -> pure ()
           let shouldValidate = not $ Codeserver.isCustomCodeserver Codeserver.defaultCodeserver
-          result <- SyncV2.syncFromCodeserver shouldValidate Share.hardCodedBaseUrl branchRef causalHashJwt knownHashes downloadedCallback
+          result <- SyncV2.syncFromCodeserver shouldValidate Share.hardCodedBaseUrl branchRef causalHashJwt downloadedCallback
           result & onLeft \err0 -> do
             done case err0 of
               Share.SyncError pullErr ->

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -667,7 +667,7 @@ loop e = do
               _ <- Cli.updateAtM description pp \destb ->
                 liftIO (Branch.merge'' (Codebase.lca codebase) Branch.RegularMerge srcb destb)
               Cli.respond Success
-            PullI syncVersion sourceTarget pullMode -> handlePull syncVersion sourceTarget pullMode
+            PullI sourceTarget pullMode -> handlePull sourceTarget pullMode
             PushRemoteBranchI pushRemoteBranchInput -> handlePushRemoteBranch pushRemoteBranchInput
             SyncToFileI syncFileDest projectBranchName -> SyncV2.handleSyncToFile syncFileDest projectBranchName
             SyncFromFileI syncFileSrc projectBranchName -> do

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/InstallLib.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/InstallLib.hs
@@ -60,7 +60,7 @@ handleInstallLib remind (ProjectAndBranch libdepProjectName unresolvedLibdepBran
   Cli.Env {codebase} <- ask
 
   causalHash <-
-    downloadProjectBranchFromShare SyncV1 Share.IncludeSquashedHead libdepProjectBranch
+    downloadProjectBranchFromShare Share.IncludeSquashedHead libdepProjectBranch
       & onLeftM (Cli.returnEarly . Output.ShareError)
 
   remoteBranchObject <- liftIO (Codebase.expectBranchForHash codebase causalHash)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectClone.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectClone.hs
@@ -13,7 +13,7 @@ import U.Codebase.Sqlite.Project qualified as Sqlite (Project (..))
 import U.Codebase.Sqlite.ProjectBranch qualified as Sqlite
 import U.Codebase.Sqlite.Queries qualified as Q
 import U.Codebase.Sqlite.Queries qualified as Queries
-import Unison.Cli.DownloadUtils (SyncVersion (..), downloadProjectBranchFromShare)
+import Unison.Cli.DownloadUtils (downloadProjectBranchFromShare)
 import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
 import Unison.Cli.MonadUtils qualified as Cli (getCurrentProjectAndBranch)
@@ -225,7 +225,7 @@ cloneInto localProjectBranch remoteProjectBranch = do
   let remoteProjectBranchNames = ProjectAndBranch remoteProjectName remoteBranchName
 
   branchHead <-
-    downloadProjectBranchFromShare SyncV1 Share.NoSquashedHead remoteProjectBranch
+    downloadProjectBranchFromShare Share.NoSquashedHead remoteProjectBranch
       & onLeftM (Cli.returnEarly . Output.ShareError)
 
   localProjectAndBranch <-

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectCreate.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectCreate.hs
@@ -13,7 +13,7 @@ import U.Codebase.Sqlite.Project (Project (..))
 import U.Codebase.Sqlite.ProjectBranch (ProjectBranch (..))
 import U.Codebase.Sqlite.Queries (expectCausalHashIdByCausalHash)
 import U.Codebase.Sqlite.Queries qualified as Queries
-import Unison.Cli.DownloadUtils (SyncVersion (..), downloadProjectBranchFromShare)
+import Unison.Cli.DownloadUtils (downloadProjectBranchFromShare)
 import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
 import Unison.Cli.Share.Projects qualified as Share
@@ -108,7 +108,7 @@ projectCreate tryDownloadingBase maybeProjectName = do
                 Share.GetProjectBranchResponseBranchNotFound -> done Nothing
                 Share.GetProjectBranchResponseProjectNotFound -> done Nothing
                 Share.GetProjectBranchResponseSuccess branch -> pure branch
-            downloadProjectBranchFromShare SyncV1 Share.NoSquashedHead baseLatestReleaseBranch
+            downloadProjectBranchFromShare Share.NoSquashedHead baseLatestReleaseBranch
               & onLeftM (Cli.returnEarly . Output.ShareError)
             Cli.Env {codebase} <- ask
             baseLatestReleaseBranchObject <-

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Pull.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Pull.hs
@@ -46,8 +46,8 @@ import Unison.Prelude
 import Unison.Project (ProjectAndBranch (..), ProjectBranchNameOrLatestRelease (..), ProjectName)
 import Witch (unsafeFrom)
 
-handlePull :: SyncVersion -> PullSourceTarget -> PullMode -> Cli ()
-handlePull syncVersion unresolvedSourceAndTarget pullMode = do
+handlePull :: PullSourceTarget -> PullMode -> Cli ()
+handlePull unresolvedSourceAndTarget pullMode = do
   let includeSquashed = case pullMode of
         Input.PullWithHistory -> Share.NoSquashedHead
         Input.PullWithoutHistory -> Share.IncludeSquashedHead
@@ -59,7 +59,6 @@ handlePull syncVersion unresolvedSourceAndTarget pullMode = do
       ReadShare'LooseCode repo -> downloadLooseCodeFromShare repo & onLeftM (Cli.returnEarly . Output.ShareError)
       ReadShare'ProjectBranch remoteBranch ->
         downloadProjectBranchFromShare
-          syncVersion
           ( case pullMode of
               Input.PullWithHistory -> Share.NoSquashedHead
               Input.PullWithoutHistory -> Share.IncludeSquashedHead

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/SyncV2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/SyncV2.hs
@@ -10,7 +10,7 @@ import Control.Lens
 import Control.Monad.Reader (MonadReader (..))
 import U.Codebase.HashTags (CausalHash)
 import U.Codebase.Sqlite.Queries qualified as Q
-import Unison.Cli.DownloadUtils (SyncVersion (..), downloadProjectBranchFromShare)
+import Unison.Cli.DownloadUtils (downloadProjectBranchFromShare)
 import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
 import Unison.Cli.MonadUtils qualified as Cli
@@ -75,4 +75,4 @@ handleSyncFromCodebase description srcCodebasePath srcBranch destBranch = do
       Cli.respond (Output.SyncPullError syncErr)
 
 handleSyncFromCodeserver :: Projects.IncludeSquashedHead -> Projects.RemoteProjectBranch -> Cli (Either Output.ShareError CausalHash)
-handleSyncFromCodeserver = downloadProjectBranchFromShare SyncV2
+handleSyncFromCodeserver = downloadProjectBranchFromShare

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -31,7 +31,6 @@ module Unison.Codebase.Editor.Input
     -- * Type aliases
     ErrorMessageOrName,
     RawQuery,
-    SyncVersion (..),
   )
 where
 
@@ -59,9 +58,6 @@ import Unison.Util.Pretty qualified as P
 data Event
   = UnisonFileChanged SourceName Source
   deriving stock (Show)
-
-data SyncVersion = SyncV1 | SyncV2
-  deriving (Eq, Show)
 
 type Source = Text -- "id x = x\nconst a b = a"
 
@@ -138,7 +134,7 @@ data Input
     MergeLocalBranchI BranchRelativePath (Maybe BranchRelativePath) Branch.MergeMode
   | PreviewMergeLocalBranchI BranchRelativePath (Maybe BranchRelativePath)
   | DiffNamespaceI BranchId2 BranchId2 -- old new
-  | PullI !SyncVersion !PullSourceTarget !PullMode
+  | PullI !PullSourceTarget !PullMode
   | PushRemoteBranchI PushRemoteBranchInput
   | SyncToFileI FilePath (ProjectAndBranch (Maybe ProjectName) (Maybe ProjectBranchName))
   | SyncFromFileI FilePath UnresolvedProjectBranch

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -92,7 +92,6 @@ module Unison.CommandLine.InputPatterns
     projectSwitch,
     projectsInputPattern,
     pull,
-    pullV2,
     pullWithoutHistory,
     push,
     pushCreate,
@@ -1788,13 +1787,7 @@ reset =
 
 pull :: InputPattern
 pull =
-  pullImpl "pull" [] Input.PullWithHistory "" Input.SyncV1
-
-pullV2 :: InputPattern
-pullV2 =
-  (pullImpl "pull.v2" [] Input.PullWithHistory "" Input.SyncV2)
-    {I.visibility = I.Hidden
-    }
+  pullImpl "pull" [] Input.PullWithHistory ""
 
 pullWithoutHistory :: InputPattern
 pullWithoutHistory =
@@ -1803,10 +1796,9 @@ pullWithoutHistory =
     []
     Input.PullWithoutHistory
     "without including the remote's history. This usually results in smaller codebase sizes."
-    Input.SyncV1
 
-pullImpl :: String -> [String] -> Input.PullMode -> P.Pretty CT.ColorText -> Input.SyncVersion -> InputPattern
-pullImpl name aliases pullMode addendum syncVersion = do
+pullImpl :: String -> [String] -> Input.PullMode -> P.Pretty CT.ColorText -> InputPattern
+pullImpl name aliases pullMode addendum = do
   self
   where
     self =
@@ -1850,10 +1842,10 @@ pullImpl name aliases pullMode addendum syncVersion = do
                 explainRemote Pull
               ],
           parse = \case
-            [] -> pure $ Input.PullI syncVersion Input.PullSourceTarget0 pullMode
+            [] -> pure $ Input.PullI Input.PullSourceTarget0 pullMode
             [sourceArg] -> do
               source <- handlePullSourceArg sourceArg
-              pure (Input.PullI syncVersion (Input.PullSourceTarget1 source) pullMode)
+              pure (Input.PullI (Input.PullSourceTarget1 source) pullMode)
             [sourceArg, targetArg] ->
               -- You used to be able to pull into a path, so this arg parser is a little complicated, because
               -- we want to provide helpful suggestions if you are doing a deprecated or invalid thing.
@@ -1861,7 +1853,7 @@ pullImpl name aliases pullMode addendum syncVersion = do
                      handleMaybeProjectBranchArg targetArg,
                      handlePath'Arg targetArg
                    ) of
-                (Right source, Right target, _) -> Right (Input.PullI syncVersion (Input.PullSourceTarget2 source target) pullMode)
+                (Right source, Right target, _) -> Right (Input.PullI (Input.PullSourceTarget2 source target) pullMode)
                 (Left err, _, _) -> Left err
                 -- Parsing as a path didn't work either; just show the branch parse error
                 (Right _, Left err, Left _) -> Left err
@@ -3821,7 +3813,6 @@ validInputs =
       projectSwitch,
       projectsInputPattern,
       pull,
-      pullV2,
       pullWithoutHistory,
       push,
       pushCreate,

--- a/unison-cli/src/Unison/Share/SyncV2.hs
+++ b/unison-cli/src/Unison/Share/SyncV2.hs
@@ -569,7 +569,7 @@ negotiateKnownCausals ::
   Cli (Either (SyncError SyncV2.PullError) (Set Hash32))
 negotiateKnownCausals unisonShareUrl branchRef hashJwt = do
   Cli.Env {authHTTPClient, codebase} <- ask
-  liftIO $ Text.hPutStrLn IO.stderr $ "  🔎  Identifying missing entities..."
+  liftIO $ Text.hPutStrLn IO.stderr $ "  🔎 Identifying missing entities..."
   Timing.time "Causal Negotiation" $ do
     liftIO . C.runResourceT . runExceptT $ httpStreamCausalDependencies
       authHTTPClient

--- a/unison-cli/src/Unison/Share/SyncV2.hs
+++ b/unison-cli/src/Unison/Share/SyncV2.hs
@@ -569,6 +569,7 @@ negotiateKnownCausals ::
   Cli (Either (SyncError SyncV2.PullError) (Set Hash32))
 negotiateKnownCausals unisonShareUrl branchRef hashJwt = do
   Cli.Env {authHTTPClient, codebase} <- ask
+  liftIO $ Text.hPutStrLn IO.stderr $ "  🔎  Identifying missing entities..."
   Timing.time "Causal Negotiation" $ do
     liftIO . C.runResourceT . runExceptT $ httpStreamCausalDependencies
       authHTTPClient

--- a/unison-cli/src/Unison/Share/SyncV2.hs
+++ b/unison-cli/src/Unison/Share/SyncV2.hs
@@ -219,7 +219,7 @@ syncUnsortedStream shouldValidate codebase stream = do
   allEntities <-
     C.runConduit $
       stream
-        C..| C.chunksOf batchSize
+        C..| CL.chunksOf batchSize
         C..| unpackChunks codebase
         C..| validateBatch
         C..| C.concat

--- a/unison-share-api/src/Unison/SyncV2/API.hs
+++ b/unison-share-api/src/Unison/SyncV2/API.hs
@@ -26,7 +26,7 @@ type DownloadEntitiesStream =
 -- | Get the relevant dependencies of a causal, including the causal spine and the causal hashes of any library roots.
 type CausalDependenciesStream =
   ReqBody '[CBOR, JSON] CausalDependenciesRequest
-    :> StreamPost NetstringFraming CBOR (SourceIO CausalDependenciesChunk)
+    :> StreamPost NoFraming OctetStream (SourceIO (CBORStream CausalDependenciesChunk))
 
 data Routes mode = Routes
   { downloadEntitiesStream :: mode :- "entities" :> "download" :> DownloadEntitiesStream,

--- a/unison-share-api/src/Unison/SyncV2/API.hs
+++ b/unison-share-api/src/Unison/SyncV2/API.hs
@@ -23,7 +23,13 @@ type DownloadEntitiesStream =
   ReqBody '[CBOR, JSON] DownloadEntitiesRequest
     :> StreamPost NoFraming OctetStream (SourceIO (CBORStream DownloadEntitiesChunk))
 
+-- | Get the relevant dependencies of a causal, including the causal spine and the causal hashes of any library roots.
+type CausalDependenciesStream =
+  ReqBody '[CBOR, JSON] CausalDependenciesRequest
+    :> StreamPost NetstringFraming CBOR (SourceIO CausalDependenciesChunk)
+
 data Routes mode = Routes
-  { downloadEntitiesStream :: mode :- "entities" :> "download" :> DownloadEntitiesStream
+  { downloadEntitiesStream :: mode :- "entities" :> "download" :> DownloadEntitiesStream,
+    causalDependenciesStream :: mode :- "entities" :> "dependencies" :> CausalDependenciesStream
   }
   deriving stock (Generic)

--- a/unison-share-api/src/Unison/SyncV2/Types.hs
+++ b/unison-share-api/src/Unison/SyncV2/Types.hs
@@ -10,6 +10,7 @@ module Unison.SyncV2.Types
     DownloadEntitiesError (..),
     CausalDependenciesRequest (..),
     CausalDependenciesChunk (..),
+    DependencyType (..),
     CBORBytes (..),
     CBORStream (..),
     EntityKind (..),

--- a/unison-src/transcripts/project-outputs/docs/configuration.output.md
+++ b/unison-src/transcripts/project-outputs/docs/configuration.output.md
@@ -9,6 +9,7 @@
       - [`UNISON_SHARE_ACCESS_TOKEN`](#unison_share_access_token)
       - [`UNISON_READONLY`](#unison_readonly)
       - [`UNISON_ENTITY_VALIDATION`](#unison_entity_validation)
+      - [`UNISON_SYNC_VERSION`](#unison_sync_version)
       - [Local Codebase Server](#local-codebase-server)
   - [Codebase Configuration](#codebase-configuration)
 
@@ -114,6 +115,14 @@ Defaults to enabled.
 
 ``` sh
 $ UNISON_ENTITY_VALIDATION="false" ucm
+```
+
+### `UNISON_SYNC_VERSION`
+
+Allows enabling the experimental Sync Version 2 protocol when downloading code from Share.
+
+``` sh
+$ UNISON_ENTITY_VALIDATION="2" ucm
 ```
 
 ### `UNISON_PULL_WORKERS`


### PR DESCRIPTION
## Overview

* [x] Based on #5513 , merge that first.

UCM will now use the new causal-dependencies endpoint to determine which dependencies of a new root it already has, then will tell Share to skip certain dependencies in its stream.

This massively speeds up incremental pulls on a given branch.

## Implementation notes

Before initiating a download, ask Share to enumerate relevant dependencies (currently the causal spine and all contained library causal hashes). Then pass the list of dependencies we've already got along to the download endpoint.

Note: this now clears the temp_entity tables before starting a pull.v2, we still have code to check temp entities on every insert, so clearing the tables speeds that up. There's not much reason to keep large amounts of code sitting around in there when the user isn't actively trying to pull.v1 something.

## Interesting/controversial decisions

Nope

## Test coverage

I've done a bunch of testing on staging, but would be good to dogfood it a bit with the Unison team or early adopters.

## Loose ends

* Track the remote causal for branches we've pulled so we can just use that as a known causal.
