### PR TITLE
Track and use last known remote hash in pullv2

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -146,6 +146,7 @@ module U.Codebase.Sqlite.Queries
     -- ** remote project branches
     loadRemoteBranch,
     ensureRemoteProjectBranch,
+    setRemoteProjectBranchLastKnownCausalHash,
     expectRemoteProjectBranchName,
     setRemoteProjectBranchName,
     insertBranchRemoteMapping,
@@ -258,6 +259,7 @@ module U.Codebase.Sqlite.Queries
     addProjectBranchReflogTable,
     addProjectBranchCausalHashIdColumn,
     addProjectBranchLastAccessedColumn,
+    trackLatestRemoteHead,
 
     -- ** schema version
     currentSchemaVersion,
@@ -422,7 +424,7 @@ type TextPathSegments = [Text]
 -- * main squeeze
 
 currentSchemaVersion :: SchemaVersion
-currentSchemaVersion = 18
+currentSchemaVersion = 19
 
 runCreateSql :: Transaction ()
 runCreateSql =
@@ -491,6 +493,10 @@ addProjectBranchCausalHashIdColumn =
 addProjectBranchLastAccessedColumn :: Transaction ()
 addProjectBranchLastAccessedColumn =
   executeStatements $(embedProjectStringFile "sql/015-add-project-branch-last-accessed.sql")
+
+trackLatestRemoteHead :: Transaction ()
+trackLatestRemoteHead =
+  executeStatements $(embedProjectStringFile "sql/016-track-latest-remote-head.sql")
 
 schemaVersion :: Transaction SchemaVersion
 schemaVersion =
@@ -4140,7 +4146,8 @@ loadRemoteBranch rpid host rbid =
         project_id,
         branch_id,
         host,
-        name
+        name,
+        last_known_causal_hash
       FROM
         remote_project_branch
       WHERE
@@ -4149,27 +4156,45 @@ loadRemoteBranch rpid host rbid =
         AND host = :host
     |]
 
-ensureRemoteProjectBranch :: RemoteProjectId -> URI -> RemoteProjectBranchId -> ProjectBranchName -> Transaction ()
-ensureRemoteProjectBranch rpid host rbid name =
+ensureRemoteProjectBranch :: RemoteProjectId -> URI -> RemoteProjectBranchId -> ProjectBranchName -> Maybe CausalHashId -> Transaction ()
+ensureRemoteProjectBranch rpid host rbid name lastKnownCausalHash =
   execute
     [sql|
       INSERT INTO remote_project_branch (
         project_id,
         host,
         branch_id,
-        name)
+        name,
+        last_known_head)
       VALUES (
         :rpid,
         :host,
         :rbid,
-        :name)
+        :name,
+        :lastKnownCausalHash
+        )
       ON CONFLICT (
         project_id,
         branch_id,
         host)
-        -- should this update the name instead?
-        DO NOTHING
+        DO UPDATE
+          SET name = :name,
+              last_known_causal_hash = :lastKnownCausalHash
         |]
+
+setRemoteProjectBranchLastKnownCausalHash :: URI -> RemoteProjectId -> RemoteProjectBranchId -> CausalHashId -> Transaction ()
+setRemoteProjectBranchLastKnownCausalHash host rpid rbid causalHashId =
+  execute
+    [sql|
+      UPDATE
+        remote_project_branch
+      SET
+        last_known_causal_hash = :causalHashId
+      WHERE
+        project_id = :rpid
+        AND branch_id = :rbid
+        AND host = :host
+    |]
 
 expectRemoteProjectBranchName :: URI -> RemoteProjectId -> RemoteProjectBranchId -> Transaction ProjectBranchName
 expectRemoteProjectBranchName host projectId branchId =

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -4165,7 +4165,7 @@ ensureRemoteProjectBranch rpid host rbid name lastKnownCausalHash =
         host,
         branch_id,
         name,
-        last_known_head)
+        last_known_causal_hash)
       VALUES (
         :rpid,
         :host,

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/RemoteProjectBranch.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/RemoteProjectBranch.hs
@@ -5,7 +5,7 @@ where
 
 import Network.URI (URI)
 import Network.URI.Orphans.Sqlite ()
-import U.Codebase.Sqlite.DbId (RemoteProjectBranchId, RemoteProjectId)
+import U.Codebase.Sqlite.DbId (CausalHashId, RemoteProjectBranchId, RemoteProjectId)
 import Unison.Core.Orphans.Sqlite ()
 import Unison.Core.Project (ProjectBranchName)
 import Unison.Prelude
@@ -15,7 +15,9 @@ data RemoteProjectBranch = RemoteProjectBranch
   { projectId :: RemoteProjectId,
     branchId :: RemoteProjectBranchId,
     host :: URI,
-    name :: ProjectBranchName
+    name :: ProjectBranchName,
+    -- Note that there's no guarantee that the causals for this hash have been downloaded/synced into the codebase.
+    lastKnownCausalHash :: CausalHashId
   }
   deriving stock (Generic, Show)
   deriving anyclass (ToRow, FromRow)

--- a/codebase2/codebase-sqlite/sql/016-track-latest-remote-head.sql
+++ b/codebase2/codebase-sqlite/sql/016-track-latest-remote-head.sql
@@ -1,7 +1,7 @@
 -- Add a field for tracking the latest known causal hash for each remote project branch.
 -- It's helpful for when we need to tell Share how much we know about a branch.
 
-ALTER TABLE remote_project
+ALTER TABLE remote_project_branch
   -- Note that there isn't a guarantee this hash has actually been synced into the codebase.
   ADD COLUMN last_known_causal_hash INTEGER NULL REFERENCES hash(id)
     ON DELETE SET NULL;

--- a/codebase2/codebase-sqlite/sql/016-track-latest-remote-head.sql
+++ b/codebase2/codebase-sqlite/sql/016-track-latest-remote-head.sql
@@ -1,0 +1,7 @@
+-- Add a field for tracking the latest known causal hash for each remote project branch.
+-- It's helpful for when we need to tell Share how much we know about a branch.
+
+ALTER TABLE remote_project
+  -- Note that there isn't a guarantee this hash has actually been synced into the codebase.
+  ADD COLUMN last_known_causal_hash INTEGER NULL REFERENCES hash(id)
+    ON DELETE SET NULL;

--- a/codebase2/codebase-sqlite/unison-codebase-sqlite.cabal
+++ b/codebase2/codebase-sqlite/unison-codebase-sqlite.cabal
@@ -25,6 +25,7 @@ extra-source-files:
     sql/013-add-project-branch-reflog-table.sql
     sql/014-add-project-branch-causal-hash-id.sql
     sql/015-add-project-branch-last-accessed.sql
+    sql/016-track-latest-remote-head.sql
     sql/create.sql
 
 source-repository head

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations.hs
@@ -85,7 +85,8 @@ migrations regionVar getDeclType termBuffer declBuffer rootCodebasePath =
       sqlMigration 15 Q.addSquashResultTableIfNotExists,
       sqlMigration 16 Q.cdToProjectRoot,
       (17 {- This migration takes a raw sqlite connection -}, \conn -> migrateSchema16To17 conn),
-      sqlMigration 18 Q.addProjectBranchLastAccessedColumn
+      sqlMigration 18 Q.addProjectBranchLastAccessedColumn,
+      sqlMigration 19 Q.trackLatestRemoteHead
     ]
   where
     runT :: Sqlite.Transaction () -> Sqlite.Connection -> IO ()

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
@@ -100,6 +100,7 @@ createSchema = do
   (_, emptyCausalHashId) <- emptyCausalHash
   (_, ProjectBranch {projectId, branchId}) <- insertProjectAndBranch scratchProjectName scratchBranchName emptyCausalHashId
   Q.setCurrentProjectPath projectId branchId []
+  Q.trackLatestRemoteHead
   where
     scratchProjectName = UnsafeProjectName "scratch"
     scratchBranchName = UnsafeProjectBranchName "main"


### PR DESCRIPTION
## Overview

TODO: Need to ensure migration happens in create-schema

If we keep track of the last known hash of a remote branch according to the last time we synced with it, we can provide that hash to the server when running syncv2 and it knows which entities we'll need to receive by diffing the two.

## Implementation notes

* Adds a migration to add the last_known_causal_hash to the remote branch table
* Sets the last known remote causal after each sync.
* Load and use this to skip causal-negotiation when running a V2 pull, if it's available (otherwise use causal negotiation).

## Test coverage

* [ ] Need to test this more thoroughly
