### PR TITLE
show full names in `dependents` output

### DIFF
--- a/parser-typechecker/src/Unison/Syntax/NamePrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/NamePrinter.hs
@@ -10,8 +10,6 @@ import Unison.LabeledDependency qualified as LD
 import Unison.Name (Name)
 import Unison.Name qualified as Name
 import Unison.NameSegment (NameSegment)
-import Unison.NameSegment.Internal (NameSegment(NameSegment))
-import Data.List.NonEmpty (NonEmpty(..))
 import Unison.Prelude
 import Unison.Reference (Reference)
 import Unison.Referent (Referent)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Dependents.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Dependents.hs
@@ -3,66 +3,77 @@ module Unison.Codebase.Editor.HandleInput.Dependents
   )
 where
 
+import Data.Bifoldable (bifoldMap, binull)
 import Data.Set qualified as Set
-import U.Codebase.Sqlite.Queries qualified as Queries
+import U.Codebase.Sqlite.Operations qualified as Operations
 import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
-import Unison.Cli.NameResolutionUtils (resolveHQToLabeledDependencies)
-import Unison.Cli.NamesUtils qualified as Cli
-import Unison.Codebase qualified as Codebase
+import Unison.Cli.MonadUtils qualified as Cli
+import Unison.Cli.NameResolutionUtils (resolveHQName)
+import Unison.Codebase.Branch qualified as Branch
+import Unison.Codebase.Branch.Names qualified as Branch
 import Unison.Codebase.Editor.Output
 import Unison.Codebase.Editor.StructuredArgument qualified as SA
-import Unison.ConstructorReference (GConstructorReference (..))
 import Unison.HashQualified qualified as HQ
 import Unison.HashQualifiedPrime qualified as HQ'
 import Unison.LabeledDependency qualified as LD
 import Unison.Name (Name)
 import Unison.Name qualified as Name
-import Unison.NameSegment qualified as NameSegment
 import Unison.Prelude
 import Unison.PrettyPrintEnv qualified as PPE
 import Unison.PrettyPrintEnv.Names qualified as PPE
-import Unison.PrettyPrintEnvDecl qualified as PPE hiding (biasTo, empty)
-import Unison.PrettyPrintEnvDecl.Names qualified as PPED
-import Unison.Reference (Reference)
+import Unison.Reference qualified as Reference
 import Unison.Referent qualified as Referent
-import Unison.Syntax.HashQualified qualified as HQ (toText)
-import Unison.Util.List (nubOrdOn)
+import Unison.Syntax.HashQualifiedPrime qualified as HQ' (toText)
+import Unison.Util.Defns (Defns (..), DefnsF)
+import Unison.Util.Set qualified as Set
 
 handleDependents :: HQ.HashQualified Name -> Cli ()
 handleDependents hq = do
-  -- todo: add flag to handle transitive efficiently
-  lds <- resolveHQToLabeledDependencies hq
-  -- Use an unsuffixified PPE here, so we display full names (relative to the current path),
-  -- rather than the shortest possible unambiguous name.
-  names <- Cli.currentNames
-  let pped = PPED.makePPED (PPE.hqNamer 10 names) (PPE.suffixifyByHash names)
-  let fqppe = PPE.unsuffixifiedPPE pped
-  let ppe = PPE.suffixifiedPPE pped
-  when (null lds) do
+  refs <- resolveHQName hq
+
+  when (binull refs) do
     Cli.returnEarly (LabeledReferenceNotFound hq)
 
-  results <- for (toList lds) \ld -> do
-    -- The full set of dependent references, any number of which may not have names in the current namespace.
-    dependents <-
-      let tp = Codebase.dependents Queries.ExcludeOwnComponent
-          tm = \case
-            Referent.Ref r -> Codebase.dependents Queries.ExcludeOwnComponent r
-            Referent.Con (ConstructorReference r _cid) _ct ->
-              Codebase.dependents Queries.ExcludeOwnComponent r
-       in Cli.runTransaction (LD.fold tp tm ld)
-    let -- True is term names, False is type names
-        results :: [(Bool, HQ.HashQualified Name, Reference)]
-        results = do
-          r <- Set.toList dependents
-          Just (isTerm, hq) <- [(True,) <$> PPE.terms fqppe (Referent.Ref r), (False,) <$> PPE.types fqppe r]
-          fullName <- [HQ'.toName hq]
-          guard (not (Name.beginsWithSegment fullName NameSegment.libSegment))
-          Just shortName <- pure $ PPE.terms ppe (Referent.Ref r) <|> PPE.types ppe r
-          pure (isTerm, HQ'.toHQ shortName, r)
-    pure results
-  let sort = fmap fst . nubOrdOn snd . Name.sortByText (HQ.toText . fst)
-  let types = sort [(n, r) | (False, n, r) <- join results]
-  let terms = sort [(n, r) | (True, n, r) <- join results]
-  Cli.setNumberedArgs . map SA.HashQualified $ types <> terms
-  Cli.respond (ListDependents ppe lds types terms)
+  namespace <- Cli.getCurrentProjectRoot0
+  let ppe =
+        let names = Branch.toNames namespace
+         in PPE.makePPE (PPE.hqNamer 10 names) (PPE.suffixifyByHash names)
+
+  let namespaceWithoutLibdeps = Branch.deleteLibdeps namespace
+  let ppeWithoutLibdeps =
+        let names = Branch.toNames namespaceWithoutLibdeps
+         in PPE.makePPE (PPE.hqNamer 10 names) (PPE.suffixifyByHash names)
+
+  dependents <- do
+    Cli.runTransaction do
+      Operations.directDependentsWithinScope
+        ( Set.union
+            (Set.mapMaybe Reference.toId (Branch.deepTypeReferences namespaceWithoutLibdeps))
+            (Set.mapMaybe Referent.toTermReferenceId (Branch.deepReferents namespaceWithoutLibdeps))
+        )
+        (bifoldMap (Set.map Referent.toReference) id refs)
+
+  let dependentNames ::
+        DefnsF
+          []
+          (HQ'.HashQualified Name, HQ'.HashQualified Name)
+          (HQ'.HashQualified Name, HQ'.HashQualified Name)
+      dependentNames =
+        bimap
+          (f (Referent.fromTermReferenceId >>> PPE.termNames ppeWithoutLibdeps))
+          (f (Reference.fromId >>> PPE.typeNames ppeWithoutLibdeps))
+          dependents
+        where
+          f g =
+            Set.toList
+              >>> mapMaybe (g >>> listToMaybe)
+              >>> Name.sortByText (fst >>> HQ'.toText)
+
+  -- Set numbered args
+  (dependentNames.types ++ dependentNames.terms)
+    & map (SA.HashQualified . HQ'.toHQ . fst)
+    & Cli.setNumberedArgs
+
+  let lds = bifoldMap (Set.map LD.referent) (Set.map LD.typeRef) refs
+  Cli.respond (ListDependents ppe lds dependentNames)

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -338,7 +338,14 @@ data Output
   | NoBranchWithHash ShortCausalHash
   | ListDependencies PPE.PrettyPrintEnv (Set LabeledDependency) [HQ.HashQualified Name] [HQ.HashQualified Name] -- types, terms
   | -- | List dependents of a type or term.
-    ListDependents PPE.PrettyPrintEnv (Set LabeledDependency) [HQ.HashQualified Name] [HQ.HashQualified Name] -- types, terms
+    ListDependents
+      PPE.PrettyPrintEnv
+      (Set LabeledDependency)
+      ( DefnsF
+          []
+          (HQ'.HashQualified Name, HQ'.HashQualified Name)
+          (HQ'.HashQualified Name, HQ'.HashQualified Name)
+      )
   | DumpNumberedArgs HashLength NumberedArgs
   | DumpBitBooster CausalHash (Map CausalHash [CausalHash])
   | DumpUnisonFileHashes Int [(Name, Reference.Id)] [(Name, Reference.Id)] [(Name, Reference.Id)]

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -5,6 +5,7 @@
 
 module Unison.CommandLine.OutputMessages where
 
+import Control.Arrow ((***))
 import Control.Lens hiding (at)
 import Control.Monad.State.Strict qualified as State
 import Data.ByteString.Lazy qualified as LazyByteString
@@ -128,6 +129,7 @@ import Unison.Syntax.Name qualified as Name (toText)
 import Unison.Syntax.NamePrinter
   ( prettyHashQualified,
     prettyHashQualified',
+    prettyHashQualifiedFull,
     prettyName,
     prettyNamedReference,
     prettyNamedReferent,
@@ -1445,9 +1447,9 @@ notifyUser dir = \case
         "dependents"
         lds
         (map (HQ'.toHQ . fst) defns.types)
-        (map (HQ'.toHQ . fst) defns.terms)
+        (map (HQ'.toHQ *** HQ'.toHQ) defns.terms)
   ListDependencies ppe lds types terms ->
-    pure $ listDependentsOrDependencies ppe "Dependencies" "dependencies" lds types terms
+    pure $ listDependentsOrDependencies ppe "Dependencies" "dependencies" lds types (map (\x -> (x, x)) terms)
   ListStructuredFind terms ->
     pure $ listFind False Nothing terms
   ListTextFind True terms ->
@@ -3771,15 +3773,15 @@ listDependentsOrDependencies ::
   Text ->
   Set LabeledDependency ->
   [HQ.HashQualified Name] ->
-  [HQ.HashQualified Name] ->
+  [(HQ.HashQualified Name, HQ.HashQualified Name)] ->
   Pretty
 listDependentsOrDependencies ppe labelStart label lds types terms =
-  if null (types <> terms)
+  if null types && null terms
     then prettyLabeledDependencies ppe lds <> " has no " <> P.text label <> "."
     else P.sepNonEmpty "\n\n" [hdr, typesOut, termsOut, tip msg]
   where
     msg = "Try " <> IP.makeExample IP.view args <> " to see the source of any numbered item in the above list."
-    args = [P.shown (length (types <> terms))]
+    args = [P.shown (length types + length terms)]
     hdr = P.text labelStart <> " of: " <> prettyLabeledDependencies ppe lds
     typesOut =
       if null types
@@ -3797,7 +3799,7 @@ listDependentsOrDependencies ppe labelStart label lds types terms =
           P.lines
             [ P.indentN 2 $ P.bold "Terms:",
               "",
-              P.indentN 2 . P.numberedListFrom (length types) $ c . prettyHashQualified <$> terms
+              P.indentN 2 . P.numberedListFrom (length types) $ prettyHashQualifiedFull <$> terms
             ]
     c = P.syntaxToColor
 

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1437,8 +1437,15 @@ notifyUser dir = \case
               "",
               "Paste that output into http://bit-booster.com/graph.html"
             ]
-  ListDependents ppe lds types terms ->
-    pure $ listDependentsOrDependencies ppe "Dependents" "dependents" lds types terms
+  ListDependents ppe lds defns ->
+    pure $
+      listDependentsOrDependencies
+        ppe
+        "Dependents"
+        "dependents"
+        lds
+        (map (HQ'.toHQ . fst) defns.types)
+        (map (HQ'.toHQ . fst) defns.terms)
   ListDependencies ppe lds types terms ->
     pure $ listDependentsOrDependencies ppe "Dependencies" "dependencies" lds types terms
   ListStructuredFind terms ->

--- a/unison-src/transcripts/idempotent/dependents-dependencies-debugfile.md
+++ b/unison-src/transcripts/idempotent/dependents-dependencies-debugfile.md
@@ -111,7 +111,7 @@ scratch/main> dependents d
 
     Terms:
 
-    1. r
+    1. inside.r
 
   Tip: Try `view 1` to see the source of any numbered item in
        the above list.


### PR DESCRIPTION
## Overview

This PR modifies `dependents` to show fully-qualified names instead of suffixified names.

However, I wonder if we should go a little further, and render the names something like this, showing both the fully-qualified name and its shortest unique suffix:

<img width="641" alt="Screen Shot 2025-02-06 at 12 52 55 PM" src="https://github.com/user-attachments/assets/04895ba8-c0fc-46b1-b4c7-9b79e7dca4dc" />

@aryairani / @ceedubs WDTY?

Still to do:
- [ ] show full names in `dependencies` output