### PR TITLE
Fix a problem with pre-evaluation in the sandboxed runtime

### DIFF
--- a/unison-src/transcripts/idempotent/fix5506.md
+++ b/unison-src/transcripts/idempotent/fix5506.md
@@ -1,0 +1,62 @@
+``` ucm :hide
+scratch/main> builtins.mergeio
+```
+
+``` unison
+
+stdOut = stdHandle StdOut
+
+putText h t = match putBytes.impl h (Text.toUtf8 t) with
+  Left e -> raise e
+  _ -> ()
+
+printLine t =
+  putText stdOut t
+  putText stdOut "\n"
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+
+    ⍟ These new definitions are ok to `add`:
+    
+      printLine : Text ->{IO, Exception} ()
+      putText   : Handle -> Text ->{IO, Exception} ()
+      stdOut    : Handle
+```
+
+``` ucm
+scratch/main> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+```
+
+``` unison
+
+hmmm = {{ I'll try {printLine}. That's a good trick. }}
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+
+    ⍟ These new definitions are ok to `add`:
+    
+      hmmm : Doc2
+```
+
+``` ucm
+scratch/main> display hmmm
+
+  I'll try printLine. That's a good trick.
+```


### PR DESCRIPTION
Pre-evaluation tries to evaluate all top level values ahead of time. There are a few such values, though, that come from operations we have marked as sandboxed, like the standard handles.

Documents (valid ones) and such would never actually use these handles, but they might be transitively referred to by the documents. Pre-evaluation was then eagerly evaluating the disallowed functions, even though the values aren't actually needed to calculate the document value (they're just used in a function _mentioned_ by the document).

This PR just ignores sandboxing failures during pre-evaluation. They will cause there to be no stored result for the value, but as long as the document (or whatever else is being evaluated) doesn't _actually_ depend on the sandboxed value, it will evaluate fine.

The reason why the error would only occur the first time is that pre-evaluation only happens for newly added definitions, and failures in pre-evaluation didn't roll back the known definitions. So, the second time running, all the definitions would be known, and evaluation would proceed as normal, completing successfully because the sensitive values aren't actually necessary. With this change, a pre-evaluation failure will only result in no cached value for the particular definition, so there's still no reason to try to roll back the cache. The top-level values that aren't sandboxed will all be cached.

Fixes #5563 and #5506