### PR TITLE
Adds FromJSON instances to enable Share Persistent JSON caching.

### DIFF
--- a/unison-share-api/src/Unison/Server/Doc.hs
+++ b/unison-share-api/src/Unison/Server/Doc.hs
@@ -9,7 +9,7 @@
 module Unison.Server.Doc where
 
 import Control.Monad
-import Data.Aeson (ToJSON)
+import Data.Aeson (ToJSON, FromJSON)
 import Data.Foldable
 import Data.Functor
 import Data.Map qualified as Map
@@ -91,7 +91,7 @@ data DocG specialForm
   | Column [(DocG specialForm)]
   | Group (DocG specialForm)
   deriving stock (Eq, Ord, Show, Generic, Functor, Foldable, Traversable)
-  deriving anyclass (ToJSON)
+  deriving anyclass (ToJSON, FromJSON)
 
 deriving instance (ToSchema specialForm) => ToSchema (DocG specialForm)
 
@@ -99,13 +99,13 @@ type UnisonHash = Text
 
 data Ref a = Term a | Type a
   deriving stock (Eq, Ord, Show, Generic, Functor, Foldable, Traversable)
-  deriving anyclass (ToJSON)
+  deriving anyclass (ToJSON, FromJSON)
 
 instance (ToSchema a) => ToSchema (Ref a)
 
 data MediaSource = MediaSource {mediaSourceUrl :: Text, mediaSourceMimeType :: Maybe Text}
   deriving stock (Eq, Ord, Show, Generic)
-  deriving anyclass (ToJSON, ToSchema)
+  deriving anyclass (ToJSON, FromJSON, ToSchema)
 
 data RenderedSpecialForm
   = Source [SrcRefs]
@@ -125,7 +125,7 @@ data RenderedSpecialForm
   | Svg Text
   | RenderError (RenderError SyntaxText)
   deriving stock (Eq, Ord, Show, Generic)
-  deriving anyclass (ToJSON, ToSchema)
+  deriving anyclass (ToJSON, FromJSON, ToSchema)
 
 data EvaluatedSpecialForm v
   = ESource [(EvaluatedSrc v)]
@@ -151,7 +151,7 @@ data EvaluatedSpecialForm v
 -- `Src folded unfolded`
 data Src = Src SyntaxText SyntaxText
   deriving stock (Eq, Ord, Show, Generic)
-  deriving anyclass (ToJSON, ToSchema)
+  deriving anyclass (ToJSON, FromJSON, ToSchema)
 
 -- | Evaluate the doc, then render it.
 evalAndRenderDoc ::
@@ -448,7 +448,7 @@ evalDoc terms typeOf eval types tm =
 data RenderError trm
   = InvalidTerm trm
   deriving stock (Eq, Ord, Show, Generic)
-  deriving anyclass (ToJSON)
+  deriving anyclass (ToJSON, FromJSON)
 
 deriving anyclass instance (ToSchema trm) => ToSchema (RenderError trm)
 


### PR DESCRIPTION
## Overview

I'm adding a persistent caching layer for JSON values on Share, see https://github.com/unisoncomputing/share-api/pull/35
 ,  and for that we need to be able to round-trip a bunch of stuff that previously only needed to be rendered.

This adds the matching FromJSON instances for types which previously only had ToJSON.

## Implementation notes

Adds FromJSON instances.

## Interesting/controversial decisions

Nope

## Test coverage

I tested roundtripping Term Definitions and rendered docs in Share here: https://github.com/unisoncomputing/share-api/pull/35

