### PR TITLE
Decl printing cleanup

### DIFF
--- a/parser-typechecker/src/Unison/PrettyPrintEnv/Util.hs
+++ b/parser-typechecker/src/Unison/PrettyPrintEnv/Util.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Unison.PrettyPrintEnv.Util (declarationPPE, declarationPPEDecl) where
+module Unison.PrettyPrintEnv.Util (declarationPPE) where
 
 import Unison.PrettyPrintEnv (PrettyPrintEnv (..))
 import Unison.PrettyPrintEnv qualified as PPE
@@ -29,8 +29,3 @@ declarationPPE ppe ref = PrettyPrintEnv tm ty
     ty r
       | hash r == rootH = PPE.typeNames (unsuffixifiedPPE ppe) r
       | otherwise = PPE.typeNames (suffixifiedPPE ppe) r
-
--- The suffixed names uses the fully-qualified name for `r`
-declarationPPEDecl :: PrettyPrintEnvDecl -> Reference -> PrettyPrintEnvDecl
-declarationPPEDecl ppe r =
-  ppe {suffixifiedPPE = declarationPPE ppe r}

--- a/parser-typechecker/src/Unison/Syntax/DeclPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/DeclPrinter.hs
@@ -84,9 +84,9 @@ prettyGADT ::
   DataDeclaration v a ->
   Pretty SyntaxText
 prettyGADT env ctorType r name dd =
-  P.hang header . P.lines $
-    constructor <$> zip [0 ..] (DD.constructors' dd)
+  header <> P.newline <> P.indentN 2 constructors
   where
+    constructors = P.lines (constructor <$> zip [0 ..] (DD.constructors' dd))
     constructor (n, (_, _, t)) =
       prettyPattern (PPED.unsuffixifiedPPE env) ctorType name (ConstructorReference r n)
         <> fmt S.TypeAscriptionColon " :"

--- a/unison-cli/src/Unison/Cli/Pretty.hs
+++ b/unison-cli/src/Unison/Cli/Pretty.hs
@@ -466,7 +466,7 @@ prettyType pped (n, r, dt) =
   case dt of
     MissingObject r -> missingDefinitionMsg n r
     BuiltinObject _ -> builtin n
-    UserObject decl -> DeclPrinter.prettyDecl (PPED.biasTo (maybeToList $ HQ.toName n) $ PPE.declarationPPEDecl pped r) r n decl
+    UserObject decl -> DeclPrinter.prettyDecl (PPED.biasTo (maybeToList $ HQ.toName n) $ pped) r n decl
   where
     builtin n = P.wrap $ "--" <> prettyHashQualified n <> " is built-in."
 

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -2634,7 +2634,7 @@ displayDefinitions' ppe0 types terms = P.syntaxToColor $ P.sep "\n\n" (prettyTyp
       case dt of
         MissingObject r -> missing n r
         BuiltinObject _ -> builtin n
-        UserObject decl -> DeclPrinter.prettyDecl (PPE.declarationPPEDecl ppe0 r) r n decl
+        UserObject decl -> DeclPrinter.prettyDecl ppe0 r n decl
     builtin n = P.wrap $ "--" <> prettyHashQualified n <> " is built-in."
     missing n r =
       P.wrap

--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -1193,7 +1193,7 @@ typesToSyntax suff width ppe0 types =
             MissingObject sh -> MissingObject sh
             UserObject d ->
               UserObject . Pretty.render width $
-                DeclPrinter.prettyDecl (PPE.declarationPPEDecl ppe0 r) r n d
+                DeclPrinter.prettyDecl ppe0 r n d
   where
     ppeDecl =
       if suffixified suff

--- a/unison-src/transcripts-manual/rewrites.output.md
+++ b/unison-src/transcripts-manual/rewrites.output.md
@@ -184,9 +184,11 @@ scratch/main> rewrite woot1to2
 -- | Rewrote using: 
 -- | Modified definition(s): wootEx
 
-ability Woot1 where woot1 : '{Woot1} Nat
+ability Woot1 where
+  woot1 : '{Woot1} Nat
 
-ability Woot2 where woot2 : '{Woot2} Nat
+ability Woot2 where
+  woot2 : '{Woot2} Nat
 
 woot1to2 x =
   @rewrite

--- a/unison-src/transcripts-round-trip/main.output.md
+++ b/unison-src/transcripts-round-trip/main.output.md
@@ -48,14 +48,17 @@ scratch/a1> edit.new 1-1000
 ```
 
 ````` unison :added-by-ucm scratch.u
-structural ability Abort where abort : {Abort} a
+structural ability Abort where
+  abort : {Abort} a
 
-structural ability Ask a where ask : {Ask a} a
+structural ability Ask a where
+  ask : {Ask a} a
 
 structural type Fix_2337
   = Fix_2337 Boolean Boolean
 
-structural ability Fix_2392 where zonk : {Fix_2392} Nat
+structural ability Fix_2392 where
+  zonk : {Fix_2392} Nat
 
 structural type Fix_2392a x y
   = Oog Nat Nat (Nat, Nat)

--- a/unison-src/transcripts/idempotent/doc1.md
+++ b/unison-src/transcripts/idempotent/doc1.md
@@ -15,7 +15,7 @@ scratch/main> view lib.builtins.Doc
     | Source Link
     | Signature Term
     | Evaluate Term
-    | Join [lib.builtins.Doc]
+    | Join [Doc]
 ```
 
 You can create these `Doc` values with ordinary code, or you can use the special syntax. A value of structural type `Doc` can be created via syntax like:

--- a/unison-src/transcripts/idempotent/formatter.md
+++ b/unison-src/transcripts/idempotent/formatter.md
@@ -138,7 +138,8 @@ ability Thing where
 
 
 Ask.doc = {{ Ability with single constructor }}
-structural ability Ask a where ask : {Ask a} a
+structural ability Ask a where
+  ask : {Ask a} a
 
 -- Regression test for: https://github.com/unisonweb/unison/issues/4666
 provide : a -> '{Ask a} r -> r

--- a/unison-src/transcripts/idempotent/top-level-exceptions.md
+++ b/unison-src/transcripts/idempotent/top-level-exceptions.md
@@ -10,10 +10,9 @@ FYI, here are the `Exception` and `Failure` types:
 scratch/main> view Exception Failure
 
   structural ability builtin.Exception where
-    raise : Failure ->{builtin.Exception} x
+    raise : Failure ->{Exception} x
 
-  type builtin.io2.Failure
-    = Failure Type Text Any
+  type builtin.io2.Failure = Failure Type Text Any
 ```
 
 Here's a sample program just to verify that the typechecker allows `run` to throw exceptions:

--- a/unison-src/transcripts/merge.output.md
+++ b/unison-src/transcripts/merge.output.md
@@ -1445,7 +1445,8 @@ my.cool.thing : Nat
 my.cool.thing = 17
 
 -- scratch/bob
-ability my.cool where thing : Nat ->{cool} Nat
+ability my.cool where
+  thing : Nat ->{cool} Nat
 
 ```
 


### PR DESCRIPTION
## Overview

Previously:

```
ability some.nested.Thing where theThing : Nat ->{some.nested.Thing} Int
```

Now:

```
ability some.nested.Thing where
  theThing : Nat ->{Thing} Int
```


## Implementation notes

* Remove the PPE modifier for printing Decls which forces the FQN for all self-references. I believe it's no longer necessary now that the parser can look up constructors/abilities by suffix.
  * If there's an ambiguity the suffixifier will kick in and disambiguate just like it does everywhere else.
* Force a newline after `where` in GADTs, it looks awkward without it.

## Test coverage

* I round-tripped base.
* Tested situations where multiple abilities had the same suffix; the pretty-printer still disambiguates as expected. 

## Loose ends

* Deploy this to share
