### PR TITLE
transcripts: Reset error state for all blocks

### DIFF
--- a/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
+++ b/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
@@ -360,7 +360,6 @@ run isTest verbosity dir codebase runtime sbRuntime nRuntime ucmVersion baseURL 
             writeIORef isHidden $ hidden infoTags
             writeIORef allowErrors $ expectingError infoTags
             writeIORef expectFailure $ hasBug infoTags
-            writeIORef hasErrors False
           traverse_ (atomically . Q.enqueue cmdQueue . Just) cmds
           atomically . Q.enqueue cmdQueue $ Nothing
           Cli.returnEarlyWithoutOutput
@@ -401,6 +400,7 @@ run isTest verbosity dir codebase runtime sbRuntime nRuntime ucmVersion baseURL 
         liftIO $ writeIORef isHidden Shown
         liftIO $ writeIORef allowErrors False
         liftIO $ writeIORef expectFailure False
+        liftIO $ writeIORef hasErrors False
         maybe (liftIO finishTranscript) (uncurry processStanza) =<< atomically (Q.tryDequeue inputQueue)
 
       awaitInput :: Cli (Either Event Input)

--- a/unison-src/transcripts/idempotent/fix-5575.md
+++ b/unison-src/transcripts/idempotent/fix-5575.md
@@ -35,31 +35,7 @@ foo =
   * typeLink
 ```
 
-But later blocks all act as if they have errors, even if they don’t.
-
-``` unison :bug
-foo : Nat
-foo =
-  1 + 2
-```
-
-``` ucm :added-by-ucm
-  Loading changes detected in scratch.u.
-
-  I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
-
-    ⍟ These new definitions are ok to `add`:
-    
-      foo : Nat
-```
-
-But an intervening `ucm` block (regardless of whether it errors) will correct it.
-
-``` ucm :hide
-scratch/main> help
-```
+Later blocks should have their error state reset.
 
 ``` unison
 foo : Nat

--- a/unison-src/transcripts/idempotent/fix-5575.md
+++ b/unison-src/transcripts/idempotent/fix-5575.md
@@ -1,0 +1,80 @@
+``` ucm :hide
+scratch/main> builtins.merge lib.builtin
+```
+
+A first `:error` block works as expected.
+
+``` unison :error
+foo : Nat
+foo =
+  1 +
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I got confused here:
+
+      4 | 
+
+  I was surprised to find an end of section here.
+  I was expecting one of these instead:
+
+  * bang
+  * do
+  * false
+  * force
+  * handle
+  * if
+  * let
+  * newline or semicolon
+  * quote
+  * termLink
+  * true
+  * tuple
+  * typeLink
+```
+
+But later blocks all act as if they have errors, even if they don’t.
+
+``` unison :bug
+foo : Nat
+foo =
+  1 + 2
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+
+    ⍟ These new definitions are ok to `add`:
+    
+      foo : Nat
+```
+
+But an intervening `ucm` block (regardless of whether it errors) will correct it.
+
+``` ucm :hide
+scratch/main> help
+```
+
+``` unison
+foo : Nat
+foo =
+  1 + 2
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+
+    ⍟ These new definitions are ok to `add`:
+    
+      foo : Nat
+```

--- a/unison-src/transcripts/idempotent/pattern-match-coverage.md
+++ b/unison-src/transcripts/idempotent/pattern-match-coverage.md
@@ -203,7 +203,7 @@ test = cases
 
 ## Complete patterns with guards should be accepted
 
-``` unison :error
+``` unison
 test : Optional Nat -> Nat
 test = cases
   None -> 0


### PR DESCRIPTION
## Overview

Previously, once there was an `:error` (or `:bug`) block, all following blocks would behave as if they had had an error. Except  `ucm` blocks would correctly reset the state so that following blocks would behave correctly again.

This moves the state reset to be shared by all blocks.

Fixes #5575.

## Test coverage

There’s a new transcript specifically for this issue. There was also another transcript that had an incorrect `:error` that worked around this bug.