### PR TITLE
add ACTIONS_CACHE_SERVICE_V2: true

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,9 @@ env:
   ## afaik, the jit sources are generated in a platform-independent way, so we choose one platform to generate them on.
   jit_generator_os: ubuntu-20.04
 
+  # work around https://github.com/actions/cache/issues/1547 which may continue causing failures until March 1, 2025
+  ACTIONS_CACHE_SERVICE_V2: true
+
 jobs:
   ormolu:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
due to weird misses we're getting
https://github.com/unisonweb/unison/actions/runs/13184837131/job/37170840841?pr=5573

hypothesis: https://github.com/actions/cache/issues/1547

Presumably we can delete this in March when the service transition is scheduled to be complete.