### PR TITLE
Implement more lax JWT decoder

### DIFF
--- a/unison-share-projects-api/package.yaml
+++ b/unison-share-projects-api/package.yaml
@@ -11,9 +11,10 @@ library:
 dependencies:
   - aeson
   - base
+  - bytestring
   - jose
-  - jwt
   - lens
+  - memory
   - servant
   - servant-auth
   - text

--- a/unison-share-projects-api/unison-share-projects-api.cabal
+++ b/unison-share-projects-api/unison-share-projects-api.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -54,9 +54,10 @@ library
   build-depends:
       aeson
     , base
+    , bytestring
     , jose
-    , jwt
     , lens
+    , memory
     , servant
     , servant-auth
     , text


### PR DESCRIPTION
## Overview

The `jwt` lib fails on EdDSA jwts even though it doesn't verify the signature 😞 

This means switching to EDDSA HashJwts isn't possible for now; which is fine I can keep those as HS256 JWTs, but I want to fix this now so we can potentially switch it in the distant future if we have to :)

Plus this removes the dependency on `jwt`, which is probably good since we should be using `jose` for everything where possible.

## Implementation notes

Manually unpack and decode the jwt when reading HashJWTs rather than depending on the `jwt` lib.
It's really easy to do, and it's part of the spec so it's not going to change.

## Test coverage

Tested against Share's push/pull transcripts
