### PR TITLE
Allow Value.value in test sandbox

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/RuntimeUtils.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/RuntimeUtils.hs
@@ -110,5 +110,8 @@ evalPureUnison native ppe useCache tm =
         tm
         (Term.app a (Term.builtin a "bug") (Term.text a msg))
     a = ABT.annotation tm
-    allow = Term.list a [Term.termLink a (Referent.Ref (Reference.Builtin "Debug.toText"))]
+    allow = Term.list a [
+        Term.termLink a (Referent.Ref (Reference.Builtin "Debug.toText"))
+      , Term.termLink a (Referent.Ref (Reference.Builtin "Value.value"))
+      ]
     msg = "pure code can't perform I/O"

--- a/unison-src/transcripts/idempotent/fix5538.md
+++ b/unison-src/transcripts/idempotent/fix5538.md
@@ -1,0 +1,108 @@
+``` ucm :hide
+fresh/main> builtins.merge
+```
+
+Check that `Value.value` works in watch expressions:
+
+``` unison
+toText' : a -> Text
+toText' a = match Debug.toText a with
+    None -> bug ("no name available", a)
+    Some (Left t) -> t
+    Some (Right t) -> t
+
+test> foo.test =
+  x = 192
+  v = Value.value 192
+  [Ok (toText' v)]
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+
+    ⍟ These new definitions are ok to `add`:
+    
+      foo.test : [Result]
+      toText'  : a -> Text
+
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    8 |   x = 192
+    
+    ✅ Passed bug "<Value>"
+```
+
+``` ucm
+fresh/main> add
+
+  ⍟ I've added these definitions:
+
+    foo.test : [Result]
+    toText'  : a -> Text
+
+fresh/main> test
+
+  Cached test results (`help testcache` to learn more)
+
+    1. foo.test   ◉ bug "<Value>"
+
+  ✅ 1 test(s) passing
+
+  Tip: Use view 1 to view the source of a test.
+```
+
+Check that it works in tests that are never executed as watch expressions. See [this
+issue](https://github.com/unisonweb/unison/issues/4685) for motivation.
+
+``` unison
+bar.test : [Test.Result]
+bar.test =
+  v = Value.value 42
+  [Ok (toText' v)]
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+
+    ⍟ These new definitions are ok to `add`:
+    
+      bar.test : [Result]
+```
+
+``` ucm
+fresh/main> add
+
+  ⍟ I've added these definitions:
+
+    bar.test : [Result]
+
+fresh/main> test
+
+    
+    Cached test results (`help testcache` to learn more)
+    
+      1. foo.test   ◉ bug "<Value>"
+    
+    ✅ 1 test(s) passing
+    
+    ✅  
+
+
+
+    New test results:
+
+    1. bar.test   ◉ builtin.bug "<Value>"
+
+  ✅ 1 test(s) passing
+
+  Tip: Use view 1 to view the source of a test.
+```


### PR DESCRIPTION
Allow `Value.value` in test sandbox.

Resolves #5538.
