### PR TITLE
Show the names of tests that fail sandbox violation

### DIFF
--- a/unison-src/transcripts/idempotent/name-test-sandbox-violators.md
+++ b/unison-src/transcripts/idempotent/name-test-sandbox-violators.md
@@ -1,0 +1,111 @@
+``` ucm :hide
+fresh/main> builtins.merge
+```
+
+This passes, because the IO sandbox doesn't seem to apply to `test>` watch expressions.
+
+``` unison
+test> foo.test =
+  x = 192
+  Debug.trace "x" x
+  [Ok "Passed"]
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+
+    ⍟ These new definitions are ok to `add`:
+    
+      foo.test : [Result]
+
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    2 |   x = 192
+    
+    ✅ Passed Passed
+```
+
+``` ucm
+fresh/main> add
+
+  ⍟ I've added these definitions:
+
+    foo.test : [Result]
+```
+
+The `test` command succeeds, because the result of `foo.test` is already cached, which skips the IO sandbox.
+
+``` ucm
+fresh/main> test
+
+  Cached test results (`help testcache` to learn more)
+
+    1. foo.test   ◉ Passed
+
+  ✅ 1 test(s) passing
+
+  Tip: Use view 1 to view the source of a test.
+```
+
+This test which is essentially the same will fail, because it is never run with a `test>` watch expression to get the result into the test cache.
+
+``` unison
+bar.test : [Test.Result]
+bar.test =
+  x = 42
+  Debug.trace "x" x
+  [Ok "Passed"]
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+
+    ⍟ These new definitions are ok to `add`:
+    
+      bar.test : [Result]
+```
+
+``` ucm
+fresh/main> add
+
+  ⍟ I've added these definitions:
+
+    bar.test : [Result]
+```
+
+``` ucm :error
+fresh/main> test
+
+    
+    Cached test results (`help testcache` to learn more)
+    
+      1. foo.test   ◉ Passed
+    
+    ✅ 1 test(s) passing
+    
+    ✅  
+
+
+
+  Error while evaluating test `bar.test`
+
+  💔💥
+
+  I've encountered a call to builtin.bug with the following
+  value:
+
+    "pure code can't perform I/O"
+
+  Stack trace:
+    builtin.bug
+    #oit1slb1i3
+```


### PR DESCRIPTION
Previously if a test violated the sandbox such as with `Debug.trace`, the output
just said `pure code can't perform I/O` but didn't actually report any failing
tests or even name the test that violated the sandbox.

With this change it will at least add a line like:

```
Error while evaluating test `bar.test`
```

This should help a lot in tracking down the sandbox violation.

This resolves the worst of [#4685](https://github.com/unisonweb/unison/issues/4685), but it doesn't do anything to address the confusing behavior of test watches being exempt from the sandbox and caching tests that would fail when running `test` on an empty cache.
