### PR TITLE
Modify the fix-2805 transcript to use return type

### DIFF
--- a/unison-src/transcripts-using-base/fix-2805.md
+++ b/unison-src/transcripts-using-base/fix-2805.md
@@ -1,15 +1,16 @@
 When running a main function in `ucm` a numeric argument is replaced by the potential last result of a find command:
 
 ``` unison
-main : '{IO, Exception} ()
-main _ =
-  printLine ("Hello " ++ Optional.getOrBug "definitely passed an arg" (List.head !getArgs) ++ "!")
+main : '{IO, Exception} Text
+main _ = "Hello " ++ Optional.getOrBug "definitely passed an arg" (List.head !getArgs) ++ "!"
 ```
 
 First we run it with no numbered results in the history, so if number expansion is applied, it should end up calling `main` with zero args, whereas without number expansion, we get a single argument, “1”, passed to it.
 
 ``` ucm
 scratch/main> run main 1
+
+  "Hello 1!"
 ```
 
 Now we set it up so there _are_ numbered results in the history. If number expansion is applied here, we will get an error “`run` can’t accept a numbered argument […]”, and otherwise our expected "1".
@@ -17,4 +18,6 @@ Now we set it up so there _are_ numbered results in the history. If number expan
 ``` ucm
 scratch/main> find.all isLeft
 scratch/main> run main 1
+
+  "Hello 1!"
 ```

--- a/unison-src/transcripts-using-base/fix-2805.output.md
+++ b/unison-src/transcripts-using-base/fix-2805.output.md
@@ -1,9 +1,8 @@
 When running a main function in `ucm` a numeric argument is replaced by the potential last result of a find command:
 
 ``` unison
-main : '{IO, Exception} ()
-main _ =
-  printLine ("Hello " ++ Optional.getOrBug "definitely passed an arg" (List.head !getArgs) ++ "!")
+main : '{IO, Exception} Text
+main _ = "Hello " ++ Optional.getOrBug "definitely passed an arg" (List.head !getArgs) ++ "!"
 ```
 
 ``` ucm :added-by-ucm
@@ -15,7 +14,7 @@ main _ =
 
     ⍟ These new definitions are ok to `add`:
     
-      main : '{IO, Exception} ()
+      main : '{IO, Exception} Text
 ```
 
 First we run it with no numbered results in the history, so if number expansion is applied, it should end up calling `main` with zero args, whereas without number expansion, we get a single argument, “1”, passed to it.
@@ -23,7 +22,7 @@ First we run it with no numbered results in the history, so if number expansion 
 ``` ucm
 scratch/main> run main 1
 
-  ()
+  "Hello 1!"
 ```
 
 Now we set it up so there *are* numbered results in the history. If number expansion is applied here, we will get an error “`run` can’t accept a numbered argument \[…\]”, and otherwise our expected "1".
@@ -35,5 +34,5 @@ scratch/main> find.all isLeft
 
 scratch/main> run main 1
 
-  ()
+  "Hello 1!"
 ```


### PR DESCRIPTION
## Overview

It previously used `printLine` to print the result from the `main`
function, but transcripts don’t capture stdout, so this changes it to
return the result instead, so it’s reflected in the output.

This is a follow-up to #5549, based on [this comment](https://github.com/unisonweb/unison/pull/5549#discussion_r1947962933).