### PR TITLE
add unison-util-recursion as dependency of unison-share-api

### DIFF
--- a/unison-share-api/package.yaml
+++ b/unison-share-api/package.yaml
@@ -52,6 +52,7 @@ library:
     - unison-prelude
     - unison-pretty-printer
     - unison-runtime
+    - unison-util-recursion
     - unison-util-relation
     - unison-util-base32hex
     - unison-share-projects-api

--- a/unison-share-api/unison-share-api.cabal
+++ b/unison-share-api/unison-share-api.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 


### PR DESCRIPTION
## Overview

On trunk, `unison-share-api` depends on `unison-util-recursion` via a direct change to its auto-generated cabal file, rather than package.yaml