### PR TITLE
Bump ubuntu runner images to ubuntu-24.04 due to deprecation

### DIFF
--- a/.github/workflows/bundle-ucm.yaml
+++ b/.github/workflows/bundle-ucm.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-13, macos-14, windows-2019]
+        os: [ubuntu-24.04, macos-13, macos-14, windows-2019]
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v4
@@ -86,7 +86,7 @@ jobs:
   package-racket-lib:
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-24.04]
     needs: build-ucm
     name: package racket lib
     runs-on: ${{matrix.os}}
@@ -141,7 +141,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-24.04
           - macos-13
           - macos-14
           - windows-2019
@@ -212,7 +212,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-13, macos-14, windows-2019]
+        os: [ubuntu-24.04, macos-13, macos-14, windows-2019]
     steps:
       - name: set up environment
         run: |

--- a/.github/workflows/check-contributor.yaml
+++ b/.github/workflows/check-contributor.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   check-contributor:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/ci-build-jit-binary.yaml
+++ b/.github/workflows/ci-build-jit-binary.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-13, windows-2019]
+        os: [ubuntu-24.04, macos-13, windows-2019]
     runs-on: ${{matrix.os}}
     steps:
       - name: set up environment

--- a/.github/workflows/ci-test-jit.yaml
+++ b/.github/workflows/ci-test-jit.yaml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-24.04
           - macos-13
           # - windows-2019
     runs-on: ${{matrix.os}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,14 +30,14 @@ env:
   interpreter_test_results: interpreter-test-results
 
   ## afaik, the jit sources are generated in a platform-independent way, so we choose one platform to generate them on.
-  jit_generator_os: ubuntu-20.04
+  jit_generator_os: ubuntu-24.04
 
   # work around https://github.com/actions/cache/issues/1547 which may continue causing failures until March 1, 2025
   ACTIONS_CACHE_SERVICE_V2: true
 
 jobs:
   ormolu:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Get changed files
@@ -73,7 +73,7 @@ jobs:
       matrix:
         os:
           # While iterating on this file, you can disable one or more of these to speed things up
-          - ubuntu-20.04
+          - ubuntu-24.04
           - macos-13
           - windows-2019
           # - windows-2022
@@ -220,7 +220,7 @@ jobs:
       matrix:
         os:
           # While iterating on this file, you can disable one or more of these to speed things up
-          - ubuntu-20.04
+          - ubuntu-24.04
           - macos-13
           - windows-2019
           # - windows-2022
@@ -303,7 +303,7 @@ jobs:
       matrix:
         os:
           # While iterating on this file, you can disable one or more of these to speed things up
-          - ubuntu-20.04
+          - ubuntu-24.04
           - macos-13
           # - windows-2019
           # - windows-2022
@@ -366,7 +366,7 @@ jobs:
     if: always() && needs.build-ucm.result == 'success'
     name: generate jit source
     needs: build-ucm
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: set up environment
         run: |

--- a/.github/workflows/haddocks.yaml
+++ b/.github/workflows/haddocks.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     name: Haddocks
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/nix-dev-cache.yaml
+++ b/.github/workflows/nix-dev-cache.yaml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-24.04
           - macos-13
           # - macos-14
     steps:

--- a/.github/workflows/ormolu.yaml
+++ b/.github/workflows/ormolu.yaml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   ormolu:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: haskell-actions/run-ormolu@v15

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -25,7 +25,7 @@ jobs:
 
   release:
     name: create release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs:
       - bundle-ucm
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
 
   release:
     name: create release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs:
       - bundle-ucm
 


### PR DESCRIPTION
They've started brownouts for our current ubuntu github actions runner: https://github.com/actions/runner-images/issues/11101

This just does a search-replace to update to the recommended upgrade image.