### PR TITLE
Run downloading, unpacking, and saving in parallel for serialized syncs

### DIFF
--- a/unison-cli/package.yaml
+++ b/unison-cli/package.yaml
@@ -37,6 +37,8 @@ library:
     - containers >= 0.6.3
     - conduit
     - conduit-extra
+    - stm-conduit
+    - stm-chans
     - cryptonite
     - either
     - errors

--- a/unison-cli/package.yaml
+++ b/unison-cli/package.yaml
@@ -37,7 +37,6 @@ library:
     - containers >= 0.6.3
     - conduit
     - conduit-extra
-    - stm-conduit
     - stm-chans
     - cryptonite
     - either

--- a/unison-cli/src/Unison/Cli/DownloadUtils.hs
+++ b/unison-cli/src/Unison/Cli/DownloadUtils.hs
@@ -77,9 +77,8 @@ downloadProjectBranchFromShare useSquashed branch =
             Cli.respond (Output.DownloadedEntities numDownloaded)
         SyncV2 -> do
           let branchRef = SyncV2.BranchRef (into @Text (ProjectAndBranch branch.projectName remoteProjectBranchName))
-          let downloadedCallback = \_ -> pure ()
           let shouldValidate = not $ Codeserver.isCustomCodeserver Codeserver.defaultCodeserver
-          result <- SyncV2.syncFromCodeserver shouldValidate Share.hardCodedBaseUrl branchRef causalHashJwt downloadedCallback
+          result <- SyncV2.syncFromCodeserver shouldValidate Share.hardCodedBaseUrl branchRef causalHashJwt
           result & onLeft \err0 -> do
             done case err0 of
               Share.SyncError pullErr ->

--- a/unison-cli/src/Unison/Share/SyncV2.hs
+++ b/unison-cli/src/Unison/Share/SyncV2.hs
@@ -107,7 +107,7 @@ syncToFile codebase rootHash mayBranchRef destFilePath = do
   liftIO $ Codebase.withConnection codebase \conn -> do
     C.runResourceT $
       withCodebaseEntityStream conn rootHash mayBranchRef \mayTotal stream -> do
-        withStreamProgressCallback (Just mayTotal) \countC -> runExceptT do
+        syncToFileProgress (Just mayTotal) \countC -> runExceptT do
           C.runConduit $
             stream
               C..| countC
@@ -126,12 +126,12 @@ syncFromFile shouldValidate syncFilePath = do
   -- Every insert into SQLite checks the temp entity tables, but syncv2 doesn't actually use them, so it's faster
   -- if we clear them out before starting a sync.
   Cli.runTransaction Q.clearTempEntityTables
-  liftIO $ withStreamProgress \progressCounters -> do
+  liftIO $ withStreamProgress False \progressCounters -> do
     runExceptT do
       mapExceptT liftIO $ Timing.time "File Sync" $ do
         header <- mapExceptT C.runResourceT $ do
           let stream = C.sourceFile syncFilePath C..| C.ungzip C..| decodeUnframedEntities
-          (header, rest) <- initializeStream stream
+          (header, rest) <- initializeStream (setTotal progressCounters) stream
           streamIntoCodebase progressCounters shouldValidate codebase header rest
           pure header
         afterSyncChecks codebase (SyncV2.rootCausalHash header)
@@ -149,9 +149,9 @@ syncFromCodebase shouldValidate srcConn destCodebase causalHash = do
   -- Every insert into SQLite checks the temp entity tables, but syncv2 doesn't actually use them, so it's faster
   -- if we clear them out before starting a sync.
   Sqlite.runTransaction srcConn Q.clearTempEntityTables
-  withStreamProgress \progressCounters -> do
+  withStreamProgress False \progressCounters -> do
     liftIO . C.runResourceT . runExceptT $ withCodebaseEntityStream srcConn causalHash Nothing \_total entityStream -> do
-      (header, rest) <- initializeStream entityStream
+      (header, rest) <- initializeStream (setTotal progressCounters) entityStream
       streamIntoCodebase progressCounters shouldValidate destCodebase header rest
       mapExceptT liftIO (afterSyncChecks destCodebase (causalHashToHash32 causalHash))
 
@@ -175,9 +175,10 @@ syncFromCodeserver shouldValidate unisonShareUrl branchRef hashJwt = do
     ExceptT $ do
       (Cli.runTransaction (Q.entityLocation hash)) >>= \case
         Just Q.EntityInMainStorage -> pure $ Right ()
-        _ -> liftIO $ withStreamProgress \progressCallbacks -> do
+        _ -> liftIO $ withStreamProgress True \progressCallbacks -> do
           Timing.time "Entity Download" $ do
             liftIO . C.runResourceT . runExceptT $ httpStreamEntities
+              (setTotal progressCallbacks)
               authHTTPClient
               unisonShareUrl
               SyncV2.DownloadEntitiesRequest {branchRef, causalHash = hashJwt, knownHashes}
@@ -525,12 +526,13 @@ handleClientError clientEnv err =
 
 -- | Stream entities from the codeserver.
 httpStreamEntities ::
+  (Int -> IO ()) ->
   Auth.AuthenticatedHttpClient ->
   Servant.BaseUrl ->
   SyncV2.DownloadEntitiesRequest ->
   (SyncV2.StreamInitInfo -> Stream () SyncV2.EntityChunk -> StreamM ()) ->
   StreamM ()
-httpStreamEntities (Auth.AuthenticatedHttpClient httpClient) unisonShareUrl req callback = do
+httpStreamEntities setTotal (Auth.AuthenticatedHttpClient httpClient) unisonShareUrl req callback = do
   let clientEnv =
         (Servant.mkClientEnv httpClient unisonShareUrl)
           { Servant.makeClientRequest = \url request ->
@@ -542,12 +544,12 @@ httpStreamEntities (Auth.AuthenticatedHttpClient httpClient) unisonShareUrl req 
                     }
           }
   (downloadEntitiesStreamClientM req) & withConduit clientEnv \stream -> do
-    (init, entityStream) <- initializeStream stream
+    (init, entityStream) <- initializeStream setTotal stream
     callback init entityStream
 
 -- | Peel the header off the stream and parse the remaining entity chunks into EntityChunks
-initializeStream :: Stream () SyncV2.DownloadEntitiesChunk -> StreamM (SyncV2.StreamInitInfo, Stream () SyncV2.EntityChunk)
-initializeStream stream = do
+initializeStream :: (Int -> IO ()) -> Stream () SyncV2.DownloadEntitiesChunk -> StreamM (SyncV2.StreamInitInfo, Stream () SyncV2.EntityChunk)
+initializeStream setTotal stream = do
   (streamRemainder, init) <- stream C.$$+ C.headC
   case init of
     Nothing -> throwError . SyncError . SyncV2.PullError'Sync $ SyncV2.SyncErrorMissingInitialChunk
@@ -555,6 +557,7 @@ initializeStream stream = do
       case chunk of
         SyncV2.InitialC info -> do
           let entityStream = C.unsealConduitT streamRemainder C..| C.mapM parseEntity
+          for (SyncV2.numEntities info) \t -> liftIO $ setTotal (fromIntegral t)
           pure $ (info, entityStream)
         SyncV2.EntityC _ -> do
           throwError . SyncError . SyncV2.PullError'Sync $ SyncV2.SyncErrorMissingInitialChunk
@@ -661,21 +664,21 @@ counterProgress msgBuilder action = do
           liftIO $ IO.atomically (IO.modifyTVar' counterVar (+ i))
 
 -- | Track how many entities have been downloaded using a counter stream.
-withStreamProgressCallback :: (MonadIO m, MonadUnliftIO n) => Maybe Int -> (ConduitT i i m () -> n a) -> n a
-withStreamProgressCallback total action = do
-  let msg n = "\n  📦 Unpacked  " <> tShow n <> maybe "" (\total -> " / " <> tShow total) total <> " entities...\n\n"
+syncToFileProgress :: (MonadIO m, MonadUnliftIO n) => Maybe Int -> (ConduitT i i m () -> n a) -> n a
+syncToFileProgress total action = do
+  let msg n = "\n  Exported  " <> tShow n <> maybe "" (\total -> " / " <> tShow total) total <> " entities 📦 \n\n"
   let action' f = action (C.iterM \_i -> f 1)
   counterProgress msg action'
 
 -- | Track how many entities have been loaded.
 withEntityLoadingCallback :: (MonadUnliftIO m) => ((Int -> m ()) -> m a) -> m a
 withEntityLoadingCallback action = do
-  let msg n = "\n  📦 Unpacked  " <> tShow n <> " entities...\n\n"
+  let msg n = "\n  Loading entities from codebase: " <> tShow n <> " 📦\n\n"
   counterProgress msg action
 
-withStreamProgress :: (MonadUnliftIO n) => (ProgressCallbacks -> n a) -> n a
-withStreamProgress action = do
-  downloadedVar <- IO.newTVarIO Nothing
+withStreamProgress :: (MonadUnliftIO n) => Bool -> (ProgressCallbacks -> n a) -> n a
+withStreamProgress hasDownload action = do
+  downloadedVar <- IO.newTVarIO 0
   doneUnpackingVar <- IO.newTVarIO False
   savedVar <- IO.newTVarIO (0 :: Int)
   totalVar <- IO.newTVarIO Nothing
@@ -689,15 +692,14 @@ withStreamProgress action = do
           total <- IO.readTVar totalVar
           pure $
             Text.unlines
-              [ "",
-                "  📩 Downloaded: " <> tShow downloaded <> maybe "" (\total -> " / " <> tShow total) total <> Monoid.whenM doneUnpacking " 🏁",
-                "  💾   Imported: " <> tShow saved
+              [ Monoid.whenM hasDownload $ "\n  Downloaded: " <> tShow @Int downloaded <> maybe "" (\total -> " / " <> tShow @Int total) total <> " 📩" <> Monoid.whenM doneUnpacking " 🏁",
+                "    Imported: " <> tShow @Int saved <> " 💾"
               ]
         toIO $
           action $
             ProgressCallbacks
               { setTotal = \total -> do liftIO $ IO.atomically (IO.writeTVar totalVar (Just total)),
-                downloadCounter = \i -> do liftIO $ IO.atomically (IO.modifyTVar' downloadedVar (Just . maybe i (+ i))),
+                downloadCounter = \i -> do liftIO $ IO.atomically (IO.modifyTVar' downloadedVar (+ i)),
                 doneDownloading = do liftIO $ IO.atomically (IO.writeTVar doneUnpackingVar True),
                 importCounter = \i -> do liftIO $ IO.atomically (IO.modifyTVar' savedVar (+ i))
               }

--- a/unison-cli/src/Unison/Share/SyncV2.hs
+++ b/unison-cli/src/Unison/Share/SyncV2.hs
@@ -81,6 +81,14 @@ type SyncErr = SyncError SyncV2.PullError
 -- The base monad we use within the conduit pipeline.
 type StreamM = (ExceptT SyncErr (C.ResourceT IO))
 
+data ProgressCallbacks
+  = ProgressCallbacks
+  { setTotal :: Int -> IO (),
+    downloadCounter :: Int -> IO (),
+    doneDownloading :: IO (),
+    importCounter :: Int -> IO ()
+  }
+
 ------------------------------------------------------------------------------------------------------------------------
 -- Main methods
 ------------------------------------------------------------------------------------------------------------------------
@@ -118,15 +126,16 @@ syncFromFile shouldValidate syncFilePath = do
   -- Every insert into SQLite checks the temp entity tables, but syncv2 doesn't actually use them, so it's faster
   -- if we clear them out before starting a sync.
   Cli.runTransaction Q.clearTempEntityTables
-  runExceptT do
-    mapExceptT liftIO $ Timing.time "File Sync" $ do
-      header <- mapExceptT C.runResourceT $ do
-        let stream = C.sourceFile syncFilePath C..| C.ungzip C..| decodeUnframedEntities
-        (header, rest) <- initializeStream stream
-        streamIntoCodebase shouldValidate codebase header rest
-        pure header
-      afterSyncChecks codebase (SyncV2.rootCausalHash header)
-      pure . hash32ToCausalHash $ SyncV2.rootCausalHash header
+  liftIO $ withStreamProgress \progressCounters -> do
+    runExceptT do
+      mapExceptT liftIO $ Timing.time "File Sync" $ do
+        header <- mapExceptT C.runResourceT $ do
+          let stream = C.sourceFile syncFilePath C..| C.ungzip C..| decodeUnframedEntities
+          (header, rest) <- initializeStream stream
+          streamIntoCodebase progressCounters shouldValidate codebase header rest
+          pure header
+        afterSyncChecks codebase (SyncV2.rootCausalHash header)
+        pure . hash32ToCausalHash $ SyncV2.rootCausalHash header
 
 syncFromCodebase ::
   Bool ->
@@ -140,10 +149,11 @@ syncFromCodebase shouldValidate srcConn destCodebase causalHash = do
   -- Every insert into SQLite checks the temp entity tables, but syncv2 doesn't actually use them, so it's faster
   -- if we clear them out before starting a sync.
   Sqlite.runTransaction srcConn Q.clearTempEntityTables
-  liftIO . C.runResourceT . runExceptT $ withCodebaseEntityStream srcConn causalHash Nothing \_total entityStream -> do
-    (header, rest) <- initializeStream entityStream
-    streamIntoCodebase shouldValidate destCodebase header rest
-    mapExceptT liftIO (afterSyncChecks destCodebase (causalHashToHash32 causalHash))
+  withStreamProgress \progressCounters -> do
+    liftIO . C.runResourceT . runExceptT $ withCodebaseEntityStream srcConn causalHash Nothing \_total entityStream -> do
+      (header, rest) <- initializeStream entityStream
+      streamIntoCodebase progressCounters shouldValidate destCodebase header rest
+      mapExceptT liftIO (afterSyncChecks destCodebase (causalHashToHash32 causalHash))
 
 syncFromCodeserver ::
   Bool ->
@@ -165,14 +175,15 @@ syncFromCodeserver shouldValidate unisonShareUrl branchRef hashJwt = do
     ExceptT $ do
       (Cli.runTransaction (Q.entityLocation hash)) >>= \case
         Just Q.EntityInMainStorage -> pure $ Right ()
-        _ -> do
+        _ -> liftIO $ withStreamProgress \progressCallbacks -> do
           Timing.time "Entity Download" $ do
             liftIO . C.runResourceT . runExceptT $ httpStreamEntities
               authHTTPClient
               unisonShareUrl
               SyncV2.DownloadEntitiesRequest {branchRef, causalHash = hashJwt, knownHashes}
               \header stream -> do
-                streamIntoCodebase shouldValidate codebase header stream
+                whenJust (SyncV2.numEntities header) (liftIO . setTotal progressCallbacks . fromIntegral)
+                streamIntoCodebase progressCallbacks shouldValidate codebase header stream
     mapExceptT liftIO (afterSyncChecks codebase hash)
 
 ------------------------------------------------------------------------------------------------------------------------
@@ -216,28 +227,28 @@ batchValidateEntities entities = do
 
 -- | Syncs a stream which could send entities in any order.
 syncUnsortedStream ::
+  ProgressCallbacks ->
   Bool ->
   (Codebase.Codebase IO v a) ->
-  (Maybe Word64) ->
   Stream () SyncV2.EntityChunk ->
   StreamM ()
-syncUnsortedStream shouldValidate codebase numEntities stream = ExceptT $ do
-  withStreamProgressCallback (fromIntegral <$> numEntities) \countC -> runExceptT do
-    allEntities <-
-      C.runConduit $
-        stream
-          C..| countC
-          C..| CL.chunksOf batchSize
-          C..| unpackChunks codebase
-          C..| validateBatch
-          C..| C.concat
-          C..| C.sinkVector @Vector
-    let sortedEntities = sortDependencyFirst allEntities
-    liftIO $ withEntitySavingCallback (Just $ Vector.length allEntities) \countC -> do
-      Codebase.runTransaction codebase $ for_ sortedEntities \(hash, entity) -> do
-        r <- Q.saveTempEntityInMain v2HashHandle hash entity
-        Sqlite.unsafeIO $ countC 1
-        pure r
+syncUnsortedStream (ProgressCallbacks {setTotal, downloadCounter, doneDownloading, importCounter}) shouldValidate codebase stream = do
+  allEntities <-
+    C.runConduit $
+      stream
+        C..| C.iterM (\_ -> liftIO $ downloadCounter 1)
+        C..| CL.chunksOf batchSize
+        C..| unpackChunks codebase
+        C..| validateBatch
+        C..| C.concat
+        C..| C.sinkVector @Vector
+  liftIO doneDownloading
+  liftIO $ setTotal (Vector.length allEntities)
+  let sortedEntities = sortDependencyFirst allEntities
+  liftIO $ Codebase.runTransaction codebase $ for_ sortedEntities \(hash, entity) -> do
+    r <- Q.saveTempEntityInMain v2HashHandle hash entity
+    Sqlite.unsafeIO $ importCounter 1
+    pure r
   where
     -- The number of entities to process in a single transaction.
     --
@@ -253,36 +264,35 @@ syncUnsortedStream shouldValidate codebase numEntities stream = ExceptT $ do
 -- | Syncs a stream which sends entities which are already sorted in dependency order.
 -- This allows us to stream them directly into the codebase as they're received.
 syncSortedStream ::
+  ProgressCallbacks ->
   Bool ->
   (Codebase.Codebase IO v a) ->
-  (Maybe Word64) ->
   Stream () SyncV2.EntityChunk ->
   StreamM ()
-syncSortedStream shouldValidate codebase numEntities stream = ExceptT do
-  withSortedStreamProgress (fromIntegral <$> numEntities) \(unpackCount, doneUnpacking, saveCount) -> runExceptT do
-    (downloaderSink, downloaderSource) <- parallelSinkAndSource (3 * batchSize) -- Allow downloading up to triple our current batch size in advance
-    (unpackerSink, unpackerSource) <- parallelSinkAndSource 5 -- Buffer of up to 5 batches.
-    let handler :: Stream (Vector (Hash32, TempEntity)) o
-        handler = C.mapM_C \entityBatch -> do
-          validateAndSave shouldValidate codebase entityBatch
-          saveCount (length entityBatch)
-    let downloadC = stream C..| downloaderSink
-    let saverC =
-          downloaderSource
-            C..| CL.chunksOf batchSize
-            C..| unpackChunks codebase
-            C..| C.iterM (unpackCount . length)
-            C..| (unpackerSink *> lift doneUnpacking)
-    let handlerC =
-          unpackerSource
-            C..| handler
+syncSortedStream (ProgressCallbacks {downloadCounter, doneDownloading, importCounter}) shouldValidate codebase stream = do
+  (downloaderSink, downloaderSource) <- parallelSinkAndSource (3 * batchSize) -- Allow downloading up to triple our current batch size in advance
+  (unpackerSink, unpackerSource) <- parallelSinkAndSource 5 -- Buffer of up to 5 batches.
+  let handler :: Stream (Vector (Hash32, TempEntity)) o
+      handler = C.mapM_C \entityBatch -> do
+        validateAndSave shouldValidate codebase entityBatch
+        liftIO $ importCounter (length entityBatch)
+  let downloadC = stream C..| downloaderSink
+  let saverC =
+        downloaderSource
+          C..| CL.chunksOf batchSize
+          C..| unpackChunks codebase
+          C..| C.iterM (liftIO . downloadCounter . length)
+          C..| (unpackerSink *> liftIO doneDownloading)
+  let handlerC =
+        unpackerSource
+          C..| handler
 
-    -- Run the three conduits concurrently, and wait for them all to finish, fail if any of them fail.
-    ExceptT . Async.runConc $ do
-      a <- Async.conc . runExceptT $ C.runConduit downloadC
-      b <- Async.conc . runExceptT $ C.runConduit saverC
-      c <- Async.conc . runExceptT $ C.runConduit handlerC
-      pure (a >> b >> c)
+  -- Run the three conduits concurrently, and wait for them all to finish, fail if any of them fail.
+  ExceptT . Async.runConc $ do
+    a <- Async.conc . runExceptT $ C.runConduit downloadC
+    b <- Async.conc . runExceptT $ C.runConduit saverC
+    c <- Async.conc . runExceptT $ C.runConduit handlerC
+    pure (a >> b >> c)
   where
     batchSize = 1000
 
@@ -317,20 +327,21 @@ unpackChunks codebase = C.mapM \xs -> ExceptT . lift . Codebase.runTransactionEx
 
 -- | Stream entities from one codebase into another.
 streamIntoCodebase ::
+  ProgressCallbacks ->
   -- | Whether to validate entities as they're imported.
   Bool ->
   Codebase.Codebase IO v a ->
   SyncV2.StreamInitInfo ->
   Stream () SyncV2.EntityChunk ->
   StreamM ()
-streamIntoCodebase shouldValidate codebase SyncV2.StreamInitInfo {version, entitySorting, numEntities = numEntities} stream = do
+streamIntoCodebase progressCounters shouldValidate codebase SyncV2.StreamInitInfo {version, entitySorting} stream = do
   case version of
     (SyncV2.Version 1) -> pure ()
     v -> throwError . SyncError . SyncV2.PullError'Sync $ SyncV2.SyncErrorUnsupportedVersion v
 
   case entitySorting of
-    SyncV2.DependenciesFirst -> syncSortedStream shouldValidate codebase numEntities stream
-    SyncV2.Unsorted -> syncUnsortedStream shouldValidate codebase numEntities stream
+    SyncV2.DependenciesFirst -> syncSortedStream progressCounters shouldValidate codebase stream
+    SyncV2.Unsorted -> syncUnsortedStream progressCounters shouldValidate codebase stream
 
 -- | A sanity-check to verify that the hash we expected to import from the stream was successfully loaded into the codebase.
 afterSyncChecks :: Codebase.Codebase IO v a -> Hash32 -> ExceptT (SyncError SyncV2.PullError) IO ()
@@ -656,42 +667,40 @@ withStreamProgressCallback total action = do
   let action' f = action (C.iterM \_i -> f 1)
   counterProgress msg action'
 
--- | Track how many entities have been saved.
-withEntitySavingCallback :: (MonadUnliftIO m) => Maybe Int -> ((Int -> m ()) -> m a) -> m a
-withEntitySavingCallback total action = do
-  let msg n = "\n  💾 Imported  " <> tShow n <> maybe "" (\total -> " / " <> tShow total) total <> " new entities...\n\n"
-  counterProgress msg action
-
 -- | Track how many entities have been loaded.
 withEntityLoadingCallback :: (MonadUnliftIO m) => ((Int -> m ()) -> m a) -> m a
 withEntityLoadingCallback action = do
   let msg n = "\n  📦 Unpacked  " <> tShow n <> " entities...\n\n"
   counterProgress msg action
 
-withSortedStreamProgress :: (MonadIO m, MonadUnliftIO n) => Maybe Int -> ((Int -> m (), m (), Int -> m ()) -> n a) -> n a
-withSortedStreamProgress total action = do
-  unpackedVar <- IO.newTVarIO (0 :: Int)
+withStreamProgress :: (MonadUnliftIO n) => (ProgressCallbacks -> n a) -> n a
+withStreamProgress action = do
+  downloadedVar <- IO.newTVarIO Nothing
   doneUnpackingVar <- IO.newTVarIO False
   savedVar <- IO.newTVarIO (0 :: Int)
+  totalVar <- IO.newTVarIO Nothing
   IO.withRunInIO \toIO -> do
     Console.Regions.displayConsoleRegions do
       Console.Regions.withConsoleRegion Console.Regions.Linear \region -> do
         Console.Regions.setConsoleRegion region do
-          unpacked <- IO.readTVar unpackedVar
+          downloaded <- IO.readTVar downloadedVar
           doneUnpacking <- IO.readTVar doneUnpackingVar
           saved <- IO.readTVar savedVar
+          total <- IO.readTVar totalVar
           pure $
             Text.unlines
               [ "",
-                "  📩 Downloaded: " <> tShow unpacked <> maybe "" (\total -> " / " <> tShow total) total <> Monoid.whenM doneUnpacking " 🏁",
+                "  📩 Downloaded: " <> tShow downloaded <> maybe "" (\total -> " / " <> tShow total) total <> Monoid.whenM doneUnpacking " 🏁",
                 "  💾   Imported: " <> tShow saved
               ]
         toIO $
           action $
-            ( \i -> do liftIO $ IO.atomically (IO.modifyTVar' unpackedVar (+ i)),
-              do liftIO $ IO.atomically (IO.writeTVar doneUnpackingVar True),
-              \i -> do liftIO $ IO.atomically (IO.modifyTVar' savedVar (+ i))
-            )
+            ProgressCallbacks
+              { setTotal = \total -> do liftIO $ IO.atomically (IO.writeTVar totalVar (Just total)),
+                downloadCounter = \i -> do liftIO $ IO.atomically (IO.modifyTVar' downloadedVar (Just . maybe i (+ i))),
+                doneDownloading = do liftIO $ IO.atomically (IO.writeTVar doneUnpackingVar True),
+                importCounter = \i -> do liftIO $ IO.atomically (IO.modifyTVar' savedVar (+ i))
+              }
 
 -- * Conduit helpers
 

--- a/unison-cli/src/Unison/Share/SyncV2.hs
+++ b/unison-cli/src/Unison/Share/SyncV2.hs
@@ -153,10 +153,8 @@ syncFromCodeserver ::
   SyncV2.BranchRef ->
   -- | The hash to download.
   Share.HashJWT ->
-  -- | Callback that's given a number of entities we just downloaded.
-  (Int -> IO ()) ->
   Cli (Either (SyncError SyncV2.PullError) ())
-syncFromCodeserver shouldValidate unisonShareUrl branchRef hashJwt _downloadedCallback = do
+syncFromCodeserver shouldValidate unisonShareUrl branchRef hashJwt = do
   Cli.Env {authHTTPClient, codebase} <- ask
   -- Every insert into SQLite checks the temp entity tables, but syncv2 doesn't actually use them, so it's faster
   -- if we clear them out before starting a sync.
@@ -661,7 +659,7 @@ withStreamProgressCallback total action = do
 -- | Track how many entities have been saved.
 withEntitySavingCallback :: (MonadUnliftIO m) => Maybe Int -> ((Int -> m ()) -> m a) -> m a
 withEntitySavingCallback total action = do
-  let msg n = "\n  💾 Saved  " <> tShow n <> maybe "" (\total -> " / " <> tShow total) total <> " new entities...\n\n"
+  let msg n = "\n  💾 Imported  " <> tShow n <> maybe "" (\total -> " / " <> tShow total) total <> " new entities...\n\n"
   counterProgress msg action
 
 -- | Track how many entities have been loaded.
@@ -685,8 +683,8 @@ withSortedStreamProgress total action = do
           pure $
             Text.unlines
               [ "",
-                "  ⬇️ Downloaded: " <> tShow unpacked <> maybe "" (\total -> " / " <> tShow total) total <> Monoid.whenM doneUnpacking " 🏁",
-                "  💾 Saved:      " <> tShow saved
+                "  📩 Downloaded: " <> tShow unpacked <> maybe "" (\total -> " / " <> tShow total) total <> Monoid.whenM doneUnpacking " 🏁",
+                "  💾   Imported: " <> tShow saved
               ]
         toIO $
           action $

--- a/unison-cli/src/Unison/Share/SyncV2.hs
+++ b/unison-cli/src/Unison/Share/SyncV2.hs
@@ -692,8 +692,8 @@ withStreamProgress hasDownload action = do
           total <- IO.readTVar totalVar
           pure $
             Text.unlines
-              [ Monoid.whenM hasDownload $ "\n  Downloaded: " <> tShow @Int downloaded <> maybe "" (\total -> " / " <> tShow @Int total) total <> " 📩" <> Monoid.whenM doneUnpacking " 🏁",
-                "    Imported: " <> tShow @Int saved <> " 💾"
+              [ Monoid.whenM hasDownload $ "\n  Downloaded: " <> tShow @Int downloaded <> maybe "" (\total -> " / " <> tShow @Int total) total <> Monoid.whenM doneUnpacking " 🏁",
+                "    Imported: " <> tShow @Int saved
               ]
         toIO $
           action $

--- a/unison-cli/src/Unison/Share/SyncV2.hs
+++ b/unison-cli/src/Unison/Share/SyncV2.hs
@@ -12,6 +12,7 @@ where
 import Codec.Serialise qualified as CBOR
 import Conduit (ConduitT)
 import Conduit qualified as C
+import Control.Category ((<<<))
 import Control.Concurrent.STM.TBMQueue qualified as STM
 import Control.Lens
 import Control.Monad.Except
@@ -31,6 +32,7 @@ import Data.Graph qualified as Graph
 import Data.Map qualified as Map
 import Data.Proxy
 import Data.Set qualified as Set
+import Data.Text qualified as Text
 import Data.Text.IO qualified as Text
 import Data.Text.Lazy qualified as Text.Lazy
 import Data.Text.Lazy.Encoding qualified as Text.Lazy
@@ -66,6 +68,7 @@ import Unison.SyncV2.API (Routes (downloadEntitiesStream))
 import Unison.SyncV2.API qualified as SyncV2
 import Unison.SyncV2.Types (CBORBytes, CBORStream, DependencyType (..))
 import Unison.SyncV2.Types qualified as SyncV2
+import Unison.Util.Monoid qualified as Monoid
 import Unison.Util.Servant.CBOR qualified as CBOR
 import Unison.Util.Timing qualified as Timing
 import UnliftIO qualified as IO
@@ -225,23 +228,26 @@ batchValidateEntities entities = do
 syncUnsortedStream ::
   Bool ->
   (Codebase.Codebase IO v a) ->
+  (Maybe Word64) ->
   Stream () SyncV2.EntityChunk ->
   StreamM ()
-syncUnsortedStream shouldValidate codebase stream = do
-  allEntities <-
-    C.runConduit $
-      stream
-        C..| CL.chunksOf batchSize
-        C..| unpackChunks codebase
-        C..| validateBatch
-        C..| C.concat
-        C..| C.sinkVector @Vector
-  let sortedEntities = sortDependencyFirst allEntities
-  liftIO $ withEntitySavingCallback (Just $ Vector.length allEntities) \countC -> do
-    Codebase.runTransaction codebase $ for_ sortedEntities \(hash, entity) -> do
-      r <- Q.saveTempEntityInMain v2HashHandle hash entity
-      Sqlite.unsafeIO $ countC 1
-      pure r
+syncUnsortedStream shouldValidate codebase numEntities stream = ExceptT $ do
+  withStreamProgressCallback (fromIntegral <$> numEntities) \countC -> runExceptT do
+    allEntities <-
+      C.runConduit $
+        stream
+          C..| countC
+          C..| CL.chunksOf batchSize
+          C..| unpackChunks codebase
+          C..| validateBatch
+          C..| C.concat
+          C..| C.sinkVector @Vector
+    let sortedEntities = sortDependencyFirst allEntities
+    liftIO $ withEntitySavingCallback (Just $ Vector.length allEntities) \countC -> do
+      Codebase.runTransaction codebase $ for_ sortedEntities \(hash, entity) -> do
+        r <- Q.saveTempEntityInMain v2HashHandle hash entity
+        Sqlite.unsafeIO $ countC 1
+        pure r
   where
     validateBatch :: Stream (Vector (Hash32, TempEntity)) (Vector (Hash32, TempEntity))
     validateBatch = C.iterM \entities -> do
@@ -252,32 +258,37 @@ syncUnsortedStream shouldValidate codebase stream = do
 syncSortedStream ::
   Bool ->
   (Codebase.Codebase IO v a) ->
+  (Maybe Word64) ->
   Stream () SyncV2.EntityChunk ->
   StreamM ()
-syncSortedStream shouldValidate codebase stream = do
-  (downloaderSink, downloaderSource) <- parallelSinkAndSource 10
-  (unpackerSink, unpackerSource) <- parallelSinkAndSource 10
-  let handler :: Stream (Vector (Hash32, TempEntity)) o
-      handler = C.mapM_C \entityBatch -> do
-        validateAndSave shouldValidate codebase entityBatch
-  let downloadC =
-        stream
-          C..| CL.chunksOf batchSize
-          C..| downloaderSink
-  let saverC =
-        downloaderSource
-          C..| unpackChunks codebase
-          C..| unpackerSink
-  let handlerC =
-        unpackerSource
-          C..| handler
+syncSortedStream shouldValidate codebase numEntities stream = ExceptT do
+  withSortedStreamProgress (fromIntegral <$> numEntities) \(downloadCount, doneDownloading, unpackCount, doneUnpacking, saveCount) -> runExceptT do
+    (downloaderSink, downloaderSource) <- parallelSinkAndSource 10
+    (unpackerSink, unpackerSource) <- parallelSinkAndSource 10
+    let handler :: Stream (Vector (Hash32, TempEntity)) o
+        handler = C.mapM_C \entityBatch -> do
+          validateAndSave shouldValidate codebase entityBatch
+          saveCount (length entityBatch)
+    let downloadC =
+          stream
+            C..| CL.chunksOf batchSize
+            C..| C.iterM (downloadCount <<< length)
+            C..| (downloaderSink *> lift doneDownloading)
+    let saverC =
+          downloaderSource
+            C..| unpackChunks codebase
+            C..| C.iterM (unpackCount <<< length)
+            C..| (unpackerSink *> lift doneUnpacking)
+    let handlerC =
+          unpackerSource
+            C..| handler
 
-  -- Run the three conduits concurrently, and wait for them all to finish, fail if any of them fail.
-  ExceptT . Async.runConc $ do
-    a <- Async.conc . runExceptT $ C.runConduit downloadC
-    b <- Async.conc . runExceptT $ C.runConduit saverC
-    c <- Async.conc . runExceptT $ C.runConduit handlerC
-    pure (a >> b >> c)
+    -- Run the three conduits concurrently, and wait for them all to finish, fail if any of them fail.
+    ExceptT . Async.runConc $ do
+      a <- Async.conc . runExceptT $ C.runConduit downloadC
+      b <- Async.conc . runExceptT $ C.runConduit saverC
+      c <- Async.conc . runExceptT $ C.runConduit handlerC
+      pure (a >> b >> c)
 
 -- | Topologically sort entities based on their dependencies, returning a list in dependency-first order.
 sortDependencyFirst :: (Foldable f, Functor f) => f (Hash32, TempEntity) -> [(Hash32, TempEntity)]
@@ -316,17 +327,14 @@ streamIntoCodebase ::
   SyncV2.StreamInitInfo ->
   Stream () SyncV2.EntityChunk ->
   StreamM ()
-streamIntoCodebase shouldValidate codebase SyncV2.StreamInitInfo {version, entitySorting, numEntities = numEntities} stream = ExceptT do
-  withStreamProgressCallback (fromIntegral <$> numEntities) \countC -> runExceptT do
-    -- Add a counter to the stream to track how many entities we've processed.
-    let stream' = stream C..| countC
-    case version of
-      (SyncV2.Version 1) -> pure ()
-      v -> throwError . SyncError . SyncV2.PullError'Sync $ SyncV2.SyncErrorUnsupportedVersion v
+streamIntoCodebase shouldValidate codebase SyncV2.StreamInitInfo {version, entitySorting, numEntities = numEntities} stream = do
+  case version of
+    (SyncV2.Version 1) -> pure ()
+    v -> throwError . SyncError . SyncV2.PullError'Sync $ SyncV2.SyncErrorUnsupportedVersion v
 
-    case entitySorting of
-      SyncV2.DependenciesFirst -> syncSortedStream shouldValidate codebase stream'
-      SyncV2.Unsorted -> syncUnsortedStream shouldValidate codebase stream'
+  case entitySorting of
+    SyncV2.DependenciesFirst -> syncSortedStream shouldValidate codebase numEntities stream
+    SyncV2.Unsorted -> syncUnsortedStream shouldValidate codebase numEntities stream
 
 -- | A sanity-check to verify that the hash we expected to import from the stream was successfully loaded into the codebase.
 afterSyncChecks :: Codebase.Codebase IO v a -> Hash32 -> ExceptT (SyncError SyncV2.PullError) IO ()
@@ -663,6 +671,38 @@ withEntityLoadingCallback :: (MonadUnliftIO m) => ((Int -> m ()) -> m a) -> m a
 withEntityLoadingCallback action = do
   let msg n = "\n  📦 Unpacked  " <> tShow n <> " entities...\n\n"
   counterProgress msg action
+
+withSortedStreamProgress :: (MonadIO m, MonadUnliftIO n) => Maybe Int -> ((Int -> m (), m (), Int -> m (), m (), Int -> m ()) -> n a) -> n a
+withSortedStreamProgress total action = do
+  downloadedVar <- IO.newTVarIO (0 :: Int)
+  doneDownloadingVar <- IO.newTVarIO False
+  unpackedVar <- IO.newTVarIO (0 :: Int)
+  doneUnpackingVar <- IO.newTVarIO False
+  savedVar <- IO.newTVarIO (0 :: Int)
+  IO.withRunInIO \toIO -> do
+    Console.Regions.displayConsoleRegions do
+      Console.Regions.withConsoleRegion Console.Regions.Linear \region -> do
+        Console.Regions.setConsoleRegion region do
+          downloaded <- IO.readTVar downloadedVar
+          doneDownloading <- IO.readTVar doneDownloadingVar
+          unpacked <- IO.readTVar unpackedVar
+          doneUnpacking <- IO.readTVar doneUnpackingVar
+          saved <- IO.readTVar savedVar
+          pure $
+            Text.unlines
+              [ "",
+                "  ⬇️ Downloaded: " <> tShow downloaded <> maybe "" (\total -> " / " <> tShow total) total <> Monoid.whenM doneDownloading " 🏁",
+                "  📦 Unpacked:   " <> tShow unpacked <> Monoid.whenM doneUnpacking " 🏁",
+                "  💾 Saved:      " <> tShow saved
+              ]
+        toIO $
+          action $
+            ( \i -> do liftIO $ IO.atomically (IO.modifyTVar' downloadedVar (+ i)),
+              do liftIO $ IO.atomically (IO.writeTVar doneDownloadingVar True),
+              \i -> do liftIO $ IO.atomically (IO.modifyTVar' unpackedVar (+ i)),
+              do liftIO $ IO.atomically (IO.writeTVar doneUnpackingVar True),
+              \i -> do liftIO $ IO.atomically (IO.modifyTVar' savedVar (+ i))
+            )
 
 -- * Conduit helpers
 

--- a/unison-cli/src/Unison/Share/SyncV2.hs
+++ b/unison-cli/src/Unison/Share/SyncV2.hs
@@ -263,7 +263,7 @@ syncSortedStream ::
   StreamM ()
 syncSortedStream shouldValidate codebase numEntities stream = ExceptT do
   withSortedStreamProgress (fromIntegral <$> numEntities) \(downloadCount, doneDownloading, unpackCount, doneUnpacking, saveCount) -> runExceptT do
-    (downloaderSink, downloaderSource) <- parallelSinkAndSource 10
+    (downloaderSink, downloaderSource) <- parallelBatchedSinkAndSource 1000
     (unpackerSink, unpackerSource) <- parallelSinkAndSource 10
     let handler :: Stream (Vector (Hash32, TempEntity)) o
         handler = C.mapM_C \entityBatch -> do
@@ -271,8 +271,7 @@ syncSortedStream shouldValidate codebase numEntities stream = ExceptT do
           saveCount (length entityBatch)
     let downloadC =
           stream
-            C..| CL.chunksOf batchSize
-            C..| C.iterM (downloadCount <<< length)
+            C..| C.iterM (const $ downloadCount 1)
             C..| (downloaderSink *> lift doneDownloading)
     let saverC =
           downloaderSource
@@ -722,3 +721,32 @@ parallelSinkAndSource bufferSize = do
             C.yield chunk
             source
   pure (sink, source)
+
+parallelBatchedSinkAndSource :: (MonadIO m) => Int -> m (ConduitT i void1 m (), ConduitT void2 [i] m ())
+parallelBatchedSinkAndSource bufferSize = do
+  q <- liftIO $ STM.newTBMQueueIO bufferSize
+  let sink = do
+        C.await >>= \case
+          Nothing -> STM.atomically $ STM.closeTBMQueue q
+          Just chunk -> do
+            STM.atomically $ STM.writeTBMQueue q chunk
+            sink
+  let source = do
+        flushTBMQueue q >>= \case
+          Nothing -> pure ()
+          Just chunk -> do
+            C.yield chunk
+            source
+  pure (sink, source)
+
+-- | Get all currently available items from a TBMQueue.
+flushTBMQueue :: (MonadIO m) => STM.TBMQueue a -> m (Maybe [a])
+flushTBMQueue q = liftIO $ STM.atomically $ do
+  STM.readTBMQueue q >>= \case
+    Nothing -> pure Nothing
+    Just x -> do
+      xs <- many $ do
+        STM.readTBMQueue q >>= \case
+          Nothing -> empty
+          Just x -> pure x
+      pure $ Just (x : xs)

--- a/unison-cli/src/Unison/Share/SyncV2.hs
+++ b/unison-cli/src/Unison/Share/SyncV2.hs
@@ -12,7 +12,6 @@ where
 import Codec.Serialise qualified as CBOR
 import Conduit (ConduitT)
 import Conduit qualified as C
-import Control.Category ((<<<))
 import Control.Concurrent.STM.TBMQueue qualified as STM
 import Control.Lens
 import Control.Monad.Except
@@ -81,13 +80,6 @@ type SyncErr = SyncError SyncV2.PullError
 
 -- The base monad we use within the conduit pipeline.
 type StreamM = (ExceptT SyncErr (C.ResourceT IO))
-
--- | The number of entities to process in a single transaction.
---
--- SQLite transactions have some fixed overhead, so setting this too low can really slow things down,
--- but going too high here means we may be waiting on the network to get a full batch when we could be starting work.
-batchSize :: Int
-batchSize = 5000
 
 ------------------------------------------------------------------------------------------------------------------------
 -- Main methods
@@ -249,6 +241,13 @@ syncUnsortedStream shouldValidate codebase numEntities stream = ExceptT $ do
         Sqlite.unsafeIO $ countC 1
         pure r
   where
+    -- The number of entities to process in a single transaction.
+    --
+    -- SQLite transactions have some fixed overhead, so setting this too low can really slow things down,
+    -- but going too high here means we may be waiting on the network to get a full batch when we could be starting work.
+    batchSize :: Int
+    batchSize = 5000
+
     validateBatch :: Stream (Vector (Hash32, TempEntity)) (Vector (Hash32, TempEntity))
     validateBatch = C.iterM \entities -> do
       when shouldValidate (mapExceptT lift $ batchValidateEntities entities)
@@ -262,21 +261,19 @@ syncSortedStream ::
   Stream () SyncV2.EntityChunk ->
   StreamM ()
 syncSortedStream shouldValidate codebase numEntities stream = ExceptT do
-  withSortedStreamProgress (fromIntegral <$> numEntities) \(downloadCount, doneDownloading, unpackCount, doneUnpacking, saveCount) -> runExceptT do
-    (downloaderSink, downloaderSource) <- parallelBatchedSinkAndSource 1000
-    (unpackerSink, unpackerSource) <- parallelSinkAndSource 10
+  withSortedStreamProgress (fromIntegral <$> numEntities) \(unpackCount, doneUnpacking, saveCount) -> runExceptT do
+    (downloaderSink, downloaderSource) <- parallelSinkAndSource (3 * batchSize) -- Allow downloading up to triple our current batch size in advance
+    (unpackerSink, unpackerSource) <- parallelSinkAndSource 5 -- Buffer of up to 5 batches.
     let handler :: Stream (Vector (Hash32, TempEntity)) o
         handler = C.mapM_C \entityBatch -> do
           validateAndSave shouldValidate codebase entityBatch
           saveCount (length entityBatch)
-    let downloadC =
-          stream
-            C..| C.iterM (const $ downloadCount 1)
-            C..| (downloaderSink *> lift doneDownloading)
+    let downloadC = stream C..| downloaderSink
     let saverC =
           downloaderSource
+            C..| CL.chunksOf batchSize
             C..| unpackChunks codebase
-            C..| C.iterM (unpackCount <<< length)
+            C..| C.iterM (unpackCount . length)
             C..| (unpackerSink *> lift doneUnpacking)
     let handlerC =
           unpackerSource
@@ -288,6 +285,8 @@ syncSortedStream shouldValidate codebase numEntities stream = ExceptT do
       b <- Async.conc . runExceptT $ C.runConduit saverC
       c <- Async.conc . runExceptT $ C.runConduit handlerC
       pure (a >> b >> c)
+  where
+    batchSize = 1000
 
 -- | Topologically sort entities based on their dependencies, returning a list in dependency-first order.
 sortDependencyFirst :: (Foldable f, Functor f) => f (Hash32, TempEntity) -> [(Hash32, TempEntity)]
@@ -671,10 +670,8 @@ withEntityLoadingCallback action = do
   let msg n = "\n  📦 Unpacked  " <> tShow n <> " entities...\n\n"
   counterProgress msg action
 
-withSortedStreamProgress :: (MonadIO m, MonadUnliftIO n) => Maybe Int -> ((Int -> m (), m (), Int -> m (), m (), Int -> m ()) -> n a) -> n a
+withSortedStreamProgress :: (MonadIO m, MonadUnliftIO n) => Maybe Int -> ((Int -> m (), m (), Int -> m ()) -> n a) -> n a
 withSortedStreamProgress total action = do
-  downloadedVar <- IO.newTVarIO (0 :: Int)
-  doneDownloadingVar <- IO.newTVarIO False
   unpackedVar <- IO.newTVarIO (0 :: Int)
   doneUnpackingVar <- IO.newTVarIO False
   savedVar <- IO.newTVarIO (0 :: Int)
@@ -682,23 +679,18 @@ withSortedStreamProgress total action = do
     Console.Regions.displayConsoleRegions do
       Console.Regions.withConsoleRegion Console.Regions.Linear \region -> do
         Console.Regions.setConsoleRegion region do
-          downloaded <- IO.readTVar downloadedVar
-          doneDownloading <- IO.readTVar doneDownloadingVar
           unpacked <- IO.readTVar unpackedVar
           doneUnpacking <- IO.readTVar doneUnpackingVar
           saved <- IO.readTVar savedVar
           pure $
             Text.unlines
               [ "",
-                "  ⬇️ Downloaded: " <> tShow downloaded <> maybe "" (\total -> " / " <> tShow total) total <> Monoid.whenM doneDownloading " 🏁",
-                "  📦 Unpacked:   " <> tShow unpacked <> Monoid.whenM doneUnpacking " 🏁",
+                "  ⬇️ Downloaded: " <> tShow unpacked <> maybe "" (\total -> " / " <> tShow total) total <> Monoid.whenM doneUnpacking " 🏁",
                 "  💾 Saved:      " <> tShow saved
               ]
         toIO $
           action $
-            ( \i -> do liftIO $ IO.atomically (IO.modifyTVar' downloadedVar (+ i)),
-              do liftIO $ IO.atomically (IO.writeTVar doneDownloadingVar True),
-              \i -> do liftIO $ IO.atomically (IO.modifyTVar' unpackedVar (+ i)),
+            ( \i -> do liftIO $ IO.atomically (IO.modifyTVar' unpackedVar (+ i)),
               do liftIO $ IO.atomically (IO.writeTVar doneUnpackingVar True),
               \i -> do liftIO $ IO.atomically (IO.modifyTVar' savedVar (+ i))
             )
@@ -721,32 +713,3 @@ parallelSinkAndSource bufferSize = do
             C.yield chunk
             source
   pure (sink, source)
-
-parallelBatchedSinkAndSource :: (MonadIO m) => Int -> m (ConduitT i void1 m (), ConduitT void2 [i] m ())
-parallelBatchedSinkAndSource bufferSize = do
-  q <- liftIO $ STM.newTBMQueueIO bufferSize
-  let sink = do
-        C.await >>= \case
-          Nothing -> STM.atomically $ STM.closeTBMQueue q
-          Just chunk -> do
-            STM.atomically $ STM.writeTBMQueue q chunk
-            sink
-  let source = do
-        flushTBMQueue q >>= \case
-          Nothing -> pure ()
-          Just chunk -> do
-            C.yield chunk
-            source
-  pure (sink, source)
-
--- | Get all currently available items from a TBMQueue.
-flushTBMQueue :: (MonadIO m) => STM.TBMQueue a -> m (Maybe [a])
-flushTBMQueue q = liftIO $ STM.atomically $ do
-  STM.readTBMQueue q >>= \case
-    Nothing -> pure Nothing
-    Just x -> do
-      xs <- many $ do
-        STM.readTBMQueue q >>= \case
-          Nothing -> empty
-          Just x -> pure x
-      pure $ Just (x : xs)

--- a/unison-cli/src/Unison/Share/SyncV2.hs
+++ b/unison-cli/src/Unison/Share/SyncV2.hs
@@ -25,7 +25,6 @@ import Data.ByteString.Lazy qualified as BL
 import Data.Conduit.Attoparsec qualified as C
 import Data.Conduit.Combinators qualified as C
 import Data.Conduit.List qualified as CL
-import Data.Conduit.TQueue qualified as TQueue
 import Data.Conduit.Zlib qualified as C
 import Data.Foldable qualified as Foldable
 import Data.Graph qualified as Graph
@@ -71,7 +70,7 @@ import Unison.Util.Servant.CBOR qualified as CBOR
 import Unison.Util.Timing qualified as Timing
 import UnliftIO qualified as IO
 import UnliftIO.Async qualified as Async
-import qualified UnliftIO.STM as STM
+import UnliftIO.STM qualified as STM
 
 type Stream i o = ConduitT i o StreamM ()
 
@@ -256,15 +255,11 @@ syncSortedStream ::
   Stream () SyncV2.EntityChunk ->
   StreamM ()
 syncSortedStream shouldValidate codebase stream = do
+  (downloaderSink, downloaderSource) <- parallelSinkAndSource 10
+  (unpackerSink, unpackerSource) <- parallelSinkAndSource 10
   let handler :: Stream (Vector (Hash32, TempEntity)) o
       handler = C.mapM_C \entityBatch -> do
         validateAndSave shouldValidate codebase entityBatch
-  downloadQ <- liftIO $ STM.newTBMQueueIO 10 -- 10 batches, not 10 entities
-  unpackerQ <- liftIO $ STM.newTBMQueueIO 10
-  let downloaderSink = TQueue.sinkTBMQueue downloadQ
-  let downloaderSource = TQueue.sourceTBMQueue downloadQ
-  let unpackerSink = TQueue.sinkTBMQueue unpackerQ
-  let unpackedSource = TQueue.sourceTBMQueue unpackerQ
   let downloadC =
         stream
           C..| CL.chunksOf batchSize
@@ -274,17 +269,13 @@ syncSortedStream shouldValidate codebase stream = do
           C..| unpackChunks codebase
           C..| unpackerSink
   let handlerC =
-        unpackedSource
+        unpackerSource
           C..| handler
 
   -- Run the three conduits concurrently, and wait for them all to finish, fail if any of them fail.
   ExceptT . Async.runConc $ do
-    a <- Async.conc . runExceptT $ do
-           C.runConduit downloadC
-           STM.atomically $ STM.closeTBMQueue downloadQ
-    b <- Async.conc . runExceptT $ do
-      C.runConduit saverC
-      STM.atomically $ STM.closeTBMQueue unpackerQ
+    a <- Async.conc . runExceptT $ C.runConduit downloadC
+    b <- Async.conc . runExceptT $ C.runConduit saverC
     c <- Async.conc . runExceptT $ C.runConduit handlerC
     pure (a >> b >> c)
 
@@ -672,3 +663,22 @@ withEntityLoadingCallback :: (MonadUnliftIO m) => ((Int -> m ()) -> m a) -> m a
 withEntityLoadingCallback action = do
   let msg n = "\n  📦 Unpacked  " <> tShow n <> " entities...\n\n"
   counterProgress msg action
+
+-- * Conduit helpers
+
+parallelSinkAndSource :: (MonadIO m) => Int -> m (ConduitT i void1 m (), ConduitT void2 i m ())
+parallelSinkAndSource bufferSize = do
+  q <- liftIO $ STM.newTBMQueueIO bufferSize
+  let sink = do
+        C.await >>= \case
+          Nothing -> STM.atomically $ STM.closeTBMQueue q
+          Just chunk -> do
+            STM.atomically $ STM.writeTBMQueue q chunk
+            sink
+  let source = do
+        STM.atomically (STM.readTBMQueue q) >>= \case
+          Nothing -> pure ()
+          Just chunk -> do
+            C.yield chunk
+            source
+  pure (sink, source)

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -251,6 +251,8 @@ library
     , servant-client
     , servant-conduit
     , stm
+    , stm-chans
+    , stm-conduit
     , temporary
     , text
     , text-ansi

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -252,7 +252,6 @@ library
     , servant-conduit
     , stm
     , stm-chans
-    , stm-conduit
     , temporary
     , text
     , text-ansi


### PR DESCRIPTION
## Overview

Corresponding with https://github.com/unisoncomputing/share-api/pull/41 ; this tweaks the download streams from a sorted source to split up downloading, unpacking, and validation/save into pipelines which run in parallel, this allows us to be saving to SQLite we're downloading things in parallel, rather than interleaving downloads with saving as we do on trunk at the moment.

## Implementation notes

* Puts a TBMQueue in between each of 3 different conduit pipelines, then run the pipelines in parallel using `UnliftIO.Conc`.
* The progress indicator now shows progress of each portion independently.

## Test coverage

* [x] Tested against local share