### PR TITLE
remove quadratic limitation on counting quotes

### DIFF
--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -271,17 +271,15 @@ pretty0
               -- we only use this syntax if we're not wrapped in something else,
               -- to avoid possible round trip issues if the text ends at an odd column
               useRaw _ | p >= Annotation = Nothing
-              useRaw s | Text.find (== '\n') s == Just '\n' && Text.all ok s = n 3
+              useRaw s | Text.find (== '\n') s == Just '\n' && Text.all ok s = Just quotes
               useRaw _ = Nothing
               ok ch = isPrint ch || ch == '\n' || ch == '\r'
               -- Picks smallest number of surrounding """ to be unique
-              n 10 = Nothing -- bail at 10, avoiding quadratic behavior in weird cases
-              n cur =
-                if null (Text.breakOnAll quotes s)
-                  then Just quotes
-                  else n (cur + 1)
-                where
-                  quotes = Text.pack (replicate cur '"')
+              quotes = Text.pack (replicate numQuotes '"')
+              numQuotes = max 3 $ longestRun '"' s + 1
+              longestRun :: Char -> Text -> Int
+              longestRun c = maximum . (0 :) . map Text.length . filter ((== c) . Text.head) . Text.group
+
           Text' s -> pure . fmt S.TextLiteral $ l $ U.ushow s
           Char' c -> pure
             . fmt S.CharLiteral

--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -271,7 +271,7 @@ pretty0
               -- we only use this syntax if we're not wrapped in something else,
               -- to avoid possible round trip issues if the text ends at an odd column
               useRaw _ | p >= Annotation = Nothing
-              useRaw s | Text.find (== '\n') s == Just '\n' && Text.all ok s = Just quotes
+              useRaw s | Text.elem '\n' s && Text.all ok s = Just quotes
               useRaw _ = Nothing
               ok ch = isPrint ch || ch == '\n' || ch == '\r'
               -- Picks smallest number of surrounding """ to be unique


### PR DESCRIPTION
The old implementation called [`Text.breakOnAll`](https://hackage.haskell.org/package/text-2.1.2/docs/Data-Text.html#v:breakOnAll) repeatedly, which could be slow, so it was capped at 10 quotes. The new implementation instead just calls [`Text.group`](https://hackage.haskell.org/package/text-2.1.2/docs/Data-Text.html#v:group) once instead.

The PR could use a before and after check with a string with more than 10 consecutive `"` in it, and we should see that the rendering is improved with the PR. Existing tests show `"""` correctly being escaped as `""""` though, and since the PR removes the reference to `10`, there isn't actually anything special about 10 going forward.