### PR TITLE
use full names in `dependencies` output

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
@@ -1102,14 +1102,15 @@ causalHashesByPrefix (ShortCausalHash b32prefix) = do
   pure $ Set.fromList . map CausalHash $ hashes
 
 directDependenciesOfScope ::
+  (C.Reference -> Bool) ->
   DefnsF Set C.TermReferenceId C.TypeReferenceId ->
   Transaction (DefnsF Set C.TermReference C.TypeReference)
-directDependenciesOfScope scope0 = do
+directDependenciesOfScope isBuiltinType scope0 = do
   -- Convert C -> S
   scope1 <- bitraverse (Set.traverse c2sReferenceId) (Set.traverse c2sReferenceId) scope0
 
   -- Do the query
-  dependencies0 <- Q.getDirectDependenciesOfScope scope1
+  dependencies0 <- Q.getDirectDependenciesOfScope (fmap isBuiltinType . s2cReference) scope1
 
   -- Convert S -> C
   dependencies1 <- bitraverse (Set.traverse s2cReference) (Set.traverse s2cReference) dependencies0

--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -81,7 +81,9 @@ names = Names terms types
 -- note: this function is really for deciding whether `r` is a term or type,
 -- but it can only answer correctly for Builtins.
 isBuiltinType :: R.Reference -> Bool
-isBuiltinType r = elem r . fmap snd $ builtinTypes
+isBuiltinType =
+  let refs = Set.fromList (map snd builtinTypes)
+  in (`Set.member` refs)
 
 typeLookup :: TL.TypeLookup Symbol Ann
 typeLookup =

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -33,7 +33,6 @@ import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
 import Unison.Cli.MonadUtils (getCurrentProjectBranch)
 import Unison.Cli.MonadUtils qualified as Cli
-import Unison.Cli.NameResolutionUtils (resolveHQToLabeledDependencies)
 import Unison.Cli.NamesUtils qualified as Cli
 import Unison.Cli.ProjectUtils qualified as ProjectUtils
 import Unison.Codebase qualified as Codebase
@@ -58,6 +57,7 @@ import Unison.Codebase.Editor.HandleInput.DebugSynhashTerm (handleDebugSynhashTe
 import Unison.Codebase.Editor.HandleInput.DeleteBranch (handleDeleteBranch)
 import Unison.Codebase.Editor.HandleInput.DeleteNamespace (getEndangeredDependents, handleDeleteNamespace)
 import Unison.Codebase.Editor.HandleInput.DeleteProject (handleDeleteProject)
+import Unison.Codebase.Editor.HandleInput.Dependencies (handleDependencies)
 import Unison.Codebase.Editor.HandleInput.Dependents (handleDependents)
 import Unison.Codebase.Editor.HandleInput.EditDependents (handleEditDependents)
 import Unison.Codebase.Editor.HandleInput.EditNamespace (handleEditNamespace)
@@ -118,13 +118,10 @@ import Unison.CommandLine.DisplayValues qualified as DisplayValues
 import Unison.CommandLine.InputPattern qualified as IP
 import Unison.CommandLine.InputPatterns qualified as IP
 import Unison.CommandLine.InputPatterns qualified as InputPatterns
-import Unison.ConstructorReference (GConstructorReference (..))
 import Unison.DataDeclaration qualified as DD
 import Unison.HashQualified qualified as HQ
 import Unison.HashQualifiedPrime qualified as HQ'
 import Unison.LabeledDependency (LabeledDependency)
-import Unison.LabeledDependency qualified as LD
-import Unison.LabeledDependency qualified as LabeledDependency
 import Unison.Name (Name)
 import Unison.Name qualified as Name
 import Unison.NameSegment qualified as NameSegment
@@ -169,7 +166,7 @@ import Unison.UnisonFile (TypecheckedUnisonFile)
 import Unison.UnisonFile qualified as UF
 import Unison.UnisonFile.Names qualified as UF
 import Unison.Util.Find qualified as Find
-import Unison.Util.List (nubOrdOn, uniqueBy)
+import Unison.Util.List (uniqueBy)
 import Unison.Util.Monoid qualified as Monoid
 import Unison.Util.Pretty qualified as P
 import Unison.Util.Pretty qualified as Pretty
@@ -1147,46 +1144,6 @@ handleFindI isVerbose fscope ws input = do
       Cli.setNumberedArgs $ fmap (SA.SearchResult searchRoot) results
       results' <- Cli.runTransaction (Backend.loadSearchResults codebase results)
       Cli.respond $ ListOfDefinitions fscope ppe isVerbose results'
-
-handleDependencies :: HQ.HashQualified Name -> Cli ()
-handleDependencies hq = do
-  Cli.Env {codebase} <- ask
-  -- todo: add flag to handle transitive efficiently
-  lds <- resolveHQToLabeledDependencies hq
-  names <- Cli.currentNames
-  let pped = PPED.makePPED (PPE.hqNamer 10 names) (PPE.suffixifyByHash names)
-  let suffixifiedPPE = PPED.suffixifiedPPE pped
-  when (null lds) do
-    Cli.returnEarly (LabeledReferenceNotFound hq)
-  results <- for (toList lds) \ld -> do
-    dependencies :: Set LabeledDependency <-
-      Cli.runTransaction do
-        let tp r@(Reference.DerivedId i) =
-              Codebase.getTypeDeclaration codebase i <&> \case
-                Nothing -> error $ "What happened to " ++ show i ++ "?"
-                Just decl ->
-                  Set.map LabeledDependency.TypeReference . Set.delete r . DD.typeDependencies $
-                    DD.asDataDecl decl
-            tp _ = pure mempty
-            tm r@(Referent.Ref (Reference.DerivedId i)) =
-              Codebase.getTerm codebase i <&> \case
-                Nothing -> error $ "What happened to " ++ show i ++ "?"
-                Just tm -> Set.delete (LabeledDependency.TermReferent r) (Term.labeledDependencies tm)
-            tm con@(Referent.Con (ConstructorReference (Reference.DerivedId i) cid) _ct) =
-              Codebase.getTypeDeclaration codebase i <&> \case
-                Nothing -> error $ "What happened to " ++ show i ++ "?"
-                Just decl -> case DD.typeOfConstructor (DD.asDataDecl decl) cid of
-                  Nothing -> error $ "What happened to " ++ show con ++ "?"
-                  Just tp -> Type.labeledDependencies tp
-            tm _ = pure mempty
-         in LD.fold tp tm ld
-    let types = [(PPE.typeName suffixifiedPPE r, r) | LabeledDependency.TypeReference r <- toList dependencies]
-    let terms = [(PPE.termName suffixifiedPPE r, r) | LabeledDependency.TermReferent r <- toList dependencies]
-    pure (types, terms)
-  let types = fmap fst . nubOrdOn snd . Name.sortByText (HQ.toText . fst) . join $ fst <$> results
-  let terms = fmap fst . nubOrdOn snd . Name.sortByText (HQ.toText . fst) . join $ snd <$> results
-  Cli.setNumberedArgs . map SA.HashQualified $ types <> terms
-  Cli.respond $ ListDependencies suffixifiedPPE lds types terms
 
 doDisplay :: OutputLocation -> Names -> Term Symbol () -> Cli ()
 doDisplay outputLoc names tm = do

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Dependencies.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Dependencies.hs
@@ -1,0 +1,73 @@
+module Unison.Codebase.Editor.HandleInput.Dependencies
+  ( handleDependencies,
+  )
+where
+
+import Control.Monad.Reader (ask)
+import Data.Set qualified as Set
+import Unison.Cli.Monad (Cli)
+import Unison.Cli.Monad qualified as Cli
+import Unison.Cli.NameResolutionUtils (resolveHQToLabeledDependencies)
+import Unison.Cli.NamesUtils qualified as Cli
+import Unison.Codebase qualified as Codebase
+import Unison.Codebase.Editor.Output
+import Unison.Codebase.Editor.StructuredArgument qualified as SA
+import Unison.ConstructorReference (GConstructorReference (..))
+import Unison.DataDeclaration qualified as DD
+import Unison.HashQualified qualified as HQ
+import Unison.LabeledDependency (LabeledDependency)
+import Unison.LabeledDependency qualified as LD
+import Unison.LabeledDependency qualified as LabeledDependency
+import Unison.Name (Name)
+import Unison.Name qualified as Name
+import Unison.Prelude
+import Unison.PrettyPrintEnv qualified as PPE
+import Unison.PrettyPrintEnv.Names qualified as PPE
+import Unison.PrettyPrintEnvDecl (PrettyPrintEnvDecl (..))
+import Unison.PrettyPrintEnvDecl.Names qualified as PPED
+import Unison.Reference qualified as Reference
+import Unison.Referent qualified as Referent
+import Unison.Syntax.HashQualified qualified as HQ
+import Unison.Term qualified as Term
+import Unison.Type qualified as Type
+import Unison.Util.List (nubOrdOn)
+
+handleDependencies :: HQ.HashQualified Name -> Cli ()
+handleDependencies hq = do
+  Cli.Env {codebase} <- ask
+  -- todo: add flag to handle transitive efficiently
+  lds <- resolveHQToLabeledDependencies hq
+  names <- Cli.currentNames
+  let pped = PPED.makePPED (PPE.hqNamer 10 names) (PPE.suffixifyByHash names)
+  let suffixifiedPPE = pped.suffixifiedPPE
+  when (null lds) do
+    Cli.returnEarly (LabeledReferenceNotFound hq)
+  results <- for (toList lds) \ld -> do
+    dependencies :: Set LabeledDependency <-
+      Cli.runTransaction do
+        let tp r@(Reference.DerivedId i) =
+              Codebase.getTypeDeclaration codebase i <&> \case
+                Nothing -> error $ "What happened to " ++ show i ++ "?"
+                Just decl ->
+                  Set.map LabeledDependency.TypeReference . Set.delete r . DD.typeDependencies $
+                    DD.asDataDecl decl
+            tp _ = pure mempty
+            tm r@(Referent.Ref (Reference.DerivedId i)) =
+              Codebase.getTerm codebase i <&> \case
+                Nothing -> error $ "What happened to " ++ show i ++ "?"
+                Just tm -> Set.delete (LabeledDependency.TermReferent r) (Term.labeledDependencies tm)
+            tm con@(Referent.Con (ConstructorReference (Reference.DerivedId i) cid) _ct) =
+              Codebase.getTypeDeclaration codebase i <&> \case
+                Nothing -> error $ "What happened to " ++ show i ++ "?"
+                Just decl -> case DD.typeOfConstructor (DD.asDataDecl decl) cid of
+                  Nothing -> error $ "What happened to " ++ show con ++ "?"
+                  Just tp -> Type.labeledDependencies tp
+            tm _ = pure mempty
+         in LD.fold tp tm ld
+    let types = [(PPE.typeName suffixifiedPPE r, r) | LabeledDependency.TypeReference r <- toList dependencies]
+    let terms = [(PPE.termName suffixifiedPPE r, r) | LabeledDependency.TermReferent r <- toList dependencies]
+    pure (types, terms)
+  let types = fmap fst . nubOrdOn snd . Name.sortByText (HQ.toText . fst) . join $ fst <$> results
+  let terms = fmap fst . nubOrdOn snd . Name.sortByText (HQ.toText . fst) . join $ snd <$> results
+  Cli.setNumberedArgs . map SA.HashQualified $ types <> terms
+  Cli.respond $ ListDependencies suffixifiedPPE lds types terms

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Dependencies.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Dependencies.hs
@@ -3,71 +3,81 @@ module Unison.Codebase.Editor.HandleInput.Dependencies
   )
 where
 
-import Control.Monad.Reader (ask)
+import Data.Bifoldable (bifoldMap, binull)
 import Data.Set qualified as Set
+import U.Codebase.Sqlite.Operations qualified as Operations
 import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
-import Unison.Cli.NameResolutionUtils (resolveHQToLabeledDependencies)
-import Unison.Cli.NamesUtils qualified as Cli
-import Unison.Codebase qualified as Codebase
+import Unison.Cli.MonadUtils qualified as Cli
+import Unison.Cli.NameResolutionUtils (resolveHQName)
+import Unison.Codebase.Branch.Names qualified as Branch
 import Unison.Codebase.Editor.Output
 import Unison.Codebase.Editor.StructuredArgument qualified as SA
-import Unison.ConstructorReference (GConstructorReference (..))
-import Unison.DataDeclaration qualified as DD
+import Unison.ConstructorReference qualified as ConstructorReference
 import Unison.HashQualified qualified as HQ
-import Unison.LabeledDependency (LabeledDependency)
+import Unison.HashQualifiedPrime qualified as HQ'
 import Unison.LabeledDependency qualified as LD
-import Unison.LabeledDependency qualified as LabeledDependency
 import Unison.Name (Name)
 import Unison.Name qualified as Name
 import Unison.Prelude
 import Unison.PrettyPrintEnv qualified as PPE
 import Unison.PrettyPrintEnv.Names qualified as PPE
-import Unison.PrettyPrintEnvDecl (PrettyPrintEnvDecl (..))
-import Unison.PrettyPrintEnvDecl.Names qualified as PPED
+import Unison.Reference (Reference)
 import Unison.Reference qualified as Reference
 import Unison.Referent qualified as Referent
-import Unison.Syntax.HashQualified qualified as HQ
-import Unison.Term qualified as Term
-import Unison.Type qualified as Type
-import Unison.Util.List (nubOrdOn)
+import Unison.Syntax.HashQualifiedPrime qualified as HQ'
+import Unison.Util.Defns (Defns (..), DefnsF)
+import Unison.Util.Defns qualified as Defns
+import qualified Unison.Builtin as Builtin
 
 handleDependencies :: HQ.HashQualified Name -> Cli ()
 handleDependencies hq = do
-  Cli.Env {codebase} <- ask
-  -- todo: add flag to handle transitive efficiently
-  lds <- resolveHQToLabeledDependencies hq
-  names <- Cli.currentNames
-  let pped = PPED.makePPED (PPE.hqNamer 10 names) (PPE.suffixifyByHash names)
-  let suffixifiedPPE = pped.suffixifiedPPE
-  when (null lds) do
+  refs <- resolveHQName hq
+
+  when (binull refs) do
     Cli.returnEarly (LabeledReferenceNotFound hq)
-  results <- for (toList lds) \ld -> do
-    dependencies :: Set LabeledDependency <-
-      Cli.runTransaction do
-        let tp r@(Reference.DerivedId i) =
-              Codebase.getTypeDeclaration codebase i <&> \case
-                Nothing -> error $ "What happened to " ++ show i ++ "?"
-                Just decl ->
-                  Set.map LabeledDependency.TypeReference . Set.delete r . DD.typeDependencies $
-                    DD.asDataDecl decl
-            tp _ = pure mempty
-            tm r@(Referent.Ref (Reference.DerivedId i)) =
-              Codebase.getTerm codebase i <&> \case
-                Nothing -> error $ "What happened to " ++ show i ++ "?"
-                Just tm -> Set.delete (LabeledDependency.TermReferent r) (Term.labeledDependencies tm)
-            tm con@(Referent.Con (ConstructorReference (Reference.DerivedId i) cid) _ct) =
-              Codebase.getTypeDeclaration codebase i <&> \case
-                Nothing -> error $ "What happened to " ++ show i ++ "?"
-                Just decl -> case DD.typeOfConstructor (DD.asDataDecl decl) cid of
-                  Nothing -> error $ "What happened to " ++ show con ++ "?"
-                  Just tp -> Type.labeledDependencies tp
-            tm _ = pure mempty
-         in LD.fold tp tm ld
-    let types = [(PPE.typeName suffixifiedPPE r, r) | LabeledDependency.TypeReference r <- toList dependencies]
-    let terms = [(PPE.termName suffixifiedPPE r, r) | LabeledDependency.TermReferent r <- toList dependencies]
-    pure (types, terms)
-  let types = fmap fst . nubOrdOn snd . Name.sortByText (HQ.toText . fst) . join $ fst <$> results
-  let terms = fmap fst . nubOrdOn snd . Name.sortByText (HQ.toText . fst) . join $ snd <$> results
-  Cli.setNumberedArgs . map SA.HashQualified $ types <> terms
-  Cli.respond $ ListDependencies suffixifiedPPE lds types terms
+
+  namespace <- Cli.getCurrentProjectRoot0
+  let ppe =
+        let names = Branch.toNames namespace
+         in PPE.makePPE (PPE.hqNamer 10 names) (PPE.suffixifyByHash names)
+
+  dependencies <- do
+    Cli.runTransaction do
+      Operations.directDependenciesOfScope
+        Builtin.isBuiltinType
+        ( let refToIds :: Reference -> Set Reference.Id
+              refToIds =
+                maybe Set.empty Set.singleton . Reference.toId
+           in bifoldMap
+                ( foldMap \case
+                    Referent.Con ref _ -> Defns.fromTypes (refToIds (ref ^. ConstructorReference.reference_))
+                    Referent.Ref ref -> Defns.fromTerms (refToIds ref)
+                )
+                (foldMap (refToIds >>> Defns.fromTypes))
+                refs
+        )
+
+  let dependencyNames ::
+        DefnsF
+          []
+          (HQ'.HashQualified Name, HQ'.HashQualified Name)
+          (HQ'.HashQualified Name, HQ'.HashQualified Name)
+      dependencyNames =
+        bimap
+          (f (Referent.fromTermReference >>> PPE.termNames ppe))
+          (f (PPE.typeNames ppe))
+          dependencies
+        where
+          f g =
+            Set.toList
+              >>> mapMaybe (g >>> listToMaybe)
+              >>> Name.sortByText (fst >>> HQ'.toText)
+
+  -- Set numbered args
+  (dependencyNames.types ++ dependencyNames.terms)
+    & map (SA.HashQualified . HQ'.toHQ . fst)
+    & Cli.setNumberedArgs
+
+  let lds = bifoldMap (Set.map LD.referent) (Set.map LD.typeRef) refs
+  Cli.respond (ListDependencies ppe lds dependencyNames)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Todo.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Todo.hs
@@ -62,6 +62,7 @@ handleTodo = do
 
       directDependencies <-
         Operations.directDependenciesOfScope
+          Builtin.isBuiltinType
           Defns
             { terms = Branch.deepTermReferenceIds currentNamespaceWithoutLibdeps,
               types = Branch.deepTypeReferenceIds currentNamespaceWithoutLibdeps

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -336,7 +336,15 @@ data Output
   | PreviewMergeAlreadyUpToDate ProjectPath ProjectPath
   | NotImplemented
   | NoBranchWithHash ShortCausalHash
-  | ListDependencies PPE.PrettyPrintEnv (Set LabeledDependency) [HQ.HashQualified Name] [HQ.HashQualified Name] -- types, terms
+  | -- | List direct dependencies of a type or term.
+    ListDependencies
+      PPE.PrettyPrintEnv
+      (Set LabeledDependency)
+      ( DefnsF
+          []
+          (HQ'.HashQualified Name, HQ'.HashQualified Name)
+          (HQ'.HashQualified Name, HQ'.HashQualified Name)
+      )
   | -- | List dependents of a type or term.
     ListDependents
       PPE.PrettyPrintEnv

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -342,8 +342,8 @@ data Output
       (Set LabeledDependency)
       ( DefnsF
           []
-          (HQ'.HashQualified Name, HQ'.HashQualified Name)
-          (HQ'.HashQualified Name, HQ'.HashQualified Name)
+          (HQ.HashQualified Name, HQ.HashQualified Name)
+          (HQ.HashQualified Name, HQ.HashQualified Name)
       )
   | -- | List dependents of a type or term.
     ListDependents

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1446,10 +1446,17 @@ notifyUser dir = \case
         "Dependents"
         "dependents"
         lds
-        (map (HQ'.toHQ . fst) defns.types)
+        (map (HQ'.toHQ *** HQ'.toHQ) defns.types)
         (map (HQ'.toHQ *** HQ'.toHQ) defns.terms)
-  ListDependencies ppe lds types terms ->
-    pure $ listDependentsOrDependencies ppe "Dependencies" "dependencies" lds types (map (\x -> (x, x)) terms)
+  ListDependencies ppe lds defns ->
+    pure $
+      listDependentsOrDependencies
+        ppe
+        "Dependencies"
+        "dependencies"
+        lds
+        (map (HQ'.toHQ *** HQ'.toHQ) defns.types)
+        (map (HQ'.toHQ *** HQ'.toHQ) defns.terms)
   ListStructuredFind terms ->
     pure $ listFind False Nothing terms
   ListTextFind True terms ->
@@ -3772,7 +3779,7 @@ listDependentsOrDependencies ::
   Text ->
   Text ->
   Set LabeledDependency ->
-  [HQ.HashQualified Name] ->
+  [(HQ.HashQualified Name, HQ.HashQualified Name)] ->
   [(HQ.HashQualified Name, HQ.HashQualified Name)] ->
   Pretty
 listDependentsOrDependencies ppe labelStart label lds types terms =
@@ -3790,7 +3797,7 @@ listDependentsOrDependencies ppe labelStart label lds types terms =
           P.lines $
             [ P.indentN 2 $ P.bold "Types:",
               "",
-              P.indentN 2 . P.numberedList $ c . prettyHashQualified <$> types
+              P.indentN 2 . P.numberedList $ prettyHashQualifiedFull <$> types
             ]
     termsOut =
       if null terms
@@ -3801,7 +3808,6 @@ listDependentsOrDependencies ppe labelStart label lds types terms =
               "",
               P.indentN 2 . P.numberedListFrom (length types) $ prettyHashQualifiedFull <$> terms
             ]
-    c = P.syntaxToColor
 
 displayProjectBranchReflogEntries ::
   Maybe UTCTime ->

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1455,8 +1455,8 @@ notifyUser dir = \case
         "Dependencies"
         "dependencies"
         lds
-        (map (HQ'.toHQ *** HQ'.toHQ) defns.types)
-        (map (HQ'.toHQ *** HQ'.toHQ) defns.terms)
+        defns.types
+        defns.terms
   ListStructuredFind terms ->
     pure $ listFind False Nothing terms
   ListTextFind True terms ->

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -59,6 +59,7 @@ library
       Unison.Codebase.Editor.HandleInput.DeleteBranch
       Unison.Codebase.Editor.HandleInput.DeleteNamespace
       Unison.Codebase.Editor.HandleInput.DeleteProject
+      Unison.Codebase.Editor.HandleInput.Dependencies
       Unison.Codebase.Editor.HandleInput.Dependents
       Unison.Codebase.Editor.HandleInput.EditDependents
       Unison.Codebase.Editor.HandleInput.EditNamespace

--- a/unison-src/transcripts/idempotent/dependents-dependencies-debugfile.md
+++ b/unison-src/transcripts/idempotent/dependents-dependencies-debugfile.md
@@ -63,13 +63,13 @@ scratch/main> dependencies q
 
     Types:
 
-    1. Nat
+    1. builtin.Nat
 
     Terms:
 
-    2. Nat.*
-    3. Nat.+
-    4. p
+    2. builtin.Nat.*
+    3. builtin.Nat.+
+    4. inside.p
 
   Tip: Try `view 4` to see the source of any numbered item in
        the above list.
@@ -80,8 +80,8 @@ scratch/main> dependencies B
 
     Types:
 
-    1. B
-    2. Int
+    1. builtin.Int
+    2. outside.B
 
   Tip: Try `view 2` to see the source of any numbered item in
        the above list.
@@ -92,17 +92,16 @@ scratch/main> dependencies d
 
     Types:
 
-    1. Boolean
-    2. Nat
+    1. builtin.Boolean
 
     Terms:
 
-    3. <
-    4. c
-    5. Nat.+
-    6. p
+    2. builtin.Nat.+
+    3. builtin.Universal.<
+    4. inside.p
+    5. outside.c
 
-  Tip: Try `view 6` to see the source of any numbered item in
+  Tip: Try `view 5` to see the source of any numbered item in
        the above list.
 
 scratch/main> dependents d


### PR DESCRIPTION
## Overview

Fixes #5592 

This PR makes `dependencies` show full names, like `dependents`. Also, it shows full type names in both commands now; previously, only terms of `dependents` showed full names.

## Test coverage

I re-ran the transcripts (only one changed), and also played around with this manually to confirm it looks right.
