### PR TITLE
fixes to the "human diff" calculation in merge algo

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Merge2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Merge2.hs
@@ -843,9 +843,9 @@ realDebugHumanDiffs diffs = do
                 <> " "
                 <> textify x
                 <> "\n  "
-                <> Text.unwords (map Name.toText (Foldable.toList oldNames))
-                <> "\n  → "
                 <> Name.toText name
+                <> " ← "
+                <> Text.unwords (map Name.toText (Foldable.toList oldNames))
           Merge.HumanDiffOp'RenamedTo x newNames ->
             Text.magenta $
               "rename "
@@ -854,7 +854,7 @@ realDebugHumanDiffs diffs = do
                 <> textify x
                 <> "\n  "
                 <> Name.toText name
-                <> "\n  → "
+                <> " → "
                 <> Text.unwords (map Name.toText (Foldable.toList newNames))
 
 realDebugCombinedDiff :: DefnsF2 (Map Name) Merge.CombinedDiffOp Referent TypeReference -> IO ()

--- a/unison-merge/package.yaml
+++ b/unison-merge/package.yaml
@@ -7,7 +7,6 @@ ghc-options: -Wall
 dependencies:
   - base
   - containers
-  - either
   - lens
   - mtl
   - nonempty-containers

--- a/unison-merge/src/Unison/Merge.hs
+++ b/unison-merge/src/Unison/Merge.hs
@@ -26,6 +26,7 @@ module Unison.Merge
     DiffOp (..),
     EitherWay (..),
     EitherWayI (..),
+    HumanDiffOp (..),
     LibdepDiffOp (..),
     Synhashed (..),
     ThreeWay (..),
@@ -48,6 +49,7 @@ import Unison.Merge.DeclCoherencyCheck
 import Unison.Merge.DiffOp (DiffOp (..))
 import Unison.Merge.EitherWay (EitherWay (..))
 import Unison.Merge.EitherWayI (EitherWayI (..))
+import Unison.Merge.HumanDiffOp (HumanDiffOp (..))
 import Unison.Merge.Libdeps (LibdepDiffOp (..))
 import Unison.Merge.Mergeblob0 (Mergeblob0 (..), makeMergeblob0)
 import Unison.Merge.Mergeblob1 (Mergeblob1 (..), makeMergeblob1)

--- a/unison-merge/src/Unison/Merge/Diff.hs
+++ b/unison-merge/src/Unison/Merge/Diff.hs
@@ -112,9 +112,12 @@ diffHashedNamespaceDefns old new =
       Map.merge
         (Map.mapMissing (\_ -> DiffOp2'Delete))
         (Map.mapMissing (\_ -> DiffOp2'Add))
-        ( let f old new
-                | Synhashed.value old == Synhashed.value new = Nothing
-                | otherwise = Just (DiffOp2'Update Updated {old, new} (old == new))
+        ( let f old new = do
+                let equalSynhashes = old == new
+                -- Drop things that haven't changed
+                when equalSynhashes do
+                  guard (Synhashed.value old /= Synhashed.value new)
+                Just (DiffOp2'Update Updated {old, new} equalSynhashes)
            in Map.zipWithMaybeMatched \_ -> f
         )
 

--- a/unison-merge/src/Unison/Merge/DiffOp.hs
+++ b/unison-merge/src/Unison/Merge/DiffOp.hs
@@ -1,5 +1,6 @@
 module Unison.Merge.DiffOp
   ( DiffOp (..),
+    DiffOp2 (..),
   )
 where
 
@@ -14,4 +15,16 @@ data DiffOp a
   = DiffOp'Add !a
   | DiffOp'Delete !a
   | DiffOp'Update !(Updated a)
+  deriving stock (Foldable, Functor, Show, Traversable)
+
+-- | Like 'DiffOp', but updates are tagged as propagated (True) or not (False).
+--
+-- This could be cleaned up a bit, but eh, it works for now. Historical context: the concept of a propagated upddate was
+-- not in the initial version of merge (which was only concerned with the merge algorithm and producing the correct
+-- output). However, it is now being incorporated, because when e.g. viewing a diff, we do want to see propagated, not
+-- drop them.
+data DiffOp2 a
+  = DiffOp2'Add !a
+  | DiffOp2'Delete !a
+  | DiffOp2'Update !(Updated a) !Bool {- is propagated? -}
   deriving stock (Foldable, Functor, Show, Traversable)

--- a/unison-merge/unison-merge.cabal
+++ b/unison-merge/unison-merge.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -85,7 +85,6 @@ library
   build-depends:
       base
     , containers
-    , either
     , lens
     , mtl
     , nonempty-containers


### PR DESCRIPTION
## Overview

This PR fixes a small issue in the "human diff" calculation: we would accidentally classify changes that didn't change at all as propagated updates.

## Test coverage

Unfortunately just manual – we don't actually use the "human diff" in ucm, just Share, so I only observed this bug (and bugfix) when integrating the two.