### PR TITLE
Set SyncV2 as the default protocol

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,10 +120,10 @@ $ UNISON_ENTITY_VALIDATION="false" ucm
 
 ### `UNISON_SYNC_VERSION`
 
-Allows enabling the experimental Sync Version 2 protocol when downloading code from Share.
+Allows regressing to sync version 1 when interacting with Share.
 
 ```sh
-$ UNISON_ENTITY_VALIDATION="2" ucm
+$ UNISON_SYNC_VERSION="1" ucm
 ```
 
 ### `UNISON_PULL_WORKERS`

--- a/unison-cli/src/Unison/Cli/DownloadUtils.hs
+++ b/unison-cli/src/Unison/Cli/DownloadUtils.hs
@@ -45,8 +45,8 @@ syncVersion :: SyncVersion
 syncVersion = unsafePerformIO do
   UnliftIO.lookupEnv "UNISON_SYNC_VERSION"
     <&> \case
-      Just "2" -> SyncV2
-      _ -> SyncV1
+      Just "1" -> SyncV1
+      _ -> SyncV2
 
 -- | Download a project/branch from Share.
 downloadProjectBranchFromShare ::

--- a/unison-src/transcripts/idempotent/pull-errors.md
+++ b/unison-src/transcripts/idempotent/pull-errors.md
@@ -5,8 +5,6 @@ test/main> pull @aryairani/test-almost-empty/main lib.base_latest
   Going forward, you can use
   `lib.install @aryairani/test-almost-empty/main`.
 
-  Downloaded 2 entities.
-
   I installed @aryairani/test-almost-empty/main as
   aryairani_test_almost_empty_main.
 

--- a/unison-src/transcripts/project-outputs/docs/configuration.output.md
+++ b/unison-src/transcripts/project-outputs/docs/configuration.output.md
@@ -122,7 +122,7 @@ $ UNISON_ENTITY_VALIDATION="false" ucm
 Allows regressing to sync version 1 when interacting with Share.
 
 ``` sh
-$ UNISON_SYNC_VALIDATION="1" ucm
+$ UNISON_SYNC_VERSION="1" ucm
 ```
 
 ### `UNISON_PULL_WORKERS`
@@ -170,7 +170,7 @@ Also, see the guide [here](https://www.unison-lang.org/learn/tooling/configurati
 The following configuration options can be provided within the `.unisonConfig` file,
 which exists within the codebase directory, or at `~/.unisonConfig` for your default codebase.
 
-```
+``` 
 # Attach myself as author and use BSD license for all of my contributions
 DefaultMetadata = [ ".metadata.authors.chrispenner"
                   , ".metadata.licenses.chrispenner" ]

--- a/unison-src/transcripts/project-outputs/docs/configuration.output.md
+++ b/unison-src/transcripts/project-outputs/docs/configuration.output.md
@@ -119,10 +119,10 @@ $ UNISON_ENTITY_VALIDATION="false" ucm
 
 ### `UNISON_SYNC_VERSION`
 
-Allows enabling the experimental Sync Version 2 protocol when downloading code from Share.
+Allows regressing to sync version 1 when interacting with Share.
 
 ``` sh
-$ UNISON_ENTITY_VALIDATION="2" ucm
+$ UNISON_SYNC_VALIDATION="1" ucm
 ```
 
 ### `UNISON_PULL_WORKERS`
@@ -170,7 +170,7 @@ Also, see the guide [here](https://www.unison-lang.org/learn/tooling/configurati
 The following configuration options can be provided within the `.unisonConfig` file,
 which exists within the codebase directory, or at `~/.unisonConfig` for your default codebase.
 
-``` 
+```
 # Attach myself as author and use BSD license for all of my contributions
 DefaultMetadata = [ ".metadata.authors.chrispenner"
                   , ".metadata.licenses.chrispenner" ]


### PR DESCRIPTION
## Overview

Set SyncV2 as the default pull protocol, should affect `pull` `lib.install`, `clone`

## Implementation notes

* Swaps the default
* Also fixes up a missing console region

## Test coverage

Peeps have been dogfooding it for a while with no issues so far.