### PR TITLE
Fix a problem with type lookups in certain kind checking scenarios

### DIFF
--- a/unison-src/transcripts/idempotent/fix5566.md
+++ b/unison-src/transcripts/idempotent/fix5566.md
@@ -1,0 +1,69 @@
+Tests a problem with kind checking with data declarations in a file
+that refer to types only in the codebase.
+
+``` unison
+
+type T1 = T1C
+type T2 = T2C
+
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+
+    ⍟ These new definitions are ok to `add`:
+    
+      type T1
+      type T2
+```
+
+``` ucm
+scratch/main> add
+
+  ⍟ I've added these definitions:
+
+    type T1
+    type T2
+```
+
+U referring to T from the codebase would cause an error that T could
+not be looked up when kind checking U. Essentially, only
+dependencies from the combinator being `run` were fetched from the
+codebase, but data decls were left in the unisonfile, and needed to
+be kind checked.
+
+``` unison
+
+type U = UT T1
+
+ability V where
+  veff : T2 -> ()
+
+bomb = do
+  _ = 1
+  ()
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+
+    ⍟ These new definitions are ok to `add`:
+    
+      type U
+      ability V
+      bomb : '()
+```
+
+``` ucm
+scratch/main> run bomb
+
+  ()
+```


### PR DESCRIPTION
In the `run` command, when running something from the latest checked file, any data and effect decls would remain in the UnisonFile used to run the expression, but their type dependencies would not be fetched from the codebase. Because they're in the file, they must be kind checked, but that would only work if the main expression depends on the same types as the data declarations.

Should fix #5566