### PR TITLE
Mark apply1 inline

### DIFF
--- a/unison-runtime/src/Unison/Runtime/Machine.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine.hs
@@ -172,6 +172,7 @@ apply1 callback env threadTracker clo = do
   apply env mempty threadTracker stk k0 True ZArgs $ clo
   where
     k0 = CB $ Hook (\stk -> callback $ packXStack stk)
+{-# inline apply1 #-}
 
 unitValue :: Val
 unitValue = BoxedVal $ unitClosure


### PR DESCRIPTION
Apparently some recent changes caused the compiler to not inline it, which causes the build to fail when `optchecks` are enabled.