### PR TITLE
Add missing type key to HashJWTClaims

### DIFF
--- a/unison-share-projects-api/src/Unison/Share/API/Hash.hs
+++ b/unison-share-projects-api/src/Unison/Share/API/Hash.hs
@@ -72,7 +72,8 @@ instance ToJSON HashJWTClaims where
   toJSON (HashJWTClaims hash userId) =
     object
       [ "h" .= hash,
-        "u" .= userId
+        "u" .= userId,
+        "t" .= hashJWTType
       ]
 
 instance FromJSON HashJWTClaims where


### PR DESCRIPTION
## Overview

I'm not sure how long it's been like this, and obviously it hasn't caused any problems yet, but I'll be changing some of how JWTs are parsed on Share soon and so it'd be good to ensure both sides are in agreement here.

## Implementation notes

* Adds the 'type' claim to HashJWT's JSON representation so it matches the `encodeJWT` representation.

## Test coverage

Nah, this is just resolving an inconsistency that I noticed.
