### PR TITLE
Don't crash on port binding failures

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/UI.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/UI.hs
@@ -16,6 +16,7 @@ import Unison.Cli.Monad qualified as Cli
 import Unison.Cli.MonadUtils qualified as Cli
 import Unison.Codebase (Codebase)
 import Unison.Codebase qualified as Codebase
+import Unison.Codebase.Editor.Output (Output (..))
 import Unison.Codebase.Path qualified as Path
 import Unison.Codebase.ProjectPath qualified as PP
 import Unison.Codebase.SqliteCodebase.Conversions qualified as Conversions
@@ -37,8 +38,10 @@ openUI path' = do
   Cli.Env {serverBaseUrl} <- ask
   defnPath <- Cli.resolvePath' path'
   pp <- Cli.getCurrentProjectPath
-  whenJust serverBaseUrl \url -> do
-    openUIForProject url pp (defnPath ^. PP.absPath_)
+  case serverBaseUrl of
+    Just url -> openUIForProject url pp (defnPath ^. PP.absPath_)
+    Nothing -> do
+      Cli.respond UCMServerNotRunning
 
 openUIForProject :: Server.BaseUrl -> PP.ProjectPath -> Path.Absolute -> Cli ()
 openUIForProject url pp@(PP.ProjectPath project projectBranch perspective) defnPath = do

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -465,6 +465,7 @@ data Output
   | SyncPullError (Sync.SyncError SyncV2.PullError)
   | SyncFromCodebaseMissingProjectBranch (ProjectAndBranch ProjectName ProjectBranchName)
   | OpenCodebaseError CodebasePath OpenCodebaseError
+  | UCMServerNotRunning
 
 data MoreEntriesThanShown = MoreEntriesThanShown | AllEntriesShown
   deriving (Eq, Show)
@@ -709,6 +710,7 @@ isFailure o = case o of
   SyncPullError {} -> True
   SyncFromCodebaseMissingProjectBranch {} -> True
   OpenCodebaseError {} -> True
+  UCMServerNotRunning -> True
 
 isNumberedFailure :: NumberedOutput -> Bool
 isNumberedFailure = \case

--- a/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
+++ b/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
@@ -103,11 +103,13 @@ withRunner isTest verbosity ucmVersion nrtp action =
         Server.defaultCodebaseServerOpts
         runtime
         codebase
-        \baseUrl ->
-          either
-            (pure . Left . ParseError)
-            (run isTest verbosity codebaseDir codebase runtime sbRuntime nRuntime ucmVersion $ tShow baseUrl)
-            $ Transcript.stanzas transcriptName transcriptSrc
+        \case
+          Nothing -> pure $ Left PortBindingFailure
+          Just baseUrl ->
+            either
+              (pure . Left . ParseError)
+              (run isTest verbosity codebaseDir codebase runtime sbRuntime nRuntime ucmVersion $ tShow @Server.BaseUrl baseUrl)
+              $ Transcript.stanzas transcriptName transcriptSrc
   where
     withRuntimes ::
       FilePath -> (Runtime.Runtime Symbol -> Runtime.Runtime Symbol -> Runtime.Runtime Symbol -> m a) -> m a
@@ -548,5 +550,6 @@ fixedBug out body = do
 data Error
   = ParseError (P.ParseErrorBundle Text Void)
   | RunFailure (Seq Stanza)
+  | PortBindingFailure
   deriving stock (Show)
   deriving anyclass (Exception)

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -2302,6 +2302,7 @@ notifyUser dir = \case
           "The codebase is at schema version " <> P.shown currentSV <> " but UCM requires schema version " <> P.shown requiredSV <> ".",
           "Please open the other codebase with UCM directly to upgrade it to the latest version, then try again."
         ]
+  UCMServerNotRunning -> pure (P.wrap "The UCM server is not running.")
 
 prettyShareError :: ShareError -> Pretty
 prettyShareError =

--- a/unison-cli/src/Unison/LSP.hs
+++ b/unison-cli/src/Unison/LSP.hs
@@ -15,6 +15,8 @@ import Compat (onWindows)
 import Control.Monad.Reader
 import Data.ByteString.Builder.Extra (defaultChunkSize)
 import Data.Char (toLower)
+import Data.Text qualified as Text
+import Data.Text.IO qualified as Text
 import GHC.IO.Exception (ioe_errno)
 import Ki qualified
 import Language.LSP.Logging qualified as LSP
@@ -26,11 +28,9 @@ import Language.LSP.Server
 import Language.LSP.VFS
 import Network.Simple.TCP qualified as TCP
 import System.Environment (lookupEnv)
-import System.IO (hPutStrLn)
 import Unison.Codebase
 import Unison.Codebase.ProjectPath qualified as PP
 import Unison.Codebase.Runtime (Runtime)
-import Unison.Debug qualified as Debug
 import Unison.LSP.CancelRequest (cancelRequestHandler)
 import Unison.LSP.CodeAction (codeActionHandler)
 import Unison.LSP.CodeLens (codeLensHandler)
@@ -94,11 +94,9 @@ spawnLsp lspFormattingConfig codebase runtime signal =
       case Errno <$> ioe_errno ioerr of
         Just errNo
           | errNo == eADDRINUSE -> do
-              putStrLn $ "Note: Port " <> lspPort <> " is already bound by another process or another UCM. The LSP server will not be started."
+              Text.hPutStrLn UnliftIO.stderr $ "Note: Port " <> Text.pack lspPort <> " is already bound by another process or another UCM. The LSP server will not be started."
         _ -> do
-          Debug.debugM Debug.LSP "LSP Exception" ioerr
-          Debug.debugM Debug.LSP "LSP Errno" (ioe_errno ioerr)
-          putStrLn "LSP server failed to start."
+          Text.hPutStrLn UnliftIO.stderr $ "LSP server failed to start."
     -- Where to send logs that occur before a client connects
     lspServerLogger = Colog.filterBySeverity Colog.Error Colog.getSeverity $ Colog.cmap (fmap tShow) (LogAction print)
     -- Where to send logs that occur after a client connects
@@ -109,7 +107,7 @@ spawnLsp lspFormattingConfig codebase runtime signal =
       lookupEnv "UNISON_LSP_ENABLED" >>= \case
         Just (fmap toLower -> "false") -> pure ()
         Just (fmap toLower -> "true") -> runServer
-        Just x -> hPutStrLn stderr $ "Invalid value for UNISON_LSP_ENABLED, expected 'true' or 'false' but found: " <> x
+        Just x -> Text.hPutStrLn stderr $ "Invalid value for UNISON_LSP_ENABLED, expected 'true' or 'false' but found: " <> Text.pack x
         Nothing -> when (not onWindows) runServer
 
 serverDefinition ::

--- a/unison-cli/src/Unison/Main.hs
+++ b/unison-cli/src/Unison/Main.hs
@@ -96,6 +96,7 @@ import Unison.Util.Pretty qualified as P
 import Unison.Version (Version)
 import Unison.Version qualified as Version
 import UnliftIO.Directory (getHomeDirectory)
+import UnliftIO qualified as UnliftIO
 
 type Runtimes =
   (RTI.Runtime Symbol, RTI.Runtime Symbol, RTI.Runtime Symbol)
@@ -135,6 +136,11 @@ main version = do
               ]
             else []
         ]
+  -- This makes our error messages more safe w/r to concurrency. Without it sometimes the
+  -- error messaging from the UCM server and LSP server (both running in separate threads) get
+  -- interleaved.
+  -- https://hackage.haskell.org/package/base-4.21.0.0/docs/GHC-IO-Handle.html#v:hPutStr
+  UnliftIO.hSetBuffering UnliftIO.stderr UnliftIO.LineBuffering
 
   withCP65001 . runInUnboundThread . Ki.scoped $ \scope -> do
     interruptHandler <- defaultInterruptHandler
@@ -318,18 +324,19 @@ main version = do
               -- Windows when we move to GHC 9.*
               -- https://gitlab.haskell.org/ghc/ghc/-/merge_requests/1224
               void . Ki.fork scope $ LSP.spawnLsp lspFormattingConfig theCodebase runtime changeSignal
-              Server.startServer (Backend.BackendEnv {Backend.useNamesIndex = False}) codebaseServerOpts sbRuntime theCodebase $ \baseUrl -> do
+              Server.startServer (Backend.BackendEnv {Backend.useNamesIndex = False}) codebaseServerOpts sbRuntime theCodebase $ \mayBaseUrl -> do
                 case exitOption of
                   DoNotExit -> do
                     case isHeadless of
                       Headless -> do
-                        PT.putPrettyLn $
-                          P.lines
-                            [ "I've started the Codebase API server at",
-                              P.text $ Server.urlFor Server.Api baseUrl,
-                              "and the Codebase UI at",
-                              P.text $ Server.urlFor (Server.ProjectBranchUI (ProjectAndBranch (UnsafeProjectName "scratch") (UnsafeProjectBranchName "main")) Path.Root Nothing) baseUrl
-                            ]
+                        whenJust mayBaseUrl \baseUrl -> do
+                          PT.putPrettyLn $
+                            P.lines
+                              [ "I've started the Codebase API server at",
+                                P.text $ Server.urlFor Server.Api baseUrl,
+                                "and the Codebase UI at",
+                                P.text $ Server.urlFor (Server.ProjectBranchUI (ProjectAndBranch (UnsafeProjectName "scratch") (UnsafeProjectBranchName "main")) Path.Root Nothing) baseUrl
+                              ]
                         PT.putPrettyLn $
                           P.string "Running the codebase manager headless with "
                             <> P.shown GHC.Conc.numCapabilities
@@ -349,7 +356,7 @@ main version = do
                           nRuntime
                           theCodebase
                           []
-                          (Just baseUrl)
+                          mayBaseUrl
                           (PP.toIds startingProjectPath)
                           initRes
                           lspCheckForChanges

--- a/unison-cli/src/Unison/Main.hs
+++ b/unison-cli/src/Unison/Main.hs
@@ -95,8 +95,8 @@ import Unison.Symbol (Symbol)
 import Unison.Util.Pretty qualified as P
 import Unison.Version (Version)
 import Unison.Version qualified as Version
-import UnliftIO.Directory (getHomeDirectory)
 import UnliftIO qualified as UnliftIO
+import UnliftIO.Directory (getHomeDirectory)
 
 type Runtimes =
   (RTI.Runtime Symbol, RTI.Runtime Symbol, RTI.Runtime Symbol)
@@ -440,6 +440,10 @@ runTranscripts' version progName nativeRtp transcriptDir markdownFiles = do
               output <-
                 either
                   ( uncurry ($>) . first (PT.putPrettyLn . P.callout "❓" . P.lines) . \case
+                      Transcript.PortBindingFailure ->
+                        ( [P.indentN 2 $ "The codebase server failed to start because the chosen port was already in use."],
+                          "Port binding failure"
+                        )
                       Transcript.ParseError err ->
                         let msg = MP.errorBundlePretty err
                          in ( [ P.indentN 2 $

--- a/unison-cli/transcripts/Transcripts.hs
+++ b/unison-cli/transcripts/Transcripts.hs
@@ -74,6 +74,12 @@ testBuilder expectFailure replaceOriginal recordFailure runtimePath inputDir out
       (filePath, Left err) -> do
         let outputFile = outputDir </> outputFileForTranscript filePath
         case err of
+          Transcript.PortBindingFailure -> do
+            let errMsg = "Failed to bind codebase server to the default port when running transcripts in " <> filePath
+            io . writeUtf8 outputFile $ Text.pack errMsg
+            when (not expectFailure) $ do
+              io $ recordFailure (inputDir </> filePath, Text.pack errMsg)
+              crash errMsg
           Transcript.ParseError errors -> do
             let bundle = MP.errorBundlePretty errors
                 errMsg = "Error parsing " <> filePath <> ": " <> bundle

--- a/unison-share-api/package.yaml
+++ b/unison-share-api/package.yaml
@@ -11,7 +11,6 @@ library:
 
   dependencies:
     - aeson >= 2.0.0.0
-    - async
     - base
     - binary
     - bytes

--- a/unison-share-api/src/Unison/Server/CodebaseServer.hs
+++ b/unison-share-api/src/Unison/Server/CodebaseServer.hs
@@ -6,7 +6,6 @@
 module Unison.Server.CodebaseServer where
 
 import Control.Concurrent (newEmptyMVar, putMVar, readMVar)
-import Control.Concurrent.Async (race)
 import Control.Exception (ErrorCall (..), throwIO)
 import Control.Monad.Reader
 import Control.Monad.Trans.Except
@@ -21,6 +20,7 @@ import Data.OpenApi.Lens qualified as OpenApi
 import Data.Proxy (Proxy (..))
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
+import Data.Text.IO qualified as Text
 import GHC.Generics ()
 import Network.HTTP.Media ((//), (/:))
 import Network.HTTP.Types (HeaderName)
@@ -81,6 +81,7 @@ import System.Directory (canonicalizePath, doesFileExist)
 import System.Environment (getExecutablePath)
 import System.FilePath ((</>))
 import System.FilePath qualified as FilePath
+import System.IO.Error qualified as IOError
 import U.Codebase.Branch qualified as V2
 import U.Codebase.Causal qualified as Causal
 import U.Codebase.HashTags (CausalHash)
@@ -122,6 +123,8 @@ import Unison.Sqlite qualified as Sqlite
 import Unison.Symbol (Symbol)
 import Unison.Syntax.NameSegment qualified as NameSegment
 import Unison.Util.Pretty qualified as Pretty
+import UnliftIO qualified
+import UnliftIO.Async qualified as Async
 
 -- HTML content type
 data HTML = HTML
@@ -449,7 +452,7 @@ startServer ::
   CodebaseServerOpts ->
   Rt.Runtime Symbol ->
   Codebase IO Symbol Ann ->
-  (BaseUrl -> IO a) ->
+  (Maybe BaseUrl -> IO a) ->
   IO a
 startServer env opts rt codebase onStart = do
   -- the `canonicalizePath` resolves symlinks
@@ -471,13 +474,28 @@ startServer env opts rt codebase onStart = do
     withPort settings baseUrl app' p = do
       started <- mkWaiter
       let settings' = setBeforeMainLoop (notify started ()) settings
-      result <-
-        race
-          (runSettings settings' app')
-          (waitFor started *> onStart (baseUrl p))
-      case result of
-        Left () -> throwIO $ ErrorCall "Server exited unexpectedly!"
-        Right x -> pure x
+      let runServer = do
+            UnliftIO.try (runSettings settings' app') >>= \case
+              Left ioerror | IOError.isAlreadyInUseError ioerror -> do
+                Text.hPutStrLn UnliftIO.stderr $
+                  Text.unlines
+                    [ "Note: Port "
+                        <> Text.pack (show p)
+                        <> " is already bound by another process or another UCM. The UCM server will not be started."
+                    ]
+              Left e -> do
+                Text.hPutStrLn UnliftIO.stderr $
+                  Text.unlines
+                    [ "UCM server failure: " <> Text.pack (show e),
+                      "The UCM server will not be restarted."
+                    ]
+              Right _ -> do
+                throwIO $ ErrorCall "The UCM server exited unexpectedly, it will not be restarted."
+      Async.withAsync runServer \serverHandle -> do
+        -- Wait until either the server has started or the server has failed to start, then proceed with the callback, passing the base URL if the server started, and Nothing otherwise.
+        UnliftIO.race (UnliftIO.wait serverHandle) (waitFor started) >>= \case
+          Left _ -> onStart Nothing
+          Right _ -> onStart (Just $ baseUrl p)
 
 serveIndex :: FilePath -> Handler RawHtml
 serveIndex path = do

--- a/unison-share-api/unison-share-api.cabal
+++ b/unison-share-api/unison-share-api.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -91,7 +91,6 @@ library
   build-depends:
       Diff
     , aeson >=2.0.0.0
-    , async
     , base
     , binary
     , bytes


### PR DESCRIPTION
## Overview

Fixes #5622 

<img width="1005" alt="image" src="https://github.com/user-attachments/assets/9bce5ecc-bb89-49a0-806a-3fb77e486907" />

## Implementation notes

* Don't crash UCM on port binding failures, print a note about it and carry on.
* Changes default stderr buffering to Line-buffering so messages don't get interleaved part-way through.
* Add a note when trying to open the `ui` when the codeserver isn't running.

## Test coverage

Tested the error case manually

