### PR TITLE
pin external github actions

### DIFF
--- a/.github/workflows/bundle-ucm.yaml
+++ b/.github/workflows/bundle-ucm.yaml
@@ -28,7 +28,7 @@ jobs:
         os: [ubuntu-24.04, macos-13, macos-14, windows-2019]
     runs-on: ${{matrix.os}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           ref: ${{inputs.ref}}
 
@@ -78,7 +78,7 @@ jobs:
           cache-prefix: release
 
       - name: upload ucm
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:
           name: unison-${{matrix.os}}
           path: ${{ env.ucm }}
@@ -104,11 +104,11 @@ jobs:
           esac
           echo "racket_arch=$racket_arch" >> $GITHUB_ENV
       - name: download racket `unison` source
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           ref: ${{inputs.ref}}
       - name: download ucm artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
         with:
           name: unison-${{matrix.os}}
           path: ${{ runner.temp }}
@@ -116,7 +116,7 @@ jobs:
         run: |
           chmod +x ${{ env.ucm }}
           ${{ env.ucm }} transcript unison-src/transcripts-manual/gen-racket-libs.md
-      - uses: Bogdanp/setup-racket@v1.11
+      - uses: Bogdanp/setup-racket@0094a9d8bd157633293a2210f373bb542687fa6d # v1.11
         with:
           architecture: ${{ env.racket_arch }}
           distribution: "full"
@@ -127,7 +127,7 @@ jobs:
           raco pkg create scheme-libs/racket/unison
           ls -l scheme-libs/racket/unison.zip{,.CHECKSUM}
       - name: upload racket lib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:
           name: racket-lib
           path: |
@@ -148,17 +148,17 @@ jobs:
           - windows-2019
     runs-on: ${{matrix.os}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           ref: ${{inputs.ref}}
       - name: download racket lib
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
         with:
           name: racket-lib
           path: scheme-libs/racket/
       - name: Cache Racket dependencies
         id: cache-racket-deps
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
         with:
           path: |
             ~/.cache/racket
@@ -177,7 +177,7 @@ jobs:
             *) echo "Unsupported architecture: ${{runner.arch}}"; exit 1 ;;
           esac
           echo "racket_arch=$racket_arch" >> $GITHUB_ENV
-      - uses: Bogdanp/setup-racket@v1.11
+      - uses: Bogdanp/setup-racket@0094a9d8bd157633293a2210f373bb542687fa6d # v1.11
         with:
           architecture: ${{ env.racket_arch }}
           distribution: "full"
@@ -200,7 +200,7 @@ jobs:
           raco distribute runtime scheme-libs/racket/unison-runtime$exe
           ls -l runtime/
       - name: upload unison-runtime
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:
           name: unison-runtime-${{matrix.os}}
           path: runtime/
@@ -222,19 +222,19 @@ jobs:
           echo "staging_dir=$staging_dir" >> $GITHUB_ENV
           echo "artifact_os=$artifact_os" >> $GITHUB_ENV
       - name: download ucm
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
         with:
           name: unison-${{matrix.os}}
           path: ${{env.staging_dir}}/unison/
       - name: restore permissions on ucm
         run: chmod +x ${{env.staging_dir}}/unison/unison
       - name: download racket lib
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
         with:
           name: racket-lib
           path: ${{env.staging_dir}}/racket/
       - name: download unison-runtime
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
         with:
           name: unison-runtime-${{matrix.os}}
           path: ${{env.staging_dir}}/runtime
@@ -251,7 +251,7 @@ jobs:
           unzip -d ${{env.staging_dir}}/ui /tmp/unisonLocal.zip
       - name: create startup script (non-Windows)
         if: runner.os != 'Windows'
-        uses: 1arp/create-a-file-action@0.4.4
+        uses: 1arp/create-a-file-action@29bab1af4675373aad48a2157c09f1917f85f008 # 0.4.4
         with:
           path: ${{env.staging_dir}}
           file: ucm
@@ -262,7 +262,7 @@ jobs:
             "${unison_root}/unison/unison" --runtime-path "${unison_root}/runtime/bin/unison-runtime" "$@"
       - name: create startup script (Windows)
         if: runner.os == 'Windows'
-        uses: 1arp/create-a-file-action@0.4.4
+        uses: 1arp/create-a-file-action@29bab1af4675373aad48a2157c09f1917f85f008 # 0.4.4
         with:
           path: ${{env.staging_dir}}
           file: ucm.cmd
@@ -282,7 +282,7 @@ jobs:
           fi
           echo "artifact_archive=${artifact_archive}" >> $GITHUB_ENV
       - name: upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:
           name: bundle-${{env.artifact_os}}
           path: ${{env.artifact_archive}}

--- a/.github/workflows/check-contributor.yaml
+++ b/.github/workflows/check-contributor.yaml
@@ -7,7 +7,7 @@ jobs:
   check-contributor:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
           sparse-checkout: CONTRIBUTORS.markdown
     - name: Look for @${{github.event.pull_request.user.login}} in CONTRIBUTORS.markdown

--- a/.github/workflows/ci-build-jit-binary.yaml
+++ b/.github/workflows/ci-build-jit-binary.yaml
@@ -45,26 +45,26 @@ jobs:
           echo "ucm=$ucm" >> $GITHUB_ENV
 
       - name: get workflow files, for checking hashes
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           sparse-checkout: .github
 
       - name: download jit source
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
         with:
           name: jit-source
           path: ${{ env.jit_src }}
 
       - name: cache/restore jit binaries
         id: cache-jit-binaries
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
         with:
           path: ${{ env.jit_dist }}
           key: jit-dist_${{matrix.os}}.racket_${{env.racket_version}}.jit-src_${{hashFiles(format('{0}/**/*.rkt',env.jit_src),format('{0}/**/*.ss',env.jit_src))}}.yaml_${{hashFiles('**/ci-build-jit-binary.yaml')}}
 
       - name: cache racket dependencies
         if: steps.cache-jit-binaries.outputs.cache-hit != 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
         with:
           path: |
             ~/.cache/racket
@@ -111,13 +111,13 @@ jobs:
 
       - name: cache/save jit binaries
         if: steps.cache-jit-binaries.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
         with:
           path: ${{ env.jit_dist }}
           key: jit-dist_${{matrix.os}}.racket_${{env.racket_version}}.jit-src_${{hashFiles(format('{0}/**/*.rkt',env.jit_src),format('{0}/**/*.ss',env.jit_src))}}.yaml_${{hashFiles('**/ci-build-jit-binary.yaml')}}
 
       - name: save jit binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:
           name: jit-binary-${{ matrix.os }}
           path: ${{ env.jit_dist }}/**

--- a/.github/workflows/ci-test-jit.yaml
+++ b/.github/workflows/ci-test-jit.yaml
@@ -51,7 +51,7 @@ jobs:
           echo "jit_dist_rel_exe=$jit_dist_rel_exe" >> $GITHUB_ENV
           echo "ucm=$ucm" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           sparse-checkout: |
             .github
@@ -60,7 +60,7 @@ jobs:
             unison-src/transcripts-using-base/serialized-cases/case-00.v4.ser
 
       - name: download jit binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
         with:
           name: jit-binary-${{ matrix.os }}
           path: ${{ env.jit_dist }}
@@ -71,13 +71,13 @@ jobs:
 
       - name: cache jit test results
         id: cache-jit-test-results
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
         with:
           path: ${{env.jit_test_results}}
           key: jit-test-results.dist-exe_${{ hashFiles(env.jit_dist_rel_exe) }}.tests_${{ env.runtime_tests_causalhash }}.yaml_${{ hashFiles('**/ci-test-jit.yaml') }}
 
       - name: install libb2 (linux)
-        uses: awalsh128/cache-apt-pkgs-action@5902b33ae29014e6ca012c5d8025d4346556bd40 #v1.4.3
+        uses: awalsh128/cache-apt-pkgs-action@5902b33ae29014e6ca012c5d8025d4346556bd40 # v1.4.3
         if: runner.os == 'Linux' && steps.cache-jit-test-results.outputs.cache-hit != 'true'
         with:
           packages: libb2-1
@@ -86,7 +86,7 @@ jobs:
       - name: cache testing codebase
         id: cache-testing-codebase
         if: steps.cache-jit-test-results.outputs.cache-hit != 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
         with:
           path: ${{ env.runtime_tests_codebase }}
           key: runtime-tests-codebase-${{ matrix.os }}-${{env.runtime_tests_causalhash}}
@@ -94,7 +94,7 @@ jobs:
 
       - name: download ucm
         if: steps.cache-jit-test-results.outputs.cache-hit != 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
         with:
           name: unison-${{ matrix.os }}
           path: ${{ runner.temp }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,23 +39,23 @@ jobs:
   ormolu:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Get changed files
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@2d756ea4c53f7f6b397767d8723b3a10a9f35bf2 # v44
         with:
           # globs copied from default settings for run-ormolu
           files: |
             **/*.hs
             **/*.hs-boot
           separator: "\n"
-      - uses: haskell-actions/run-ormolu@v15
+      - uses: haskell-actions/run-ormolu@15b0083a0ef416915994fb511652b187f6026a40 # v15
         with:
           version: ${{ env.ormolu_version }}
           mode: inplace
           pattern: ${{ steps.changed-files.outputs.all_changed_files }}
       - name: apply formatting changes
-        uses: stefanzweifel/git-auto-commit-action@v5
-        # Only try to commit formatting changes if we're running within the repo containing the PR,
+        uses: stefanzweifel/git-auto-commit-action@e348103e9026cc0eee72ae06630dbe30c8bf7a79
+        # v5
         # and not on a protected branch.
         # The job doesn't have permission to push back to contributor forks on contributor PRs.
         if: |
@@ -78,7 +78,7 @@ jobs:
           - windows-2019
           # - windows-2022
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: tweak environment
         id: tweak-environment
@@ -96,7 +96,7 @@ jobs:
 
       - name: cache ucm binaries
         id: cache-ucm-binaries
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
         with:
           path: ${{env.ucm_local_bin}}
           key: ucm-${{ matrix.os }}-${{ hashFiles('**/stack.yaml', '**/package.yaml', '**/*.hs', '**/unison-cli-integration/integrationtests/IntegrationTests/*')}}
@@ -195,7 +195,7 @@ jobs:
         run: echo | stack ghci
 
       - name: save ucm artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:
           name: unison-${{ matrix.os }}
           path: ${{ env.ucm }}
@@ -225,7 +225,7 @@ jobs:
           - windows-2019
           # - windows-2022
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: tweak environment
         run: |
           transcript_test_results="${RUNNER_TEMP//\\//}/${transcript_test_results}"
@@ -244,12 +244,12 @@ jobs:
 
       - name: cache transcript test results
         id: cache-transcript-test-results
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
         with:
           path: ${{env.transcript_test_results}}
           key: transcripts-results-${{ matrix.os }}-${{ hashFiles('**/stack.yaml', '**/package.yaml', '**/*.hs')}}-${{ hashFiles('**/unison-src/**/*.md', '**/unison-src/**/*.u') }}
       - name: restore binaries
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
         if: steps.cache-transcript-test-results.outputs.cache-hit != 'true'
         with:
           path: ${{env.ucm_local_bin}}
@@ -308,7 +308,7 @@ jobs:
           # - windows-2019
           # - windows-2022
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: tweak environment
         run: |
           interpreter_test_results="${RUNNER_TEMP//\\//}/${interpreter_test_results}"
@@ -328,20 +328,20 @@ jobs:
         run: echo "runtime_tests_causalhash=$(scripts/get-share-hash.sh ${{env.runtime_tests_version}})" >> $GITHUB_ENV
       - name: cache interpreter test results
         id: cache-interpreter-test-results
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
         with:
           path: ${{env.interpreter_test_results}}
           key: interpreter-test-results-${{ matrix.os }}-${{ hashFiles('**/stack.yaml', '**/package.yaml', '**/*.hs')}}-${{ hashFiles('**/interpreter-tests.tpl.md') }}-${{env.runtime_tests_causalhash}}
       - name: cache testing codebase
         id: cache-testing-codebase
         if: steps.cache-interpreter-test-results.outputs.cache-hit != 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
         with:
           path: ${{ env.runtime_tests_codebase }}
           key: runtime-tests-codebase-${{env.runtime_tests_causalhash}}
           restore-keys: runtime-tests-codebase-
       - name: restore binaries
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
         if: steps.cache-interpreter-test-results.outputs.cache-hit != 'true'
         with:
           path: ${{env.ucm_local_bin}}
@@ -374,14 +374,14 @@ jobs:
           echo "jit_src_scheme=${{ runner.temp }}/${{ env.jit_src_scheme }}" >> $GITHUB_ENV
           echo "ucm=${{ runner.temp }}/unison" >> $GITHUB_ENV
       - name: download scheme-libs
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           sparse-checkout: |
             scripts/get-share-hash.sh
             scheme-libs
       - name: look up hash for jit source generator
         run: echo "jit_causalhash=$(scripts/get-share-hash.sh ${{env.jit_version}})" >> $GITHUB_ENV
-      - uses: actions/cache@v4
+      - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
         name: cache auto-generated jit source
         id: cache-generated-source
         with:
@@ -389,7 +389,7 @@ jobs:
           key: jit_generated_src_scheme-jit_${{env.jit_version}}-${{env.jit_causalhash}}
       - name: create transcript
         if: steps.cache-generated-source.outputs.cache-hit != 'true'
-        uses: DamianReeves/write-file-action@v1.3
+        uses: DamianReeves/write-file-action@6929a9a6d1807689191dcc8bbe62b54d70a32b42 # v1.3
         with:
           path: ${{ runner.temp }}/setup-jit.md
           write-mode: overwrite
@@ -406,7 +406,7 @@ jobs:
             ```
       - name: download ucm artifact
         if: steps.cache-generated-source.outputs.cache-hit != 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
         with:
           name: unison-${{ env.jit_generator_os }}
           path: ${{ runner.temp }}
@@ -426,7 +426,7 @@ jobs:
           cp -R "${{ env.jit_generated_src_scheme }}"/* ${{ env.jit_src_scheme }}
       - name: save jit source
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:
           name: jit-source
           path: ${{ env.jit_src_scheme }}/**

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,14 +40,14 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      # - name: Get changed files
-      #   uses:
-      #   with:
-      #     # globs copied from default settings for run-ormolu
-      #     files: |
-      #       **/*.hs
-      #       **/*.hs-boot
-      #     separator: "\n"
+      - name: Get changed files
+        uses: tj-actions/changed-files@v44
+        with:
+          # globs copied from default settings for run-ormolu
+          files: |
+            **/*.hs
+            **/*.hs-boot
+          separator: "\n"
       - uses: haskell-actions/run-ormolu@v15
         with:
           version: ${{ env.ormolu_version }}

--- a/.github/workflows/haddocks.yaml
+++ b/.github/workflows/haddocks.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Haddocks
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           path: unison
 
@@ -42,7 +42,7 @@ jobs:
 
       # Haddocks
       - name: Checkout haddocks branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           ref: haddocks
           path: haddocks

--- a/.github/workflows/nix-dev-cache.yaml
+++ b/.github/workflows/nix-dev-cache.yaml
@@ -24,22 +24,22 @@ jobs:
           - macos-13
           # - macos-14
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: mount Nix store on larger partition
       # on the Linux runner `/` doesn't have enough space, but there's a `/mnt` which does.
       if: runner.os == 'Linux'
       run: |
         sudo mkdir /nix /mnt/nix
         sudo mount --bind /mnt/nix /nix
-    - uses: cachix/install-nix-action@v27
+    - uses: cachix/install-nix-action@ba0dd844c9180cbf77aa72a116d6fbc515d0e87b # v27
       if: runner.os == 'Linux'
       with:
         extra_nix_config: |
           extra-trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
           extra-substituters = https://cache.iog.io
-    - uses: cachix/install-nix-action@v27
+    - uses: cachix/install-nix-action@ba0dd844c9180cbf77aa72a116d6fbc515d0e87b # v27
       if: runner.os != 'Linux'
-    - uses: cachix/cachix-action@v15
+    - uses: cachix/cachix-action@ad2ddac53f961de1989924296a1f236fcfbaa4fc # v15
       with:
         name: unison
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'

--- a/.github/workflows/ormolu.yaml
+++ b/.github/workflows/ormolu.yaml
@@ -13,13 +13,13 @@ jobs:
   ormolu:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: haskell-actions/run-ormolu@v15
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: haskell-actions/run-ormolu@15b0083a0ef416915994fb511652b187f6026a40 # v15
         with:
           version: ${{ env.ormolu_version }}
           mode: inplace
       - name: create pull request with formatting changes
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           commit-message: automatically run ormolu
           branch: autoformat/${{github.ref_name}}

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -34,14 +34,14 @@ jobs:
         run: mkdir /tmp/ucm
 
       - name: "download artifacts"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
         with:
           path: /tmp/ucm
 
       - name: derive release tag
         run: echo "ref_name=$(echo ${{ github.ref_name }} | awk -F'/' '{print $NF}')" >> $GITHUB_ENV
 
-      - uses: "marvinpinto/action-automatic-releases@latest"
+      - uses: "marvinpinto/action-automatic-releases@d68defdd11f9dcc7f52f35c1b7c236ee7513bcc1" # latest
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: ${{ env.ref_name }}-build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
         run: mkdir /tmp/ucm
 
       - name: "download artifacts"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
         with:
           path: /tmp/ucm
 

--- a/.github/workflows/update-transcripts.yaml
+++ b/.github/workflows/update-transcripts.yaml
@@ -14,7 +14,7 @@ jobs:
         os:
           - macos-13
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: unisonweb/actions/stack/cache/restore@main
         with:
           # take cache from the ci job, read-only
@@ -42,6 +42,6 @@ jobs:
         run: |
           stack exec unison transcript unison-src/transcripts-manual/docs.to-html.md
       - name: save transcript changes
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@e348103e9026cc0eee72ae06630dbe30c8bf7a79 # v5
         with:
           commit_message: rerun transcripts (reminder to rerun CI!)


### PR DESCRIPTION
## Overview

This reverts commit 8ebcd2d (which had disabled `tj-actions/changed-files`) and pins the rest of the external workflow dependencies.

see https://www.wiz.io/blog/github-action-tj-actions-changed-files-supply-chain-attack-cve-2025-30066

## Implementation notes

I pinned everything except `unisonweb/actions`. So don't hack that.

I used `https://github.com/mheap/pin-github-action` to automatically modify the files.

`pin-github-action <paths> --allow=unisonweb/actions`

## Interesting/controversial decisions

I debated leaving `github/actions` unpinned for convenience, but whatever.

## Test coverage

Like most CI stuff, we have to test it in CI.

## Loose ends