### PR TITLE
tweak: dont enqueue filesystem events

### DIFF
--- a/unison-cli/package.yaml
+++ b/unison-cli/package.yaml
@@ -27,7 +27,6 @@ library:
     - aeson >= 2.0.0.0
     - aeson-pretty
     - ansi-terminal
-    - async
     - bytestring
     - cmark
     - co-log-core

--- a/unison-cli/src/Unison/Codebase/Watch.hs
+++ b/unison-cli/src/Unison/Codebase/Watch.hs
@@ -1,153 +1,99 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE TypeApplications #-}
-
-module Unison.Codebase.Watch where
-
-import Control.Concurrent
-  ( forkIO,
-    killThread,
-    threadDelay,
+module Unison.Codebase.Watch
+  ( watchDirectory,
   )
+where
+
+import Control.Concurrent (threadDelay)
 import Control.Concurrent.STM qualified as STM
+import Control.Exception (MaskingState (..))
+import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.Map qualified as Map
-import Data.Time.Clock
-  ( UTCTime,
-    diffUTCTime,
-  )
+import Data.Time.Clock (UTCTime, diffUTCTime)
+import GHC.Conc (registerDelay)
+import GHC.IO (unsafeUnmask)
+import Ki qualified
 import System.FSNotify (Event (Added, Modified))
 import System.FSNotify qualified as FSNotify
 import Unison.Prelude
-import Unison.Util.TQueue (TQueue)
-import Unison.Util.TQueue qualified as TQueue
-import UnliftIO.Exception (catch)
-import UnliftIO.IORef
-  ( newIORef,
-    readIORef,
-    writeIORef,
-  )
-import UnliftIO.MVar
-  ( newEmptyMVar,
-    putMVar,
-    takeMVar,
-    tryPutMVar,
-    tryTakeMVar,
-  )
+import UnliftIO.Exception (finally, tryAny)
 import UnliftIO.STM (atomically)
 
-untilJust :: (Monad m) => m (Maybe a) -> m a
-untilJust act = act >>= maybe (untilJust act) return
+watchDirectory :: Ki.Scope -> FSNotify.WatchManager -> FilePath -> (FilePath -> Bool) -> IO (IO (FilePath, Text))
+watchDirectory scope mgr dir allow = do
+  eventQueue <- forkDirWatcherThread scope mgr dir allow
 
-watchDirectory' ::
-  forall m. (MonadIO m) => FilePath -> m (IO (), IO (FilePath, UTCTime))
-watchDirectory' d = do
-  mvar <- newEmptyMVar
+  -- Await an event from the event queue with the following simple debounce logic, which is intended to work around the
+  -- tendency for modern editors to create a flurry of rapid filesystem events when a file is saved:
+  --
+  -- 1. Block until an event arrives.
+  -- 2. Keep consuming events until 50ms elapse without an event.
+  -- 3. Return only the last event.
+  --
+  -- Note we don't have any smarts here for a flurry of events that are related to more than one file; we just throw
+  -- everything away except the last event. In practice, this has seemed to work fine.
+  let awaitEvent0 :: IO (FilePath, UTCTime)
+      awaitEvent0 = do
+        let go :: (FilePath, UTCTime) -> IO (FilePath, UTCTime)
+            go event0 = do
+              var <- registerDelay 50_000
+              (join . atomically . asum)
+                [ do
+                    event1 <- STM.readTQueue eventQueue
+                    pure (go event1),
+                  do
+                    STM.readTVar var >>= STM.check
+                    pure (pure event0)
+                ]
+        event <- atomically (STM.readTQueue eventQueue)
+        go event
+
+  -- Enhance the previous "await event" action with a small file cache that serves as a second debounce implementation.
+  -- We keep in memory the file contents of previously-saved files, so that we can avoid emitting events for files that
+  -- last changed less than 500ms ago, and whose contents haven't changed.
+  previousFilesRef <- newIORef Map.empty
+  let awaitEvent1 :: IO (FilePath, Text)
+      awaitEvent1 = do
+        (file, t) <- awaitEvent0
+        tryAny (readUtf8 file) >>= \case
+          -- Somewhat-expected read error from a file that was just written. Just ignore the event and try again.
+          Left _ -> awaitEvent1
+          Right contents -> do
+            previousFiles <- readIORef previousFilesRef
+            case Map.lookup file previousFiles of
+              Just (contents0, t0) | contents == contents0 && (t `diffUTCTime` t0) < 0.5 -> awaitEvent1
+              _ -> do
+                writeIORef previousFilesRef $! Map.insert file (contents, t) previousFiles
+                pure (file, contents)
+
+  -- Enhance the previous "await" event action by first clearing the whole event queue (tossing old filesystem events
+  -- we may have accumulated while e.g. running a long-running IO action), and *then* waiting.
+  let awaitEvent2 :: IO (FilePath, Text)
+      awaitEvent2 = do
+        _ <- STM.atomically (STM.flushTQueue eventQueue)
+        awaitEvent1
+
+  pure awaitEvent2
+
+-- | `forkDirWatcherThread scope mgr dir allow` forks a background thread into `scope` that, using "file watcher
+-- manager" `mgr` (just a boilerplate argument the caller is responsible for creating), watches directory `dir` for
+-- all "added" and "modified" filesystem events that occur on files that pass the `allow` predicate. It returns a queue
+-- of such event that is (obviously) meant to be read or flushed, never written.
+forkDirWatcherThread :: Ki.Scope -> FSNotify.WatchManager -> FilePath -> (FilePath -> Bool) -> IO (STM.TQueue (FilePath, UTCTime))
+forkDirWatcherThread scope mgr dir allow = do
+  queue <- STM.newTQueueIO
+
   let handler :: Event -> IO ()
-      handler e = case e of
-        Added fp t FSNotify.IsFile -> doIt fp t
-        Modified fp t FSNotify.IsFile -> doIt fp t
+      handler = \case
+        Added fp t FSNotify.IsFile | allow fp -> atomically (STM.writeTQueue queue (fp, t))
+        Modified fp t FSNotify.IsFile | allow fp -> atomically (STM.writeTQueue queue (fp, t))
         _ -> pure ()
-        where
-          doIt fp t = do
-            _ <- tryTakeMVar mvar
-            putMVar mvar (fp, t)
-  -- janky: used to store the cancellation action returned
-  -- by `watchDir`, which is created asynchronously
-  cleanupRef <- newEmptyMVar
-  -- we don't like FSNotify's debouncing (it seems to drop later events)
-  -- so we will be doing our own instead
-  let config = FSNotify.defaultConfig
-  cancel <- liftIO $
-    forkIO $
-      FSNotify.withManagerConf config $ \mgr -> do
-        cancelInner <- FSNotify.watchDir mgr d (const True) handler <|> (pure (pure ()))
-        putMVar cleanupRef $ liftIO cancelInner
-        forever $ threadDelay 1000000
-  let cleanup :: IO ()
-      cleanup = join (takeMVar cleanupRef) >> killThread cancel
-  pure (cleanup, takeMVar mvar)
 
-collectUntilPause :: forall a. TQueue a -> Int -> IO [a]
-collectUntilPause queue minPauseµsec = do
-  -- 1. wait for at least one element in the queue
-  void . atomically $ TQueue.peek queue
+  -- A bit of a "one too many threads" situation but there's not much we can easily do about it. The `fsnotify` API
+  -- doesn't expose any synchronous API; the only option is to fork a background thread with a callback. So, we spawn
+  -- a thread that spawns *that* thread, then waits forever. The purpose here is to simply leverage `ki` exception
+  -- propagation machinery to ensure that the `fsnotify` thread is properly cleaned up.
+  Ki.forkWith_ scope Ki.defaultThreadOptions {Ki.maskingState = MaskedUninterruptible} do
+    stopListening <- FSNotify.watchDir mgr dir (const True) handler <|> pure (pure ())
+    unsafeUnmask (forever (threadDelay maxBound)) `finally` stopListening
 
-  let go :: IO [a]
-      go = do
-        before <- atomically $ TQueue.enqueueCount queue
-        threadDelay minPauseµsec
-        after <- atomically $ TQueue.enqueueCount queue
-        -- if nothing new is on the queue, then return the contents
-        if before == after
-          then atomically $ TQueue.flush queue
-          else go
-  go
-
-watchDirectory ::
-  forall m.
-  (MonadIO m) =>
-  FilePath ->
-  (FilePath -> Bool) ->
-  m (IO (), IO (FilePath, Text))
-watchDirectory dir allow = do
-  previousFiles <- newIORef Map.empty
-  (cancelWatch, watcher) <- watchDirectory' dir
-  let process :: FilePath -> UTCTime -> IO (Maybe (FilePath, Text))
-      process file t =
-        if allow file
-          then
-            let handle :: IOException -> IO ()
-                handle _e =
-                  -- Sometimes we notice a change and try to read a file while it's being written.
-                  -- This typically occurs when UCM is writing to the scratch file and can be
-                  -- ignored anyways.
-                  pure ()
-                go :: IO (Maybe (FilePath, Text))
-                go = liftIO $ do
-                  contents <- readUtf8 file
-                  prevs <- readIORef previousFiles
-                  case Map.lookup file prevs of
-                    -- if the file's content's haven't changed and less than .5s
-                    -- have elapsed, wait for the next update
-                    Just (contents0, t0)
-                      | contents == contents0 && (t `diffUTCTime` t0) < 0.5 ->
-                          return Nothing
-                    _ ->
-                      Just (file, contents)
-                        <$ writeIORef previousFiles (Map.insert file (contents, t) prevs)
-             in catch go (\e -> Nothing <$ handle e)
-          else return Nothing
-  queue <- TQueue.newIO
-  gate <- liftIO newEmptyMVar
-  -- We spawn a separate thread to siphon the file change events
-  -- into a queue, which can be debounced using `collectUntilPause`
-  enqueuer <- liftIO . forkIO $ do
-    takeMVar gate -- wait until gate open before starting
-    forever $ do
-      event@(file, _) <- watcher
-      when (allow file) $
-        STM.atomically $
-          TQueue.enqueue queue event
-  pending <- newIORef []
-  let await :: IO (FilePath, Text)
-      await =
-        untilJust $
-          readIORef pending >>= \case
-            [] -> do
-              -- open the gate
-              tryPutMVar gate ()
-              -- this debounces the events, waits for 50ms pause
-              -- in file change events
-              events <- collectUntilPause queue 50000
-              -- traceM $ "Collected file change events" <> show events
-              case events of
-                [] -> pure Nothing
-                -- we pick the last of the events within the 50ms window
-                -- TODO: consider enqueing other events if there are
-                -- multiple events for different files
-                _ -> uncurry process $ last events
-            ((file, t) : rest) -> do
-              writeIORef pending rest
-              process file t
-      cancel = cancelWatch >> killThread enqueuer
-  pure (cancel, await)
+  pure queue

--- a/unison-cli/src/Unison/Codebase/Watch.hs
+++ b/unison-cli/src/Unison/Codebase/Watch.hs
@@ -93,7 +93,11 @@ forkDirWatcherThread scope mgr dir allow = do
   -- a thread that spawns *that* thread, then waits forever. The purpose here is to simply leverage `ki` exception
   -- propagation machinery to ensure that the `fsnotify` thread is properly cleaned up.
   Ki.forkWith_ scope Ki.defaultThreadOptions {Ki.maskingState = MaskedUninterruptible} do
-    stopListening <- FSNotify.watchDir mgr dir (const True) handler <|> pure (pure ())
+    -- The goal here is to prevent spawning this background watching thread before installing an exception handler that
+    -- guarantees it's killed. Unfortunately the fsnotify API doesn't seem to make that possible (hence the first
+    -- `unsafeUnmask` here), since we do need the thread *it* spawns to be killable, and (at least as of version
+    -- 0.4.2.0) they don't take care to guarantee that; it just inherits the masking state.
+    stopListening <- unsafeUnmask (FSNotify.watchDir mgr dir (const True) handler) <|> pure (pure ())
     unsafeUnmask (forever (threadDelay maxBound)) `finally` stopListening
 
   pure queue

--- a/unison-cli/src/Unison/CommandLine.hs
+++ b/unison-cli/src/Unison/CommandLine.hs
@@ -10,11 +10,9 @@ module Unison.CommandLine
     parseInput,
     prompt,
     reportParseFailure,
-    watchFileSystem,
   )
 where
 
-import Control.Concurrent (forkIO, killThread)
 import Control.Lens hiding (aside)
 import Control.Monad.Except
 import Control.Monad.Trans.Except
@@ -31,11 +29,10 @@ import Text.Regex.TDFA ((=~))
 import Unison.Codebase (Codebase)
 import Unison.Codebase.Branch (Branch0)
 import Unison.Codebase.Branch qualified as Branch
-import Unison.Codebase.Editor.Input (Event (..), Input (..))
+import Unison.Codebase.Editor.Input (Input (..))
 import Unison.Codebase.Editor.Output (NumberedArgs)
 import Unison.Codebase.Editor.StructuredArgument (StructuredArgument)
 import Unison.Codebase.ProjectPath qualified as PP
-import Unison.Codebase.Watch qualified as Watch
 import Unison.CommandLine.FZFResolvers qualified as FZFResolvers
 import Unison.CommandLine.FuzzySelect qualified as Fuzzy
 import Unison.CommandLine.Helpers (warn)
@@ -46,8 +43,6 @@ import Unison.Parser.Ann (Ann)
 import Unison.Prelude
 import Unison.Symbol (Symbol)
 import Unison.Util.Pretty qualified as P
-import Unison.Util.TQueue qualified as Q
-import UnliftIO.STM
 import Prelude hiding (readFile, writeFile)
 
 allow :: FilePath -> Bool
@@ -55,14 +50,6 @@ allow p =
   -- ignore Emacs .# prefixed files, see https://github.com/unisonweb/unison/issues/457
   not (".#" `isPrefixOf` takeFileName p)
     && (isSuffixOf ".u" p || isSuffixOf ".uu" p)
-
-watchFileSystem :: Q.TQueue Event -> FilePath -> IO (IO ())
-watchFileSystem q dir = do
-  (cancel, watcher) <- Watch.watchDirectory dir allow
-  t <- forkIO . forever $ do
-    (filePath, text) <- watcher
-    atomically . Q.enqueue q $ UnisonFileChanged (Text.pack filePath) text
-  pure (cancel >> killThread t)
 
 data ExpansionFailure
   = TooManyArguments (NonEmpty InputPattern.Argument)

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -303,25 +303,27 @@ main dir welcome ppIds initialInputs runtime sbRuntime nRuntime codebase serverB
               -- typechecking, they are not likely to be trying to input things into the prompt nor trying to typecheck
               -- a different file.
               let stepEvent :: Event -> IO (Cli.ReturnType (), Cli.LoopState)
-                  stepEvent event@(UnisonFileChanged file contents) =
-                    Ki.scoped \scope -> do
-                      handleEventThread <- Ki.fork scope (stepInput (Left event))
-                      fileEventThread <-
-                        Ki.fork scope do
-                          let loop =
-                                awaitFileEvent >>= \case
-                                  event2@(UnisonFileChanged file2 contents2)
-                                    | file2 == file && contents /= contents2 -> pure event2
-                                  _ -> loop
-                          loop
-                      (join . atomically . asum)
-                        [ do
-                            result <- Ki.await handleEventThread
-                            pure (pure result),
-                          do
-                            event2 <- Ki.await fileEventThread
-                            pure (stepEvent event2)
-                        ]
+                  stepEvent event@(UnisonFileChanged file contents) = do
+                    action <-
+                      Ki.scoped \scope -> do
+                        handleEventThread <- Ki.fork scope (stepInput (Left event))
+                        fileEventThread <-
+                          Ki.fork scope do
+                            let loop =
+                                  awaitFileEvent >>= \case
+                                    event2@(UnisonFileChanged file2 contents2)
+                                      | file2 == file && contents /= contents2 -> pure event2
+                                    _ -> loop
+                            loop
+                        (atomically . asum)
+                          [ do
+                              result <- Ki.await handleEventThread
+                              pure (pure result),
+                            do
+                              event2 <- Ki.await fileEventThread
+                              pure (stepEvent event2)
+                          ]
+                    action
 
               let step :: IO (Cli.ReturnType (), Cli.LoopState)
                   step = do

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -4,6 +4,7 @@ module Unison.CommandLine.Main
 where
 
 import Compat (withInterruptHandler)
+import Control.Concurrent qualified as Concurrent
 import Control.Concurrent.Async qualified as Async
 import Control.Exception (catch, displayException, finally, mask)
 import Control.Lens ((?~))
@@ -31,11 +32,12 @@ import Unison.Codebase (Codebase)
 import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Branch (Branch)
 import Unison.Codebase.Editor.HandleInput qualified as HandleInput
-import Unison.Codebase.Editor.Input (Event, Input (..))
+import Unison.Codebase.Editor.Input (Event (UnisonFileChanged), Input (..))
 import Unison.Codebase.Editor.Output (NumberedArgs, Output)
 import Unison.Codebase.Editor.UCMVersion (UCMVersion)
 import Unison.Codebase.ProjectPath qualified as PP
 import Unison.Codebase.Runtime qualified as Runtime
+import Unison.Codebase.Watch qualified as Watch
 import Unison.CommandLine
 import Unison.CommandLine.Completion (haskelineTabComplete)
 import Unison.CommandLine.InputPatterns qualified as IP
@@ -158,9 +160,16 @@ main dir welcome ppIds initialInputs runtime sbRuntime nRuntime codebase serverB
   eventQueue <- Q.newIO
   initialInputsRef <- newIORef $ Welcome.run welcome ++ initialInputs
   pageOutput <- newIORef True
-  cancelFileSystemWatch <- case shouldWatchFiles of
-    ShouldNotWatchFiles -> pure (pure ())
-    ShouldWatchFiles -> watchFileSystem eventQueue dir
+  cancelFileSystemWatch <-
+    case shouldWatchFiles of
+      ShouldNotWatchFiles -> pure (pure ())
+      ShouldWatchFiles -> do
+        (cancel, watcher) <- Watch.watchDirectory dir allow
+        t <- Concurrent.forkIO . forever $ do
+          (filePath, text) <- watcher
+          atomically . Q.enqueue eventQueue $ UnisonFileChanged (Text.pack filePath) text
+        pure (cancel >> Concurrent.killThread t)
+
   credentialManager <- newCredentialManager
   let tokenProvider = AuthN.newTokenProvider credentialManager
   authHTTPClient <- AuthN.newAuthenticatedHTTPClient tokenProvider ucmVersion

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -159,16 +159,19 @@ main dir welcome ppIds initialInputs runtime sbRuntime nRuntime codebase serverB
       _ <- Ki.fork scope (IO.evaluate IOSource.typecheckedFile)
       -- Fork the file watcher thread, which returns an IO action we can call to get one filesystem event (automatically
       -- first tossing all that have accumulated since the last call)
-      awaitFileEvent <-
-        Watch.watchDirectory
-          scope
-          mgr
-          dir
-          -- We could elect to not spawn a file-watching thread at all if --no-file-watch is passed to ucm, but that
-          -- is an extremely uncommon option, this isn't super inefficient, and this makes the types simpler.
-          case shouldWatchFiles of
-            ShouldNotWatchFiles -> const False
-            ShouldWatchFiles -> allow
+      awaitFileEvent <- do
+        (fmap . fmap)
+          (\(file, contents) -> UnisonFileChanged (Text.pack file) contents)
+          ( Watch.watchDirectory
+              scope
+              mgr
+              dir
+              -- We could elect to not spawn a file-watching thread at all if --no-file-watch is passed to ucm, but that
+              -- is an extremely uncommon option, this isn't super inefficient, and this makes the types simpler.
+              case shouldWatchFiles of
+                ShouldNotWatchFiles -> const False
+                ShouldWatchFiles -> allow
+          )
 
       let initialState = Cli.loopState0 ppIds
       initialInputsRef <- newIORef $ Welcome.run welcome ++ initialInputs
@@ -229,10 +232,10 @@ main dir welcome ppIds initialInputs runtime sbRuntime nRuntime codebase serverB
                     userInputThread <- Ki.fork scope (getInput loopState)
                     (atomically . asum)
                       [ do
-                          (file, contents) <- Ki.await fileEventThread
+                          event <- Ki.await fileEventThread
                           pure do
                             writeIORef pageOutput False
-                            pure (Left (UnisonFileChanged (Text.pack file) contents)),
+                            pure (Left event),
                         do
                           input <- Ki.await userInputThread
                           pure (pure (Right input))
@@ -275,9 +278,58 @@ main dir welcome ppIds initialInputs runtime sbRuntime nRuntime codebase serverB
         -- Handle inputs until @HaltRepl@, staying in the loop on Ctrl+C or synchronous exception.
         let loop0 :: Cli.LoopState -> IO ()
             loop0 s0 = do
-              let step = do
+              let stepInput :: Either Event Input -> IO (Cli.ReturnType (), Cli.LoopState)
+                  stepInput input =
+                    Cli.runCli env s0 (HandleInput.loop input)
+
+              -- We want to handle file-change events in a way that allow interruption by other file-change events for
+              -- the same file. The idea here is that, if we're (say) typechecking a big file any edits made in the
+              -- meantime should cause the typecheck to be canceled and started anew.
+              --
+              -- This does raise the question: what do we do with both of the following, which we could receive while
+              -- handling a file-change event?
+              --
+              --   1. File-change events for a different .u file than the one we're processing.
+              --   2. User input (i.e. they're typing stuff into the prompt against the flow of typechecking output).
+              --
+              -- Our answers:
+              --
+              --   1. Throw these away.
+              --   2. Don't even try to read these, so they'll buffer and be handled later.
+              --
+              -- This simplifies the implementation and avoids doing weird stuff like handling file-change events that
+              -- were made against a arbitrarily different loop state than the one resulting from the handling of the
+              -- first file-change event. Users are unlikely to even notice these details, as while one file is
+              -- typechecking, they are not likely to be trying to input things into the prompt nor trying to typecheck
+              -- a different file.
+              let stepEvent :: Event -> IO (Cli.ReturnType (), Cli.LoopState)
+                  stepEvent event@(UnisonFileChanged file contents) =
+                    Ki.scoped \scope -> do
+                      handleEventThread <- Ki.fork scope (stepInput (Left event))
+                      fileEventThread <-
+                        Ki.fork scope do
+                          let loop =
+                                awaitFileEvent >>= \case
+                                  event2@(UnisonFileChanged file2 contents2)
+                                    | file2 == file && contents /= contents2 -> pure event2
+                                  _ -> loop
+                          loop
+                      (join . atomically . asum)
+                        [ do
+                            result <- Ki.await handleEventThread
+                            pure (pure result),
+                          do
+                            event2 <- Ki.await fileEventThread
+                            pure (stepEvent event2)
+                        ]
+
+              let step :: IO (Cli.ReturnType (), Cli.LoopState)
+                  step = do
                     input <- awaitInput s0
-                    (!result, resultState) <- Cli.runCli env s0 (HandleInput.loop input)
+                    (!result, resultState) <-
+                      case input of
+                        Left event -> stepEvent event
+                        Right _ -> stepInput input
                     let sNext = case input of
                           Left _ -> resultState
                           Right inp -> resultState & #lastInput ?~ inp

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -4,7 +4,7 @@ module Unison.CommandLine.Main
 where
 
 import Compat (withInterruptHandler)
-import Control.Exception (catch, displayException, finally, mask)
+import Control.Exception (catch, displayException, mask)
 import Control.Lens ((?~))
 import Control.Lens.Lens
 import Crypto.Random qualified as Random
@@ -216,9 +216,7 @@ main dir welcome ppIds initialInputs runtime sbRuntime nRuntime codebase serverB
                         (putPrettyLnUnpaged o)
                   )
 
-      let cleanup :: IO ()
-          cleanup = pure ()
-          awaitInput :: Cli.LoopState -> IO (Either Event Input)
+      let awaitInput :: Cli.LoopState -> IO (Either Event Input)
           awaitInput loopState = do
             -- use up buffered input before consulting external events
             readIORef initialInputsRef >>= \case
@@ -299,7 +297,7 @@ main dir welcome ppIds initialInputs runtime sbRuntime nRuntime codebase serverB
                     Cli.Continue -> loop0 s1
                     Cli.HaltRepl -> pure ()
 
-        withInterruptHandler onInterrupt (loop0 initialState `finally` cleanup)
+        withInterruptHandler onInterrupt (loop0 initialState)
 
 -- | Installs a posix interrupt handler for catching SIGINT.
 -- This replaces GHC's default sigint handler which throws a UserInterrupt async exception

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -4,8 +4,6 @@ module Unison.CommandLine.Main
 where
 
 import Compat (withInterruptHandler)
-import Control.Concurrent qualified as Concurrent
-import Control.Concurrent.Async qualified as Async
 import Control.Exception (catch, displayException, finally, mask)
 import Control.Lens ((?~))
 import Control.Lens.Lens
@@ -15,10 +13,12 @@ import Data.List.NonEmpty qualified as NEL
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Text qualified as Text
 import Data.Text.IO qualified as Text
+import GHC.IO qualified as IO
 import Ki qualified
 import System.Console.Haskeline (Settings (autoAddHistory))
 import System.Console.Haskeline qualified as Line
 import System.Console.Haskeline.History qualified as Line
+import System.FSNotify qualified as FSNotify
 import System.IO (hGetEcho, hPutStrLn, hSetEcho, stderr, stdin)
 import System.IO.Error (isDoesNotExistError)
 import Unison.Auth.CredentialManager (newCredentialManager)
@@ -54,7 +54,6 @@ import Unison.Share.Codeserver qualified as Codeserver
 import Unison.Symbol (Symbol)
 import Unison.Syntax.Parser qualified as Parser
 import Unison.Util.Pretty qualified as P
-import Unison.Util.TQueue qualified as Q
 import UnliftIO qualified
 import UnliftIO.Directory qualified as Directory
 import UnliftIO.STM
@@ -148,147 +147,159 @@ main ::
   (PP.ProjectPathIds -> IO ()) ->
   ShouldWatchFiles ->
   IO ()
-main dir welcome ppIds initialInputs runtime sbRuntime nRuntime codebase serverBaseUrl ucmVersion lspCheckForChanges shouldWatchFiles = Ki.scoped \scope -> do
-  _ <- Ki.fork scope do
-    -- Pre-load the project root in the background so it'll be ready when a command needs it.
-    projectRoot <- Codebase.expectProjectBranchRoot codebase ppIds.project ppIds.branch
-    -- Start forcing thunks in a background thread.
-    UnliftIO.concurrently_
-      (UnliftIO.evaluate projectRoot)
-      (UnliftIO.evaluate IOSource.typecheckedFile) -- IOSource takes a while to compile, we should start compiling it on startup
-  let initialState = Cli.loopState0 ppIds
-  eventQueue <- Q.newIO
-  initialInputsRef <- newIORef $ Welcome.run welcome ++ initialInputs
-  pageOutput <- newIORef True
-  cancelFileSystemWatch <-
-    case shouldWatchFiles of
-      ShouldNotWatchFiles -> pure (pure ())
-      ShouldWatchFiles -> do
-        (cancel, watcher) <- Watch.watchDirectory dir allow
-        t <- Concurrent.forkIO . forever $ do
-          (filePath, text) <- watcher
-          atomically . Q.enqueue eventQueue $ UnisonFileChanged (Text.pack filePath) text
-        pure (cancel >> Concurrent.killThread t)
+main dir welcome ppIds initialInputs runtime sbRuntime nRuntime codebase serverBaseUrl ucmVersion lspCheckForChanges shouldWatchFiles = do
+  -- we don't like FSNotify's debouncing (it seems to drop later events)
+  -- so we will be doing our own instead
+  let config = FSNotify.defaultConfig
+  FSNotify.withManagerConf config \mgr -> do
+    Ki.scoped \scope -> do
+      -- Pre-load the project root in the background so it'll be ready when a command needs it.
+      _ <- Ki.fork scope (Codebase.expectProjectBranchRoot codebase ppIds.project ppIds.branch)
+      -- IOSource takes a while to compile, we should start compiling it on startup
+      _ <- Ki.fork scope (IO.evaluate IOSource.typecheckedFile)
+      -- Fork the file watcher thread, which returns an IO action we can call to get one filesystem event (automatically
+      -- first tossing all that have accumulated since the last call)
+      awaitFileEvent <-
+        Watch.watchDirectory
+          scope
+          mgr
+          dir
+          -- We could elect to not spawn a file-watching thread at all if --no-file-watch is passed to ucm, but that
+          -- is an extremely uncommon option, this isn't super inefficient, and this makes the types simpler.
+          case shouldWatchFiles of
+            ShouldNotWatchFiles -> const False
+            ShouldWatchFiles -> allow
 
-  credentialManager <- newCredentialManager
-  let tokenProvider = AuthN.newTokenProvider credentialManager
-  authHTTPClient <- AuthN.newAuthenticatedHTTPClient tokenProvider ucmVersion
-  initialEcho <- hGetEcho stdin
-  let restoreEcho = (\currentEcho -> when (currentEcho /= initialEcho) $ hSetEcho stdin initialEcho)
-  let getInput :: Cli.LoopState -> IO Input
-      getInput loopState = do
-        currentEcho <- hGetEcho stdin
-        liftIO $ restoreEcho currentEcho
-        let PP.ProjectAndBranch projId branchId = PP.toProjectAndBranch $ NonEmpty.head loopState.projectPathStack
-        let getProjectRoot = liftIO $ Codebase.expectProjectBranchRoot codebase projId branchId
-        pp <- loopStateProjectPath codebase loopState
-        getUserInput
-          codebase
-          authHTTPClient
-          pp
-          getProjectRoot
-          (loopState ^. #numberedArgs)
-  let loadSourceFile :: Text -> IO Cli.LoadSourceResult
-      loadSourceFile fname =
-        if allow $ Text.unpack fname
-          then
-            let handle :: IOException -> IO Cli.LoadSourceResult
-                handle e =
-                  case e of
-                    _ | isDoesNotExistError e -> return Cli.InvalidSourceNameError
-                    _ -> return Cli.LoadError
-                go = do
-                  contents <- readUtf8 $ Text.unpack fname
-                  return $ Cli.LoadSuccess contents
-             in catch go handle
-          else return Cli.InvalidSourceNameError
-  let notify :: Output -> IO ()
-      notify =
-        notifyUser dir
-          >=> ( \o ->
-                  ifM
-                    (readIORef pageOutput)
-                    (putPrettyNonempty o)
-                    (putPrettyLnUnpaged o)
-              )
+      let initialState = Cli.loopState0 ppIds
+      initialInputsRef <- newIORef $ Welcome.run welcome ++ initialInputs
+      pageOutput <- newIORef True
 
-  let cleanup :: IO ()
-      cleanup = cancelFileSystemWatch
-      awaitInput :: Cli.LoopState -> IO (Either Event Input)
-      awaitInput loopState = do
-        -- use up buffered input before consulting external events
-        readIORef initialInputsRef >>= \case
-          h : t -> writeIORef initialInputsRef t >> pure h
-          [] ->
-            -- Race the user input and file watch.
-            Async.race (atomically $ Q.peek eventQueue) (getInput loopState) >>= \case
-              Left _ -> do
-                let e = Left <$> atomically (Q.dequeue eventQueue)
-                writeIORef pageOutput False
-                e
-              x -> do
-                writeIORef pageOutput True
-                pure x
+      credentialManager <- newCredentialManager
+      let tokenProvider = AuthN.newTokenProvider credentialManager
+      authHTTPClient <- AuthN.newAuthenticatedHTTPClient tokenProvider ucmVersion
+      initialEcho <- hGetEcho stdin
+      let restoreEcho = (\currentEcho -> when (currentEcho /= initialEcho) $ hSetEcho stdin initialEcho)
+      let getInput :: Cli.LoopState -> IO Input
+          getInput loopState = do
+            currentEcho <- hGetEcho stdin
+            liftIO $ restoreEcho currentEcho
+            let PP.ProjectAndBranch projId branchId = PP.toProjectAndBranch $ NonEmpty.head loopState.projectPathStack
+            let getProjectRoot = liftIO $ Codebase.expectProjectBranchRoot codebase projId branchId
+            pp <- loopStateProjectPath codebase loopState
+            getUserInput
+              codebase
+              authHTTPClient
+              pp
+              getProjectRoot
+              (loopState ^. #numberedArgs)
+      let loadSourceFile :: Text -> IO Cli.LoadSourceResult
+          loadSourceFile fname =
+            if allow $ Text.unpack fname
+              then
+                let handle :: IOException -> IO Cli.LoadSourceResult
+                    handle e =
+                      case e of
+                        _ | isDoesNotExistError e -> return Cli.InvalidSourceNameError
+                        _ -> return Cli.LoadError
+                    go = do
+                      contents <- readUtf8 $ Text.unpack fname
+                      return $ Cli.LoadSuccess contents
+                 in catch go handle
+              else return Cli.InvalidSourceNameError
+      let notify :: Output -> IO ()
+          notify =
+            notifyUser dir
+              >=> ( \o ->
+                      ifM
+                        (readIORef pageOutput)
+                        (putPrettyNonempty o)
+                        (putPrettyLnUnpaged o)
+                  )
 
-  let writeSource :: Text -> Text -> Bool -> IO ()
-      writeSource fp contents addFold = do
-        path <- Directory.canonicalizePath (Text.unpack fp)
-        prependUtf8
-          path
-          if addFold
-            then contents <> "\n\n---- Anything below this line is ignored by Unison.\n\n"
-            else contents <> "\n\n"
+      let cleanup :: IO ()
+          cleanup = pure ()
+          awaitInput :: Cli.LoopState -> IO (Either Event Input)
+          awaitInput loopState = do
+            -- use up buffered input before consulting external events
+            readIORef initialInputsRef >>= \case
+              h : t -> writeIORef initialInputsRef t >> pure h
+              [] -> do
+                -- Race the user input and file watch.
+                action <-
+                  Ki.scoped \scope -> do
+                    fileEventThread <- Ki.fork scope awaitFileEvent
+                    userInputThread <- Ki.fork scope (getInput loopState)
+                    (atomically . asum)
+                      [ do
+                          (file, contents) <- Ki.await fileEventThread
+                          pure do
+                            writeIORef pageOutput False
+                            pure (Left (UnisonFileChanged (Text.pack file) contents)),
+                        do
+                          input <- Ki.await userInputThread
+                          pure (pure (Right input))
+                      ]
+                action
 
-  let env =
-        Cli.Env
-          { authHTTPClient,
-            codebase,
-            credentialManager,
-            loadSource = loadSourceFile,
-            lspCheckForChanges,
-            writeSource,
-            generateUniqueName = Parser.uniqueBase32Namegen <$> Random.getSystemDRG,
-            notify,
-            notifyNumbered = \o ->
-              let (p, args) = notifyNumbered o
-               in putPrettyNonempty p $> args,
-            runtime,
-            sandboxedRuntime = sbRuntime,
-            nativeRuntime = nRuntime,
-            serverBaseUrl,
-            ucmVersion,
-            isTranscriptTest = False
-          }
+      let writeSource :: Text -> Text -> Bool -> IO ()
+          writeSource fp contents addFold = do
+            path <- Directory.canonicalizePath (Text.unpack fp)
+            prependUtf8
+              path
+              if addFold
+                then contents <> "\n\n---- Anything below this line is ignored by Unison.\n\n"
+                else contents <> "\n\n"
 
-  (onInterrupt, waitForInterrupt) <- buildInterruptHandler
+      let env =
+            Cli.Env
+              { authHTTPClient,
+                codebase,
+                credentialManager,
+                loadSource = loadSourceFile,
+                lspCheckForChanges,
+                writeSource,
+                generateUniqueName = Parser.uniqueBase32Namegen <$> Random.getSystemDRG,
+                notify,
+                notifyNumbered = \o ->
+                  let (p, args) = notifyNumbered o
+                   in putPrettyNonempty p $> args,
+                runtime,
+                sandboxedRuntime = sbRuntime,
+                nativeRuntime = nRuntime,
+                serverBaseUrl,
+                ucmVersion,
+                isTranscriptTest = False
+              }
 
-  mask \restore -> do
-    -- Handle inputs until @HaltRepl@, staying in the loop on Ctrl+C or synchronous exception.
-    let loop0 :: Cli.LoopState -> IO ()
-        loop0 s0 = do
-          let step = do
-                input <- awaitInput s0
-                (!result, resultState) <- Cli.runCli env s0 (HandleInput.loop input)
-                let sNext = case input of
-                      Left _ -> resultState
-                      Right inp -> resultState & #lastInput ?~ inp
-                pure (result, sNext)
-          UnliftIO.race waitForInterrupt (UnliftIO.tryAny (restore step)) >>= \case
-            -- SIGINT
-            Left () -> do
-              hPutStrLn stderr "\nAborted."
-              loop0 s0
-            -- Exception during command execution
-            Right (Left e) -> do
-              Text.hPutStrLn stderr ("Encountered exception:\n" <> Text.pack (displayException e))
-              loop0 s0
-            Right (Right (result, s1)) -> do
-              case result of
-                Cli.Success () -> loop0 s1
-                Cli.Continue -> loop0 s1
-                Cli.HaltRepl -> pure ()
+      (onInterrupt, waitForInterrupt) <- buildInterruptHandler
 
-    withInterruptHandler onInterrupt (loop0 initialState `finally` cleanup)
+      mask \restore -> do
+        -- Handle inputs until @HaltRepl@, staying in the loop on Ctrl+C or synchronous exception.
+        let loop0 :: Cli.LoopState -> IO ()
+            loop0 s0 = do
+              let step = do
+                    input <- awaitInput s0
+                    (!result, resultState) <- Cli.runCli env s0 (HandleInput.loop input)
+                    let sNext = case input of
+                          Left _ -> resultState
+                          Right inp -> resultState & #lastInput ?~ inp
+                    pure (result, sNext)
+              UnliftIO.race waitForInterrupt (UnliftIO.tryAny (restore step)) >>= \case
+                -- SIGINT
+                Left () -> do
+                  hPutStrLn stderr "\nAborted."
+                  loop0 s0
+                -- Exception during command execution
+                Right (Left e) -> do
+                  Text.hPutStrLn stderr ("Encountered exception:\n" <> Text.pack (displayException e))
+                  loop0 s0
+                Right (Right (result, s1)) -> do
+                  case result of
+                    Cli.Success () -> loop0 s1
+                    Cli.Continue -> loop0 s1
+                    Cli.HaltRepl -> pure ()
+
+        withInterruptHandler onInterrupt (loop0 initialState `finally` cleanup)
 
 -- | Installs a posix interrupt handler for catching SIGINT.
 -- This replaces GHC's default sigint handler which throws a UserInterrupt async exception

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -201,7 +201,6 @@ library
     , aeson >=2.0.0.0
     , aeson-pretty
     , ansi-terminal
-    , async
     , attoparsec
     , base
     , bytestring


### PR DESCRIPTION
## Overview

Our implementation of filesystem event queueing is simple and straightforward (well the code wasn't, somehow): we essentially just buffer all filesystem events (with a little bit of debounce logic), and processes them one at a time, with user inputs interleaved.

This has some undesirable properties, though. When executing a long-running IO action, or a local http microservice, a bunch of file change events can build up (if editing while the thing is running), which then slowly get worked through upon the IO action completing or web server being torn down.

I had gotten in the bad habit of just holding down Ctrl+C when killing a local http microservice, because of the high likelihood that I had been editing a unison file while it was running and had enqueued a bunch of unwanted file change events.

I changed the implementation to basically just remove the queue. (The diff is big because I also cleaned up a ton of complex stuff). The behavior in this PR is roughly as follows: when the main loop is ready to wait for either an event or a user input, it does so with a freshly-emptied filesystem event queue. I kept the existing debounce logic we already had, which is sort of a two-layered thing: only emit a filesystem event after 50ms elapse without an event (to avoid reacting to the flurry of writes that modern editors typically make), and also don't emit events for files that haven't changed, if the events are within 500ms of each other (I guess this is to save a little CPU?) 

## Test coverage

I tested this manually at the prompt, it seems to work.

## Loose ends

The user experience of editing a large .u file that takes multiple seconds to typecheck could perhaps be further improved.

The trunk behavior is to enqueue one slow typecheck after another, for every edit the user makes, which obviously isn't very nice. This PR's behavior is to basically ignore user edits that are made while a slow type check is in progress. We might instead want to interrupt a typecheck on file change, so that we don't waste time typechecking an old thing, and can just start over with the latest contents.