### PR TITLE
More runtime function replacements for Map, Set, Multimap

### DIFF
--- a/unison-runtime/src/Unison/Runtime/Builtin.hs
+++ b/unison-runtime/src/Unison/Runtime/Builtin.hs
@@ -1282,8 +1282,16 @@ declareForeigns = do
   declareForeign Untracked 2 Map_lookup
   declareForeign Untracked 1 Map_fromList
   declareForeign Untracked 2 Map_eq
+  declareForeign Untracked 2 Map_union
+  declareForeign Untracked 2 Map_intersect
+  declareForeign Untracked 1 Map_toList
   declareForeign Untracked 2 List_range
   declareForeign Untracked 1 List_sort
+  declareForeign Untracked 1 Multimap_fromList
+  declareForeign Untracked 1 Set_fromList
+  declareForeign Untracked 2 Set_union
+  declareForeign Untracked 2 Set_intersect
+  declareForeign Untracked 1 Set_toList
 
 foreignDeclResults :: (Map ForeignFunc (Sandbox, SuperNormal Symbol))
 foreignDeclResults =

--- a/unison-runtime/src/Unison/Runtime/Foreign/Function.hs
+++ b/unison-runtime/src/Unison/Runtime/Foreign/Function.hs
@@ -878,6 +878,12 @@ foreignCallHelper = \case
     evaluate $ Map.fromList l
   Map_eq -> mkForeign $ \(l :: Map Val Val, r :: Map Val Val) ->
     pure $ l == r
+  Map_union -> mkForeign $ \(l :: Map Val Val, r :: Map Val Val) ->
+    evaluate $ Map.union l r
+  Map_intersect -> mkForeign $ \(l :: Map Val Val, r :: Map Val Val) ->
+    evaluate $ Map.intersection l r
+  Map_toList -> mkForeign $ \(m :: Map Val Val) ->
+    evaluate $ Map.toList m
   List_range -> mkForeign $ \(m :: Word64, n :: Word64) ->
     let sz
           | m < n = fromIntegral $ n - m
@@ -886,6 +892,17 @@ foreignCallHelper = \case
         force s = foldl (\u x -> x `seq` u) s s
      in evaluate . force $ Sq.fromFunction sz mk
   List_sort -> mkForeign $ \(l :: Seq Val) -> pure $ Sq.unstableSort l
+  Multimap_fromList -> mkForeign $ \(l :: [(Val, Val)]) -> do
+    let listVals = l <&> \(k, v) -> (k, Sq.singleton v)
+    evaluate $ Map.fromListWith (<>) listVals
+  Set_fromList -> mkForeign $ \(l :: [Val]) -> do
+    evaluate $ Map.fromList $ zip l (repeat ())
+  Set_union -> mkForeign $ \(l :: Map Val (), r :: Map Val ()) ->
+    evaluate $ Map.union l r
+  Set_intersect -> mkForeign $ \(l :: Map Val (), r :: Map Val ()) ->
+    evaluate $ Map.intersection l r
+  Set_toList -> mkForeign $ \(s :: Map Val ()) ->
+    evaluate $ Map.keys s
   where
     chop = reverse . dropWhile isPathSeparator . reverse
 

--- a/unison-runtime/src/Unison/Runtime/Foreign/Function.hs
+++ b/unison-runtime/src/Unison/Runtime/Foreign/Function.hs
@@ -883,14 +883,13 @@ foreignCallHelper = \case
   Map_intersect -> mkForeign $ \(l :: Map Val Val, r :: Map Val Val) ->
     evaluate $ Map.intersection l r
   Map_toList -> mkForeign $ \(m :: Map Val Val) ->
-    evaluate $ Map.toList m
+    evaluate . forceListSpine $ Map.toList m
   List_range -> mkForeign $ \(m :: Word64, n :: Word64) ->
     let sz
           | m < n = fromIntegral $ n - m
           | otherwise = 0
         mk i = NatVal $ m + fromIntegral i
-        force s = foldl (\u x -> x `seq` u) s s
-     in evaluate . force $ Sq.fromFunction sz mk
+     in evaluate . forceListSpine $ Sq.fromFunction sz mk
   List_sort -> mkForeign $ \(l :: Seq Val) -> pure $ Sq.unstableSort l
   Multimap_fromList -> mkForeign $ \(l :: [(Val, Val)]) -> do
     let listVals = l <&> \(k, v) -> (k, Sq.singleton v)
@@ -902,8 +901,9 @@ foreignCallHelper = \case
   Set_intersect -> mkForeign $ \(l :: Map Val (), r :: Map Val ()) ->
     evaluate $ Map.intersection l r
   Set_toList -> mkForeign $ \(s :: Map Val ()) ->
-    evaluate $ Map.keys s
+    evaluate . forceListSpine $ Map.keys s
   where
+    forceListSpine xs = foldl (\u x -> x `seq` u) xs xs
     chop = reverse . dropWhile isPathSeparator . reverse
 
     hostPreference :: Maybe Util.Text.Text -> SYS.HostPreference

--- a/unison-runtime/src/Unison/Runtime/Foreign/Function.hs
+++ b/unison-runtime/src/Unison/Runtime/Foreign/Function.hs
@@ -2100,6 +2100,30 @@ functionReplacementList =
     ( "005mc1fq7ojq72c238qlm2rspjgqo2furjodf28icruv316odu6du",
       Map_fromList
     ),
+    ( "01qqpul0ttlgjhr5i2gtmdr2uarns2hbtnjpipmk1575ipkrlug42",
+      Map_union
+    ),
+    ( "00c363e340il8q0fai6peiv3586o931nojj98qfek09hg1tjkm9ma",
+      Map_intersect
+    ),
+    ( "03pjq0jijrr7ebf6s3tuqi4d5hi5mrv19nagp7ql2j9ltm55c32ek",
+      Map_toList
+    ),
+    ( "03putoun7i5n0lhf8iu990u9p08laklnp668i170dka2itckmadlq",
+      Multimap_fromList
+    ),
+    ( "03q6giac0qlva6u4mja29tr7mv0jqnsugk8paibatdrns8lhqqb92",
+      Set_fromList
+    ),
+    ( "03362vaalqq28lcrmmsjhha637is312j01jme3juj980ugd93up28",
+      Set_union
+    ),
+    ( "01lm6ejo31na1ti6u85bv0klliefll7q0c0da2qnefvcrq1l8rlqe",
+      Set_intersect
+    ),
+    ( "01p7ot36tg62na408mnk1psve6rc7fog30gv6n7thkrv6t3na2gdm",
+      Set_toList
+    ),
     ( "03c559iihi2vj0qps6cln48nv31ajup2srhas4pd05b9k46ds8jvk",
       Map_eq
     ),

--- a/unison-runtime/src/Unison/Runtime/Foreign/Function/Type.hs
+++ b/unison-runtime/src/Unison/Runtime/Foreign/Function/Type.hs
@@ -260,8 +260,16 @@ data ForeignFunc
   | Map_lookup
   | Map_fromList
   | Map_eq
+  | Map_union
+  | Map_intersect
+  | Map_toList
   | List_range
   | List_sort
+  | Multimap_fromList
+  | Set_fromList
+  | Set_union
+  | Set_intersect
+  | Set_toList
   deriving (Show, Eq, Ord, Enum, Bounded)
 
 foreignFuncBuiltinName :: ForeignFunc -> Text
@@ -518,5 +526,13 @@ foreignFuncBuiltinName = \case
   Map_lookup -> "Map.lookup"
   Map_fromList -> "Map.fromList"
   Map_eq -> "Map.=="
+  Map_union -> "Map.union"
+  Map_intersect -> "Map.intersect"
+  Map_toList -> "Map.toList"
   List_range -> "List.range"
   List_sort -> "List.sort"
+  Multimap_fromList -> "Multimap.fromList"
+  Set_fromList -> "Set.fromList"
+  Set_union -> "Set.union"
+  Set_intersect -> "Set.intersect"
+  Set_toList -> "Set.toList"


### PR DESCRIPTION
closes https://github.com/unisonweb/unison/issues/5638

## Overview

Remaps the following into Haskell implementations:

[Multimap.fromList](https://share.unison-lang.org/@unison/base/code/releases/3.34.0/latest/terms/data/Multimap/fromList)

[Set.fromList](https://share.unison-lang.org/@unison/base/code/releases/3.34.0/latest/terms/data/Set/fromList)

[Map.union](https://share.unison-lang.org/@unison/base/code/releases/3.34.0/latest/terms/data/Map/union)

[Set.union](https://share.unison-lang.org/@unison/base/code/releases/3.34.0/latest/terms/data/Set/union)

[Set.intersect](https://share.unison-lang.org/@unison/base/code/releases/3.34.0/latest/terms/data/Set/intersect)

[Map.intersect](https://share.unison-lang.org/@unison/base/code/releases/3.34.0/latest/terms/data/Map/intersect)

[Map.toList](https://share.unison-lang.org/@unison/base/code/releases/3.34.0/latest/terms/data/Map/toList)

[Set.toList](https://share.unison-lang.org/@unison/base/code/releases/3.34.0/latest/terms/data/Set/toList).

## Testing

I ran the following on both trunk and this branch:

```
suite : '{IO, Exception} ()
suite =
  do
    use List map replicate
    use Nat + - <= == range

    printTime
      "Multimap.fromList" 1 let
        ns = range 0 1000 |> map (i -> (i, range i (i + 5)))
        n -> repeat n do Multimap.fromList ns

    printTime
      "Set.fromList (range 0 1000)" 1 let
        ns = range 0 1000
        n -> repeat n do Set.fromList ns

    printTime
      "Set.toList (1000 element set)" 1 let
        ns = range 0 1000 |> Set.fromList
        n -> repeat n do Set.toList ns
    printTime
      "Map.toList (1000 element map)" 1 let
        ns = range 0 1000 |> map (i -> (i, i)) |> Map.fromList
        n -> repeat n do Map.toList ns
    printTime
      "Map.union" 1 let
        ns = range 0 1000 |> map (i -> (i, i)) |> Map.fromList
        n -> repeat n do Map.union ns ns

    printTime
      "Set.union" 1 let
        ns = range 0 1000 |> Set.fromList
        n -> repeat n do Set.union ns ns

    printTime
      "Set.intersect" 1 let
        ns = range 0 1000 |> Set.fromList
        n -> repeat n do Set.intersect ns ns

    printTime
      "Map.intersect" 1 let
        ns = range 0 1000 |> map (i -> (i, i)) |> Map.fromList
        n -> repeat n do Map.intersect ns ns

```

```
trunk -> remapped

Multimap.fromList
542.7µs -> 169.041µs

Set.fromList (range 0 1000)
218.519µs -> 23.639µs

Set.toList (1000 element set)
193.321µs -> 109ns

Map.toList (1000 element map)
216.732µs -> 102ns

Map.union
585.356µs -> 10.617µs

Set.union
579.137µs -> 10.648µs

Set.intersect
828.059µs -> 12.179µs

Map.intersect
823.589µs -> 12.168µs
```

## Implementation notes

Just followed Dan's instructions in https://github.com/unisonweb/unison/pull/5634

## Test coverage

- [x] Run the base tests with the new builtins remappings.
