### PR TITLE
Get rid of obsolete `ORMOLU_DISABLE` usage

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -524,8 +524,6 @@ setSchemaVersion schemaVersion =
       SET version = :schemaVersion
     |]
 
-{- ORMOLU_DISABLE -}
-{- Please don't try to format the SQL blocks —AI -}
 countObjects :: Transaction Int
 countObjects = queryOneCol [sql| SELECT COUNT(*) FROM object |]
 
@@ -544,7 +542,7 @@ saveHash hash = do
     |]
   expectHashId hash
 
-saveHashes :: Traversable f => f Hash32 -> Transaction (f HashId)
+saveHashes :: (Traversable f) => f Hash32 -> Transaction (f HashId)
 saveHashes hashes = do
   for_ hashes \hash ->
     execute
@@ -623,7 +621,7 @@ expectBranchHash = coerce expectHash
 
 expectBranchHashForCausalHash :: CausalHash -> Transaction BranchHash
 expectBranchHashForCausalHash ch = do
-  (_, bhId)<- expectCausalByCausalHash ch
+  (_, bhId) <- expectCausalByCausalHash ch
   expectBranchHash bhId
 
 saveText :: Text -> Transaction TextId
@@ -636,7 +634,7 @@ saveText t = do
     |]
   expectTextId t
 
-saveTexts :: Traversable f => f Text -> Transaction (f TextId)
+saveTexts :: (Traversable f) => f Text -> Transaction (f TextId)
 saveTexts =
   traverse saveText
 
@@ -657,7 +655,7 @@ loadTextIdSql t =
 expectText :: TextId -> Transaction Text
 expectText h = queryOneCol (loadTextSql h)
 
-expectTextCheck :: SqliteExceptionReason e => TextId -> (Text -> Either e a) -> Transaction a
+expectTextCheck :: (SqliteExceptionReason e) => TextId -> (Text -> Either e a) -> Transaction a
 expectTextCheck h = queryOneColCheck (loadTextSql h)
 
 loadTextSql :: TextId -> Sql
@@ -670,7 +668,7 @@ loadTextSql h =
 
 saveNameSegment :: NameSegment -> Transaction TextId
 saveNameSegment =
- saveText . NameSegment.toUnescapedText
+  saveText . NameSegment.toUnescapedText
 
 expectNameSegment :: TextId -> Transaction NameSegment
 expectNameSegment =
@@ -707,7 +705,7 @@ saveObject hh h t blob = do
       tryMoveTempEntityDependents hh hash
   pure oId
 
-expectObject :: SqliteExceptionReason e => ObjectId -> (ByteString -> Either e a) -> Transaction a
+expectObject :: (SqliteExceptionReason e) => ObjectId -> (ByteString -> Either e a) -> Transaction a
 expectObject oId check =
   queryOneColCheck
     [sql|
@@ -718,7 +716,7 @@ expectObject oId check =
     check
 
 loadObjectOfType ::
-  SqliteExceptionReason e =>
+  (SqliteExceptionReason e) =>
   ObjectId ->
   ObjectType ->
   (ByteString -> Either e a) ->
@@ -726,7 +724,7 @@ loadObjectOfType ::
 loadObjectOfType oid ty =
   queryMaybeColCheck (loadObjectOfTypeSql oid ty) -- (oid, ty)
 
-expectObjectOfType :: SqliteExceptionReason e => ObjectId -> ObjectType -> (ByteString -> Either e a) -> Transaction a
+expectObjectOfType :: (SqliteExceptionReason e) => ObjectId -> ObjectType -> (ByteString -> Either e a) -> Transaction a
 expectObjectOfType oid ty =
   queryOneColCheck (loadObjectOfTypeSql oid ty)
 
@@ -740,42 +738,42 @@ loadObjectOfTypeSql oid ty =
   |]
 
 -- | Load a decl component object.
-loadDeclObject :: SqliteExceptionReason e => ObjectId -> (ByteString -> Either e a) -> Transaction (Maybe a)
+loadDeclObject :: (SqliteExceptionReason e) => ObjectId -> (ByteString -> Either e a) -> Transaction (Maybe a)
 loadDeclObject oid =
   loadObjectOfType oid DeclComponent
 
 -- | Expect a decl component object.
-expectDeclObject :: SqliteExceptionReason e => ObjectId -> (ByteString -> Either e a) -> Transaction a
+expectDeclObject :: (SqliteExceptionReason e) => ObjectId -> (ByteString -> Either e a) -> Transaction a
 expectDeclObject oid =
   expectObjectOfType oid DeclComponent
 
 -- | Load a namespace object.
-loadNamespaceObject :: SqliteExceptionReason e => ObjectId -> (ByteString -> Either e a) -> Transaction (Maybe a)
+loadNamespaceObject :: (SqliteExceptionReason e) => ObjectId -> (ByteString -> Either e a) -> Transaction (Maybe a)
 loadNamespaceObject oid =
   loadObjectOfType oid Namespace
 
 -- | Expect a namespace object.
-expectNamespaceObject :: SqliteExceptionReason e => ObjectId -> (ByteString -> Either e a) -> Transaction a
+expectNamespaceObject :: (SqliteExceptionReason e) => ObjectId -> (ByteString -> Either e a) -> Transaction a
 expectNamespaceObject oid =
   expectObjectOfType oid Namespace
 
 -- | Load a patch object.
-loadPatchObject :: SqliteExceptionReason e => ObjectId -> (ByteString -> Either e a) -> Transaction (Maybe a)
+loadPatchObject :: (SqliteExceptionReason e) => ObjectId -> (ByteString -> Either e a) -> Transaction (Maybe a)
 loadPatchObject oid =
   loadObjectOfType oid Patch
 
 -- | Expect a patch object.
-expectPatchObject :: SqliteExceptionReason e => ObjectId -> (ByteString -> Either e a) -> Transaction a
+expectPatchObject :: (SqliteExceptionReason e) => ObjectId -> (ByteString -> Either e a) -> Transaction a
 expectPatchObject oid =
   expectObjectOfType oid Patch
 
 -- | Load a term component object.
-loadTermObject :: SqliteExceptionReason e => ObjectId -> (ByteString -> Either e a) -> Transaction (Maybe a)
+loadTermObject :: (SqliteExceptionReason e) => ObjectId -> (ByteString -> Either e a) -> Transaction (Maybe a)
 loadTermObject oid =
   loadObjectOfType oid TermComponent
 
 -- | Expect a term component object.
-expectTermObject :: SqliteExceptionReason e => ObjectId -> (ByteString -> Either e a) -> Transaction a
+expectTermObject :: (SqliteExceptionReason e) => ObjectId -> (ByteString -> Either e a) -> Transaction a
 expectTermObject oid =
   expectObjectOfType oid TermComponent
 
@@ -788,7 +786,7 @@ expectPrimaryHashIdForObject oId = do
       WHERE id = :oId
     |]
 
-expectObjectWithType :: SqliteExceptionReason e => ObjectId -> (ObjectType -> ByteString -> Either e a) -> Transaction a
+expectObjectWithType :: (SqliteExceptionReason e) => ObjectId -> (ObjectType -> ByteString -> Either e a) -> Transaction a
 expectObjectWithType oId check =
   queryOneRowCheck
     [sql|
@@ -905,13 +903,14 @@ loadObjectIdForAnyHashIdSql h =
 isObjectHash :: HashId -> Transaction Bool
 isObjectHash h =
   queryOneCol
+    -- sql (Only h)
     [sql|
       SELECT EXISTS (
         SELECT 1
         FROM object
         WHERE primary_hash_id = :h
       )
-    |] -- sql (Only h)
+    |]
 
 -- | All objects have corresponding hashes.
 expectPrimaryHashByObjectId :: ObjectId -> Transaction Hash
@@ -929,7 +928,8 @@ expectPrimaryHash32ByObjectId oId =
 
 expectHashIdsForObject :: ObjectId -> Transaction (NonEmpty HashId)
 expectHashIdsForObject oId = do
-  primaryHashId <- queryOneCol [sql| SELECT primary_hash_id FROM object WHERE id = :oId |] -- sql1 (Only oId)
+  -- sql1 (Only oId)
+  primaryHashId <- queryOneCol [sql| SELECT primary_hash_id FROM object WHERE id = :oId |]
   hashIds <- queryListCol [sql| SELECT hash_id FROM hash_object WHERE object_id = :oId |]
   pure $ primaryHashId Nel.:| filter (/= primaryHashId) hashIds
 
@@ -954,7 +954,7 @@ recordObjectRehash old new =
       WHERE object_id = :old
     |]
 
--- |Maybe we would generalize this to something other than NamespaceHash if we
+-- | Maybe we would generalize this to something other than NamespaceHash if we
 -- end up wanting to store other kinds of Causals here too.
 saveCausal ::
   HashHandle ->
@@ -1081,8 +1081,6 @@ expectTempEntity hash = do
         TempEntityType.PatchType -> Entity.P <$> decodeTempPatchFormat blob
         TempEntityType.CausalType -> Entity.C <$> decodeTempCausalFormat blob
 
-{- ORMOLU_ENABLE -}
-
 -- | look up all of the input entity's dependencies in the main table, to convert it to a sync entity
 tempToSyncEntity :: TempEntity -> Transaction SyncEntity
 tempToSyncEntity = \case
@@ -1163,8 +1161,6 @@ tempToSyncEntity = \case
                   <*> traverse expectObjectIdForHash32 defnLookup
             )
             terms
-
-{- ORMOLU_DISABLE -}
 
 -- | looking up all of the text and hashes is the first step of converting a SyncEntity to a Share.Entity
 syncToTempEntity :: SyncEntity -> Transaction TempEntity
@@ -1362,7 +1358,7 @@ saveWatch k r blob = do
     |]
 
 loadWatch ::
-  SqliteExceptionReason e =>
+  (SqliteExceptionReason e) =>
   WatchKind ->
   S.Reference.IdH ->
   (ByteString -> Either e a) ->
@@ -1408,6 +1404,7 @@ clearWatches = do
   execute [sql| DELETE FROM watch |]
 
 -- * Index-building
+
 addToTypeIndex :: S.ReferenceH -> S.Referent.Id -> Transaction ()
 addToTypeIndex tp tm =
   execute
@@ -1471,7 +1468,9 @@ getTypeReferencesForComponent oId =
 filterTermsByReferentHavingType :: S.ReferenceH -> [S.Referent.Id] -> Transaction [S.Referent.Id]
 filterTermsByReferentHavingType typ terms = create *> for_ terms insert *> select <* drop
   where
-    select = queryListRow [sql|
+    select =
+      queryListRow
+        [sql|
       SELECT
         q.term_referent_object_id,
         q.term_referent_component_index,
@@ -1484,7 +1483,9 @@ filterTermsByReferentHavingType typ terms = create *> for_ terms insert *> selec
         AND t.term_referent_component_index = q.term_referent_component_index
         AND t.term_referent_constructor_index IS q.term_referent_constructor_index
     |]
-    insert r = execute [sql|
+    insert r =
+      execute
+        [sql|
       INSERT INTO filter_query (
         term_referent_object_id,
         term_referent_component_index,
@@ -1494,20 +1495,23 @@ filterTermsByReferentHavingType typ terms = create *> for_ terms insert *> selec
     typeBuiltin :: Maybe TextId = Lens.preview C.Reference.t_ typ
     typeHashId :: Maybe HashId = Lens.preview (C.Reference._ReferenceDerived . C.Reference.idH) typ
     typeComponentIndex :: Maybe C.Reference.Pos = Lens.preview (C.Reference._ReferenceDerived . C.Reference.idPos) typ
-    create =  execute
-      [sql|
+    create =
+      execute
+        [sql|
         CREATE TEMPORARY TABLE filter_query (
           term_referent_object_id INTEGER NOT NULL,
           term_referent_component_index INTEGER NOT NULL,
           term_referent_constructor_index INTEGER NULL
         )
       |]
-    drop =  execute [sql|DROP TABLE filter_query|]
+    drop = execute [sql|DROP TABLE filter_query|]
 
 filterTermsByReferenceHavingType :: S.ReferenceH -> [S.Reference.Id] -> Transaction [S.Reference.Id]
 filterTermsByReferenceHavingType typ terms = create *> for_ terms insert *> select <* drop
   where
-    select = queryListRow [sql|
+    select =
+      queryListRow
+        [sql|
       SELECT
         q.term_reference_object_id,
         q.term_reference_component_index
@@ -1519,7 +1523,9 @@ filterTermsByReferenceHavingType typ terms = create *> for_ terms insert *> sele
         AND t.term_referent_component_index = q.term_reference_component_index
         AND t.term_referent_constructor_index IS NULL
     |]
-    insert r = execute [sql|
+    insert r =
+      execute
+        [sql|
       INSERT INTO filter_query (
         term_reference_object_id,
         term_reference_component_index
@@ -1528,15 +1534,15 @@ filterTermsByReferenceHavingType typ terms = create *> for_ terms insert *> sele
     typeBuiltin :: Maybe TextId = Lens.preview C.Reference.t_ typ
     typeHashId :: Maybe HashId = Lens.preview (C.Reference._ReferenceDerived . C.Reference.idH) typ
     typeComponentIndex :: Maybe C.Reference.Pos = Lens.preview (C.Reference._ReferenceDerived . C.Reference.idPos) typ
-    create =  execute
-      [sql|
+    create =
+      execute
+        [sql|
         CREATE TEMPORARY TABLE filter_query (
           term_reference_object_id INTEGER NOT NULL,
           term_reference_component_index INTEGER NOT NULL
         )
       |]
-    drop =  execute [sql|DROP TABLE filter_query|]
-
+    drop = execute [sql|DROP TABLE filter_query|]
 
 addToTypeMentionsIndex :: S.ReferenceH -> S.Referent.Id -> Transaction ()
 addToTypeMentionsIndex tp tm =
@@ -1698,8 +1704,8 @@ getDependentsForDependency selector dependency = do
 
 getDependentsForDependencyComponent :: ObjectId -> Transaction [S.Reference.Id]
 getDependentsForDependencyComponent dependency =
-  filter isNotSelfReference <$>
-    queryListRow
+  filter isNotSelfReference
+    <$> queryListRow
       [sql|
         SELECT dependent_object_id, dependent_component_index
         FROM dependents_index
@@ -1756,38 +1762,38 @@ getDependenciesBetweenTerms oid1 oid2 =
     --   init  ^^^^^^^^^^^^^
     --   last                 ^^^
     --
-    -- +-paths-------------------------+
-    -- +-level-+-path_last-+-path_init-+
-    -- |     0 |         X |        '' | -- path: [X]
-    -- |     0 |         Y |        '' | -- path: [Y]
-    -- |     1 |         B |      'X,' | -- path: [X,B]   -- ends in B, yay!
-    -- |     1 |         Q |      'X,' | -- path: [X,Q]
-    -- |     1 |         Z |      'Y,' | -- path: [Y,Z]
-    -- |     2 |         B |    'Z,Y,' | -- path: [Y,Z,B] -- ends in B, yay!
-    -- +-------+-----------+-----------+
+    --  +-paths-------------------------+
+    --  +-level-+-path_last-+-path_init-+
+    --  |     0 |         X |        '' | -- path: [X]
+    --  |     0 |         Y |        '' | -- path: [Y]
+    --  |     1 |         B |      'X,' | -- path: [X,B]   -- ends in B, yay!
+    --  |     1 |         Q |      'X,' | -- path: [X,Q]
+    --  |     1 |         Z |      'Y,' | -- path: [Y,Z]
+    --  |     2 |         B |    'Z,Y,' | -- path: [Y,Z,B] -- ends in B, yay!
+    --  +-------+-----------+-----------+
     --
     -- Next, we seed another recursive CTE with those paths that end in the sink `B`. This is just the (very verbose)
     -- way to unnest an array in SQLite. All we're doing is turning the set of strings {'X,' 'Z,Y,'}, each of which
     -- represents the inner nodes of a full path between `A` and `B`, into the set {X Z Y}, which is just the full set
     -- of such inner nodes, along any path.
     --
-    -- +-elems-----------------+
-    -- +-path_elem-+-path_init-+
-    -- |           |      'X,' |
-    -- |           |    'Z,Y,' |
-    -- |       'X' |        '' |
-    -- |       'Z' |      'Y,' |
-    -- |       'Y' |        '' |
-    -- +-----------+-----------+
+    --  +-elems-----------------+
+    --  +-path_elem-+-path_init-+
+    --  |           |      'X,' |
+    --  |           |    'Z,Y,' |
+    --  |       'X' |        '' |
+    --  |       'Z' |      'Y,' |
+    --  |       'Y' |        '' |
+    --  +-----------+-----------+
     --
     -- And finally, we just select out the non-null `path_elem` rows from here, casting the strings back to integers for
     -- clarity (this isn't very matter - SQLite would cast on-the-fly).
     --
-    -- +-path_elem-+
-    -- |         X |
-    -- |         Z |
-    -- |         Y |
-    -- +-----------+
+    --  +-path_elem-+
+    --  |         X |
+    --  |         Z |
+    --  |         Y |
+    --  +-----------+
     --
     -- Notes
     --
@@ -1796,7 +1802,8 @@ getDependenciesBetweenTerms oid1 oid2 =
     -- (2) No need to search beyond the sink itself, since component dependencies form a DAG.
     -- (3) An explicit cast from e.g. string '1' to int 1 isn't strictly necessary.
     theSql :: Sql
-    theSql = [sql|
+    theSql =
+      [sql|
       WITH RECURSIVE paths(level, path_last, path_init) AS (
         SELECT
           0,
@@ -1836,11 +1843,6 @@ getDependenciesBetweenTerms oid1 oid2 =
       FROM elems
       WHERE path_elem IS NOT null
     |]
-
--- Mitchell says: why are we enabling and disabling ormolu all over this file? Let's just enable. But right now I'm only
--- adding this one query and don't want a big diff in my PR.
-
-{- ORMOLU_ENABLE -}
 
 getDirectDependenciesOfScope ::
   (S.Reference -> Transaction Bool) ->
@@ -2042,8 +2044,6 @@ createTemporaryTableOfReferenceIds tableName refs = do
   for_ refs \ref ->
     execute [sql| INSERT INTO $tableName VALUES (@ref, @) |]
 
-{- ORMOLU_DISABLE -}
-
 objectIdByBase32Prefix :: ObjectType -> Text -> Transaction [ObjectId]
 objectIdByBase32Prefix objType prefix =
   queryListCol
@@ -2092,8 +2092,6 @@ getCausalsWithoutBranchObjects =
         FROM hash_object
       )
     |]
-
-{- ORMOLU_ENABLE -}
 
 -- | Delete all hash objects of a given hash version.
 -- Leaves the corresponding `hash`es in the hash table alone.

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -1471,39 +1471,39 @@ filterTermsByReferentHavingType typ terms = create *> for_ terms insert *> selec
     select =
       queryListRow
         [sql|
-      SELECT
-        q.term_referent_object_id,
-        q.term_referent_component_index,
-        q.term_referent_constructor_index
-      FROM filter_query q, find_type_index t
-      WHERE t.type_reference_builtin IS :typeBuiltin
-        AND t.type_reference_hash_id IS :typeHashId
-        AND t.type_reference_component_index IS :typeComponentIndex
-        AND t.term_referent_object_id = q.term_referent_object_id
-        AND t.term_referent_component_index = q.term_referent_component_index
-        AND t.term_referent_constructor_index IS q.term_referent_constructor_index
-    |]
+          SELECT
+            q.term_referent_object_id,
+            q.term_referent_component_index,
+            q.term_referent_constructor_index
+          FROM filter_query q, find_type_index t
+          WHERE t.type_reference_builtin IS :typeBuiltin
+            AND t.type_reference_hash_id IS :typeHashId
+            AND t.type_reference_component_index IS :typeComponentIndex
+            AND t.term_referent_object_id = q.term_referent_object_id
+            AND t.term_referent_component_index = q.term_referent_component_index
+            AND t.term_referent_constructor_index IS q.term_referent_constructor_index
+        |]
     insert r =
       execute
         [sql|
-      INSERT INTO filter_query (
-        term_referent_object_id,
-        term_referent_component_index,
-        term_referent_constructor_index
-      ) VALUES (@r, @, @)
-    |]
+          INSERT INTO filter_query (
+            term_referent_object_id,
+            term_referent_component_index,
+            term_referent_constructor_index
+          ) VALUES (@r, @, @)
+        |]
     typeBuiltin :: Maybe TextId = Lens.preview C.Reference.t_ typ
     typeHashId :: Maybe HashId = Lens.preview (C.Reference._ReferenceDerived . C.Reference.idH) typ
     typeComponentIndex :: Maybe C.Reference.Pos = Lens.preview (C.Reference._ReferenceDerived . C.Reference.idPos) typ
     create =
       execute
         [sql|
-        CREATE TEMPORARY TABLE filter_query (
-          term_referent_object_id INTEGER NOT NULL,
-          term_referent_component_index INTEGER NOT NULL,
-          term_referent_constructor_index INTEGER NULL
-        )
-      |]
+          CREATE TEMPORARY TABLE filter_query (
+            term_referent_object_id INTEGER NOT NULL,
+            term_referent_component_index INTEGER NOT NULL,
+            term_referent_constructor_index INTEGER NULL
+          )
+        |]
     drop = execute [sql|DROP TABLE filter_query|]
 
 filterTermsByReferenceHavingType :: S.ReferenceH -> [S.Reference.Id] -> Transaction [S.Reference.Id]
@@ -1512,36 +1512,36 @@ filterTermsByReferenceHavingType typ terms = create *> for_ terms insert *> sele
     select =
       queryListRow
         [sql|
-      SELECT
-        q.term_reference_object_id,
-        q.term_reference_component_index
-      FROM filter_query q, find_type_index t
-      WHERE t.type_reference_builtin IS :typeBuiltin
-        AND t.type_reference_hash_id IS :typeHashId
-        AND t.type_reference_component_index IS :typeComponentIndex
-        AND t.term_referent_object_id = q.term_reference_object_id
-        AND t.term_referent_component_index = q.term_reference_component_index
-        AND t.term_referent_constructor_index IS NULL
-    |]
+          SELECT
+            q.term_reference_object_id,
+            q.term_reference_component_index
+          FROM filter_query q, find_type_index t
+          WHERE t.type_reference_builtin IS :typeBuiltin
+            AND t.type_reference_hash_id IS :typeHashId
+            AND t.type_reference_component_index IS :typeComponentIndex
+            AND t.term_referent_object_id = q.term_reference_object_id
+            AND t.term_referent_component_index = q.term_reference_component_index
+            AND t.term_referent_constructor_index IS NULL
+        |]
     insert r =
       execute
         [sql|
-      INSERT INTO filter_query (
-        term_reference_object_id,
-        term_reference_component_index
-      ) VALUES (@r, @)
-    |]
+          INSERT INTO filter_query (
+            term_reference_object_id,
+            term_reference_component_index
+          ) VALUES (@r, @)
+        |]
     typeBuiltin :: Maybe TextId = Lens.preview C.Reference.t_ typ
     typeHashId :: Maybe HashId = Lens.preview (C.Reference._ReferenceDerived . C.Reference.idH) typ
     typeComponentIndex :: Maybe C.Reference.Pos = Lens.preview (C.Reference._ReferenceDerived . C.Reference.idPos) typ
     create =
       execute
         [sql|
-        CREATE TEMPORARY TABLE filter_query (
-          term_reference_object_id INTEGER NOT NULL,
-          term_reference_component_index INTEGER NOT NULL
-        )
-      |]
+          CREATE TEMPORARY TABLE filter_query (
+            term_reference_object_id INTEGER NOT NULL,
+            term_reference_component_index INTEGER NOT NULL
+          )
+        |]
     drop = execute [sql|DROP TABLE filter_query|]
 
 addToTypeMentionsIndex :: S.ReferenceH -> S.Referent.Id -> Transaction ()
@@ -1804,45 +1804,45 @@ getDependenciesBetweenTerms oid1 oid2 =
     theSql :: Sql
     theSql =
       [sql|
-      WITH RECURSIVE paths(level, path_last, path_init) AS (
-        SELECT
-          0,
-          dependents_index.dependency_object_id,
-          ''
-        FROM dependents_index
-          JOIN object ON dependents_index.dependency_object_id = object.id
-        WHERE dependents_index.dependent_object_id = :oid1
-          AND object.type_id = 0 -- Note (1)
-          AND dependents_index.dependent_object_id != dependents_index.dependency_object_id
-        UNION ALL
-        SELECT
-          paths.level + 1 AS level,
-          dependents_index.dependency_object_id,
-          dependents_index.dependent_object_id || ',' || paths.path_init
-        FROM paths
-          JOIN dependents_index
-            ON paths.path_last = dependents_index.dependent_object_id
-          JOIN object ON dependents_index.dependency_object_id = object.id
-        WHERE object.type_id = 0 -- Note (1)
-          AND dependents_index.dependent_object_id != dependents_index.dependency_object_id
-          AND paths.path_last != :oid2 -- Note (2)
-        ORDER BY level DESC
-      ),
-      elems(path_elem, path_init) AS (
-        SELECT null, path_init
-        FROM paths
-        WHERE paths.path_last = :oid2
-        UNION ALL
-        SELECT
-          substr(path_init, 0, instr(path_init, ',')),
-          substr(path_init, instr(path_init, ',') + 1)
+        WITH RECURSIVE paths(level, path_last, path_init) AS (
+          SELECT
+            0,
+            dependents_index.dependency_object_id,
+            ''
+          FROM dependents_index
+            JOIN object ON dependents_index.dependency_object_id = object.id
+          WHERE dependents_index.dependent_object_id = :oid1
+            AND object.type_id = 0 -- Note (1)
+            AND dependents_index.dependent_object_id != dependents_index.dependency_object_id
+          UNION ALL
+          SELECT
+            paths.level + 1 AS level,
+            dependents_index.dependency_object_id,
+            dependents_index.dependent_object_id || ',' || paths.path_init
+          FROM paths
+            JOIN dependents_index
+              ON paths.path_last = dependents_index.dependent_object_id
+            JOIN object ON dependents_index.dependency_object_id = object.id
+          WHERE object.type_id = 0 -- Note (1)
+            AND dependents_index.dependent_object_id != dependents_index.dependency_object_id
+            AND paths.path_last != :oid2 -- Note (2)
+          ORDER BY level DESC
+        ),
+        elems(path_elem, path_init) AS (
+          SELECT null, path_init
+          FROM paths
+          WHERE paths.path_last = :oid2
+          UNION ALL
+          SELECT
+            substr(path_init, 0, instr(path_init, ',')),
+            substr(path_init, instr(path_init, ',') + 1)
+          FROM elems
+          WHERE path_init != ''
+        )
+        SELECT DISTINCT CAST(path_elem AS integer) AS path_elem -- Note (3)
         FROM elems
-        WHERE path_init != ''
-      )
-      SELECT DISTINCT CAST(path_elem AS integer) AS path_elem -- Note (3)
-      FROM elems
-      WHERE path_elem IS NOT null
-    |]
+        WHERE path_elem IS NOT null
+      |]
 
 getDirectDependenciesOfScope ::
   (S.Reference -> Transaction Bool) ->

--- a/development.markdown
+++ b/development.markdown
@@ -22,17 +22,19 @@ On startup, Unison prints a url for the codebase UI. If you did step 3 above, th
 
 ## Autoformatting your code with Ormolu
 
-We use 0.5.0.1 of Ormolu and CI will add an extra commit, if needed, to autoformat your code.
+We use Ormolu (see [the specific version](./nix/versions.nix)) and CI will add an extra commit, if needed, to autoformat your code.
 
 Also note that you can always wrap a comment around some code you don't want Ormolu to touch, using:
 
 ```haskell
 {- ORMOLU_DISABLE -}
+{- because we carefully formatted this code for readability -}
 dontFormatMe = do blah
                     blah
                   blah
 {- ORMOLU_ENABLE -}
 ```
+__NB__: Always include an extra comment (as above) to explain _why_ you’re disabling Ormolu.
 
 ## Running Tests
 

--- a/unison-cli/src/Compat.hs
+++ b/unison-cli/src/Compat.hs
@@ -8,7 +8,6 @@ import System.Mem.Weak (deRefWeak)
 import Unison.Prelude
 import UnliftIO qualified
 
-{- ORMOLU_DISABLE -}
 #if defined(mingw32_HOST_OS)
 import qualified GHC.ConsoleHandler as WinSig
 #else
@@ -16,13 +15,11 @@ import qualified System.Posix.Signals as Sig
 #endif
 
 onWindows :: Bool
-onWindows =
 #if defined(mingw32_HOST_OS)
-  True
+onWindows = True
 #else
-  False
+onWindows = False
 #endif
-{- ORMOLU_ENABLE -}
 
 -- | Constructs a default interrupt handler which builds an interrupt handler which throws a
 -- UserInterrupt exception to the thread in which the setup was initially called.
@@ -48,15 +45,15 @@ withInterruptHandler handler action = do
   where
     -- Installs the new handler and returns an action to restore the old handlers.
     installNewHandlers :: IO (IO ())
-    installNewHandlers = do
-{- ORMOLU_DISABLE -}
 #if defined(mingw32_HOST_OS)
+    installNewHandlers = do
       let sig_handler WinSig.ControlC = handler
           sig_handler WinSig.Break    = handler
           sig_handler _               = return ()
       oldHandler <- WinSig.installHandler (WinSig.Catch sig_handler)
       pure (void $ WinSig.installHandler oldHandler)
 #else
+    installNewHandlers = do
       oldQuitHandler <- Sig.installHandler Sig.sigQUIT  (Sig.Catch handler) Nothing
       oldInterruptHandler <- Sig.installHandler Sig.sigINT   (Sig.Catch handler) Nothing
       pure do
@@ -65,4 +62,3 @@ withInterruptHandler handler action = do
 #endif
     restoreOldHandlers :: IO () -> IO ()
     restoreOldHandlers restore = restore
-{- ORMOLU_ENABLE -}

--- a/unison-runtime/src/Unison/Runtime/Builtin.hs
+++ b/unison-runtime/src/Unison/Runtime/Builtin.hs
@@ -902,9 +902,10 @@ declareForeign ::
   FDecl Symbol ()
 declareForeign sand arity func = declareForeignWrap sand wrap func
   where
-  -- Special case: turn 0-arg foreigns into unit-accepting functions
-  wrap | 0 == arity = unitDirect
-       | otherwise = argNDirect arity
+    -- Special case: turn 0-arg foreigns into unit-accepting functions
+    wrap
+      | 0 == arity = unitDirect
+      | otherwise = argNDirect arity
 
 unitValue :: Val
 unitValue = BoxedVal $ Closure.Enum Ty.unitRef TT.unitTag
@@ -1283,7 +1284,6 @@ declareForeigns = do
   declareForeign Untracked 2 Map_eq
   declareForeign Untracked 2 List_range
   declareForeign Untracked 1 List_sort
-
 
 foreignDeclResults :: (Map ForeignFunc (Sandbox, SuperNormal Symbol))
 foreignDeclResults =

--- a/unison-runtime/src/Unison/Runtime/Decompile.hs
+++ b/unison-runtime/src/Unison/Runtime/Decompile.hs
@@ -38,9 +38,9 @@ import Unison.Runtime.Stack
     USeq,
     UnboxedTypeTag (..),
     Val (..),
+    inflateMap,
     pattern DataC,
     pattern PApV,
-    inflateMap,
   )
 import Unison.Syntax.NamePrinter (prettyReference)
 import Unison.Term

--- a/unison-runtime/src/Unison/Runtime/Foreign/Function.hs
+++ b/unison-runtime/src/Unison/Runtime/Foreign/Function.hs
@@ -4,14 +4,15 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 module Unison.Runtime.Foreign.Function
-  ( ForeignConvention (..)
-  , foreignCall
-  , readsAtError
-  , foreignConventionError
-  , pseudoConstructors
-  , functionReplacements
-  , functionUnreplacements
-  ) where
+  ( ForeignConvention (..),
+    foreignCall,
+    readsAtError,
+    foreignConventionError,
+    pseudoConstructors,
+    functionReplacements,
+    functionUnreplacements,
+  )
+where
 
 import Control.Concurrent (ThreadId)
 import Control.Concurrent as SYS
@@ -154,7 +155,9 @@ import Unison.Runtime.Exception
 import Unison.Runtime.Foreign hiding (Failure)
 import Unison.Runtime.Foreign qualified as F
 import Unison.Runtime.Foreign.Function.Type
-  (ForeignFunc (..), foreignFuncBuiltinName)
+  ( ForeignFunc (..),
+    foreignFuncBuiltinName,
+  )
 import Unison.Runtime.MCode
 import Unison.Runtime.Stack
 import Unison.Runtime.TypeTags qualified as TT
@@ -876,8 +879,9 @@ foreignCallHelper = \case
   Map_eq -> mkForeign $ \(l :: Map Val Val, r :: Map Val Val) ->
     pure $ l == r
   List_range -> mkForeign $ \(m :: Word64, n :: Word64) ->
-    let sz | m < n = fromIntegral $ n - m
-           | otherwise = 0
+    let sz
+          | m < n = fromIntegral $ n - m
+          | otherwise = 0
         mk i = NatVal $ m + fromIntegral i
         force s = foldl (\u x -> x `seq` u) s s
      in evaluate . force $ Sq.fromFunction sz mk
@@ -935,7 +939,7 @@ mkForeignIOF f = mkForeign $ \a -> tryIOE (f a)
     handleIOE (Left e) = Left $ F.Failure Ty.ioFailureRef (Util.Text.pack (show e)) unitValue
     handleIOE (Right a) = Right a
 
-{-# inline mkForeignExn #-}
+{-# INLINE mkForeignExn #-}
 mkForeignExn ::
   (ForeignConvention a, ForeignConvention e, ForeignConvention r) =>
   (a -> IO (Either (F.Failure e) r)) ->
@@ -1390,7 +1394,9 @@ foreignConventionError ty v = throwIO $ Panic msg (Just v)
 instance
   ( ForeignConvention a,
     ForeignConvention b
-  ) => ForeignConvention (Either a b) where
+  ) =>
+  ForeignConvention (Either a b)
+  where
   decodeVal (BoxedVal (Data1 _ t v))
     | t == TT.leftTag = Left <$> decodeVal v
     | otherwise = Right <$> decodeVal v
@@ -1401,18 +1407,19 @@ instance
   encodeVal (Right y) =
     BoxedVal . Data1 Ty.eitherRef TT.rightTag $ encodeVal y
 
-  readAtIndex stk i = bpeekOff stk i >>= \case
-    Data1 _ t v
-      | t == TT.leftTag -> Left <$> decodeVal v
-      | otherwise -> Right <$> decodeVal v
-    c -> foreignConventionError "Either" (BoxedVal c)
+  readAtIndex stk i =
+    bpeekOff stk i >>= \case
+      Data1 _ t v
+        | t == TT.leftTag -> Left <$> decodeVal v
+        | otherwise -> Right <$> decodeVal v
+      c -> foreignConventionError "Either" (BoxedVal c)
 
   writeBack stk (Left x) =
     bpoke stk . Data1 Ty.eitherRef TT.leftTag $ encodeVal x
   writeBack stk (Right y) =
     bpoke stk . Data1 Ty.eitherRef TT.rightTag $ encodeVal y
 
-instance ForeignConvention a => ForeignConvention (Maybe a) where
+instance (ForeignConvention a) => ForeignConvention (Maybe a) where
   decodeVal (BoxedVal (Enum _ _)) = pure Nothing
   decodeVal (BoxedVal (Data1 _ _ v)) = Just <$> decodeVal v
   decodeVal v = foreignConventionError "Maybe" v
@@ -1420,10 +1427,11 @@ instance ForeignConvention a => ForeignConvention (Maybe a) where
   encodeVal Nothing = noneVal
   encodeVal (Just v) = someVal (encodeVal v)
 
-  readAtIndex stk i = bpeekOff stk i >>= \case
-    Data1 _ _ v -> Just <$> decodeVal v
-    Enum _ _ -> pure Nothing
-    c -> foreignConventionError "Maybe" (BoxedVal c)
+  readAtIndex stk i =
+    bpeekOff stk i >>= \case
+      Data1 _ _ v -> Just <$> decodeVal v
+      Enum _ _ -> pure Nothing
+      c -> foreignConventionError "Maybe" (BoxedVal c)
 
   writeBack stk Nothing = bpoke stk noneClo
   writeBack stk (Just v) = bpoke stk (someClo (encodeVal v))
@@ -1526,25 +1534,29 @@ decodeTup2 (Tup2C x y) = (,) <$> decodeVal x <*> decodeVal y
 decodeTup2 c = foreignConventionError "Pair" (BoxedVal c)
 
 encodeTup2 :: (ForeignConvention a, ForeignConvention b) => (a, b) -> Closure
-encodeTup2 (x,y) = Tup2C (encodeVal x) (encodeVal y)
+encodeTup2 (x, y) = Tup2C (encodeVal x) (encodeVal y)
 
 instance
   ( ForeignConvention a,
     ForeignConvention b
-  ) => ForeignConvention (a, b) where
+  ) =>
+  ForeignConvention (a, b)
+  where
   decodeVal (BoxedVal v) = decodeTup2 v
   decodeVal v = foreignConventionError "Pair" v
   encodeVal p = BoxedVal $ encodeTup2 p
 
   readsAt stk (VArg2 i j) =
-    (,) <$> readAtIndex stk i
-        <*> readAtIndex stk j
+    (,)
+      <$> readAtIndex stk i
+      <*> readAtIndex stk j
   readsAt _ as = readsAtError "two arguments" as
 
   readAtIndex stk i = bpeekOff stk i >>= decodeTup2
   writeBack stk p = bpoke stk $ encodeTup2 p
 
 pattern Tup3C x y z = ConsC x (Tup2V y z)
+
 pattern Tup3V x y z = BoxedVal (Tup3C x y z)
 
 decodeTup3 :: (ForeignConvention a, ForeignConvention b, ForeignConvention c) => Closure -> IO (a, b, c)
@@ -1553,27 +1565,31 @@ decodeTup3 (Tup3C x y z) =
 decodeTup3 c = foreignConventionError "Triple" (BoxedVal c)
 
 encodeTup3 :: (ForeignConvention a, ForeignConvention b, ForeignConvention c) => (a, b, c) -> Closure
-encodeTup3 (x,y,z) = Tup3C (encodeVal x) (encodeVal y) (encodeVal z)
+encodeTup3 (x, y, z) = Tup3C (encodeVal x) (encodeVal y) (encodeVal z)
 
 instance
   ( ForeignConvention a,
     ForeignConvention b,
     ForeignConvention c
-  ) => ForeignConvention (a, b, c) where
+  ) =>
+  ForeignConvention (a, b, c)
+  where
   decodeVal (BoxedVal v) = decodeTup3 v
   decodeVal v = foreignConventionError "Triple" v
   encodeVal p = BoxedVal $ encodeTup3 p
 
   readsAt stk (VArgN v) =
-    (,,) <$> readAtIndex stk (PA.indexPrimArray v 0)
-         <*> readAtIndex stk (PA.indexPrimArray v 1)
-         <*> readAtIndex stk (PA.indexPrimArray v 2)
+    (,,)
+      <$> readAtIndex stk (PA.indexPrimArray v 0)
+      <*> readAtIndex stk (PA.indexPrimArray v 1)
+      <*> readAtIndex stk (PA.indexPrimArray v 2)
   readsAt _ as = readsAtError "three arguments" as
 
   readAtIndex stk i = bpeekOff stk i >>= decodeTup3
   writeBack stk p = bpoke stk $ encodeTup3 p
 
 pattern Tup4C w x y z = ConsC w (Tup3V x y z)
+
 pattern Tup4V w x y z = BoxedVal (Tup4C w x y z)
 
 decodeTup4 :: (ForeignConvention a, ForeignConvention b, ForeignConvention c, ForeignConvention d) => Closure -> IO (a, b, c, d)
@@ -1582,7 +1598,7 @@ decodeTup4 (Tup4C w x y z) =
 decodeTup4 c = foreignConventionError "Quadruple" (BoxedVal c)
 
 encodeTup4 :: (ForeignConvention a, ForeignConvention b, ForeignConvention c, ForeignConvention d) => (a, b, c, d) -> Closure
-encodeTup4 (w,x,y,z) =
+encodeTup4 (w, x, y, z) =
   Tup4C (encodeVal w) (encodeVal x) (encodeVal y) (encodeVal z)
 
 instance
@@ -1590,17 +1606,20 @@ instance
     ForeignConvention b,
     ForeignConvention c,
     ForeignConvention d
-  ) => ForeignConvention (a, b, c, d) where
+  ) =>
+  ForeignConvention (a, b, c, d)
+  where
   decodeVal (BoxedVal v) = decodeTup4 v
   decodeVal v = foreignConventionError "Quadruple" v
 
   encodeVal p = BoxedVal $ encodeTup4 p
 
   readsAt stk (VArgN v) =
-    (,,,) <$> readAtIndex stk (PA.indexPrimArray v 0)
-          <*> readAtIndex stk (PA.indexPrimArray v 1)
-          <*> readAtIndex stk (PA.indexPrimArray v 2)
-          <*> readAtIndex stk (PA.indexPrimArray v 3)
+    (,,,)
+      <$> readAtIndex stk (PA.indexPrimArray v 0)
+      <*> readAtIndex stk (PA.indexPrimArray v 1)
+      <*> readAtIndex stk (PA.indexPrimArray v 2)
+      <*> readAtIndex stk (PA.indexPrimArray v 3)
   readsAt _ as = readsAtError "four arguments" as
 
   readAtIndex stk i = bpeekOff stk i >>= decodeTup4
@@ -1614,7 +1633,7 @@ decodeTup5 (Tup5C v w x y z) =
 decodeTup5 c = foreignConventionError "Quintuple" (BoxedVal c)
 
 encodeTup5 :: (ForeignConvention a, ForeignConvention b, ForeignConvention c, ForeignConvention d, ForeignConvention e) => (a, b, c, d, e) -> Closure
-encodeTup5 (v,w,x,y,z) =
+encodeTup5 (v, w, x, y, z) =
   Tup5C (encodeVal v) (encodeVal w) (encodeVal x) (encodeVal y) (encodeVal z)
 
 instance
@@ -1632,18 +1651,18 @@ instance
   encodeVal = BoxedVal . encodeTup5
 
   readsAt stk (VArgN v) =
-    (,,,,) <$> readAtIndex stk (PA.indexPrimArray v 0)
-           <*> readAtIndex stk (PA.indexPrimArray v 1)
-           <*> readAtIndex stk (PA.indexPrimArray v 2)
-           <*> readAtIndex stk (PA.indexPrimArray v 3)
-           <*> readAtIndex stk (PA.indexPrimArray v 4)
+    (,,,,)
+      <$> readAtIndex stk (PA.indexPrimArray v 0)
+      <*> readAtIndex stk (PA.indexPrimArray v 1)
+      <*> readAtIndex stk (PA.indexPrimArray v 2)
+      <*> readAtIndex stk (PA.indexPrimArray v 3)
+      <*> readAtIndex stk (PA.indexPrimArray v 4)
   readsAt _ as = readsAtError "five arguments" as
 
   readAtIndex stk i = bpeekOff stk i >>= decodeTup5
   writeBack stk p = bpoke stk $ encodeTup5 p
 
-
-decodeFailure :: ForeignConvention a => Closure -> IO (F.Failure a)
+decodeFailure :: (ForeignConvention a) => Closure -> IO (F.Failure a)
 decodeFailure (DataG _ _ (_, args)) =
   F.Failure
     <$> decodeTypeLink (PA.indexArray args 0)
@@ -1651,7 +1670,7 @@ decodeFailure (DataG _ _ (_, args)) =
     <*> decodeAny (PA.indexArray args 2)
 decodeFailure c = foreignConventionError "Failure" (BoxedVal c)
 
-encodeFailure :: ForeignConvention a => F.Failure a -> Closure
+encodeFailure :: (ForeignConvention a) => F.Failure a -> Closure
 encodeFailure (F.Failure r msg v) = DataG Ty.failureRef TT.failureTag payload
   where
     payload = boxedSeg [encodeTypeLink r, encodeText msg, encodeAny v]
@@ -1665,10 +1684,10 @@ decodeTypeLink = marshalUnwrapForeignIO
 encodeTypeLink :: Reference -> Closure
 encodeTypeLink rf = Foreign (Wrap typeLinkRef rf)
 
-encodeAny :: ForeignConvention a => a -> Closure
+encodeAny :: (ForeignConvention a) => a -> Closure
 encodeAny v = Data1 anyRef TT.anyTag (encodeVal v)
 
-decodeAny :: ForeignConvention a => Closure -> IO a
+decodeAny :: (ForeignConvention a) => Closure -> IO a
 decodeAny (Data1 _ _ v) = decodeVal v
 decodeAny c = foreignConventionError "Any" (BoxedVal c)
 
@@ -1678,7 +1697,7 @@ decodeText = marshalUnwrapForeignIO
 encodeText :: Text -> Closure
 encodeText tx = Foreign (Wrap textRef tx)
 
-instance ForeignConvention a => ForeignConvention (F.Failure a) where
+instance (ForeignConvention a) => ForeignConvention (F.Failure a) where
   decodeVal (BoxedVal v) = decodeFailure v
   decodeVal v = foreignConventionError "Failure" v
   encodeVal v = BoxedVal $ encodeFailure v
@@ -1693,39 +1712,39 @@ decodeForeignClo ty c = foreignConventionError ty (BoxedVal c)
 encodeForeignClo :: Reference -> a -> Closure
 encodeForeignClo r = Foreign . Wrap r
 
-decodeBuiltin :: forall a. BuiltinForeign a => Val -> IO a
+decodeBuiltin :: forall a. (BuiltinForeign a) => Val -> IO a
 decodeBuiltin v
   | BoxedVal c <- v = decodeForeignClo ty c
   | otherwise = foreignConventionError ty v
   where
     Tagged ty = foreignName :: Tagged a String
 
-encodeBuiltin :: forall a. BuiltinForeign a => a -> Val
+encodeBuiltin :: forall a. (BuiltinForeign a) => a -> Val
 encodeBuiltin = BoxedVal . encodeForeignClo r
   where
     Tagged r = foreignRef :: Tagged a Reference
 
-readBuiltinAt :: forall a. BuiltinForeign a => Stack -> Int -> IO a
+readBuiltinAt :: forall a. (BuiltinForeign a) => Stack -> Int -> IO a
 readBuiltinAt stk i = bpeekOff stk i >>= decodeForeignClo ty
   where
     Tagged ty = foreignName :: Tagged a String
 
-writeBuiltin :: forall a. BuiltinForeign a => Stack -> a -> IO ()
+writeBuiltin :: forall a. (BuiltinForeign a) => Stack -> a -> IO ()
 writeBuiltin stk = bpoke stk . encodeForeignClo r
   where
     Tagged r = foreignRef :: Tagged a Reference
 
-decodeAsBuiltin :: BuiltinForeign t => (t -> a) -> Val -> IO a
+decodeAsBuiltin :: (BuiltinForeign t) => (t -> a) -> Val -> IO a
 decodeAsBuiltin k = fmap k . decodeBuiltin
 
-encodeAsBuiltin :: BuiltinForeign t => (a -> t) -> a -> Val
+encodeAsBuiltin :: (BuiltinForeign t) => (a -> t) -> a -> Val
 encodeAsBuiltin k = encodeBuiltin . k
 
-readAsBuiltin
-  :: BuiltinForeign t => (t -> a) -> Stack -> Int -> IO a
+readAsBuiltin ::
+  (BuiltinForeign t) => (t -> a) -> Stack -> Int -> IO a
 readAsBuiltin k stk i = k <$> readBuiltinAt stk i
 
-writeAsBuiltin :: BuiltinForeign t => (a -> t) -> Stack -> a -> IO ()
+writeAsBuiltin :: (BuiltinForeign t) => (a -> t) -> Stack -> a -> IO ()
 writeAsBuiltin k stk = writeBuiltin stk . k
 
 instance ForeignConvention POSIXTime where
@@ -1874,7 +1893,7 @@ instance ForeignConvention StdHnd where
 --   writeForeign = writeForeignAs (fmap Foreign)
 --
 
-instance {-# overlapping #-} ForeignConvention String where
+instance {-# OVERLAPPING #-} ForeignConvention String where
   decodeVal = decodeAsBuiltin unpack
   encodeVal = encodeAsBuiltin pack
 
@@ -1920,9 +1939,10 @@ instance ForeignConvention Foreign where
   decodeVal v = foreignConventionError "Foreign" v
   encodeVal f = BoxedVal (Foreign f)
 
-  readAtIndex stk i = bpeekOff stk i >>= \case
-    Foreign f -> pure f
-    c -> foreignConventionError "Foreign" (BoxedVal c)
+  readAtIndex stk i =
+    bpeekOff stk i >>= \case
+      Foreign f -> pure f
+      c -> foreignConventionError "Foreign" (BoxedVal c)
   writeBack stk f = bpoke stk (Foreign f)
 
 instance ForeignConvention (Seq Val) where
@@ -1935,7 +1955,7 @@ instance ForeignConvention (Seq Val) where
 
   writeBack = pokeS
 
-instance ForeignConvention a => ForeignConvention [a] where
+instance (ForeignConvention a) => ForeignConvention [a] where
   decodeVal (BoxedVal (Foreign f))
     | (sq :: Sq.Seq Val) <- unwrapForeign f = traverse decodeVal (toList sq)
   decodeVal v = foreignConventionError "List" v
@@ -1947,7 +1967,7 @@ instance ForeignConvention a => ForeignConvention [a] where
 
   writeBack stk sq = pokeS stk . Sq.fromList $ encodeVal <$> sq
 
-instance {-# overlappable #-} (BuiltinForeign b) => ForeignConvention b where
+instance {-# OVERLAPPABLE #-} (BuiltinForeign b) => ForeignConvention b where
   decodeVal = decodeBuiltin
   encodeVal = encodeBuiltin
   readAtIndex = readBuiltinAt
@@ -2048,29 +2068,29 @@ pseudoConstructors :: Map Reference (Map TT.CTag ForeignFunc)
 pseudoConstructors =
   Map.singleton Ty.mapRef $
     Map.fromList
-      [ (fromIntegral Ty.mapTip, Map_tip)
-      , (fromIntegral Ty.mapBin, Map_bin)
+      [ (fromIntegral Ty.mapTip, Map_tip),
+        (fromIntegral Ty.mapBin, Map_bin)
       ]
 
 functionReplacementList :: [(Data.Text.Text, ForeignFunc)]
 functionReplacementList =
-  [ ( "03hqp8knrcgdc733mitcunjlug4cpi9headkggu8h9d87nfgneo6e"
-    , Map_insert
-    )
-  , ( "03g44bb2bp3g5eld8eh07g6e8iq7oiqiplapeb6jerbs7ee3icq9s"
-    , Map_lookup
-    )
-  , ( "005mc1fq7ojq72c238qlm2rspjgqo2furjodf28icruv316odu6du"
-    , Map_fromList
-    )
-  , ( "03c559iihi2vj0qps6cln48nv31ajup2srhas4pd05b9k46ds8jvk"
-    , Map_eq
-    )
-  , ( "01f446li3b0j5gcnj7fa99jfqir43shs0jqu779oo0npb7v8d3v22"
-    , List_range
-    )
-  , ( "00jh7o3l67okqqalho1sqgl4ei9n2sdhrpqobgkf7j390v4e938km"
-    , List_sort
+  [ ( "03hqp8knrcgdc733mitcunjlug4cpi9headkggu8h9d87nfgneo6e",
+      Map_insert
+    ),
+    ( "03g44bb2bp3g5eld8eh07g6e8iq7oiqiplapeb6jerbs7ee3icq9s",
+      Map_lookup
+    ),
+    ( "005mc1fq7ojq72c238qlm2rspjgqo2furjodf28icruv316odu6du",
+      Map_fromList
+    ),
+    ( "03c559iihi2vj0qps6cln48nv31ajup2srhas4pd05b9k46ds8jvk",
+      Map_eq
+    ),
+    ( "01f446li3b0j5gcnj7fa99jfqir43shs0jqu779oo0npb7v8d3v22",
+      List_range
+    ),
+    ( "00jh7o3l67okqqalho1sqgl4ei9n2sdhrpqobgkf7j390v4e938km",
+      List_sort
     )
   ]
 

--- a/unison-runtime/src/Unison/Runtime/Machine.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine.hs
@@ -31,8 +31,8 @@ import Control.Concurrent.STM as STM
 import Control.Exception
 import Control.Lens
 import Data.Atomics qualified as Atomic
-import Data.List qualified as List
 import Data.IORef (IORef)
+import Data.List qualified as List
 import Data.Map.Strict qualified as M
 import Data.Map.Strict.Internal qualified as M
 import Data.Sequence qualified as Sq
@@ -74,9 +74,9 @@ import Unison.Runtime.Foreign.Function
     functionUnreplacements,
     pseudoConstructors,
   )
-import Unison.Runtime.Machine.Types
-import Unison.Runtime.Machine.Primops
 import Unison.Runtime.MCode
+import Unison.Runtime.Machine.Primops
+import Unison.Runtime.Machine.Types
 import Unison.Runtime.Stack
 import Unison.Runtime.TypeTags qualified as TT
 import Unison.Symbol (Symbol)
@@ -178,7 +178,7 @@ apply1 callback env threadTracker clo = do
   apply env mempty threadTracker stk k0 True ZArgs $ clo
   where
     k0 = CB $ Hook (\stk -> callback $ packXStack stk)
-{-# inline apply1 #-}
+{-# INLINE apply1 #-}
 
 unitValue :: Val
 unitValue = BoxedVal $ unitClosure
@@ -485,15 +485,16 @@ eval env !denv !activeThreads !stk !k r (Ins i nx) = do
       -- currently points to an appropriate `Failure` value, and
       -- we must handle the rest.
       | exception -> case EC.lookup TT.exceptionTag denv of
-        Just eh -> do
-          -- wrap the failure in an exception raise box
-          fv <- peek stk
-          bpoke stk $ Data1 exceptionRef TT.exceptionRaiseTag fv
-          (stk, fsz, asz) <- saveFrame stk
-          let kk = Push fsz asz fakeCix 10 nx k
-          apply env denv activeThreads stk kk False (VArg1 0) eh
-        Nothing -> -- should be impossible
-          unhandledAbilityRequest
+          Just eh -> do
+            -- wrap the failure in an exception raise box
+            fv <- peek stk
+            bpoke stk $ Data1 exceptionRef TT.exceptionRaiseTag fv
+            (stk, fsz, asz) <- saveFrame stk
+            let kk = Push fsz asz fakeCix 10 nx k
+            apply env denv activeThreads stk kk False (VArg1 0) eh
+          Nothing ->
+            -- should be impossible
+            unhandledAbilityRequest
       | otherwise -> eval env denv activeThreads stk k r nx
 eval _ !_ !_ !_activeThreads !_ _ Exit = pure ()
 eval _ !_ !_ !_activeThreads !_ _ (Die s) = die s
@@ -762,7 +763,7 @@ dumpDataValNoTag stk (BoxedVal c) =
   (closureTag c,) <$> dumpDataNoTag Nothing stk c
 dumpDataValNoTag _ v =
   die $ "dumpDataValNoTag: unboxed val: " ++ show v
-{-# inline dumpDataValNoTag #-}
+{-# INLINE dumpDataValNoTag #-}
 
 -- Dumps a data type closure to the stack without writing its tag.
 -- Instead, the tag is returned for direct case analysis.
@@ -863,22 +864,22 @@ selectBranch _ (TestT {}) = error "impossible"
 -- default cases potentially cover many constructors which could result
 -- in a variable number of values being put on the stack. Default cases
 -- uniformly expect _no_ values to be added to the stack.
-dataBranch
-  :: Maybe Reference -> Stack -> MBranch -> Closure -> IO (MSection, Stack)
+dataBranch ::
+  Maybe Reference -> Stack -> MBranch -> Closure -> IO (MSection, Stack)
 dataBranch mrf stk (Test1 u cu df) = \case
   Enum _ t
     | maskTags t == u -> pure (cu, stk)
     | otherwise -> pure (df, stk)
   Data1 _ t x
     | maskTags t == u -> do
-      stk <- bump stk
-      (cu, stk) <$ poke stk x
+        stk <- bump stk
+        (cu, stk) <$ poke stk x
     | otherwise -> pure (df, stk)
   Data2 _ t x y
     | maskTags t == u -> do
-      stk <- bumpn stk 2
-      pokeOff stk 1 y
-      (cu, stk) <$ poke stk x
+        stk <- bumpn stk 2
+        pokeOff stk 1 y
+        (cu, stk) <$ poke stk x
     | otherwise -> pure (df, stk)
   DataG _ t seg
     | maskTags t == u -> (cu,) <$> dumpSeg stk seg S
@@ -898,21 +899,21 @@ dataBranch mrf stk (Test2 u cu v cv df) = \case
     | otherwise -> pure (df, stk)
   Data1 _ t x
     | maskTags t == u -> do
-      stk <- bump stk
-      (cu, stk) <$ poke stk x
+        stk <- bump stk
+        (cu, stk) <$ poke stk x
     | maskTags t == v -> do
-      stk <- bump stk
-      (cv, stk) <$ poke stk x
+        stk <- bump stk
+        (cv, stk) <$ poke stk x
     | otherwise -> pure (df, stk)
   Data2 _ t x y
     | maskTags t == u -> do
-      stk <- bumpn stk 2
-      pokeOff stk 1 y
-      (cu, stk) <$ poke stk x
+        stk <- bumpn stk 2
+        pokeOff stk 1 y
+        (cu, stk) <$ poke stk x
     | maskTags t == v -> do
-      stk <- bumpn stk 2
-      pokeOff stk 1 y
-      (cv, stk) <$ poke stk x
+        stk <- bumpn stk 2
+        pokeOff stk 1 y
+        (cv, stk) <$ poke stk x
     | otherwise -> pure (df, stk)
   DataG _ t seg
     | maskTags t == u -> (cu,) <$> dumpSeg stk seg S
@@ -934,18 +935,18 @@ dataBranch mrf stk (TestW df bs) = \case
     | otherwise -> pure (df, stk)
   Data1 _ t x
     | Just ca <- EC.lookup (maskTags t) bs -> do
-      stk <- bump stk
-      (ca, stk) <$ poke stk x
+        stk <- bump stk
+        (ca, stk) <$ poke stk x
     | otherwise -> pure (df, stk)
   Data2 _ t x y
     | Just ca <- EC.lookup (maskTags t) bs -> do
-      stk <- bumpn stk 2
-      pokeOff stk 1 y
-      (ca, stk) <$ poke stk x
+        stk <- bumpn stk 2
+        pokeOff stk 1 y
+        (ca, stk) <$ poke stk x
     | otherwise -> pure (df, stk)
   DataG _ t seg
     | Just ca <- EC.lookup (maskTags t) bs ->
-      (ca,) <$> dumpSeg stk seg S
+        (ca,) <$> dumpSeg stk seg S
     | otherwise -> pure (df, stk)
   Foreign f
     | Just m <- maybeUnwrapForeign Rf.hmapRef f -> case m of
@@ -959,7 +960,7 @@ dataBranch mrf stk (TestW df bs) = \case
   clo -> dataBranchClosureError mrf clo
 dataBranch _ _ br = \_ ->
   dataBranchBranchError br
-{-# inline dataBranch #-}
+{-# INLINE dataBranch #-}
 
 dumpBin :: Int -> Val -> Val -> Map Val Val -> Map Val Val -> Stack -> IO Stack
 dumpBin sz k e l r stk = do
@@ -970,13 +971,14 @@ dumpBin sz k e l r stk = do
   pokeOffBi stk 3 l
   pokeOffBi stk 4 r
   pure stk
-{-# inline dumpBin #-}
+{-# INLINE dumpBin #-}
 
 dataBranchClosureError :: Maybe Reference -> Closure -> IO a
 dataBranchClosureError mrf clo =
-  die $ "dataBranch: bad closure: "
-    ++ show clo
-    ++ maybe "" (\ r -> "\nexpected type: " ++ show r) mrf
+  die $
+    "dataBranch: bad closure: "
+      ++ show clo
+      ++ maybe "" (\r -> "\nexpected type: " ++ show r) mrf
 
 dataBranchBranchError :: MBranch -> IO a
 dataBranchBranchError br =
@@ -1121,8 +1123,9 @@ cacheAdd0 ntys0 termSuperGroups sands cc = do
         inlinfo =
           ANF.buildInlineMap (fmap replace int) <> builtinInlineInfo
         rns = RN (refLookup "ty" rty) (refLookup "tm" rtm) (flip M.lookup arities)
-        replace = ANF.replaceConstructors pseudoConstructors
-                . ANF.replaceFunctions functionReplacements
+        replace =
+          ANF.replaceConstructors pseudoConstructors
+            . ANF.replaceFunctions functionReplacements
         optimize = ANF.inline inlinfo . replace
         combinate :: Word64 -> (Reference, SuperGroup Symbol) -> (Word64, EnumMap Word64 Comb)
         combinate n (r, g) =

--- a/unison-runtime/src/Unison/Runtime/Machine.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine.hs
@@ -88,7 +88,6 @@ import Unison.Util.Text qualified as Util.Text
 import UnliftIO qualified
 import UnliftIO.Concurrent qualified as UnliftIO
 
-{- ORMOLU_DISABLE -}
 #ifdef STACK_CHECK
 import Unison.Debug qualified as Debug
 import System.IO.Unsafe (unsafePerformIO)
@@ -97,7 +96,6 @@ import System.IO.Unsafe (unsafePerformIO)
 #ifdef OPT_CHECK
 import Test.Inspection qualified as TI
 #endif
-{- ORMOLU_ENABLE -}
 
 info :: (Show a) => String -> a -> IO ()
 info ctx x = infos ctx (show x)
@@ -195,7 +193,6 @@ litToVal = \case
   MD d -> DoubleVal d
 {-# INLINE litToVal #-}
 
-{- ORMOLU_DISABLE -}
 #ifdef STACK_CHECK
 debugger :: (Show a) => Stack -> String -> a -> Bool
 debugger stk msg a = unsafePerformIO $ do
@@ -214,7 +211,6 @@ dumpStack stk@(Stack ap fp sp _ustk _bstk)
         peekOff stk (i + (sp - fp))
       Debug.debugM Debug.Interpreter "Stack args 👇:" stkArgs
 #endif
-{- ORMOLU_ENABLE -}
 
 -- | Execute an instruction
 exec ::
@@ -226,12 +222,10 @@ exec ::
   Reference ->
   MInstr ->
   IO (Bool, DEnv, Stack, K)
-{- ORMOLU_DISABLE -}
 #ifdef STACK_CHECK
 exec _ !_ !_ !stk !_ !_ instr
   | debugger stk "exec" instr = undefined
 #endif
-{- ORMOLU_ENABLE -}
 exec _ !denv !_activeThreads !stk !k _ (Info tx) = do
   info tx stk
   info tx k
@@ -425,12 +419,10 @@ eval ::
   Reference ->
   MSection ->
   IO ()
-{- ORMOLU_DISABLE -}
 #ifdef STACK_CHECK
 eval _ !_ !_ !stk !_ !_ section
   | debugger stk "eval" section = undefined
 #endif
-{- ORMOLU_ENABLE -}
 eval env !denv !activeThreads !stk !k r (Match i (TestT df cs)) = do
   t <- peekOffBi stk i
   eval env denv activeThreads stk k r $ selectTextBranch t df cs
@@ -591,12 +583,10 @@ apply ::
   Args ->
   Val ->
   IO ()
-{- ORMOLU_DISABLE -}
 #ifdef STACK_CHECK
 apply _env !_denv !_activeThreads !stk !_k !_ck !args !val
   | debugger stk "apply" (args, val) = undefined
 #endif
-{- ORMOLU_ENABLE -}
 apply env !denv !activeThreads !stk !k !ck !args !val =
   case val of
     BoxedVal (PAp cix@(CIx combRef _ _) comb seg) ->
@@ -1414,7 +1404,6 @@ reifyValue0 (combs, rty, rtm) = goV
     goL (ANF.Neg w) = pure $ IntVal (negate (fromIntegral w :: Int))
     goL (ANF.Float d) = pure $ DoubleVal d
     goL (ANF.Arr a) = boxedVal . Foreign . Wrap Rf.iarrayRef <$> traverse goV a
-{- ORMOLU_DISABLE -}
 #ifdef OPT_CHECK
 -- Assert that we don't allocate any 'Stack' objects in 'eval', since we expect GHC to always
 -- trigger the worker/wrapper optimization and unbox it fully, and if it fails to do so, we want to
@@ -1442,4 +1431,3 @@ reifyValue0 (combs, rty, rtm) = goV
 -- Best of luck!
 TI.inspect $ 'eval0 `TI.hasNoType` ''Stack
 #endif
-{- ORMOLU_ENABLE -}

--- a/unison-runtime/src/Unison/Runtime/Machine/Primops.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine/Primops.hs
@@ -1,25 +1,24 @@
-
 module Unison.Runtime.Machine.Primops where
 
-import Control.Exception
 import Control.Concurrent.STM as STM
+import Control.Exception
 import Data.Atomics qualified as Atomic
 import Data.Bits
-import Data.Map.Strict qualified as M
 import Data.IORef (IORef)
 import Data.IORef qualified as IORef
+import Data.Map.Strict qualified as M
 import Data.Sequence qualified as Sq
 import Data.Set qualified as S
 import Data.Word
 import Unison.Builtin.Decls qualified as Ty
 import Unison.Prelude hiding (Text)
 import Unison.Reference (Reference)
-import Unison.Referent (Referent, pattern Ref, toShortHash)
-import Unison.Runtime.ANF (Value, Code, codeGroup)
+import Unison.Referent (Referent, toShortHash, pattern Ref)
+import Unison.Runtime.ANF (Code, Value, codeGroup)
 import Unison.Runtime.Foreign
 import Unison.Runtime.Foreign.Function
-import Unison.Runtime.Machine.Types
 import Unison.Runtime.MCode
+import Unison.Runtime.Machine.Types
 import Unison.Runtime.Stack
 import Unison.Runtime.TypeTags qualified as Ty
 import Unison.ShortHash qualified as SH
@@ -29,14 +28,16 @@ import Unison.Util.Bytes qualified as By
 import Unison.Util.Text as UText
 
 prim1wrap ::
-  ForeignConvention x =>
+  (ForeignConvention x) =>
   (Stack -> x -> IO ()) ->
-  Stack -> Int -> IO Stack
+  Stack ->
+  Int ->
+  IO Stack
 prim1wrap f stk i = do
   x <- readAtIndex stk i
   stk <- bump stk
   stk <$ f stk x
-{-# inline prim1wrap #-}
+{-# INLINE prim1wrap #-}
 
 prim1 :: CCache -> Stack -> Prim1 -> Int -> IO Stack
 prim1 !_env !stk DECI !i = prim1wrap deci stk i
@@ -96,32 +97,33 @@ prim1 !_env !stk REFR i = prim1wrap refr stk i
 prim1 !_env !stk REFN i = prim1wrap refn stk i
 prim1 !env !stk RRFC i = prim1wrap (rrfc env) stk i
 prim1 !_env !stk TIKR i = prim1wrap tikr stk i
-
 prim1 !env !stk MISS i = prim1wrap (miss env) stk i
 prim1 !env !stk SDBL i = prim1wrap (sdbl env) stk i
 prim1 !env !stk LKUP i = prim1wrap (lkup env) stk i
 prim1 !env !stk CVLD i = prim1wrap (cvld env) stk i
 prim1 !_env !stk TLTT i = prim1wrap tltt stk i
 prim1 !env !stk DBTX i = prim1wrap (dbtx env) stk i
-
 -- handled elsewhere
 prim1 !_env !stk CACH _ = pure stk
 prim1 !_env !stk LOAD _ = pure stk
 prim1 !_env !stk VALU _ = pure stk
-{-# inline prim1 #-}
+{-# INLINE prim1 #-}
 
 -- Wrap an implementation to act on an index on two indices
 prim2wrap2 ::
-  ForeignConvention x =>
-  ForeignConvention y =>
+  (ForeignConvention x) =>
+  (ForeignConvention y) =>
   (Stack -> x -> y -> IO ()) ->
-  Stack -> Int -> Int -> IO Stack
+  Stack ->
+  Int ->
+  Int ->
+  IO Stack
 prim2wrap2 f stk i j = do
   x <- readAtIndex stk i
   y <- readAtIndex stk j
   stk <- bump stk
   stk <$ f stk x y
-{-# inline prim2wrap2 #-}
+{-# INLINE prim2wrap2 #-}
 
 -- Primops applied to two stack indices
 primxx :: CCache -> Stack -> Prim2 -> Int -> Int -> IO Stack
@@ -140,7 +142,6 @@ primxx _env stk XORI i j = prim2wrap2 xori stk i j
 primxx _env stk SHLI i j = prim2wrap2 shli stk i j
 primxx _env stk SHRI i j = prim2wrap2 shri stk i j
 primxx _env stk POWI i j = prim2wrap2 powi stk i j
-
 primxx _env stk ADDN i j = prim2wrap2 addn stk i j
 primxx _env stk SUBN i j = prim2wrap2 subn stk i j
 primxx _env stk MULN i j = prim2wrap2 muln stk i j
@@ -157,7 +158,6 @@ primxx _env stk ANDN i j = prim2wrap2 andn stk i j
 primxx _env stk IORN i j = prim2wrap2 iorn stk i j
 primxx _env stk XORN i j = prim2wrap2 xorn stk i j
 primxx _env stk DRPN i j = prim2wrap2 drpn stk i j
-
 primxx _env stk EQLF i j = prim2wrap2 eqlf stk i j
 primxx _env stk NEQF i j = prim2wrap2 neqf stk i j
 primxx _env stk LEQF i j = prim2wrap2 leqf stk i j
@@ -199,14 +199,12 @@ primxx _env stk REFW i j = prim2wrap2 refw stk i j
 primxx _env stk CAST i j = prim2wrap2 cast stk i j
 primxx _env stk ANDB i j = prim2wrap2 andb stk i j
 primxx _env stk IORB i j = prim2wrap2 iorb stk i j
-
 primxx env stk SDBV i j = prim2wrap2 (sdbv env) stk i j
 primxx env stk SDBX i j = prim2wrap2 (sdbx env) stk i j
-
 -- handled elsewhere
 primxx _env stk THRO _ _ = pure stk
 primxx _env stk TRCE _ _ = pure stk
-{-# inline primxx #-}
+{-# INLINE primxx #-}
 
 termLinkVal :: Referent -> Val
 termLinkVal = BoxedVal . Foreign . Wrap Rf.termLinkRef
@@ -344,15 +342,15 @@ ftot stk f = pokeBi stk . UText.pack $ show f
 
 usnc :: Stack -> Text -> IO ()
 usnc stk t = writeBack stk (UText.unsnoc t)
-{-# inline usnc #-}
+{-# INLINE usnc #-}
 
 ucns :: Stack -> Text -> IO ()
 ucns stk t = writeBack stk (UText.uncons t)
-{-# inline ucns #-}
+{-# INLINE ucns #-}
 
 readIntegral :: (Bounded n, Integral n) => String -> Maybe n
 readIntegral s = clamp =<< readMaybe s
-{-# inline readIntegral #-}
+{-# INLINE readIntegral #-}
 
 clamp :: forall n. (Bounded n, Integral n) => Integer -> Maybe n
 clamp i
@@ -361,7 +359,7 @@ clamp i
   where
     minb = fromIntegral (minBound :: n)
     maxb = fromIntegral (maxBound :: n)
-{-# inline clamp #-}
+{-# INLINE clamp #-}
 
 ttoi :: Stack -> Text -> IO ()
 ttoi stk t = writeBack stk (readi $ UText.unpack t)
@@ -369,11 +367,11 @@ ttoi stk t = writeBack stk (readi $ UText.unpack t)
     readi :: String -> Maybe Int
     readi ('+' : s) = readIntegral s
     readi s = readIntegral s
-{-# inline ttoi #-}
+{-# INLINE ttoi #-}
 
 tton :: Stack -> Text -> IO ()
 tton stk t = writeBack stk (readIntegral @Word64 $ UText.unpack t)
-{-# inline tton #-}
+{-# INLINE tton #-}
 
 ttof :: Stack -> Text -> IO ()
 ttof stk t = writeBack stk (readd $ UText.unpack t)
@@ -387,7 +385,7 @@ vwls stk s = writeBack stk result
     result = case s of
       Sq.Empty -> SeqViewEmpty
       x Sq.:<| xs -> SeqViewElem x xs
-{-# inline vwls #-}
+{-# INLINE vwls #-}
 
 vwrs :: Stack -> USeq -> IO ()
 vwrs stk s = writeBack stk result
@@ -395,7 +393,7 @@ vwrs stk s = writeBack stk result
     result = case s of
       Sq.Empty -> SeqViewEmpty
       xs Sq.:|> x -> SeqViewElem xs x
-{-# inline vwrs #-}
+{-# INLINE vwrs #-}
 
 pakt :: Stack -> USeq -> IO ()
 pakt stk s = pokeBi stk . UText.pack . toList $ val2char <$> s
@@ -468,11 +466,11 @@ miss env stk tl
         m <- readTVarIO (intermed env)
         pokeBool stk (link `M.member` m)
       _ -> die "exec:prim1:MISS: expected Ref"
-{-# inline miss #-}
+{-# INLINE miss #-}
 
 sdbl :: CCache -> Stack -> Referent -> IO ()
 sdbl env stk tl = writeBack stk =<< sandboxList env tl
-{-# inline sdbl #-}
+{-# INLINE sdbl #-}
 
 sandboxList :: CCache -> Referent -> IO [Reference]
 sandboxList cc (Ref r) = do
@@ -484,7 +482,7 @@ lkup :: CCache -> Stack -> Referent -> IO ()
 lkup env stk tl
   | sandboxed env = die "attempted to use sandboxed operation: lookup"
   | otherwise = writeBack stk =<< lookupCode env tl
-{-# inline lkup #-}
+{-# INLINE lkup #-}
 
 cvld :: CCache -> Stack -> [(Referent, Code)] -> IO ()
 cvld env stk news
@@ -494,12 +492,12 @@ cvld env stk news
   where
     extract (Ref r, code) = pure (r, codeGroup code)
     extract _ = die "Prim1:CVLD: Con reference"
-{-# inline cvld #-}
+{-# INLINE cvld #-}
 
 tltt :: Stack -> Referent -> IO ()
 tltt stk r =
   pokeBi stk . UText.fromText . SH.toText $ toShortHash r
-{-# inline tltt #-}
+{-# INLINE tltt #-}
 
 dbtx :: CCache -> Stack -> Val -> IO ()
 dbtx env stk val
@@ -511,183 +509,183 @@ dbtx env stk val
       NoTrace -> Nothing
       MsgTrace _ _ tx -> Just . Left $ UText.pack tx
       SimpleTrace tx -> Just . Right $ UText.pack tx
-{-# inline dbtx #-}
+{-# INLINE dbtx #-}
 
 addi :: Stack -> Int -> Int -> IO ()
 addi stk m n = pokeI stk (m + n)
-{-# inline addi #-}
+{-# INLINE addi #-}
 
 subi :: Stack -> Int -> Int -> IO ()
 subi stk m n = pokeI stk (m - n)
-{-# inline subi #-}
+{-# INLINE subi #-}
 
 muli :: Stack -> Int -> Int -> IO ()
 muli stk m n = pokeI stk (m * n)
-{-# inline muli #-}
+{-# INLINE muli #-}
 
 divi :: Stack -> Int -> Int -> IO ()
 divi stk m n = pokeI stk (m `div` n)
-{-# inline divi #-}
+{-# INLINE divi #-}
 
 modi :: Stack -> Int -> Int -> IO ()
 modi stk m n = pokeI stk (m `mod` n)
-{-# inline modi #-}
+{-# INLINE modi #-}
 
 eqli :: Stack -> Int -> Int -> IO ()
 eqli stk m n = pokeBool stk (m == n)
-{-# inline eqli #-}
+{-# INLINE eqli #-}
 
 neqi :: Stack -> Int -> Int -> IO ()
 neqi stk m n = pokeBool stk (m /= n)
-{-# inline neqi #-}
+{-# INLINE neqi #-}
 
 leqi :: Stack -> Int -> Int -> IO ()
 leqi stk m n = pokeBool stk (m <= n)
-{-# inline leqi #-}
+{-# INLINE leqi #-}
 
 lesi :: Stack -> Int -> Int -> IO ()
 lesi stk m n = pokeBool stk (m < n)
-{-# inline lesi #-}
+{-# INLINE lesi #-}
 
 andi :: Stack -> Int -> Int -> IO ()
 andi stk m n = pokeI stk (m .&. n)
-{-# inline andi #-}
+{-# INLINE andi #-}
 
 iori :: Stack -> Int -> Int -> IO ()
 iori stk m n = pokeI stk (m .|. n)
-{-# inline iori #-}
+{-# INLINE iori #-}
 
 xori :: Stack -> Int -> Int -> IO ()
 xori stk m n = pokeI stk (m `xor` n)
-{-# inline xori #-}
+{-# INLINE xori #-}
 
 shli :: Stack -> Int -> Int -> IO ()
 shli stk m n = pokeI stk (m `shiftL` n)
-{-# inline shli #-}
+{-# INLINE shli #-}
 
 shri :: Stack -> Int -> Int -> IO ()
 shri stk m n = pokeI stk (m `shiftR` n)
-{-# inline shri #-}
+{-# INLINE shri #-}
 
 powi :: Stack -> Int -> Word64 -> IO ()
 powi stk m n = pokeI stk (m ^ n)
-{-# inline powi #-}
+{-# INLINE powi #-}
 
 addn :: Stack -> Word64 -> Word64 -> IO ()
 addn stk m n = pokeN stk (m + n)
-{-# inline addn #-}
+{-# INLINE addn #-}
 
 subn :: Stack -> Word64 -> Word64 -> IO ()
 subn stk m n = pokeI stk . fromIntegral $ m - n
-{-# inline subn #-}
+{-# INLINE subn #-}
 
 muln :: Stack -> Word64 -> Word64 -> IO ()
 muln stk m n = pokeN stk (m * n)
-{-# inline muln #-}
+{-# INLINE muln #-}
 
 divn :: Stack -> Word64 -> Word64 -> IO ()
 divn stk m n = pokeN stk (m `div` n)
-{-# inline divn #-}
+{-# INLINE divn #-}
 
 modn :: Stack -> Word64 -> Word64 -> IO ()
 modn stk m n = pokeN stk (m `mod` n)
-{-# inline modn #-}
+{-# INLINE modn #-}
 
 shln :: Stack -> Word64 -> Int -> IO ()
 shln stk m n = pokeN stk (m `shiftL` n)
-{-# inline shln #-}
+{-# INLINE shln #-}
 
 shrn :: Stack -> Word64 -> Int -> IO ()
 shrn stk m n = pokeN stk (m `shiftR` n)
-{-# inline shrn #-}
+{-# INLINE shrn #-}
 
 pown :: Stack -> Word64 -> Word64 -> IO ()
 pown stk m n = pokeN stk (m ^ n)
-{-# inline pown #-}
+{-# INLINE pown #-}
 
 eqln :: Stack -> Word64 -> Word64 -> IO ()
 eqln stk m n = pokeBool stk (m == n)
-{-# inline eqln #-}
+{-# INLINE eqln #-}
 
 neqn :: Stack -> Word64 -> Word64 -> IO ()
 neqn stk m n = pokeBool stk (m /= n)
-{-# inline neqn #-}
+{-# INLINE neqn #-}
 
 leqn :: Stack -> Word64 -> Word64 -> IO ()
 leqn stk m n = pokeBool stk (m <= n)
-{-# inline leqn #-}
+{-# INLINE leqn #-}
 
 lesn :: Stack -> Word64 -> Word64 -> IO ()
 lesn stk m n = pokeBool stk (m < n)
-{-# inline lesn #-}
+{-# INLINE lesn #-}
 
 andn :: Stack -> Word64 -> Word64 -> IO ()
 andn stk m n = pokeN stk (m .&. n)
-{-# inline andn #-}
+{-# INLINE andn #-}
 
 iorn :: Stack -> Word64 -> Word64 -> IO ()
 iorn stk m n = pokeN stk (m .|. n)
-{-# inline iorn #-}
+{-# INLINE iorn #-}
 
 xorn :: Stack -> Word64 -> Word64 -> IO ()
 xorn stk m n = pokeN stk (m `xor` n)
-{-# inline xorn #-}
+{-# INLINE xorn #-}
 
 drpn :: Stack -> Word64 -> Word64 -> IO ()
 drpn stk m n = pokeN stk $ if n >= m then 0 else m - n
-{-# inline drpn #-}
+{-# INLINE drpn #-}
 
 eqlf :: Stack -> Double -> Double -> IO ()
 eqlf stk x y = pokeBool stk (x == y)
-{-# inline eqlf #-}
+{-# INLINE eqlf #-}
 
 neqf :: Stack -> Double -> Double -> IO ()
 neqf stk x y = pokeBool stk (x /= y)
-{-# inline neqf #-}
+{-# INLINE neqf #-}
 
 leqf :: Stack -> Double -> Double -> IO ()
 leqf stk x y = pokeBool stk (x <= y)
-{-# inline leqf #-}
+{-# INLINE leqf #-}
 
 lesf :: Stack -> Double -> Double -> IO ()
 lesf stk x y = pokeBool stk (x < y)
-{-# inline lesf #-}
+{-# INLINE lesf #-}
 
 addf :: Stack -> Double -> Double -> IO ()
 addf stk x y = pokeD stk (x + y)
-{-# inline addf #-}
+{-# INLINE addf #-}
 
 subf :: Stack -> Double -> Double -> IO ()
 subf stk x y = pokeD stk (x - y)
-{-# inline subf #-}
+{-# INLINE subf #-}
 
 mulf :: Stack -> Double -> Double -> IO ()
 mulf stk x y = pokeD stk (x * y)
-{-# inline mulf #-}
+{-# INLINE mulf #-}
 
 divf :: Stack -> Double -> Double -> IO ()
 divf stk x y = pokeD stk (x / y)
-{-# inline divf #-}
+{-# INLINE divf #-}
 
 atn2 :: Stack -> Double -> Double -> IO ()
 atn2 stk x y = pokeD stk (atan2 x y)
-{-# inline atn2 #-}
+{-# INLINE atn2 #-}
 
 powf :: Stack -> Double -> Double -> IO ()
 powf stk x y = pokeD stk (x ** y)
-{-# inline powf #-}
+{-# INLINE powf #-}
 
 logb :: Stack -> Double -> Double -> IO ()
 logb stk x y = pokeD stk (logBase x y)
-{-# inline logb #-}
+{-# INLINE logb #-}
 
 maxf :: Stack -> Double -> Double -> IO ()
 maxf stk x y = pokeD stk (max x y)
-{-# inline maxf #-}
+{-# INLINE maxf #-}
 
 minf :: Stack -> Double -> Double -> IO ()
 minf stk x y = pokeD stk (min x y)
-{-# inline minf #-}
+{-# INLINE minf #-}
 
 drpt :: Stack -> Int -> Text -> IO ()
 drpt stk n t0 = pokeBi stk t
@@ -696,7 +694,8 @@ drpt stk n t0 = pokeBi stk t
     -- signed integer. As an approximation, just return the empty
     -- string, as a string larger than this would require an absurd
     -- amount of memory.
-    t | n < 0 = UText.empty
+    t
+      | n < 0 = UText.empty
       | otherwise = UText.drop n t0
 
 takt :: Stack -> Int -> Text -> IO ()
@@ -706,44 +705,45 @@ takt stk n t0 = pokeBi stk t
     -- signed integer. As an approximation, we just return the
     -- original string, because it's unlikely such a large string
     -- exists.
-    t | n < 0 = t0
+    t
+      | n < 0 = t0
       | otherwise = UText.take n t0
 
 catt :: Stack -> Text -> Text -> IO ()
 catt stk x y = pokeBi stk (x <> y :: UText.Text)
-{-# inline catt #-}
+{-# INLINE catt #-}
 
 ixot :: Stack -> Text -> Text -> IO ()
 ixot stk x y = writeBack stk $ UText.indexOf x y
-{-# inline ixot #-}
+{-# INLINE ixot #-}
 
 eqlt :: Stack -> Text -> Text -> IO ()
 eqlt stk x y = pokeBool stk $ x == y
-{-# inline eqlt #-}
+{-# INLINE eqlt #-}
 
 leqt :: Stack -> Text -> Text -> IO ()
 leqt stk x y = pokeBool stk $ x <= y
-{-# inline leqt #-}
+{-# INLINE leqt #-}
 
 lest :: Stack -> Text -> Text -> IO ()
 lest stk x y = pokeBool stk $ x < y
-{-# inline lest #-}
+{-# INLINE lest #-}
 
 eqlu :: Stack -> Val -> Val -> IO ()
 eqlu stk x y = pokeBool stk $ universalEq (==) x y
-{-# inline eqlu #-}
+{-# INLINE eqlu #-}
 
 cmpu :: Stack -> Val -> Val -> IO ()
 cmpu stk x y = pokeI stk . pred . fromEnum $ universalCompare compare x y
-{-# inline cmpu #-}
+{-# INLINE cmpu #-}
 
 lequ :: Stack -> Val -> Val -> IO ()
 lequ stk x y = pokeBool stk $ universalCompare compare x y /= GT
-{-# inline lequ #-}
+{-# INLINE lequ #-}
 
 lesu :: Stack -> Val -> Val -> IO ()
 lesu stk x y = pokeBool stk $ universalCompare compare x y == LT
-{-# inline lesu #-}
+{-# INLINE lesu #-}
 
 -- Note: if n < 0, then the Nat argument was larger than the largest
 -- signed integer. Seq actually doesn't handle this well, despite it
@@ -751,30 +751,31 @@ lesu stk x y = pokeBool stk $ universalCompare compare x y == LT
 -- approximate by yielding the empty sequence.
 drps :: Stack -> Int -> USeq -> IO ()
 drps stk n s = pokeS stk $ if n < 0 then Sq.empty else Sq.drop n s
-{-# inline drps #-}
+{-# INLINE drps #-}
 
 taks :: Stack -> Int -> USeq -> IO ()
 taks stk n s = pokeS stk $ if n < 0 then s else Sq.take n s
-{-# inline taks #-}
+{-# INLINE taks #-}
 
 cons :: Stack -> Val -> USeq -> IO ()
 cons stk x s = pokeS stk $ x Sq.<| s
-{-# inline cons #-}
+{-# INLINE cons #-}
 
 snoc :: Stack -> USeq -> Val -> IO ()
 snoc stk s x = pokeS stk $ s Sq.|> x
-{-# inline snoc #-}
+{-# INLINE snoc #-}
 
 idxs :: Stack -> Int -> USeq -> IO ()
 idxs stk n s = writeBack stk $ Sq.lookup n s
-{-# inline idxs #-}
+{-# INLINE idxs #-}
 
 data SeqView a b = SeqViewEmpty | SeqViewElem a b
 
 decodeSeqView ::
-  ForeignConvention a =>
-  ForeignConvention b =>
-  Closure -> IO (SeqView a b)
+  (ForeignConvention a) =>
+  (ForeignConvention b) =>
+  Closure ->
+  IO (SeqView a b)
 decodeSeqView (Enum _ t)
   | t == Ty.seqViewEmptyTag = pure SeqViewEmpty
 decodeSeqView (Data2 _ t x y)
@@ -785,17 +786,21 @@ seqViewE :: Closure
 seqViewE = Enum Ty.seqViewRef Ty.seqViewEmptyTag
 
 encodeSeqView ::
-  ForeignConvention a =>
-  ForeignConvention b =>
-  SeqView a b -> Closure
+  (ForeignConvention a) =>
+  (ForeignConvention b) =>
+  SeqView a b ->
+  Closure
 encodeSeqView SeqViewEmpty = seqViewE
 encodeSeqView (SeqViewElem x y) =
   Data2 Ty.seqViewRef Ty.seqViewElemTag (encodeVal x) (encodeVal y)
-{-# inline encodeSeqView #-}
+{-# INLINE encodeSeqView #-}
 
-instance ( ForeignConvention a
-         , ForeignConvention b
-         ) => ForeignConvention (SeqView a b) where
+instance
+  ( ForeignConvention a,
+    ForeignConvention b
+  ) =>
+  ForeignConvention (SeqView a b)
+  where
   readAtIndex stk i = decodeSeqView =<< bpeekOff stk i
 
   decodeVal (BoxedVal c) = decodeSeqView c
@@ -807,65 +812,67 @@ instance ( ForeignConvention a
   encodeVal = BoxedVal . encodeSeqView
 
   writeBack stk v = bpoke stk $ encodeSeqView v
-  {-# inline writeBack #-}
+  {-# INLINE writeBack #-}
 
 spll :: Stack -> Int -> USeq -> IO ()
 spll stk n s = writeBack stk result
   where
-    result | Sq.length s < n = SeqViewEmpty
-           | (l, r) <- Sq.splitAt n s = SeqViewElem l r
-{-# inline spll #-}
+    result
+      | Sq.length s < n = SeqViewEmpty
+      | (l, r) <- Sq.splitAt n s = SeqViewElem l r
+{-# INLINE spll #-}
 
 splr :: Stack -> Int -> USeq -> IO ()
 splr stk n s = writeBack stk result
   where
-    result | Sq.length s < n = SeqViewEmpty
-           | (l, r) <- Sq.splitAt (Sq.length s - n) s = SeqViewElem l r
-{-# inline splr #-}
+    result
+      | Sq.length s < n = SeqViewEmpty
+      | (l, r) <- Sq.splitAt (Sq.length s - n) s = SeqViewElem l r
+{-# INLINE splr #-}
 
 cats :: Stack -> USeq -> USeq -> IO ()
 cats stk x y = pokeS stk $ x Sq.>< y
-{-# inline cats #-}
+{-# INLINE cats #-}
 
 -- If n < 0, the Nat argument was larger than the maximum signed
 -- integer. Building a value this large would reuire an absurd
 -- amount of memory, so just assume n is larger.
 takb :: Stack -> Int -> Bytes -> IO ()
 takb stk n b = pokeBi stk $ if n < 0 then b else By.take n b
-{-# inline takb #-}
+{-# INLINE takb #-}
 
 -- See above for n < 0
 drpb :: Stack -> Int -> Bytes -> IO ()
 drpb stk n b = pokeBi stk $ if n < 0 then By.empty else By.drop n b
-{-# inline drpb #-}
+{-# INLINE drpb #-}
 
 idxb :: Stack -> Int -> Bytes -> IO ()
 idxb stk n b = writeBack stk $ By.at n b
-{-# inline idxb #-}
+{-# INLINE idxb #-}
 
 catb :: Stack -> Bytes -> Bytes -> IO ()
 catb stk l r = writeBack stk $ l <> r
-{-# inline catb #-}
+{-# INLINE catb #-}
 
 ixob :: Stack -> Bytes -> Bytes -> IO ()
 ixob stk l r = writeBack stk $ By.indexOf l r
-{-# inline ixob #-}
+{-# INLINE ixob #-}
 
 refw :: Stack -> IORef Val -> Val -> IO ()
 refw stk ref v = IORef.writeIORef ref v *> bpoke stk unitClosure
-{-# inline refw #-}
+{-# INLINE refw #-}
 
 cast :: Stack -> Int -> Int -> IO ()
 cast stk n tag = poke stk $ UnboxedVal n (unboxedTypeTagFromInt tag)
-{-# inline cast #-}
+{-# INLINE cast #-}
 
 andb :: Stack -> Bool -> Bool -> IO ()
 andb stk x y = pokeBool stk $ x && y
-{-# inline andb #-}
+{-# INLINE andb #-}
 
 iorb :: Stack -> Bool -> Bool -> IO ()
 iorb stk x y = pokeBool stk $ x || y
-{-# inline iorb #-}
+{-# INLINE iorb #-}
 
 sdbv :: CCache -> Stack -> [Referent] -> Value -> IO ()
 sdbv env stk allowed0 v
@@ -873,12 +880,11 @@ sdbv env stk allowed0 v
       die "attempted to use sandboxed operation: Value.validateSandboxed"
   | otherwise = checkValueSandboxing env allowed v >>= writeBack stk
   where
-    allowed = allowed0 >>= \case (Ref r) -> [r] ; _ -> []
-{-# inline sdbv #-}
+    allowed = allowed0 >>= \case (Ref r) -> [r]; _ -> []
+{-# INLINE sdbv #-}
 
 sdbx :: CCache -> Stack -> [Referent] -> Closure -> IO ()
 sdbx env stk allowed0 c = checkSandboxing env allowed c >>= pokeBool stk
   where
-    allowed = allowed0 >>= \case (Ref r) -> [r] ; _ -> []
-{-# inline sdbx #-}
-
+    allowed = allowed0 >>= \case (Ref r) -> [r]; _ -> []
+{-# INLINE sdbx #-}

--- a/unison-runtime/src/Unison/Runtime/Stack.hs
+++ b/unison-runtime/src/Unison/Runtime/Stack.hs
@@ -191,7 +191,6 @@ import Unison.Util.EnumContainers as EC
 import Unison.Util.Monoid qualified as Monoid
 import Prelude hiding (words)
 
-{- ORMOLU_DISABLE -}
 #ifdef STACK_CHECK
 type DebugCallStack = (HasCallStack :: Constraint)
 
@@ -228,7 +227,6 @@ pokeSentinelOff (Stack _ _ sp ustk bstk) off = do
 -- Don't track callstacks in production, it's expensive
 type DebugCallStack = (() :: Constraint)
 #endif
-{- ORMOLU_ENABLE -}
 
 newtype Callback = Hook (XStack -> IO ())
 
@@ -287,7 +285,6 @@ unboxedTypeTagFromInt = \case
   3 -> NatTag
   _ -> error "intToUnboxedTypeTag: invalid tag"
 
-{- ORMOLU_DISABLE -}
 data GClosure comb
   = GPAp
       !CombIx
@@ -309,7 +306,6 @@ data GClosure comb
   | GUnboxedSentinel
 #endif
   deriving stock (Show, Functor, Foldable, Traversable)
-{- ORMOLU_ENABLE -}
 
 -- Singleton black hole value to avoid allocation.
 blackHole :: Closure
@@ -806,7 +802,6 @@ alloc = do
   pure $ Stack {ap = -1, fp = -1, sp = -1, ustk, bstk}
 {-# INLINE alloc #-}
 
-{- ORMOLU_DISABLE -}
 peek :: DebugCallStack => Stack -> IO Val
 peek stk@(Stack _ _ sp ustk _) = do
   -- Can't use upeek here because in stack-check mode it will assert that the stack slot is unboxed.
@@ -1175,8 +1170,6 @@ peekOffC _stk@(Stack _ _ sp ustk _) i = do
 #endif
   Char.chr <$> readByteArray ustk (sp - i)
 {-# INLINE peekOffC #-}
-
-{- ORMOLU_ENABLE -}
 
 pokeN :: Stack -> Word64 -> IO ()
 pokeN stk@(Stack _ _ sp ustk _) n = do

--- a/unison-runtime/src/Unison/Runtime/Stack.hs
+++ b/unison-runtime/src/Unison/Runtime/Stack.hs
@@ -155,7 +155,6 @@ module Unison.Runtime.Stack
     hasNoAllocations,
     universalEq,
     universalCompare,
-
     -- pseudo data stuff
     inflateMap,
     deflateMap,
@@ -394,7 +393,7 @@ closureTag (Data2 _ t _ _) = t
 closureTag (DataG _ t _) = t
 closureTag c =
   throw $ Panic "closureTag: unexpected closure" (Just $ BoxedVal c)
-{-# inline closureTag #-}
+{-# INLINE closureTag #-}
 
 -- | Converts a list of integers representing an unboxed segment back into the
 -- appropriate segment. Segments are stored backwards in the runtime, so this
@@ -565,7 +564,7 @@ data RuntimePanic = Panic String (Maybe Val)
 
 instance Exception RuntimePanic
 
-marshalUnwrapForeignIO :: HasCallStack => Closure -> IO a
+marshalUnwrapForeignIO :: (HasCallStack) => Closure -> IO a
 marshalUnwrapForeignIO (Foreign x) = pure $ unwrapForeign x
 marshalUnwrapForeignIO c =
   throwIO $ Panic "marshalUnwrapForeignIO: unhandled closure" (Just v)
@@ -744,7 +743,7 @@ estackIOToIOX (IO f) = \s -> case f s of
 
 exStackIOToIO :: IOEXStack -> IO (Bool, Stack)
 exStackIOToIO f = IO $ \s -> case f s of
-  (# s , b, x #) -> (# s, (b, packXStack x) #)
+  (# s, b, x #) -> (# s, (b, packXStack x) #)
 
 instance Show Stack where
   show (Stack ap fp sp _ _) =
@@ -1354,7 +1353,6 @@ unitClosure :: Closure
 unitClosure = Enum Ty.unitRef TT.unitTag
 {-# NOINLINE unitClosure #-}
 
-
 -- Universal comparison functions
 
 closureNum :: Closure -> Int
@@ -1564,28 +1562,32 @@ arrayEq eqc l r
 mapEq :: (k -> k -> Bool) -> (v -> v -> Bool) -> Map k v -> Map k v -> Bool
 mapEq _ _ Tip Tip = True
 mapEq ek ev (Bin szl kl vl ll rl) (Bin szr kr vr lr rr) =
-  and [ szl == szr
-      , ek kl kr
-      , ev vl vr
-      , mapEq ek ev ll lr
-      , mapEq ek ev rl rr
-      ]
+  and
+    [ szl == szr,
+      ek kl kr,
+      ev vl vr,
+      mapEq ek ev ll lr,
+      mapEq ek ev rl rr
+    ]
 mapEq _ _ _ _ = False
 
 mapCmp ::
   (k -> k -> Ordering) ->
   (v -> v -> Ordering) ->
-  Map k v -> Map k v -> Ordering
-mapCmp _  _  Tip Tip = EQ
+  Map k v ->
+  Map k v ->
+  Ordering
+mapCmp _ _ Tip Tip = EQ
 mapCmp ck cv (Bin szl kl vl ll rl) (Bin szr kr vr lr rr) =
-  fold [ compare szl szr
-       , ck kl kr
-       , cv vl vr
-       , mapCmp ck cv ll lr
-       , mapCmp ck cv rl rr
-       ]
-mapCmp _ _ Tip Bin{} = compare mapTip mapBin
-mapCmp _ _ Bin{} Tip = compare mapBin mapTip
+  fold
+    [ compare szl szr,
+      ck kl kr,
+      cv vl vr,
+      mapCmp ck cv ll lr,
+      mapCmp ck cv rl rr
+    ]
+mapCmp _ _ Tip Bin {} = compare mapTip mapBin
+mapCmp _ _ Bin {} Tip = compare mapBin mapTip
 
 -- serialization doesn't necessarily preserve Int tags, so be
 -- more accepting for those.
@@ -1608,7 +1610,9 @@ matchUnboxedTypes ct1 ct2 =
 inflateMap :: Map Val Val -> Closure
 inflateMap Tip = Enum mapRef TT.mapTipTag
 inflateMap (Bin sz k v l r) =
-  DataC mapRef TT.mapBinTag
+  DataC
+    mapRef
+    TT.mapBinTag
     [NatVal $ fromIntegral sz, k, v, BoxedVal $ inflateMap l, BoxedVal $ inflateMap r]
 
 -- Reverses the above conversion, turning a unison data


### PR DESCRIPTION
## Overview

Ormolu has improved over the years, and no longer has the issues that needed to be worked around in this repo.

This removes all uses of `ORMOLU_DISABLE` and updates the documentation around Ormolu a bit.

## Implementation notes

I was making changes in one of the files here, and got frustrated by having to manually format some of my code, so I did a global find/replace to see which uses were still helpful, and it turns out none of them are.
