### PR TITLE
Limit maximum amount of negotiating done before starting a sync, and show negotiation progress

### DIFF
--- a/unison-cli/src/Unison/Share/SyncV2.hs
+++ b/unison-cli/src/Unison/Share/SyncV2.hs
@@ -680,7 +680,7 @@ withEntityLoadingCallback action = do
 
 withCausalNegotiationCallback :: (MonadUnliftIO m) => Int -> ((Int -> m ()) -> m a) -> m a
 withCausalNegotiationCallback maxEntities action = do
-  let msg n = "\n    🔎 Identifying missing entities: " <> tShow n <> "/" <> tShow maxEntities <> "\n\n"
+  let msg n = "\n    Identifying missing entities:  " <> tShow n <> "/" <> tShow maxEntities <> " 🔎 \n\n"
   counterProgress msg action
 
 withStreamProgress :: (MonadUnliftIO n) => Bool -> (ProgressCallbacks -> n a) -> n a

--- a/unison-cli/src/Unison/Share/SyncV2.hs
+++ b/unison-cli/src/Unison/Share/SyncV2.hs
@@ -607,17 +607,15 @@ negotiateKnownCausals ::
   Cli (Either (SyncError SyncV2.PullError) (Set Hash32))
 negotiateKnownCausals unisonShareUrl branchRef hashJwt = Timing.time "Causal Negotiation" $ do
   Cli.Env {authHTTPClient, codebase} <- ask
-  liftIO $ Console.Regions.displayConsoleRegions do
-    Console.Regions.withConsoleRegion Console.Regions.Linear \region -> do
-      Console.Regions.setConsoleRegion @Text @IO region $ "  🔎 Identifying missing entities..."
-      C.runResourceT
-        . runExceptT
-        $ httpStreamCausalDependencies
-          authHTTPClient
-          unisonShareUrl
-          SyncV2.CausalDependenciesRequest {branchRef, rootCausal = hashJwt}
-          \stream -> do
-            Set.fromList <$> C.runConduit (stream C..| C.map unpack C..| findKnownDeps codebase C..| C.sinkList)
+  liftIO $ withCausalNegotiationCallback maxNegotiationEntities \counter -> do
+    C.runResourceT
+      . runExceptT
+      $ httpStreamCausalDependencies
+        authHTTPClient
+        unisonShareUrl
+        SyncV2.CausalDependenciesRequest {branchRef, rootCausal = hashJwt}
+        \stream -> do
+          Set.fromList <$> C.runConduit (stream C..| C.takeC maxNegotiationEntities C..| C.iterM (\_ -> liftIO $ counter 1) C..| C.map unpack C..| findKnownDeps codebase C..| C.sinkList)
   where
     -- Go through the dependencies of the remote root from top-down, yielding all causal hashes that we already
     -- have until we find one in the causal spine we already have, then yield that one and stop since we'll implicitly
@@ -648,6 +646,8 @@ negotiateKnownCausals unisonShareUrl branchRef hashJwt = Timing.time "Causal Neg
     haveCausalHash codebase causalHash = do
       liftIO $ Codebase.runTransaction codebase do
         Q.causalExistsByHash32 causalHash
+    maxNegotiationEntities :: Int
+    maxNegotiationEntities = 1000
 
 ------------------------------------------------------------------------------------------------------------------------
 -- Progress Tracking
@@ -676,6 +676,11 @@ syncToFileProgress total action = do
 withEntityLoadingCallback :: (MonadUnliftIO m) => ((Int -> m ()) -> m a) -> m a
 withEntityLoadingCallback action = do
   let msg n = "\n  Loading entities from codebase: " <> tShow n <> " 📦\n\n"
+  counterProgress msg action
+
+withCausalNegotiationCallback :: (MonadUnliftIO m) => Int -> ((Int -> m ()) -> m a) -> m a
+withCausalNegotiationCallback maxEntities action = do
+  let msg n = "\n    🔎 Identifying missing entities: " <> tShow n <> "/" <> tShow maxEntities <> "\n\n"
   counterProgress msg action
 
 withStreamProgress :: (MonadUnliftIO n) => Bool -> (ProgressCallbacks -> n a) -> n a

--- a/unison-cli/src/Unison/Share/SyncV2.hs
+++ b/unison-cli/src/Unison/Share/SyncV2.hs
@@ -69,8 +69,10 @@ import Unison.SyncV2.Types qualified as SyncV2
 import Unison.Util.Monoid qualified as Monoid
 import Unison.Util.Servant.CBOR qualified as CBOR
 import Unison.Util.Timing qualified as Timing
+import UnliftIO qualified
 import UnliftIO qualified as IO
 import UnliftIO.Async qualified as Async
+import UnliftIO.Concurrent (threadDelay)
 import UnliftIO.STM qualified as STM
 
 type Stream i o = ConduitT i o StreamM ()
@@ -690,26 +692,45 @@ withStreamProgress hasDownload action = do
   savedVar <- IO.newTVarIO (0 :: Int)
   totalVar <- IO.newTVarIO Nothing
   IO.withRunInIO \toIO -> do
-    Console.Regions.displayConsoleRegions do
-      Console.Regions.withConsoleRegion Console.Regions.Linear \region -> do
-        Console.Regions.setConsoleRegion region do
-          downloaded <- IO.readTVar downloadedVar
-          doneUnpacking <- IO.readTVar doneUnpackingVar
-          saved <- IO.readTVar savedVar
-          total <- IO.readTVar totalVar
-          pure $
-            Text.unlines
-              [ Monoid.whenM hasDownload $ "\n  Downloaded: " <> tShow @Int downloaded <> maybe "" (\total -> " / " <> tShow @Int total) total <> Monoid.whenM doneUnpacking " 🏁",
-                "    Imported: " <> tShow @Int saved
-              ]
-        toIO $
-          action $
-            ProgressCallbacks
-              { setTotal = \total -> do liftIO $ IO.atomically (IO.writeTVar totalVar (Just total)),
-                downloadCounter = \i -> do liftIO $ IO.atomically (IO.modifyTVar' downloadedVar (+ i)),
-                doneDownloading = do liftIO $ IO.atomically (IO.writeTVar doneUnpackingVar True),
-                importCounter = \i -> do liftIO $ IO.atomically (IO.modifyTVar' savedVar (+ i))
-              }
+    withSpinner \spinnerVar -> do
+      Console.Regions.displayConsoleRegions do
+        Console.Regions.withConsoleRegion Console.Regions.Linear \region -> do
+          Console.Regions.setConsoleRegion region do
+            downloaded <- IO.readTVar downloadedVar
+            doneUnpacking <- IO.readTVar doneUnpackingVar
+            saved <- IO.readTVar savedVar
+            total <- IO.readTVar totalVar
+            if (downloaded == 0)
+              then do
+                spinChar <- UnliftIO.readTVar spinnerVar
+                pure $ "\n  Preparing entities " <> spinChar <> " \n\n"
+              else do
+                pure $
+                  Text.unlines
+                    [ Monoid.whenM hasDownload $ "\n  Downloaded: " <> tShow @Int downloaded <> maybe "" (\total -> " / " <> tShow @Int total) total <> Monoid.whenM doneUnpacking " 🏁",
+                      "    Imported: " <> tShow @Int saved
+                    ]
+          toIO $
+            action $
+              ProgressCallbacks
+                { setTotal = \total -> do liftIO $ IO.atomically (IO.writeTVar totalVar (Just total)),
+                  downloadCounter = \i -> do liftIO $ IO.atomically (IO.modifyTVar' downloadedVar (+ i)),
+                  doneDownloading = do liftIO $ IO.atomically (IO.writeTVar doneUnpackingVar True),
+                  importCounter = \i -> do liftIO $ IO.atomically (IO.modifyTVar' savedVar (+ i))
+                }
+  where
+    withSpinner :: (MonadUnliftIO m) => (UnliftIO.TVar Text -> m a) -> m a
+    withSpinner action = do
+      spinnerVar <- IO.newTVarIO ("⣾" :: Text)
+      UnliftIO.withAsync (go spinnerVar spinnerChars) \_ -> do
+        action spinnerVar
+      where
+        spinnerChars = cycle "⣷⣯⣟⡿⢿⣻⣽⣾" :: String
+        go :: (MonadUnliftIO m) => UnliftIO.TVar Text -> String -> m ()
+        go spinnerVar spinner = do
+          threadDelay 500000
+          UnliftIO.atomically $ UnliftIO.writeTVar spinnerVar (Text.singleton $ head spinner)
+          go spinnerVar (tail spinner)
 
 -- * Conduit helpers
 

--- a/unison-cli/src/Unison/Share/SyncV2.hs
+++ b/unison-cli/src/Unison/Share/SyncV2.hs
@@ -703,7 +703,7 @@ withStreamProgress hasDownload action = do
             if (downloaded == 0)
               then do
                 spinChar <- UnliftIO.readTVar spinnerVar
-                pure $ "\n  Preparing entities " <> spinChar <> " \n\n"
+                pure $ "\n  Hang tight while Share prepares your download " <> spinChar <> " \n\n"
               else do
                 pure $
                   Text.unlines


### PR DESCRIPTION
## Overview

Sometimes negotiation can seem to take a long while on projects with a ton of dependencies, but realistically if you don't get a hit on some shared causal within the first N causals you probably won't find one at all, or would be better off just doing a total sync.

This PR cuts off negotiation after 1000 causals and falls back to a total sync.

During negotiation

<img width="385" alt="image" src="https://github.com/user-attachments/assets/cce8ddfe-8f0a-4dd6-918a-dc78eef4a3f4" />

Progress bar before entities make it over the network, it changes states every half-second to show things are still waiting:

<img width="366" alt="image" src="https://github.com/user-attachments/assets/221583e3-ddcf-466b-b6ce-21ee5e8cfcb8" />


## Implementation notes

* Cut off negotiation at 1000 causals
* Show progress of negotiation out of 1000
* Add a spinner while waiting for the server to prep the first entities in the stream (which can take a few seconds)

## Test coverage

I tried a couple syncs locally