### PR TITLE
Improve constructor typo parse error

### DIFF
--- a/parser-typechecker/src/Unison/Syntax/TermParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermParser.hs
@@ -14,7 +14,9 @@ module Unison.Syntax.TermParser
 where
 
 import Control.Comonad.Trans.Cofree (CofreeF ((:<)))
+import Control.Lens (_2)
 import Control.Monad.Reader (asks, local)
+import Control.Monad.Trans.Writer
 import Data.Bitraversable (bitraverse)
 import Data.Char qualified as Char
 import Data.Foldable (foldrM)
@@ -45,7 +47,6 @@ import Unison.Names.ResolutionResult (ResolutionError (..), ResolutionFailure (.
 import Unison.NamesWithHistory qualified as Names
 import Unison.Parser.Ann (Ann (Ann))
 import Unison.Parser.Ann qualified as Ann
-import Unison.Pattern (Pattern)
 import Unison.Pattern qualified as Pattern
 import Unison.Prelude
 import Unison.Reference (TypeReference)
@@ -57,6 +58,7 @@ import Unison.Syntax.NameSegment qualified as NameSegment
 import Unison.Syntax.Parser hiding (seq)
 import Unison.Syntax.Parser qualified as Parser (seq, uniqueName)
 import Unison.Syntax.Parser.Doc.Data qualified as Doc
+import Unison.Syntax.Pattern qualified as Syntax.Pattern
 import Unison.Syntax.Precedence (operatorPrecedence)
 import Unison.Syntax.TypeParser qualified as TypeParser
 import Unison.Term (IsTop, Term)
@@ -243,71 +245,104 @@ matchCase = do
   let mk (guard, t) = Term.MatchCase pat (fmap (absChain boundVars') guard) (absChain boundVars' t)
   pure $ (length pats, mk <$> guardsAndBlocks)
 
-parsePattern :: forall m v. (Monad m, Var v) => P v m (Pattern Ann, [(Ann, v)])
-parsePattern = label "pattern" root
+parsePattern :: (Monad m, Var v) => P v m (Pattern.Pattern Ann, [(Ann, v)])
+parsePattern =
+  parsePattern2 >>= bindConstructorsInPattern
+
+bindConstructorsInPattern :: (Monad m, Var v) => Syntax.Pattern.Pattern v -> P v m (Pattern.Pattern Ann, [(Ann, v)])
+bindConstructorsInPattern =
+  fmap (over _2 (\f -> (map tokenToPair (f [])))) . runWriterT . bindConstructorsInPattern1
+
+bindConstructorsInPattern1 ::
+  forall m v.
+  (Monad m, Var v) =>
+  Syntax.Pattern.Pattern v ->
+  WriterT ([L.Token v] -> [L.Token v]) (P v m) (Pattern.Pattern Ann)
+bindConstructorsInPattern1 = \case
+  Syntax.Pattern.As pos v lpat -> do
+    tell (v :)
+    pat <- bindConstructorsInPattern1 lpat
+    pure (Pattern.As pos pat)
+  Syntax.Pattern.Boolean pos b -> pure (Pattern.Boolean pos b)
+  Syntax.Pattern.Char pos c -> pure (Pattern.Char pos c)
+  Syntax.Pattern.Constructor pos name pats ->
+    Pattern.Constructor pos
+      <$> lift (bindConstructor CT.Data name)
+      <*> traverse bindConstructorsInPattern1 pats
+  Syntax.Pattern.EffectBind pos name pats cont ->
+    Pattern.EffectBind pos
+      <$> lift (bindConstructor CT.Effect name)
+      <*> traverse bindConstructorsInPattern1 pats
+      <*> bindConstructorsInPattern1 cont
+  Syntax.Pattern.EffectPure pos lpat -> Pattern.EffectPure pos <$> bindConstructorsInPattern1 lpat
+  Syntax.Pattern.Float pos n -> pure (Pattern.Float pos n)
+  Syntax.Pattern.Int pos n -> pure (Pattern.Int pos n)
+  Syntax.Pattern.Nat pos n -> pure (Pattern.Nat pos n)
+  Syntax.Pattern.Pair _ lpat1 lpat2 ->
+    ( \pat1 pat2 ->
+        Pattern.Constructor
+          (ann pat1 <> ann pat2)
+          (ConstructorReference DD.pairRef 0)
+          [pat1, pat2]
+    )
+      <$> bindConstructorsInPattern1 lpat1
+      <*> bindConstructorsInPattern1 lpat2
+  Syntax.Pattern.SequenceLiteral pos pats -> Pattern.SequenceLiteral pos <$> traverse bindConstructorsInPattern1 pats
+  Syntax.Pattern.SequenceOp pos lpat1 op lpat2 ->
+    Pattern.SequenceOp pos
+      <$> bindConstructorsInPattern1 lpat1
+      <*> pure case op of
+        Syntax.Pattern.Concat -> Pattern.Concat
+        Syntax.Pattern.Cons -> Pattern.Cons
+        Syntax.Pattern.Snoc -> Pattern.Snoc
+      <*> bindConstructorsInPattern1 lpat2
+  Syntax.Pattern.Text pos t -> pure (Pattern.Text pos t)
+  Syntax.Pattern.Unbound pos -> pure (Pattern.Unbound pos)
+  Syntax.Pattern.Unit pos -> pure (Pattern.Constructor pos (ConstructorReference DD.unitRef 0) [])
+  -- Not awesome: something can be at once a syntactically valid nullary constructor and a syntactically valid
+  -- variable. We currently handle this by simply looking in the namespace to determine whether it's a
+  -- constructor, and if it isn't, we treat it as a variable.
+  Syntax.Pattern.VarOrNullaryConstructor pos name ->
+    lift (maybeBindLocalConstructor CT.Data (L.payload name)) >>= \case
+      Just localCtor -> pure (Pattern.Constructor pos localCtor [])
+      Nothing -> do
+        names <- asks names
+        let failure :: ResolutionError Referent -> P v m a
+            failure err =
+              failCommitted $
+                ResolutionFailures
+                  [ TermResolutionFailure
+                      (HQ.NameOnly (L.payload name))
+                      (ann name)
+                      err
+                  ]
+        case Names.lookupHQPattern Names.IncludeSuffixes (HQ.NameOnly (L.payload name)) CT.Data names of
+          constructors
+            | Set.size constructors == 1 -> pure (Pattern.Constructor pos (Set.findMin constructors) [])
+            | Set.null constructors ->
+                -- Not great thing alert :alarm: :alarm:
+                -- This is a syntactically valid variable, however, if it begins with a capital letter, we choose to
+                -- consider it a constructor-out-of-scope, since that's probably what the user meant.
+                if lastSegmentBeginsWithCapitalLetter
+                  then lift (failure NotFound)
+                  else do
+                    tell ((Name.toVar <$> name) :)
+                    pure (Pattern.Var pos)
+            | otherwise ->
+                lift $
+                  failure
+                    ( Ambiguous
+                        names
+                        (Set.map (\ref -> Referent.Con ref CT.Data) constructors)
+                        Set.empty
+                    )
+    where
+      lastSegmentBeginsWithCapitalLetter :: Bool
+      lastSegmentBeginsWithCapitalLetter =
+        not (Char.isLower (Text.head (NameSegment.toUnescapedText (Name.lastSegment (L.payload name)))))
   where
-    root = chainl1 patternCandidates patternInfixApp
-    patternCandidates = constructor <|> leaf
-    patternInfixApp ::
-      P
-        v
-        m
-        ( (Pattern Ann, [(Ann, v)]) ->
-          (Pattern Ann, [(Ann, v)]) ->
-          (Pattern Ann, [(Ann, v)])
-        )
-    patternInfixApp = f <$> seqOp
-      where
-        f op (l, lvs) (r, rvs) =
-          (Pattern.SequenceOp (ann l <> ann r) l op r, lvs ++ rvs)
-
-    -- note: nullaryCtor comes before var patterns, since (for better or worse)
-    -- they can overlap (a variable could be called 'Foo' in the current grammar).
-    -- This order treats ambiguous patterns as nullary constructors if there's
-    -- a constructor with a matching name.
-    leaf =
-      literal
-        <|> nullaryCtor
-        <|> varOrAs
-        <|> unbound
-        <|> seqLiteral
-        <|> parenthesizedOrTuplePattern
-        <|> effect
-    literal = (,[]) <$> asum [true, false, number, text, char]
-    true = (\t -> Pattern.Boolean (ann t) True) <$> reserved "true"
-    false = (\t -> Pattern.Boolean (ann t) False) <$> reserved "false"
-    number =
-      join $
-        number'
-          (pure . tok Pattern.Int)
-          (pure . tok Pattern.Nat)
-          (tok (const . failCommitted . FloatPattern))
-    text = (\t -> Pattern.Text (ann t) (L.payload t)) <$> string
-    char = (\c -> Pattern.Char (ann c) (L.payload c)) <$> character
-    parenthesizedOrTuplePattern :: P v m (Pattern Ann, [(Ann, v)])
-    parenthesizedOrTuplePattern = do
-      (_spanAnn, (pat, pats)) <- tupleOrParenthesized parsePattern unit pair
-      pure (pat, pats)
-    unit ann = (Pattern.Constructor ann (ConstructorReference DD.unitRef 0) [], [])
-    pair (p1, v1) (p2, v2) =
-      ( Pattern.Constructor (ann p1 <> ann p2) (ConstructorReference DD.pairRef 0) [p1, p2],
-        v1 ++ v2
-      )
-    -- Foo x@(Blah 10)
-    varOrAs :: P v m (Pattern Ann, [(Ann, v)])
-    varOrAs = do
-      v <- wordyPatternName
-      o <- optional (reserved "@")
-      if isJust o
-        then (\(p, vs) -> (Pattern.As (ann v) p, tokenToPair v : vs)) <$> leaf
-        else pure (Pattern.Var (ann v), [tokenToPair v])
-    unbound :: P v m (Pattern Ann, [(Ann, v)])
-    unbound = (\tok -> (Pattern.Unbound (ann tok), [])) <$> blank
-    ctor :: CT.ConstructorType -> P v m (L.Token ConstructorReference)
-    ctor ct = do
-      -- this might be a var, so we avoid consuming it at first
-      tok <- P.lookAhead hqPrefixId
-
+    bindConstructor :: CT.ConstructorType -> L.Token (HQ.HashQualified Name) -> P v m ConstructorReference
+    bindConstructor ct hqName = do
       -- First, if:
       --
       --   * The token isn't hash-qualified (e.g. "Foo.Bar")
@@ -322,83 +357,149 @@ parsePattern = label "pattern" root
       --
       --   * Fall through to the normal logic of looking the constructor name up in all of the names (which includes
       --     the locally-bound constructors).
-
       maybeLocalCtor <-
-        case L.payload tok of
-          HQ.NameOnly name ->
-            asks maybeNamespace >>= \case
-              Nothing -> pure Nothing
-              Just namespace -> do
-                localNames <- asks localNamespacePrefixedTypesAndConstructors
-                case Names.lookupHQPattern Names.ExactName (HQ.NameOnly (Name.joinDot namespace name)) ct localNames of
-                  refs
-                    | Set.null refs -> pure Nothing
-                    -- 2+ name case is impossible: we looked up exact names in the locally-bound names. Two bindings
-                    -- with the same name would have been a parse error. So, just take the minimum element from the set,
-                    -- which we know is a singleton.
-                    | otherwise -> do
-                        -- matched ctor name, consume the token
-                        _ <- anyToken
-                        pure (Just (Set.findMin refs))
+        case L.payload hqName of
+          HQ.NameOnly name -> maybeBindLocalConstructor ct name
           _ -> pure Nothing
 
       case maybeLocalCtor of
-        Just localCtor -> pure (localCtor <$ tok)
+        Just localCtor -> pure localCtor
         Nothing -> do
           names <- asks names
-          case Names.lookupHQPattern Names.IncludeSuffixes (L.payload tok) ct names of
+          case Names.lookupHQPattern Names.IncludeSuffixes (L.payload hqName) ct names of
             s
-              | Set.size s == 1 -> do
-                  -- matched ctor name, consume the token
-                  _ <- anyToken
-                  pure (Set.findMin s <$ tok)
-              | otherwise -> die names tok s
+              | Set.size s == 1 -> pure (Set.findMin s)
+              | otherwise ->
+                  failCommitted $
+                    ResolutionFailures
+                      [ TermResolutionFailure
+                          (L.payload hqName)
+                          (ann hqName)
+                          if Set.null s
+                            then NotFound
+                            else
+                              Ambiguous
+                                names
+                                (Set.map (\ref -> Referent.Con ref ct) s)
+                                -- Eh, here we're saying there are no "local" constructors – they're all from "the
+                                -- namespace". That's not necessarily true, but it doesn't (currently) affect the error
+                                -- message any, and we have already parsed and hashed local constructors (so they aren't
+                                -- really different from namespace constructors).
+                                Set.empty
+                      ]
+
+    maybeBindLocalConstructor :: CT.ConstructorType -> Name -> P v m (Maybe ConstructorReference)
+    maybeBindLocalConstructor ct name =
+      asks maybeNamespace >>= \case
+        Nothing -> pure Nothing
+        Just namespace -> do
+          localNames <- asks localNamespacePrefixedTypesAndConstructors
+          pure case Names.lookupHQPattern Names.ExactName (HQ.NameOnly (Name.joinDot namespace name)) ct localNames of
+            refs
+              | Set.null refs -> Nothing
+              -- 2+ name case is impossible: we looked up exact names in the locally-bound names. Two bindings
+              -- with the same name would have been a parse error. So, just take the minimum element from the set,
+              -- which we know is a singleton.
+              | otherwise -> Just (Set.findMin refs)
+
+parsePattern2 :: forall m v. (Monad m, Var v) => P v m (Syntax.Pattern.Pattern v)
+parsePattern2 =
+  label "pattern" pRoot
+  where
+    pRoot :: P v m (Syntax.Pattern.Pattern v)
+    pRoot =
+      chainl1 (pHqNamey1 <|> pLeaf1) pInfix
       where
-        isLower = Text.all Char.isLower . Text.take 1 . NameSegment.toUnescapedText . Name.lastSegment
-        isIgnored n = Text.take 1 (Name.toText n) == "_"
-        die :: Names -> L.Token (HQ.HashQualified Name) -> Set ConstructorReference -> P v m a
-        die names hq s = case L.payload hq of
-          -- if token not hash qualified and not uppercase,
-          -- fail w/out consuming it to allow backtracking
-          HQ.NameOnly n
-            | Set.null s
-                && (isLower n || isIgnored n) ->
-                fail $ "not a constructor name: " <> show n
-          -- it was hash qualified and/or uppercase, and was either not found or ambiguous, that's a failure!
-          _ ->
-            failCommitted $
-              ResolutionFailures
-                [ TermResolutionFailure
-                    (L.payload hq)
-                    (ann hq)
-                    if Set.null s
-                      then NotFound
-                      else
-                        Ambiguous
-                          names
-                          (Set.map (\ref -> Referent.Con ref ct) s)
-                          -- Eh, here we're saying there are no "local" constructors – they're all from "the namespace".
-                          -- That's not necessarily true, but it doesn't (currently) affect the error message any, and
-                          -- we have already parsed and hashed local constructors (so they aren't really different from
-                          -- namespace constructors).
-                          Set.empty
-                ]
-    unzipPatterns f elems = case unzip elems of (patterns, vs) -> f patterns (join vs)
+        pHqNamey1 :: P v m (Syntax.Pattern.Pattern v)
+        pHqNamey1 = do
+          pat <- pHqNamey
+          let datacon name patterns =
+                (Syntax.Pattern.Constructor ((ann pat <> maybe mempty ann (lastMay patterns))) name patterns)
+          case pat of
+            Syntax.Pattern.Constructor _ name _ {- this is [] -} -> do
+              patterns <- many pLeaf
+              pure (datacon name patterns)
+            Syntax.Pattern.VarOrNullaryConstructor _ name ->
+              many pLeaf <&> \case
+                [] -> pat
+                patterns -> datacon (HQ.NameOnly <$> name) patterns
+            -- This is Syntax.Pattern.As
+            _ -> pure pat
 
-    effectBind = do
-      tok <- ctor CT.Effect
-      leaves <- many leaf
-      _ <- reserved "->"
-      (cont, vsp) <- parsePattern
-      pure $
-        let f patterns vs = (Pattern.EffectBind (ann tok <> ann cont) (L.payload tok) patterns cont, vs ++ vsp)
-         in unzipPatterns f leaves
+        pInfix :: P v m (Syntax.Pattern.Pattern v -> Syntax.Pattern.Pattern v -> Syntax.Pattern.Pattern v)
+        pInfix =
+          pSeqOp <&> \op l r ->
+            Syntax.Pattern.SequenceOp (ann l <> ann r) l op r
+          where
+            pSeqOp :: (Ord v) => P v m Syntax.Pattern.SeqOp
+            pSeqOp =
+              Syntax.Pattern.Snoc <$ matchToken (L.SymbolyId (HQ'.fromName (Name.fromSegment NameSegment.snocSegment)))
+                <|> Syntax.Pattern.Cons <$ matchToken (L.SymbolyId (HQ'.fromName (Name.fromSegment NameSegment.consSegment)))
+                <|> Syntax.Pattern.Concat <$ matchToken (L.SymbolyId (HQ'.fromName (Name.fromSegment NameSegment.concatSegment)))
 
-    effectPure = go <$> parsePattern
+    pLeaf :: P v m (Syntax.Pattern.Pattern v)
+    pLeaf =
+      pHqNamey <|> pLeaf1
+
+    pLeaf1 :: P v m (Syntax.Pattern.Pattern v)
+    pLeaf1 =
+      asum
+        [ -- true or false or 5 or "text" or ?c
+          pLiteral,
+          -- _
+          do
+            tok <- blank
+            pure (Syntax.Pattern.Unbound (ann tok)),
+          -- [pat, pat, pat]
+          Parser.seq Syntax.Pattern.SequenceLiteral pRoot,
+          -- () or (pat, pat) or (pat, pat, pat) [which is actually parsed as (pat, (pat, pat)]
+          pParenOrTuple,
+          -- { pat -> pat } or { pat }
+          pEffect
+        ]
+
+    pLiteral :: P v m (Syntax.Pattern.Pattern v)
+    pLiteral =
+      asum [pTrue, pFalse, pNumber, pText, pChar]
       where
-        go (p, vs) = (Pattern.EffectPure (ann p) p, vs)
+        pTrue :: P v m (Syntax.Pattern.Pattern v)
+        pTrue = do
+          tok <- reserved "true"
+          pure (Syntax.Pattern.Boolean (ann tok) True)
 
-    effect = do
+        pFalse :: P v m (Syntax.Pattern.Pattern v)
+        pFalse = do
+          tok <- reserved "false"
+          pure (Syntax.Pattern.Boolean (ann tok) False)
+
+        pNumber :: P v m (Syntax.Pattern.Pattern v)
+        pNumber =
+          join $
+            number'
+              (pure . tok Syntax.Pattern.Int)
+              (pure . tok Syntax.Pattern.Nat)
+              (tok (const . failCommitted . FloatPattern))
+
+        pText :: P v m (Syntax.Pattern.Pattern v)
+        pText = do
+          tok <- string
+          pure (Syntax.Pattern.Text (ann tok) (L.payload tok))
+
+        pChar :: P v m (Syntax.Pattern.Pattern v)
+        pChar = do
+          tok <- character
+          pure (Syntax.Pattern.Char (ann tok) (L.payload tok))
+
+    pParenOrTuple :: P v m (Syntax.Pattern.Pattern v)
+    pParenOrTuple = do
+      snd <$> tupleOrParenthesized parsePattern2 Syntax.Pattern.Unit mkPair
+      where
+        mkPair :: Syntax.Pattern.Pattern v -> Syntax.Pattern.Pattern v -> Syntax.Pattern.Pattern v
+        mkPair p1 p2 =
+          Syntax.Pattern.Pair (ann p1 <> ann p2) p1 p2
+
+    pEffect :: P v m (Syntax.Pattern.Pattern v)
+    pEffect = do
       start <- openBlockWith "{"
 
       -- After the opening curly brace, we are expecting either an EffectBind or an EffectPure:
@@ -415,35 +516,47 @@ parsePattern = label "pattern" root
       --
       -- This won't always result in the best possible error messages, but it's not exactly trivial to do better,
       -- requiring more sophisticated look-ahead logic. So, this is how it works for now.
-      (inner, vs, end) <-
+      (inner, end) <-
         asum
           [ P.try do
-              (inner, vs) <- effectPure
+              inner <- pEffectPure
               end <- closeBlock
-              pure (inner, vs, end),
+              pure (inner, end),
             do
-              (inner, vs) <- effectBind
+              inner <- pEffectBind
               end <- closeBlock
-              pure (inner, vs, end)
+              pure (inner, end)
           ]
 
-      pure (Pattern.setLoc inner (ann start <> ann end), vs)
-
-    -- ex: unique type Day = Mon | Tue | ...
-    nullaryCtor = do
-      tok <- ctor CT.Data
-      pure (Pattern.Constructor (ann tok) (L.payload tok) [], [])
-
-    constructor = do
-      tok <- ctor CT.Data
-      let f patterns vs =
-            let loc = foldl (<>) (ann tok) $ map ann patterns
-             in (Pattern.Constructor loc (L.payload tok) patterns, vs)
-      unzipPatterns f <$> many leaf
-
-    seqLiteral = Parser.seq f root
+      pure (Syntax.Pattern.setPos (ann start <> ann end) inner)
       where
-        f loc = unzipPatterns ((,) . Pattern.SequenceLiteral loc)
+        pEffectBind :: P v m (Syntax.Pattern.Pattern v)
+        pEffectBind = do
+          name <- hqPrefixId
+          patterns <- many pLeaf
+          _ <- reserved "->"
+          cont <- parsePattern2
+          pure (Syntax.Pattern.EffectBind (ann name <> ann cont) name patterns cont)
+
+        pEffectPure :: P v m (Syntax.Pattern.Pattern v)
+        pEffectPure =
+          parsePattern2 <&> \pat -> Syntax.Pattern.EffectPure (ann pat) pat
+
+    -- Parse an "HQ-namey", which could either definitely be a nullary constructor (because it's either hash-only or
+    -- hash-qualified or symboly), or either a variable or nullary constructor (because it's a wordy name-only). And if
+    -- it's the latter, we might see that it's actually not a nullary constructor but actually a variable in an
+    -- as-pattern, e.g. `Foo@Bar`.
+    pHqNamey :: P v m (Syntax.Pattern.Pattern v)
+    pHqNamey = do
+      tok <- varOrNullaryConstructor
+      case L.payload tok of
+        Left name -> pure (Syntax.Pattern.Constructor (ann tok) (name <$ tok) [])
+        Right name -> do
+          optional (reserved "@") >>= \case
+            Nothing -> pure (Syntax.Pattern.VarOrNullaryConstructor (ann tok) (name <$ tok))
+            Just _ -> do
+              p <- pLeaf
+              pure (Syntax.Pattern.As (ann tok <> ann p) (Name.toVar name <$ tok) p)
 
 lam :: (Var v) => TermP v m -> TermP v m
 lam p = label "lambda" $ mkLam <$> P.try (some prefixDefinitionName <* reserved "->") <*> p
@@ -1130,12 +1243,6 @@ force = P.label "force" $ P.try do
   guard (L.column (Ann.start tok) == L.column (Ann.end (ann fn)))
   close <- closeBlock
   pure $ DD.forceTerm (ann fn <> ann close) (tok <> ann close) fn
-
-seqOp :: (Ord v) => P v m Pattern.SeqOp
-seqOp =
-  Pattern.Snoc <$ matchToken (L.SymbolyId (HQ'.fromName (Name.fromSegment NameSegment.snocSegment)))
-    <|> Pattern.Cons <$ matchToken (L.SymbolyId (HQ'.fromName (Name.fromSegment NameSegment.consSegment)))
-    <|> Pattern.Concat <$ matchToken (L.SymbolyId (HQ'.fromName (Name.fromSegment NameSegment.concatSegment)))
 
 term4 :: (Monad m, Var v) => TermP v m
 term4 = f <$> some termLeaf

--- a/parser-typechecker/src/Unison/Syntax/TermParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermParser.hs
@@ -14,7 +14,7 @@ module Unison.Syntax.TermParser
 where
 
 import Control.Comonad.Trans.Cofree (CofreeF ((:<)))
-import Control.Lens (_2)
+import Control.Lens (mapped, _2)
 import Control.Monad.Reader (asks, local)
 import Control.Monad.Trans.Writer
 import Data.Bitraversable (bitraverse)
@@ -1365,11 +1365,8 @@ destructuringBind = do
   --   (Some 42)
   --   vs
   --   (Some 42) = List.head elems
-  (p, boundVars) <- P.try do
-    (p, boundVars) <- parsePattern
-    let boundVars' = snd <$> boundVars
-    _ <- P.lookAhead (openBlockWith "=")
-    pure (p, boundVars')
+  pat <- P.try (parsePattern2 <* P.lookAhead (openBlockWith "="))
+  (p, boundVars) <- over (_2 . mapped) snd <$> bindConstructorsInPattern pat
   (_spanAnn, scrute) <- layoutBlock "=" -- Dwight K. Scrute ("The People's Scrutinee")
   let guard = Nothing
   let absChain vs t = foldr (\v t -> ABT.abs' (ann t) v t) t vs

--- a/parser-typechecker/src/Unison/Syntax/TermParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermParser.hs
@@ -220,7 +220,7 @@ matchCases = sepBy semi matchCase <&> \cases_ -> [(n, c) | (n, cs) <- cases_, c 
 --   (42, x) -> ...
 matchCase :: (Monad m, Var v) => P v m (Int, [Term.MatchCase Ann (Term v Ann)])
 matchCase = do
-  pats <- sepBy1 (label "\",\"" $ reserved ",") parsePattern
+  pats <- sepBy1 (label "\",\"" $ reserved ",") (parsePattern >>= bindConstructorsInPattern)
   let boundVars' = [v | (_, vs) <- pats, (_ann, v) <- vs]
       pat = case fst <$> pats of
         [p] -> p
@@ -245,165 +245,8 @@ matchCase = do
   let mk (guard, t) = Term.MatchCase pat (fmap (absChain boundVars') guard) (absChain boundVars' t)
   pure $ (length pats, mk <$> guardsAndBlocks)
 
-parsePattern :: (Monad m, Var v) => P v m (Pattern.Pattern Ann, [(Ann, v)])
+parsePattern :: forall m v. (Monad m, Var v) => P v m (Syntax.Pattern.Pattern v)
 parsePattern =
-  parsePattern2 >>= bindConstructorsInPattern
-
-bindConstructorsInPattern :: (Monad m, Var v) => Syntax.Pattern.Pattern v -> P v m (Pattern.Pattern Ann, [(Ann, v)])
-bindConstructorsInPattern =
-  fmap (over _2 (\f -> (map tokenToPair (f [])))) . runWriterT . bindConstructorsInPattern1
-
-bindConstructorsInPattern1 ::
-  forall m v.
-  (Monad m, Var v) =>
-  Syntax.Pattern.Pattern v ->
-  WriterT ([L.Token v] -> [L.Token v]) (P v m) (Pattern.Pattern Ann)
-bindConstructorsInPattern1 = \case
-  Syntax.Pattern.As pos v lpat -> do
-    tell (v :)
-    pat <- bindConstructorsInPattern1 lpat
-    pure (Pattern.As pos pat)
-  Syntax.Pattern.Boolean pos b -> pure (Pattern.Boolean pos b)
-  Syntax.Pattern.Char pos c -> pure (Pattern.Char pos c)
-  Syntax.Pattern.Constructor pos name pats ->
-    Pattern.Constructor pos
-      <$> lift (bindConstructor CT.Data name)
-      <*> traverse bindConstructorsInPattern1 pats
-  Syntax.Pattern.EffectBind pos name pats cont ->
-    Pattern.EffectBind pos
-      <$> lift (bindConstructor CT.Effect name)
-      <*> traverse bindConstructorsInPattern1 pats
-      <*> bindConstructorsInPattern1 cont
-  Syntax.Pattern.EffectPure pos lpat -> Pattern.EffectPure pos <$> bindConstructorsInPattern1 lpat
-  Syntax.Pattern.Float pos n -> pure (Pattern.Float pos n)
-  Syntax.Pattern.Int pos n -> pure (Pattern.Int pos n)
-  Syntax.Pattern.Nat pos n -> pure (Pattern.Nat pos n)
-  Syntax.Pattern.Pair _ lpat1 lpat2 ->
-    ( \pat1 pat2 ->
-        Pattern.Constructor
-          (ann pat1 <> ann pat2)
-          (ConstructorReference DD.pairRef 0)
-          [pat1, pat2]
-    )
-      <$> bindConstructorsInPattern1 lpat1
-      <*> bindConstructorsInPattern1 lpat2
-  Syntax.Pattern.SequenceLiteral pos pats -> Pattern.SequenceLiteral pos <$> traverse bindConstructorsInPattern1 pats
-  Syntax.Pattern.SequenceOp pos lpat1 op lpat2 ->
-    Pattern.SequenceOp pos
-      <$> bindConstructorsInPattern1 lpat1
-      <*> pure case op of
-        Syntax.Pattern.Concat -> Pattern.Concat
-        Syntax.Pattern.Cons -> Pattern.Cons
-        Syntax.Pattern.Snoc -> Pattern.Snoc
-      <*> bindConstructorsInPattern1 lpat2
-  Syntax.Pattern.Text pos t -> pure (Pattern.Text pos t)
-  Syntax.Pattern.Unbound pos -> pure (Pattern.Unbound pos)
-  Syntax.Pattern.Unit pos -> pure (Pattern.Constructor pos (ConstructorReference DD.unitRef 0) [])
-  -- Not awesome: something can be at once a syntactically valid nullary constructor and a syntactically valid
-  -- variable. We currently handle this by simply looking in the namespace to determine whether it's a
-  -- constructor, and if it isn't, we treat it as a variable.
-  Syntax.Pattern.VarOrNullaryConstructor pos name ->
-    lift (maybeBindLocalConstructor CT.Data (L.payload name)) >>= \case
-      Just localCtor -> pure (Pattern.Constructor pos localCtor [])
-      Nothing -> do
-        names <- asks names
-        let failure :: ResolutionError Referent -> P v m a
-            failure err =
-              failCommitted $
-                ResolutionFailures
-                  [ TermResolutionFailure
-                      (HQ.NameOnly (L.payload name))
-                      (ann name)
-                      err
-                  ]
-        case Names.lookupHQPattern Names.IncludeSuffixes (HQ.NameOnly (L.payload name)) CT.Data names of
-          constructors
-            | Set.size constructors == 1 -> pure (Pattern.Constructor pos (Set.findMin constructors) [])
-            | Set.null constructors ->
-                -- Not great thing alert :alarm: :alarm:
-                -- This is a syntactically valid variable, however, if it begins with a capital letter, we choose to
-                -- consider it a constructor-out-of-scope, since that's probably what the user meant.
-                if lastSegmentBeginsWithCapitalLetter
-                  then lift (failure NotFound)
-                  else do
-                    tell ((Name.toVar <$> name) :)
-                    pure (Pattern.Var pos)
-            | otherwise ->
-                lift $
-                  failure
-                    ( Ambiguous
-                        names
-                        (Set.map (\ref -> Referent.Con ref CT.Data) constructors)
-                        Set.empty
-                    )
-    where
-      lastSegmentBeginsWithCapitalLetter :: Bool
-      lastSegmentBeginsWithCapitalLetter =
-        not (Char.isLower (Text.head (NameSegment.toUnescapedText (Name.lastSegment (L.payload name)))))
-  where
-    bindConstructor :: CT.ConstructorType -> L.Token (HQ.HashQualified Name) -> P v m ConstructorReference
-    bindConstructor ct hqName = do
-      -- First, if:
-      --
-      --   * The token isn't hash-qualified (e.g. "Foo.Bar")
-      --   * We're under a namespace directive (e.g. "baz")
-      --   * There's an exact match for a locally-bound constructor (e.g. "baz.Foo.Bar")
-      --
-      -- Then:
-      --
-      --   * Use that constructor reference (duh)
-      --
-      -- Else:
-      --
-      --   * Fall through to the normal logic of looking the constructor name up in all of the names (which includes
-      --     the locally-bound constructors).
-      maybeLocalCtor <-
-        case L.payload hqName of
-          HQ.NameOnly name -> maybeBindLocalConstructor ct name
-          _ -> pure Nothing
-
-      case maybeLocalCtor of
-        Just localCtor -> pure localCtor
-        Nothing -> do
-          names <- asks names
-          case Names.lookupHQPattern Names.IncludeSuffixes (L.payload hqName) ct names of
-            s
-              | Set.size s == 1 -> pure (Set.findMin s)
-              | otherwise ->
-                  failCommitted $
-                    ResolutionFailures
-                      [ TermResolutionFailure
-                          (L.payload hqName)
-                          (ann hqName)
-                          if Set.null s
-                            then NotFound
-                            else
-                              Ambiguous
-                                names
-                                (Set.map (\ref -> Referent.Con ref ct) s)
-                                -- Eh, here we're saying there are no "local" constructors – they're all from "the
-                                -- namespace". That's not necessarily true, but it doesn't (currently) affect the error
-                                -- message any, and we have already parsed and hashed local constructors (so they aren't
-                                -- really different from namespace constructors).
-                                Set.empty
-                      ]
-
-    maybeBindLocalConstructor :: CT.ConstructorType -> Name -> P v m (Maybe ConstructorReference)
-    maybeBindLocalConstructor ct name =
-      asks maybeNamespace >>= \case
-        Nothing -> pure Nothing
-        Just namespace -> do
-          localNames <- asks localNamespacePrefixedTypesAndConstructors
-          pure case Names.lookupHQPattern Names.ExactName (HQ.NameOnly (Name.joinDot namespace name)) ct localNames of
-            refs
-              | Set.null refs -> Nothing
-              -- 2+ name case is impossible: we looked up exact names in the locally-bound names. Two bindings
-              -- with the same name would have been a parse error. So, just take the minimum element from the set,
-              -- which we know is a singleton.
-              | otherwise -> Just (Set.findMin refs)
-
-parsePattern2 :: forall m v. (Monad m, Var v) => P v m (Syntax.Pattern.Pattern v)
-parsePattern2 =
   label "pattern" pRoot
   where
     pRoot :: P v m (Syntax.Pattern.Pattern v)
@@ -492,7 +335,7 @@ parsePattern2 =
 
     pParenOrTuple :: P v m (Syntax.Pattern.Pattern v)
     pParenOrTuple = do
-      snd <$> tupleOrParenthesized parsePattern2 Syntax.Pattern.Unit mkPair
+      snd <$> tupleOrParenthesized parsePattern Syntax.Pattern.Unit mkPair
       where
         mkPair :: Syntax.Pattern.Pattern v -> Syntax.Pattern.Pattern v -> Syntax.Pattern.Pattern v
         mkPair p1 p2 =
@@ -535,12 +378,12 @@ parsePattern2 =
           name <- hqPrefixId
           patterns <- many pLeaf
           _ <- reserved "->"
-          cont <- parsePattern2
+          cont <- parsePattern
           pure (Syntax.Pattern.EffectBind (ann name <> ann cont) name patterns cont)
 
         pEffectPure :: P v m (Syntax.Pattern.Pattern v)
         pEffectPure =
-          parsePattern2 <&> \pat -> Syntax.Pattern.EffectPure (ann pat) pat
+          parsePattern <&> \pat -> Syntax.Pattern.EffectPure (ann pat) pat
 
     -- Parse an "HQ-namey", which could either definitely be a nullary constructor (because it's either hash-only or
     -- hash-qualified or symboly), or either a variable or nullary constructor (because it's a wordy name-only). And if
@@ -557,6 +400,159 @@ parsePattern2 =
             Just _ -> do
               p <- pLeaf
               pure (Syntax.Pattern.As (ann tok <> ann p) (Name.toVar name <$ tok) p)
+
+bindConstructorsInPattern :: (Monad m, Var v) => Syntax.Pattern.Pattern v -> P v m (Pattern.Pattern Ann, [(Ann, v)])
+bindConstructorsInPattern =
+  fmap (over _2 (\f -> (map tokenToPair (f [])))) . runWriterT . bindConstructorsInPattern1
+  where
+    bindConstructorsInPattern1 ::
+      forall m v.
+      (Monad m, Var v) =>
+      Syntax.Pattern.Pattern v ->
+      WriterT ([L.Token v] -> [L.Token v]) (P v m) (Pattern.Pattern Ann)
+    bindConstructorsInPattern1 = \case
+      Syntax.Pattern.As pos v lpat -> do
+        tell (v :)
+        pat <- bindConstructorsInPattern1 lpat
+        pure (Pattern.As pos pat)
+      Syntax.Pattern.Boolean pos b -> pure (Pattern.Boolean pos b)
+      Syntax.Pattern.Char pos c -> pure (Pattern.Char pos c)
+      Syntax.Pattern.Constructor pos name pats ->
+        Pattern.Constructor pos
+          <$> lift (bindConstructor CT.Data name)
+          <*> traverse bindConstructorsInPattern1 pats
+      Syntax.Pattern.EffectBind pos name pats cont ->
+        Pattern.EffectBind pos
+          <$> lift (bindConstructor CT.Effect name)
+          <*> traverse bindConstructorsInPattern1 pats
+          <*> bindConstructorsInPattern1 cont
+      Syntax.Pattern.EffectPure pos lpat -> Pattern.EffectPure pos <$> bindConstructorsInPattern1 lpat
+      Syntax.Pattern.Float pos n -> pure (Pattern.Float pos n)
+      Syntax.Pattern.Int pos n -> pure (Pattern.Int pos n)
+      Syntax.Pattern.Nat pos n -> pure (Pattern.Nat pos n)
+      Syntax.Pattern.Pair _ lpat1 lpat2 ->
+        ( \pat1 pat2 ->
+            Pattern.Constructor
+              (ann pat1 <> ann pat2)
+              (ConstructorReference DD.pairRef 0)
+              [pat1, pat2]
+        )
+          <$> bindConstructorsInPattern1 lpat1
+          <*> bindConstructorsInPattern1 lpat2
+      Syntax.Pattern.SequenceLiteral pos pats -> Pattern.SequenceLiteral pos <$> traverse bindConstructorsInPattern1 pats
+      Syntax.Pattern.SequenceOp pos lpat1 op lpat2 ->
+        Pattern.SequenceOp pos
+          <$> bindConstructorsInPattern1 lpat1
+          <*> pure case op of
+            Syntax.Pattern.Concat -> Pattern.Concat
+            Syntax.Pattern.Cons -> Pattern.Cons
+            Syntax.Pattern.Snoc -> Pattern.Snoc
+          <*> bindConstructorsInPattern1 lpat2
+      Syntax.Pattern.Text pos t -> pure (Pattern.Text pos t)
+      Syntax.Pattern.Unbound pos -> pure (Pattern.Unbound pos)
+      Syntax.Pattern.Unit pos -> pure (Pattern.Constructor pos (ConstructorReference DD.unitRef 0) [])
+      -- Not awesome: something can be at once a syntactically valid nullary constructor and a syntactically valid
+      -- variable. We currently handle this by simply looking in the namespace to determine whether it's a
+      -- constructor, and if it isn't, we treat it as a variable.
+      Syntax.Pattern.VarOrNullaryConstructor pos name ->
+        lift (maybeBindLocalConstructor CT.Data (L.payload name)) >>= \case
+          Just localCtor -> pure (Pattern.Constructor pos localCtor [])
+          Nothing -> do
+            names <- asks names
+            let failure :: ResolutionError Referent -> P v m a
+                failure err =
+                  failCommitted $
+                    ResolutionFailures
+                      [ TermResolutionFailure
+                          (HQ.NameOnly (L.payload name))
+                          (ann name)
+                          err
+                      ]
+            case Names.lookupHQPattern Names.IncludeSuffixes (HQ.NameOnly (L.payload name)) CT.Data names of
+              constructors
+                | Set.size constructors == 1 -> pure (Pattern.Constructor pos (Set.findMin constructors) [])
+                | Set.null constructors ->
+                    -- Not great thing alert :alarm: :alarm:
+                    -- This is a syntactically valid variable, however, if it begins with a capital letter, we choose to
+                    -- consider it a constructor-out-of-scope, since that's probably what the user meant.
+                    if lastSegmentBeginsWithCapitalLetter
+                      then lift (failure NotFound)
+                      else do
+                        tell ((Name.toVar <$> name) :)
+                        pure (Pattern.Var pos)
+                | otherwise ->
+                    lift $
+                      failure
+                        ( Ambiguous
+                            names
+                            (Set.map (\ref -> Referent.Con ref CT.Data) constructors)
+                            Set.empty
+                        )
+        where
+          lastSegmentBeginsWithCapitalLetter :: Bool
+          lastSegmentBeginsWithCapitalLetter =
+            not (Char.isLower (Text.head (NameSegment.toUnescapedText (Name.lastSegment (L.payload name)))))
+      where
+        bindConstructor :: CT.ConstructorType -> L.Token (HQ.HashQualified Name) -> P v m ConstructorReference
+        bindConstructor ct hqName = do
+          -- First, if:
+          --
+          --   * The token isn't hash-qualified (e.g. "Foo.Bar")
+          --   * We're under a namespace directive (e.g. "baz")
+          --   * There's an exact match for a locally-bound constructor (e.g. "baz.Foo.Bar")
+          --
+          -- Then:
+          --
+          --   * Use that constructor reference (duh)
+          --
+          -- Else:
+          --
+          --   * Fall through to the normal logic of looking the constructor name up in all of the names (which includes
+          --     the locally-bound constructors).
+          maybeLocalCtor <-
+            case L.payload hqName of
+              HQ.NameOnly name -> maybeBindLocalConstructor ct name
+              _ -> pure Nothing
+
+          case maybeLocalCtor of
+            Just localCtor -> pure localCtor
+            Nothing -> do
+              names <- asks names
+              case Names.lookupHQPattern Names.IncludeSuffixes (L.payload hqName) ct names of
+                s
+                  | Set.size s == 1 -> pure (Set.findMin s)
+                  | otherwise ->
+                      failCommitted $
+                        ResolutionFailures
+                          [ TermResolutionFailure
+                              (L.payload hqName)
+                              (ann hqName)
+                              if Set.null s
+                                then NotFound
+                                else
+                                  Ambiguous
+                                    names
+                                    (Set.map (\ref -> Referent.Con ref ct) s)
+                                    -- Eh, here we're saying there are no "local" constructors – they're all from "the
+                                    -- namespace". That's not necessarily true, but it doesn't (currently) affect the error
+                                    -- message any, and we have already parsed and hashed local constructors (so they aren't
+                                    -- really different from namespace constructors).
+                                    Set.empty
+                          ]
+
+        maybeBindLocalConstructor :: CT.ConstructorType -> Name -> P v m (Maybe ConstructorReference)
+        maybeBindLocalConstructor ct name =
+          asks maybeNamespace >>= \case
+            Nothing -> pure Nothing
+            Just namespace -> do
+              localNames <- asks localNamespacePrefixedTypesAndConstructors
+              pure case Names.lookupHQPattern Names.ExactName (HQ.NameOnly (Name.joinDot namespace name)) ct localNames of
+                refs
+                  | Set.null refs -> Nothing
+                  -- 2+ name case is impossible: we looked up exact names in the locally-bound names. Two bindings
+                  -- with the same name would have been a parse error. So, just take the minimum element from the set,
+                  -- which we know is a singleton.
+                  | otherwise -> Just (Set.findMin refs)
 
 lam :: (Var v) => TermP v m -> TermP v m
 lam p = label "lambda" $ mkLam <$> P.try (some prefixDefinitionName <* reserved "->") <*> p
@@ -1365,7 +1361,7 @@ destructuringBind = do
   --   (Some 42)
   --   vs
   --   (Some 42) = List.head elems
-  pat <- P.try (parsePattern2 <* P.lookAhead (openBlockWith "="))
+  pat <- P.try (parsePattern <* P.lookAhead (openBlockWith "="))
   (p, boundVars) <- over (_2 . mapped) snd <$> bindConstructorsInPattern pat
   (_spanAnn, scrute) <- layoutBlock "=" -- Dwight K. Scrute ("The People's Scrutinee")
   let guard = Nothing

--- a/unison-core/src/Unison/Pattern.hs
+++ b/unison-core/src/Unison/Pattern.hs
@@ -1,8 +1,3 @@
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DeriveTraversable #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PatternSynonyms #-}
-
 module Unison.Pattern where
 
 import Data.List (intercalate)

--- a/unison-src/transcripts/idempotent/fix-3982.md
+++ b/unison-src/transcripts/idempotent/fix-3982.md
@@ -1,0 +1,55 @@
+``` ucm
+scratch/main> builtins.mergeio lib.builtin
+
+  Done.
+```
+
+``` unison :error
+type Foo = Bar Nat
+
+foo : Foo -> Nat
+foo x =
+  (Barr n) = x
+  n
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+
+    ❓
+    
+    I couldn't resolve any of these symbols:
+    
+        5 |   (Barr n) = x
+    
+    
+    Symbol   Suggestions
+             
+    Barr     No matches
+```
+
+``` unison :error
+type Foo = Bar Nat
+
+foo : Foo -> Nat
+foo x =
+  b@(Barr n) = x
+  n
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+
+    ❓
+    
+    I couldn't resolve any of these symbols:
+    
+        5 |   b@(Barr n) = x
+    
+    
+    Symbol   Suggestions
+             
+    Barr     No matches
+```

--- a/unison-syntax/src/Unison/Syntax/Parser.hs
+++ b/unison-syntax/src/Unison/Syntax/Parser.hs
@@ -57,6 +57,7 @@ module Unison.Syntax.Parser
     tupleOrParenthesized,
     uniqueBase32Namegen,
     uniqueName,
+    varOrNullaryConstructor,
     wordyDefinitionName,
     wordyPatternName,
   )
@@ -242,8 +243,6 @@ instance (Annotated a, Annotated b) => Annotated (MatchCase a b) where
 label :: (Ord v, Show a) => String -> P v m a -> P v m a
 label = P.label
 
--- label = P.dbg
-
 traceRemainingTokens :: (Ord v) => String -> P v m ()
 traceRemainingTokens label = do
   remainingTokens <- lookAhead $ many anyToken
@@ -416,6 +415,25 @@ hqSymbolyId_ :: (Ord v) => P v m (L.Token (HQ.HashQualified Name))
 hqSymbolyId_ = queryToken \case
   L.SymbolyId n -> Just (HQ'.toHQ n)
   _ -> Nothing
+
+-- Syntax  | Returns | Meaning
+-- ------- +---------+----------------------------------------
+-- Foo     | Right   | Could be a var or a nullary constructor
+-- Foo#Bar | Left    | Definitely a nullary constructor
+-- #Bar    | Left    | Definitely a nullary constructor
+-- (+)     | Left    | Definitely a nullary constructor (wait really? why?)
+varOrNullaryConstructor :: (Ord v) => P v m (L.Token (Either (HQ.HashQualified Name) Name))
+varOrNullaryConstructor =
+  wordy <|> symboly
+  where
+    wordy =
+      queryToken \case
+        L.WordyId (HQ'.NameOnly n) -> if isBlank n then Nothing else Just (Right n)
+        L.WordyId n -> Just (Left (HQ'.toHQ n))
+        L.Hash h -> Just (Left (HQ.HashOnly h))
+        _ -> Nothing
+    symboly =
+      (fmap . fmap) Left (parenthesize hqSymbolyId_)
 
 -- | Parse a reserved word
 reserved :: (Ord v) => String -> P v m (L.Token String)

--- a/unison-syntax/src/Unison/Syntax/Pattern.hs
+++ b/unison-syntax/src/Unison/Syntax/Pattern.hs
@@ -1,0 +1,78 @@
+module Unison.Syntax.Pattern
+  ( Pattern (..),
+    setPos,
+    SeqOp (..),
+  )
+where
+
+import Unison.HashQualified (HashQualified)
+import Unison.Name (Name)
+import Unison.Parser.Ann (Ann)
+import Unison.Prelude
+import Unison.Syntax.Lexer.Token (Token)
+import Unison.Syntax.Parser (Annotated (..))
+
+data Pattern v
+  = As Ann (Token v) (Pattern v)
+  | Boolean Ann !Bool
+  | Char Ann !Char
+  | Constructor Ann !(Token (HashQualified Name)) [Pattern v]
+  | EffectBind Ann !(Token (HashQualified Name)) [Pattern v] (Pattern v)
+  | EffectPure Ann (Pattern v)
+  | Float Ann !Double
+  | Int Ann !Int64
+  | Nat Ann !Word64
+  | Pair Ann (Pattern v) (Pattern v)
+  | SequenceLiteral Ann [Pattern v]
+  | SequenceOp Ann (Pattern v) !SeqOp (Pattern v)
+  | Text Ann !Text
+  | Unbound Ann
+  | Unit Ann
+  | -- There's unfortunately no syntactic difference between nullary constructors and variables,
+    -- so we can't commit to one or the other yet.
+    VarOrNullaryConstructor Ann !(Token Name)
+  deriving stock (Show)
+
+instance Annotated (Pattern v) where
+  ann = \case
+    As pos _ _ -> pos
+    Boolean pos _ -> pos
+    Char pos _ -> pos
+    Constructor pos _ _ -> pos
+    EffectBind pos _ _ _ -> pos
+    EffectPure pos _ -> pos
+    Float pos _ -> pos
+    Int pos _ -> pos
+    Nat pos _ -> pos
+    Pair pos _ _ -> pos
+    SequenceLiteral pos _ -> pos
+    SequenceOp pos _ _ _ -> pos
+    Text pos _ -> pos
+    Unbound pos -> pos
+    Unit pos -> pos
+    VarOrNullaryConstructor pos _ -> pos
+
+setPos :: Ann -> Pattern v -> Pattern v
+setPos pos = \case
+  As _ a b -> As pos a b
+  Boolean _ a -> Boolean pos a
+  Char _ a -> Char pos a
+  Constructor _ a b -> Constructor pos a b
+  EffectBind _ a b c -> EffectBind pos a b c
+  EffectPure _ a -> EffectPure pos a
+  Float _ a -> Float pos a
+  Int _ a -> Int pos a
+  Nat _ a -> Nat pos a
+  Pair _ a b -> Pair pos a b
+  SequenceLiteral _ a -> SequenceLiteral pos a
+  SequenceOp _ a b c -> SequenceOp pos a b c
+  Text _ a -> Text pos a
+  Unbound _ -> Unbound pos
+  Unit _ -> Unit pos
+  VarOrNullaryConstructor _ a -> VarOrNullaryConstructor pos a
+
+data SeqOp
+  = Concat
+  | Cons
+  | Snoc
+  deriving stock (Show)

--- a/unison-syntax/unison-syntax.cabal
+++ b/unison-syntax/unison-syntax.cabal
@@ -29,6 +29,7 @@ library
       Unison.Syntax.Parser
       Unison.Syntax.Parser.Doc
       Unison.Syntax.Parser.Doc.Data
+      Unison.Syntax.Pattern
       Unison.Syntax.ReservedWords
       Unison.Syntax.ShortHash
       Unison.Syntax.Var


### PR DESCRIPTION
## Overview

Fixes #3982 

This PR improves the error message you get when misspelling a constructor in an irrefutable pattern match, e.g.

```unison
type Foo = Bar Nat

foo : Foo -> Nat
foo x =
  (Typo n) = x
  n
```

Previously, it would bafflingly complain about an unexpected `=`:

<img width="450" alt="Screenshot 2025-04-16 at 8 31 43 PM" src="https://github.com/user-attachments/assets/12b986ee-351f-4398-a682-edf83dbb1fb2" />

Now, it prints a better "thing not found" error:

<img width="450" alt="Screenshot 2025-04-16 at 8 33 01 PM" src="https://github.com/user-attachments/assets/1e7b2551-8bbc-4886-92f1-cf7d38e32731" />