### PR TITLE
Maps now decompile as a single call to `Map.fromList`

### DIFF
--- a/unison-runtime/src/Unison/Runtime/Decompile.hs
+++ b/unison-runtime/src/Unison/Runtime/Decompile.hs
@@ -12,6 +12,7 @@ module Unison.Runtime.Decompile
   )
 where
 
+import Data.Map qualified as Map
 import Data.Set (singleton)
 import Unison.ABT (substs)
 import Unison.Codebase.Runtime (Error)
@@ -19,6 +20,7 @@ import Unison.ConstructorReference (GConstructorReference (..))
 import Unison.Prelude
 import Unison.Reference (Reference, pattern Builtin)
 import Unison.Referent (pattern Ref)
+import Unison.Referent qualified as Referent
 import Unison.Runtime.ANF (maskTags)
 import Unison.Runtime.Array
   ( Array,
@@ -38,7 +40,6 @@ import Unison.Runtime.Stack
     USeq,
     UnboxedTypeTag (..),
     Val (..),
-    inflateMap,
     pattern DataC,
     pattern PApV,
   )
@@ -77,6 +78,7 @@ import Unison.Util.Bytes qualified as By
 import Unison.Util.Pretty (indentN, lines, lit, shown, syntaxToColor, wrap)
 import Unison.Util.Text qualified as Text
 import Unison.Var (Var)
+import Unison.Builtin.Decls qualified as DD
 import Prelude hiding (lines)
 
 con :: (Var v) => Reference -> Word64 -> Term v ()
@@ -230,14 +232,28 @@ decompileForeign backref topTerms f
           (decompileBytes . By.fromWord8s $ byteArrayToList a)
   | Just s <- unwrapSeq f =
       list' () <$> traverse (decompile backref topTerms) s
-  | Just m <- maybeUnwrapForeign hmapRef f =
-      decompile backref topTerms . BoxedVal $ inflateMap m
+  | Just m <- maybeUnwrapForeign hmapRef f = do
+      let decompileEntry k v = pair <$> decompile backref topTerms k <*> decompile backref topTerms v
+      kvs <- traverse (uncurry decompileEntry) (Map.toList m)
+      pure $ app () map_fromList (list () kvs)
 decompileForeign _ _ (Wrap r _) =
   err (BadForeign r) $ bug text
   where
     text
       | Builtin name <- r = "<" <> name <> ">"
       | otherwise = "<Foreign>"
+
+map_fromList :: (Var v) => Term v ()
+map_fromList = 
+   case Referent.fromText "#apmvhl40hl48q1s7383g5ev3sh7td8qo374t87bchpnu24sccmnvm13e2a1q0f2p1prm2uk9prfpg598dc9jo23iagact6gmi18vta8" of
+     Just r -> Term.fromReferent () r
+     Nothing -> error "Map_fromList"
+
+pair :: (Var v) => Term v () -> Term v () -> Term v ()
+pair a b =
+  Term.apps' (Term.fromReferent () DD.pairCtorRef) [
+    a, Term.apps' (Term.fromReferent () DD.pairCtorRef) [b, Term.fromReferent () DD.unitCtorRef]
+  ]
 
 decompileBytes :: (Var v) => By.Bytes -> Term v ()
 decompileBytes =

--- a/unison-src/transcripts/base_release_transcript.md
+++ b/unison-src/transcripts/base_release_transcript.md
@@ -1,0 +1,14 @@
+
+# Testing functions that use the base library
+
+``` ucm
+scratch/main> lib.install @unison/base/releases/3.35.0
+```
+
+This just verifies that a `Map` prints out nicely, as a call to `Map.fromList`:
+
+```unison
+> Map.fromList [("Alice", 1), ("Bob", 2), ("Carol", 3)]
+
+> Map.fromList (List.range 0 25 |> List.map (i -> (i,i)))
+```

--- a/unison-src/transcripts/base_release_transcript.output.md
+++ b/unison-src/transcripts/base_release_transcript.output.md
@@ -1,0 +1,61 @@
+# Testing functions that use the base library
+
+``` ucm
+scratch/main> lib.install @unison/base/releases/3.35.0
+
+  I installed @unison/base/releases/3.35.0 as
+  unison_base_3_35_0.
+```
+
+This just verifies that a `Map` prints out nicely, as a call to `Map.fromList`:
+
+``` unison
+> Map.fromList [("Alice", 1), ("Bob", 2), ("Carol", 3)]
+
+> Map.fromList (List.range 0 25 |> List.map (i -> (i,i)))
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  ✅
+
+  scratch.u changed.
+
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    1 | > Map.fromList [("Alice", 1), ("Bob", 2), ("Carol", 3)]
+          ⧩
+          Map.fromList [("Alice", 1), ("Bob", 2), ("Carol", 3)]
+
+    3 | > Map.fromList (List.range 0 25 |> List.map (i -> (i,i)))
+          ⧩
+          Map.fromList
+            [ (0, 0)
+            , (1, 1)
+            , (2, 2)
+            , (3, 3)
+            , (4, 4)
+            , (5, 5)
+            , (6, 6)
+            , (7, 7)
+            , (8, 8)
+            , (9, 9)
+            , (10, 10)
+            , (11, 11)
+            , (12, 12)
+            , (13, 13)
+            , (14, 14)
+            , (15, 15)
+            , (16, 16)
+            , (17, 17)
+            , (18, 18)
+            , (19, 19)
+            , (20, 20)
+            , (21, 21)
+            , (22, 22)
+            , (23, 23)
+            , (24, 24)
+            ]
+```


### PR DESCRIPTION
**Before:**

<img width="778" alt="CleanShot 2025-04-17 at 15 42 44@2x" src="https://github.com/user-attachments/assets/33f1adbc-e6bf-4027-afdf-0cc5023850de" />

**After:**

<img width="1019" alt="CleanShot 2025-04-17 at 15 42 16@2x" src="https://github.com/user-attachments/assets/f2482fe5-2dcb-470a-b9fa-920dd5cdb700" />

This doesn't affect anything runtime-related, the decompilation is just used for display purposes when rendering watch expressions.

If you want to see the actual internal tree structure of the `Map`, you can write a custom function to do so, but this is a pretty niche use case, more for debugging purposes for people implementing `Map`. So I think it's fine for this to be the default.
 
I added a transcript test that pulls from base. The release pull takes maybe 10s, so I just added it as regular transcript.

## Possibly controversial

If you don't have `Map.fromList` in your codebase, it'll just render as the hash applied to the list of entries. I think this case will be quite rare, you'd have to be using a very old version of base, and it's not terrible to see a hash there regardless - the most important thing is that you can see the entries of the map, and this is just for debugging / display purposes.

