### PR TITLE
LSP Jump to Definition for LOCAL bindings

### DIFF
--- a/unison-cli/src/Unison/LSP.hs
+++ b/unison-cli/src/Unison/LSP.hs
@@ -40,6 +40,7 @@ import Unison.LSP.Configuration qualified as Config
 import Unison.LSP.FileAnalysis qualified as Analysis
 import Unison.LSP.FoldingRange (foldingRangeRequest)
 import Unison.LSP.Formatting (formatDocRequest, formatRangeRequest)
+import Unison.LSP.GoToDefinition (goToDeclarationHandler, goToDefinitionHandler, goToImplementationHandler)
 import Unison.LSP.HandlerUtils qualified as Handlers
 import Unison.LSP.Hover (hoverHandler)
 import Unison.LSP.NotificationHandlers qualified as Notifications
@@ -181,6 +182,9 @@ lspRequestHandlers lspFormattingConfig =
     & SMM.insert Msg.SMethod_TextDocumentFoldingRange (mkHandler foldingRangeRequest)
     & SMM.insert Msg.SMethod_TextDocumentCompletion (mkHandler completionHandler)
     & SMM.insert Msg.SMethod_CompletionItemResolve (mkHandler completionItemResolveHandler)
+    & SMM.insert Msg.SMethod_TextDocumentDeclaration (mkHandler goToDeclarationHandler)
+    & SMM.insert Msg.SMethod_TextDocumentDefinition (mkHandler goToDefinitionHandler)
+    & SMM.insert Msg.SMethod_TextDocumentImplementation (mkHandler goToImplementationHandler)
     & addFormattingHandlers
   where
     addFormattingHandlers handlers =

--- a/unison-cli/src/Unison/LSP/Conversions.hs
+++ b/unison-cli/src/Unison/LSP/Conversions.hs
@@ -13,6 +13,13 @@ rangeToInterval :: Range -> Interval.Interval Position
 rangeToInterval (Range start end) =
   Interval.ClosedInterval start end
 
+intervalToRange :: Interval.Interval Position -> Range
+intervalToRange = \case
+  (Interval.ClosedInterval start end) -> Range start end
+  (Interval.OpenInterval start end) -> Range start end
+  (Interval.IntervalCO start end) -> Range start end
+  (Interval.IntervalOC start end) -> Range start end
+
 annToInterval :: Ann -> Maybe (Interval.Interval Position)
 annToInterval ann = annToRange ann <&> rangeToInterval
 

--- a/unison-cli/src/Unison/LSP/FileAnalysis.hs
+++ b/unison-cli/src/Unison/LSP/FileAnalysis.hs
@@ -114,7 +114,7 @@ checkFileContents fileUri sourceName fileVersion contents = do
             maybeNamespace = Nothing,
             localNamespacePrefixedTypesAndConstructors = mempty
           }
-  (localBindingTypes, notes, parsedFile, typecheckedFile) <- do
+  (localBindingInfo, notes, parsedFile, typecheckedFile) <- do
     liftIO do
       Codebase.runTransaction cb do
         parseResult <- Parsers.parseFile (Text.unpack sourceName) (Text.unpack srcText) parsingEnv
@@ -124,29 +124,33 @@ checkFileContents fileUri sourceName fileVersion contents = do
             typecheckingEnv <- computeTypecheckingEnvironment (ShouldUseTndr'Yes parsingEnv) cb ambientAbilities parsedFile
             let Result.Result typecheckingNotes maybeTypecheckedFile = FileParsers.synthesizeFile typecheckingEnv parsedFile
 
-            symbolTypes <-
+            symbolInfo <-
               typecheckingNotes
                 & Foldable.toList
                 & reverse -- Type notes that come later in typechecking have more information filled in.
                 & foldMap \case
-                  Result.TypeInfo (Context.VarBinding v _loc typ) -> Map.singleton v typ
+                  Result.TypeInfo (Context.VarBinding v loc typ) ->
+                    annToRange loc
+                      & foldMap \definitionSite -> Map.singleton v (typ, definitionSite)
                   _ -> mempty
                 & pure
 
-            let localBindings :: (IntervalMap Position (Context.Type Symbol Ann)) =
+            let localBindingInfo :: (IntervalMap Position (Context.Type Symbol Ann, Range)) =
                   typecheckingNotes
                     & Foldable.toList
                     & reverse -- Type notes that come later in typechecking have more information filled in.
                     & foldMap \case
                       Result.TypeInfo (Context.VarBinding _v loc typ) -> do
-                        ((annToInterval loc) & foldMap \interval -> (IM.singleton interval typ))
+                        ( (liftA2 (,) (annToInterval loc) (annToRange loc))
+                            & foldMap \(interval, definitionSite) -> (IM.singleton interval (typ, definitionSite))
+                          )
                       Result.TypeInfo (Context.VarMention v loc) -> do
-                        case Map.lookup v symbolTypes of
-                          Just typ ->
-                            ((annToInterval loc) & foldMap \interval -> (IM.singleton interval typ))
+                        case Map.lookup v symbolInfo of
+                          Just (typ, definitionSite) ->
+                            ((annToInterval loc) & foldMap \interval -> (IM.singleton interval (typ, definitionSite)))
                           _ -> mempty
                       _ -> mempty
-            pure (localBindings, typecheckingNotes, Just parsedFile, maybeTypecheckedFile)
+            pure (localBindingInfo, typecheckingNotes, Just parsedFile, maybeTypecheckedFile)
 
   filePPED <- ppedForFileHelper parsedFile typecheckedFile
   (errDiagnostics, codeActions) <- analyseFile fileUri srcText filePPED notes
@@ -178,7 +182,7 @@ checkFileContents fileUri sourceName fileVersion contents = do
             parsedFile,
             typecheckedFile,
             notes,
-            localBindingTypes
+            localBindingInfo
           }
   pure fileAnalysis
 

--- a/unison-cli/src/Unison/LSP/GoToDefinition.hs
+++ b/unison-cli/src/Unison/LSP/GoToDefinition.hs
@@ -1,0 +1,57 @@
+-- | goToDeclaration, goToDefinition, and goToImplementation are equivalent except for the input/return wrappers
+module Unison.LSP.GoToDefinition
+  ( goToDefinitionHandler,
+    goToDeclarationHandler,
+    goToImplementationHandler,
+  )
+where
+
+import Control.Lens hiding (List)
+import Data.IntervalMap.Lazy qualified as IM
+import Language.LSP.Protocol.Lens
+import Language.LSP.Protocol.Message qualified as Msg
+import Language.LSP.Protocol.Types
+import Unison.LSP.FileAnalysis qualified as FileAnalysis
+import Unison.LSP.Types
+import Unison.Prelude
+
+-- | Go to Definition handler
+goToDefinitionHandler :: Msg.TRequestMessage 'Msg.Method_TextDocumentDefinition -> (Either Msg.ResponseError (Msg.MessageResult 'Msg.Method_TextDocumentDefinition) -> Lsp ()) -> Lsp ()
+goToDefinitionHandler m respond = do
+  respond . Right . maybe (InR . InL $ []) (InR . InL) =<< runMaybeT do
+    let pos = (m ^. params . position)
+    targetRange <- locationInfo (m ^. params . textDocument . uri) pos
+    let originLoc = Nothing -- Just use default
+    let targetUri = m ^. params . textDocument . uri
+    pure $
+      [DefinitionLink (LocationLink originLoc targetUri targetRange targetRange)]
+
+-- | Go to Declaration handler
+goToDeclarationHandler :: Msg.TRequestMessage 'Msg.Method_TextDocumentDeclaration -> (Either Msg.ResponseError (Msg.MessageResult 'Msg.Method_TextDocumentDeclaration) -> Lsp ()) -> Lsp ()
+goToDeclarationHandler m respond = do
+  respond . Right . maybe (InR . InL $ []) (InR . InL) =<< runMaybeT do
+    let pos = (m ^. params . position)
+    targetRange <- locationInfo (m ^. params . textDocument . uri) pos
+    let originLoc = Nothing -- Just use default
+    let targetUri = m ^. params . textDocument . uri
+    pure $
+      [DeclarationLink (LocationLink originLoc targetUri targetRange targetRange)]
+
+goToImplementationHandler :: Msg.TRequestMessage 'Msg.Method_TextDocumentImplementation -> (Either Msg.ResponseError (Msg.MessageResult 'Msg.Method_TextDocumentImplementation) -> Lsp ()) -> Lsp ()
+goToImplementationHandler m respond = do
+  respond . Right . maybe (InR . InL $ []) (InR . InL) =<< runMaybeT do
+    let pos = (m ^. params . position)
+    targetRange <- locationInfo (m ^. params . textDocument . uri) pos
+    let originLoc = Nothing -- Just use default
+    let targetUri = m ^. params . textDocument . uri
+    pure $
+      [DefinitionLink (LocationLink originLoc targetUri targetRange targetRange)]
+
+locationInfo :: Uri -> Position -> MaybeT Lsp Range
+locationInfo uri pos = do
+  FileAnalysis {localBindingInfo} <- FileAnalysis.getFileAnalysis uri
+  (_interval, (_typ, range)) <- hoistMaybe $ IM.lookupMin $ IM.intersecting localBindingInfo (IM.ClosedInterval pos pos)
+  pure range
+  where
+    hoistMaybe :: Maybe a -> MaybeT Lsp a
+    hoistMaybe = MaybeT . pure

--- a/unison-cli/src/Unison/LSP/Hover.hs
+++ b/unison-cli/src/Unison/LSP/Hover.hs
@@ -130,8 +130,8 @@ hoverInfo uri pos =
           (Term.Var' v) -> pure v
           (ABT.Abs'' v _body) -> pure v
           _ -> empty
-      FileAnalysis {localBindingTypes} <- FileAnalysis.getFileAnalysis uri
-      (_range, typ) <- hoistMaybe $ IM.lookupMin $ IM.intersecting localBindingTypes (IM.ClosedInterval pos pos)
+      FileAnalysis {localBindingInfo} <- FileAnalysis.getFileAnalysis uri
+      (_range, (typ, _definitionSite)) <- hoistMaybe $ IM.lookupMin $ IM.intersecting localBindingInfo (IM.ClosedInterval pos pos)
 
       pped <- lift $ ppedForFile uri
       let varName = case localVar of

--- a/unison-cli/src/Unison/LSP/Types.hs
+++ b/unison-cli/src/Unison/LSP/Types.hs
@@ -131,7 +131,7 @@ data FileAnalysis = FileAnalysis
     diagnostics :: IntervalMap Position [Diagnostic],
     codeActions :: IntervalMap Position [CodeAction],
     -- | The types of local variable bindings keyed by the mention's location.
-    localBindingTypes :: IntervalMap Position (Context.Type Symbol Ann),
+    localBindingInfo :: IntervalMap Position (Context.Type Symbol Ann {- type of binding -}, Range {- binding definition site -}),
     typeSignatureHints :: Map Symbol TypeSignatureHint,
     fileSummary :: Maybe FileSummary
   }

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -140,6 +140,7 @@ library
       Unison.LSP.FileAnalysis.UnusedBindings
       Unison.LSP.FoldingRange
       Unison.LSP.Formatting
+      Unison.LSP.GoToDefinition
       Unison.LSP.HandlerUtils
       Unison.LSP.Hover
       Unison.LSP.NotificationHandlers


### PR DESCRIPTION
## Overview

Adds LSP support for "jump to definition" for local bindings.

After the changes for local-var type info this was absolutely trivial to add :)

Notes: 
* this uses the same implementation for 'jump to definition" "jump to declaration" and "jump to implementation" when invoked on locally bound var references.
* Types, and jumping to things in your codebase aren't implemented and aren't likely to be implemented unless VSCode changes its "prefetch" behaviour :'( 

![jump](https://github.com/user-attachments/assets/e6e2e6da-16ff-4dc0-9efd-3429cb7bcb79)

## Implementation notes

* Use the binding location information collected during typechecking
* When invoked, use the location of the cursor to look up the relevant symbol, map that to its binding site, then jump there.

## Test coverage

* None yet, a bit annoying to write, but could try to dream some up; will probably wait until someone notices it broke to go through the effort since it's not trivial to do, nor is it a mission-critical feature.
