### PR TITLE
Fix completion on symbols ending in '.'

### DIFF
--- a/unison-cli/src/Unison/LSP/Completion.hs
+++ b/unison-cli/src/Unison/LSP/Completion.hs
@@ -60,9 +60,12 @@ completionHandler m respond =
   respond . maybe (Right $ InL mempty) (Right . InR . InL) =<< runMaybeT do
     let fileUri = (m ^. params . textDocument . uri)
     (range, prefix) <- VFS.completionPrefix (m ^. params . textDocument . uri) (m ^. params . position)
+    -- dots are separators in names and a name with a trailing '.' doesn't parse and short-circuits completion.
+    -- Since the completion overwrites the explicitly provided range anyways, stripping just works better.
+    let strippedPrefix = Text.dropWhileEnd (== '.') prefix
     ppe <- PPED.suffixifiedPPE <$> lift currentPPED
     codebaseCompletions <- lift getCodebaseCompletions
-    let (isIncomplete, matches) = completionsForQuery codebaseCompletions prefix
+    let (isIncomplete, matches) = completionsForQuery codebaseCompletions strippedPrefix
     let defCompletionItems =
           matches
             & mapMaybe \(path, fqn, dep) ->


### PR DESCRIPTION
## Overview

Partial fix for the issue @pchiusano  and Baccata were talking about in Discord: https://discord.com/channels/862108724948500490/1200119435931942994/1366397443964665867

Completion just didn't work when your cursor was after a dot, e.g. `List.^` 

Looks like the names parser just didn't like names ending in '.'; now I just strip trailing dots, one line fix.

## Test coverage

Nah
