### PR TITLE
Fix Multimap.fromList

### DIFF
--- a/unison-runtime/src/Unison/Runtime/Foreign/Function.hs
+++ b/unison-runtime/src/Unison/Runtime/Foreign/Function.hs
@@ -901,7 +901,9 @@ foreignCallHelper = \case
   List_sort -> mkForeign $ \(l :: Seq Val) -> pure $ Sq.unstableSort l
   Multimap_fromList -> mkForeign $ \(l :: [(Val, Val)]) -> do
     let listVals = l <&> \(k, v) -> (k, Sq.singleton v)
-    evaluate $ Map.fromListWith (<>) listVals
+    -- Haskell Map.fromList calls the semigroup in reverse order, so we correct for it by flipping.
+    let result :: Map Val Val = fmap encodeVal $ Map.fromListWith (flip (<>)) listVals
+    evaluate result
   Set_fromList -> mkForeign $ \(l :: [Val]) -> do
     m <- evaluate $ Map.fromList $ zip l (repeat unitValue)
     pure . Data1 Ty.setRef TT.setWrapTag $ encodeVal m


### PR DESCRIPTION
## Overview

Running:

```
main = do
  xs = Multimap.fromList [(1,"a"), (1,"b"), (2,"c"), (2,"d"), (3,"e"), (3,"f"), (3,"g")]
  xs
```

on trunk causes a segfault.

This appears to be because the ForeignConvention being applied to `Map (Seq Val)` isn't correctly converting `Seq Val` into a `Val`.

We should investigate that foreign convention, but in the meantime, this will stop the segfault.

I also flipped the mappend order to match what we expected in Unison; since Haskell's lib flips it.

## Test coverage

On this branch:

```
@unison/base/remapping> run main

  Map.fromList [(1, ["a", "b"]), (2, ["c", "d"]), (3, ["e", "f", "g"])]

```

## Loose ends

* [ ] Investigate the bad foreign convention
