### PR TITLE
Restrict Map builtin foreign to 'Map Val Val'

### DIFF
--- a/unison-runtime/src/Unison/Runtime/Foreign.hs
+++ b/unison-runtime/src/Unison/Runtime/Foreign.hs
@@ -24,7 +24,6 @@ import Control.Concurrent.STM (TVar)
 import Crypto.Hash qualified as Hash
 import Data.Atomics qualified as Atomic
 import Data.IORef (IORef)
-import Data.Map.Strict (Map)
 import Data.Tagged (Tagged (..))
 import Data.X509 qualified as X509
 import Network.Socket (Socket)
@@ -358,15 +357,6 @@ instance BuiltinForeign CPattern where
 instance BuiltinForeign CharPattern where
   foreignName = Tagged "CharPattern"
   foreignRef = Tagged Ty.charClassRef
-
--- Note: this doesn't do any recursive conversion of keys/values,
--- so any use of it needs to be an exact match for the map that was
--- originally placed in the box. The current intention is for use
--- at `Map Val Val`, but `Val` is in a module further along the
--- dependency graph.
-instance BuiltinForeign (Map k v) where
-  foreignName = Tagged "Map"
-  foreignRef = Tagged Ty.hmapRef
 
 wrapBuiltin :: forall f. (BuiltinForeign f) => f -> Foreign
 wrapBuiltin x = Wrap r x

--- a/unison-runtime/src/Unison/Runtime/Foreign/Function.hs
+++ b/unison-runtime/src/Unison/Runtime/Foreign/Function.hs
@@ -875,7 +875,7 @@ foreignCallHelper = \case
     let v = TPat.cpattern (TPat.Lookbehind1 cp) in pure v
   Text_patterns_negativeLookbehind1 -> mkForeign $ \cp ->
     let v = TPat.cpattern (TPat.NegativeLookbehind1 cp) in pure v
-  Map_tip -> mkForeign $ \() -> pure Map.empty
+  Map_tip -> mkForeign $ \() -> pure (Map.empty @Val @Val)
   Map_bin -> mkForeign $ \(sz :: Word64, k :: Val, v :: Val, l, r) ->
     pure (Map.Bin (fromIntegral sz) k v l r)
   Map_insert -> mkForeign $ \(k :: Val, v :: Val, m :: Map Val Val) ->

--- a/unison-runtime/src/Unison/Runtime/Stack.hs
+++ b/unison-runtime/src/Unison/Runtime/Stack.hs
@@ -760,6 +760,11 @@ instance Eq Val where
 instance Ord Val where
   compare = universalCompare compare
 
+instance BuiltinForeign (Map Val Val) where
+  foreignName = Tagged "Map"
+  foreignRef = Tagged Ty.hmapRef
+
+
 instance BuiltinForeign (IORef Val) where
   foreignName = Tagged "IORef"
   foreignRef = Tagged Ty.refRef


### PR DESCRIPTION
* [x] Wait for #5677 

As a mitigation for the recent incident with `Multimap.fromList` causing segfaults, restrict to BuiltinForeign instance so those things won't even compile next time :) 