### PR TITLE
Restrict more BuiltinForeign instances

### DIFF
--- a/unison-runtime/src/Unison/Runtime/Foreign.hs
+++ b/unison-runtime/src/Unison/Runtime/Foreign.hs
@@ -22,7 +22,6 @@ where
 import Control.Concurrent (MVar, ThreadId)
 import Control.Concurrent.STM (TVar)
 import Crypto.Hash qualified as Hash
-import Data.Atomics qualified as Atomic
 import Data.IORef (IORef)
 import Data.Tagged (Tagged (..))
 import Data.X509 qualified as X509
@@ -38,7 +37,6 @@ import Unison.Runtime.ANF (Code, Value)
 import Unison.Runtime.Array
 import Unison.Type qualified as Ty
 import Unison.Util.Bytes (Bytes)
-import Unison.Util.RefPromise (Promise)
 import Unison.Util.Text (Text)
 import Unison.Util.Text.Pattern (CPattern, CharPattern)
 import Unsafe.Coerce
@@ -305,30 +303,6 @@ instance BuiltinForeign Value where
 instance BuiltinForeign TimeSpec where
   foreignName = Tagged "TimeSpec"
   foreignRef = Tagged Ty.timeSpecRef
-
-instance BuiltinForeign (Atomic.Ticket a) where
-  foreignName = Tagged "Ticket"
-  foreignRef = Tagged Ty.ticketRef
-
-instance BuiltinForeign (MVar a) where
-  foreignName = Tagged "MVar"
-  foreignRef = Tagged Ty.mvarRef
-
-instance BuiltinForeign (TVar a) where
-  foreignName = Tagged "TVar"
-  foreignRef = Tagged Ty.tvarRef
-
-instance BuiltinForeign (Promise a) where
-  foreignName = Tagged "Promise"
-  foreignRef = Tagged Ty.promiseRef
-
-instance BuiltinForeign (MutableArray s e) where
-  foreignName = Tagged "MutableArray"
-  foreignRef = Tagged Ty.marrayRef
-
-instance BuiltinForeign (Array e) where
-  foreignName = Tagged "Array"
-  foreignRef = Tagged Ty.iarrayRef
 
 instance BuiltinForeign (MutableByteArray s) where
   foreignName = Tagged "MutableByteArray"

--- a/unison-runtime/src/Unison/Runtime/Stack.hs
+++ b/unison-runtime/src/Unison/Runtime/Stack.hs
@@ -190,6 +190,12 @@ import Unison.Type qualified as Ty
 import Unison.Util.EnumContainers as EC
 import Unison.Util.Monoid qualified as Monoid
 import Prelude hiding (words)
+import qualified Data.Atomics as Atomic
+
+import Control.Concurrent (MVar)
+import Control.Concurrent.STM (TVar)
+import Unison.Util.RefPromise (Promise)
+
 
 #ifdef STACK_CHECK
 type DebugCallStack = (HasCallStack :: Constraint)
@@ -768,6 +774,30 @@ instance BuiltinForeign (Map Val Val) where
 instance BuiltinForeign (IORef Val) where
   foreignName = Tagged "IORef"
   foreignRef = Tagged Ty.refRef
+
+instance BuiltinForeign (Atomic.Ticket Val) where
+  foreignName = Tagged "Ticket"
+  foreignRef = Tagged Ty.ticketRef
+
+instance BuiltinForeign (MVar Val) where
+  foreignName = Tagged "MVar"
+  foreignRef = Tagged Ty.mvarRef
+
+instance BuiltinForeign (TVar Val) where
+  foreignName = Tagged "TVar"
+  foreignRef = Tagged Ty.tvarRef
+
+instance BuiltinForeign (Promise Val) where
+  foreignName = Tagged "Promise"
+  foreignRef = Tagged Ty.promiseRef
+
+instance BuiltinForeign (MutableArray s Val) where
+  foreignName = Tagged "MutableArray"
+  foreignRef = Tagged Ty.marrayRef
+
+instance BuiltinForeign (Array Val) where
+  foreignName = Tagged "Array"
+  foreignRef = Tagged Ty.iarrayRef
 
 -- | A nulled out value you can use when filling empty arrays, etc.
 emptyVal :: Val


### PR DESCRIPTION
## Overview

Restrict the rest of the BuiltinForeign instances, hopefully preventing more segfaults as we replace more function implementations in the runtime in the future.

## Implementation notes

Specializes all the BuiltinForeign instances to `Val`

## Test coverage

Nah, this only makes the type system more restrictive
