### PR TITLE
bugfix: track merge branch parents in database to fix nameless dependency bug

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -136,6 +136,8 @@ module U.Codebase.Sqlite.Queries
     loadMostRecentBranch,
     insertMergeBranchLocal,
     insertMergeBranchRemote,
+    insertMergeBranchLooseCode,
+    existsAnyNamespaceUniqueTypeGuidForNamespace,
     insertNamespaceUniqueTypeGuid,
 
     -- ** remote projects
@@ -4411,6 +4413,48 @@ insertMergeBranchRemote
           :targetCausalHashId
         )
       |]
+
+insertMergeBranchLooseCode ::
+  ProjectId ->
+  ProjectBranchId ->
+  CausalHashId ->
+  (ProjectBranchId, CausalHashId) ->
+  Transaction ()
+insertMergeBranchLooseCode
+  projectId
+  mergeBranchId
+  sourceCausalHashId
+  (targetBranchId, targetCausalHashId) =
+    execute
+      [sql|
+        INSERT INTO merge_branch (
+          project_id,
+          branch_id,
+          source_causal_hash_id,
+          target_project_id,
+          target_branch_id,
+          target_causal_hash_id
+        )
+        VALUES (
+          :projectId,
+          :mergeBranchId,
+          :sourceCausalHashId,
+          :projectId,
+          :targetBranchId,
+          :targetCausalHashId
+        )
+      |]
+
+existsAnyNamespaceUniqueTypeGuidForNamespace :: BranchHashId -> Transaction Bool
+existsAnyNamespaceUniqueTypeGuidForNamespace namespaceHashId =
+  queryOneCol
+    [sql|
+      SELECT EXISTS (
+        SELECT 1
+        FROM namespace_unique_type_guid
+        WHERE namespace_hash_id = :namespaceHashId
+      )
+    |]
 
 insertNamespaceUniqueTypeGuid :: BranchHashId -> Name -> Text -> Transaction ()
 insertNamespaceUniqueTypeGuid namespaceHashId typeName typeGuid =

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -134,7 +134,9 @@ module U.Codebase.Sqlite.Queries
     expectProjectBranchHead,
     setMostRecentBranch,
     loadMostRecentBranch,
-    insertMergeBranch,
+    insertMergeBranchLocal,
+    insertMergeBranchRemote,
+    insertNamespaceUniqueTypeGuid,
 
     -- ** remote projects
     loadRemoteProject,
@@ -305,11 +307,13 @@ import Control.Monad.Writer qualified as Writer
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Text qualified as Aeson
 import Data.Bitraversable (bitraverse)
+import Data.ByteString.Lazy (LazyByteString)
 import Data.Bytes.Put (runPutS)
 import Data.Foldable qualified as Foldable
 import Data.List qualified as List
 import Data.List.Extra qualified as List
 import Data.List.NonEmpty (NonEmpty)
+import Data.List.NonEmpty qualified as List.NonEmpty
 import Data.List.NonEmpty qualified as Nel
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map qualified as Map
@@ -403,6 +407,8 @@ import Unison.Hash qualified as Hash
 import Unison.Hash32 (Hash32)
 import Unison.Hash32 qualified as Hash32
 import Unison.Hash32.Orphans.Sqlite ()
+import Unison.Name (Name)
+import Unison.Name qualified as Name
 import Unison.NameSegment.Internal (NameSegment (NameSegment))
 import Unison.NameSegment.Internal qualified as NameSegment
 import Unison.Prelude
@@ -4334,36 +4340,93 @@ loadMostRecentBranch projectId =
         project_id = :projectId
     |]
 
-insertMergeBranch ::
+insertMergeBranchLocal ::
   ProjectId ->
   ProjectBranchId ->
   (ProjectBranchId, CausalHashId) ->
   (ProjectBranchId, CausalHashId) ->
   Transaction ()
-insertMergeBranch projectId mergeBranchId (sourceBranchId, sourceCausalHashId) (targetBranchId, targetCausalHashId) =
+insertMergeBranchLocal
+  projectId
+  mergeBranchId
+  (sourceBranchId, sourceCausalHashId)
+  (targetBranchId, targetCausalHashId) =
+    execute
+      [sql|
+        INSERT INTO merge_branch (
+          project_id,
+          branch_id,
+          local_source_project_id,
+          local_source_branch_id,
+          source_causal_hash_id,
+          target_project_id,
+          target_branch_id,
+          target_causal_hash_id
+        )
+        VALUES (
+          :projectId,
+          :mergeBranchId,
+          :projectId,
+          :sourceBranchId,
+          :sourceCausalHashId,
+          :projectId,
+          :targetBranchId,
+          :targetCausalHashId
+        )
+      |]
+
+insertMergeBranchRemote ::
+  ProjectId ->
+  ProjectBranchId ->
+  (RemoteProjectId, RemoteProjectBranchId, URI, CausalHashId) ->
+  (ProjectBranchId, CausalHashId) ->
+  Transaction ()
+insertMergeBranchRemote
+  projectId
+  mergeBranchId
+  (sourceProjectId, sourceBranchId, sourceHost, sourceCausalHashId)
+  (targetBranchId, targetCausalHashId) =
+    execute
+      [sql|
+        INSERT INTO merge_branch (
+          project_id,
+          branch_id,
+          remote_source_project_id,
+          remote_source_branch_id,
+          remote_source_host,
+          source_causal_hash_id,
+          target_project_id,
+          target_branch_id,
+          target_causal_hash_id
+        )
+        VALUES (
+          :projectId,
+          :mergeBranchId,
+          :sourceProjectId,
+          :sourceBranchId,
+          :sourceHost,
+          :sourceCausalHashId,
+          :projectId,
+          :targetBranchId,
+          :targetCausalHashId
+        )
+      |]
+
+insertNamespaceUniqueTypeGuid :: BranchHashId -> Name -> Text -> Transaction ()
+insertNamespaceUniqueTypeGuid namespaceHashId typeName typeGuid =
   execute
     [sql|
-      INSERT INTO merge_branch (
-        project_id,
-        branch_id,
-        source_project_id,
-        source_branch_id,
-        source_causal_hash_id,
-        target_project_id uuid,
-        target_branch_id uuid,
-        target_causal_hash_id
-      )
-      VALUES (
-        :projectId,
-        :mergeBranchId,
-        :projectId,
-        :sourceBranchId,
-        :sourceCausalHashId,
-        :projectId,
-        :targetBranchId,
-        :targetCausalHashId
-      )
+      INSERT INTO namespace_unique_type_guid (namespace_hash_id, type_name, type_guid)
+      VALUES (:namespaceHashId, :typeNameJson, :typeGuid)
     |]
+  where
+    typeNameJson :: LazyByteString
+    typeNameJson =
+      typeName
+        & Name.segments
+        & List.NonEmpty.toList
+        & map NameSegment.toUnescapedText
+        & Aeson.encode
 
 -- | Searches for all names within the given name lookup which contain the provided list of segments
 -- in order.

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -134,9 +134,12 @@ module U.Codebase.Sqlite.Queries
     expectProjectBranchHead,
     setMostRecentBranch,
     loadMostRecentBranch,
+    loadProjectBranchParent,
+    loadMergeBranchParents,
     insertMergeBranchLocal,
     insertMergeBranchRemote,
     insertMergeBranchLooseCode,
+    loadNamespaceUniqueTypeGuids,
     existsAnyNamespaceUniqueTypeGuidForNamespace,
     insertNamespaceUniqueTypeGuid,
 
@@ -4342,6 +4345,36 @@ loadMostRecentBranch projectId =
         project_id = :projectId
     |]
 
+loadProjectBranchParent :: ProjectId -> ProjectBranchId -> Transaction (Maybe ProjectBranchId)
+loadProjectBranchParent projectId projectBranchId =
+  queryMaybeCol
+    [sql|
+      SELECT parent_branch_id
+      FROM project_branch_parent
+      WHERE project_id = :projectId
+        AND branch_id = :projectBranchId
+    |]
+
+loadMergeBranchParents ::
+  ProjectId ->
+  ProjectBranchId ->
+  Transaction
+    ( Maybe
+        ( Maybe ProjectBranchId,
+          CausalHashId,
+          Maybe ProjectBranchId,
+          CausalHashId
+        )
+    )
+loadMergeBranchParents projectId branchId =
+  queryMaybeRow
+    [sql|
+      SELECT local_source_branch_id, source_causal_hash_id, target_branch_id, target_causal_hash_id
+      FROM merge_branch
+      WHERE project_id = :projectId
+        AND branch_id = :branchId
+    |]
+
 insertMergeBranchLocal ::
   ProjectId ->
   ProjectBranchId ->
@@ -4444,6 +4477,32 @@ insertMergeBranchLooseCode
           :targetCausalHashId
         )
       |]
+
+loadNamespaceUniqueTypeGuids :: BranchHashId -> Transaction (Map Name Text)
+loadNamespaceUniqueTypeGuids namespaceHashId = do
+  rows <-
+    queryListRow
+      [sql|
+        SELECT type_name, type_guid
+        FROM namespace_unique_type_guid
+        WHERE namespace_hash_id = :namespaceHashId
+      |]
+
+  let f :: ByteString -> Name
+      f bytes =
+        case Aeson.decodeStrict @[Text] bytes of
+          Just (segment : segments) ->
+            Name.fromSegments (NameSegment segment NonEmpty.:| map NameSegment segments)
+          _ ->
+            error $
+              reportBug
+                "E955495"
+                ( "busted name in namespace_unique_type_guid (namespace hash id = "
+                    ++ show namespaceHashId
+                    ++ ")"
+                )
+
+  pure (Map.fromList (over (Lens.mapped . Lens._1) f rows))
 
 existsAnyNamespaceUniqueTypeGuidForNamespace :: BranchHashId -> Transaction Bool
 existsAnyNamespaceUniqueTypeGuidForNamespace namespaceHashId =

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -134,6 +134,7 @@ module U.Codebase.Sqlite.Queries
     expectProjectBranchHead,
     setMostRecentBranch,
     loadMostRecentBranch,
+    insertMergeBranch,
 
     -- ** remote projects
     loadRemoteProject,
@@ -257,6 +258,7 @@ module U.Codebase.Sqlite.Queries
     addProjectBranchReflogTable,
     addProjectBranchCausalHashIdColumn,
     addProjectBranchLastAccessedColumn,
+    addMergeBranchTables,
 
     -- ** schema version
     currentSchemaVersion,
@@ -421,7 +423,7 @@ type TextPathSegments = [Text]
 -- * main squeeze
 
 currentSchemaVersion :: SchemaVersion
-currentSchemaVersion = 18
+currentSchemaVersion = 19
 
 runCreateSql :: Transaction ()
 runCreateSql =
@@ -490,6 +492,10 @@ addProjectBranchCausalHashIdColumn =
 addProjectBranchLastAccessedColumn :: Transaction ()
 addProjectBranchLastAccessedColumn =
   executeStatements $(embedProjectStringFile "sql/015-add-project-branch-last-accessed.sql")
+
+addMergeBranchTables :: Transaction ()
+addMergeBranchTables =
+  executeStatements $(embedProjectStringFile "sql/016-add-merge-branch-tables.sql")
 
 schemaVersion :: Transaction SchemaVersion
 schemaVersion =
@@ -4326,6 +4332,37 @@ loadMostRecentBranch projectId =
         most_recent_branch
       WHERE
         project_id = :projectId
+    |]
+
+insertMergeBranch ::
+  ProjectId ->
+  ProjectBranchId ->
+  (ProjectBranchId, CausalHashId) ->
+  (ProjectBranchId, CausalHashId) ->
+  Transaction ()
+insertMergeBranch projectId mergeBranchId (sourceBranchId, sourceCausalHashId) (targetBranchId, targetCausalHashId) =
+  execute
+    [sql|
+      INSERT INTO merge_branch (
+        project_id,
+        branch_id,
+        source_project_id,
+        source_branch_id,
+        source_causal_hash_id,
+        target_project_id uuid,
+        target_branch_id uuid,
+        target_causal_hash_id
+      )
+      VALUES (
+        :projectId,
+        :mergeBranchId,
+        :projectId,
+        :sourceBranchId,
+        :sourceCausalHashId,
+        :projectId,
+        :targetBranchId,
+        :targetCausalHashId
+      )
     |]
 
 -- | Searches for all names within the given name lookup which contain the provided list of segments

--- a/codebase2/codebase-sqlite/sql/016-add-merge-branch-tables.sql
+++ b/codebase2/codebase-sqlite/sql/016-add-merge-branch-tables.sql
@@ -6,10 +6,10 @@ create table merge_branch (
   remote_source_project_id uuid,
   remote_source_branch_id uuid,
   remote_source_host text,
-  source_causal_hash_id integer references hash (id) on delete set null,
+  source_causal_hash_id integer not null references hash (id) on delete cascade,
   target_project_id uuid,
   target_branch_id uuid,
-  target_causal_hash_id integer references hash (id) on delete set null,
+  target_causal_hash_id integer not null references hash (id) on delete cascade,
   primary key (project_id, branch_id),
   foreign key (project_id, branch_id)
     references project_branch (project_id, branch_id)

--- a/codebase2/codebase-sqlite/sql/016-add-merge-branch-tables.sql
+++ b/codebase2/codebase-sqlite/sql/016-add-merge-branch-tables.sql
@@ -1,61 +1,11 @@
--- When on branch `foo/main`, if you run `merge /topic` and the merge fails, you're placed on a "merge branch"
--- `foo/merge-topic-into-main`. (Say project `foo` has uuid `foo-uuid`, and similar for the branches).
---
--- If that happens, you'll have a single row in this table that looks like this:
---
---   +----------------------------------------------------+
---   | merge_branch                                       |
---   +====================================================+
---   |            project_id |                   foo-uuid |
---   +-----------------------+----------------------------+
---   |             branch_id | merge-topic-into-main-uuid |
---   +-----------------------+----------------------------+
---   |     source_project_id |                   foo-uuid |
---   +-----------------------+----------------------------+
---   |      source_branch_id |                 topic-uuid |
---   +-----------------------+----------------------------+
---   | source_causal_hash_id |                        100 |
---   +-----------------------+----------------------------+
---   |     target_project_id |                   foo-uuid |
---   +-----------------------+----------------------------+
---   |      target_branch_id |                  main-uuid |
---   +-----------------------+----------------------------+
---   | target_causal_hash_id |                        200 |
---   +-----------------------+----------------------------+
---
--- There's a check constraint that asserts all three project ids are the same, because we don't support cross-project
--- merges. So why three columns instead of just one? Because we want to allow the source or target branch to be deleted,
--- and set the corresponding branch id to null, but because the "on delete set null" clause sets all columns in the
--- foreign key reference to null, we have additional columns for the source and target projects. So say the user deletes
--- `/main`; the row will then look like this:
---
---   +----------------------------------------------------+
---   | merge_branch                                       |
---   +====================================================+
---   |            project_id |                   foo-uuid |
---   +-----------------------+----------------------------+
---   |             branch_id | merge-topic-into-main-uuid |
---   +-----------------------+----------------------------+
---   |     source_project_id |                   foo-uuid |
---   +-----------------------+----------------------------+
---   |      source_branch_id |                 topic-uuid |
---   +-----------------------+----------------------------+
---   | source_causal_hash_id |                        100 |
---   +-----------------------+----------------------------+
---   |     target_project_id |                            |
---   +-----------------------+----------------------------+
---   |      target_branch_id |                            |
---   +-----------------------+----------------------------+
---   | target_causal_hash_id |                        200 |
---   +-----------------------+----------------------------+
 create table merge_branch (
   project_id uuid not null,
   branch_id uuid not null,
   local_source_project_id uuid,
   local_source_branch_id uuid,
-  remote_host text,
   remote_source_project_id uuid,
   remote_source_branch_id uuid,
+  remote_source_host text,
   source_causal_hash_id integer references hash (id) on delete set null,
   target_project_id uuid,
   target_branch_id uuid,
@@ -64,14 +14,21 @@ create table merge_branch (
   foreign key (project_id, branch_id)
     references project_branch (project_id, branch_id)
     on delete cascade,
-  foreign key (source_project_id, source_branch_id)
+  foreign key (local_source_project_id, local_source_branch_id)
     references project_branch (project_id, branch_id)
+    on delete set null,
+  foreign key (remote_source_project_id, remote_source_branch_id, remote_source_host)
+    references remote_project_branch (project_id, branch_id, host)
     on delete set null,
   foreign key (target_project_id, target_branch_id)
     references project_branch (project_id, branch_id)
     on delete set null,
   check (
-    (project_id = source_project_id or source_project_id is null) and
+    local_source_branch_id is null or
+    remote_source_branch_id is null
+  ),
+  check (
+    (project_id = local_source_project_id or local_source_project_id is null) and
     (project_id = target_project_id or target_project_id is null)
   )
 );

--- a/codebase2/codebase-sqlite/sql/016-add-merge-branch-tables.sql
+++ b/codebase2/codebase-sqlite/sql/016-add-merge-branch-tables.sql
@@ -1,0 +1,83 @@
+-- When on branch `foo/main`, if you run `merge /topic` and the merge fails, you're placed on a "merge branch"
+-- `foo/merge-topic-into-main`. (Say project `foo` has uuid `foo-uuid`, and similar for the branches).
+--
+-- If that happens, you'll have a single row in this table that looks like this:
+--
+--   +----------------------------------------------------+
+--   | merge_branch                                       |
+--   +====================================================+
+--   |            project_id |                   foo-uuid |
+--   +-----------------------+----------------------------+
+--   |             branch_id | merge-topic-into-main-uuid |
+--   +-----------------------+----------------------------+
+--   |     source_project_id |                   foo-uuid |
+--   +-----------------------+----------------------------+
+--   |      source_branch_id |                 topic-uuid |
+--   +-----------------------+----------------------------+
+--   | source_causal_hash_id |                        100 |
+--   +-----------------------+----------------------------+
+--   |     target_project_id |                   foo-uuid |
+--   +-----------------------+----------------------------+
+--   |      target_branch_id |                  main-uuid |
+--   +-----------------------+----------------------------+
+--   | target_causal_hash_id |                        200 |
+--   +-----------------------+----------------------------+
+--
+-- There's a check constraint that asserts all three project ids are the same, because we don't support cross-project
+-- merges. So why three columns instead of just one? Because we want to allow the source or target branch to be deleted,
+-- and set the corresponding branch id to null, but because the "on delete set null" clause sets all columns in the
+-- foreign key reference to null, we have additional columns for the source and target projects. So say the user deletes
+-- `/main`; the row will then look like this:
+--
+--   +----------------------------------------------------+
+--   | merge_branch                                       |
+--   +====================================================+
+--   |            project_id |                   foo-uuid |
+--   +-----------------------+----------------------------+
+--   |             branch_id | merge-topic-into-main-uuid |
+--   +-----------------------+----------------------------+
+--   |     source_project_id |                   foo-uuid |
+--   +-----------------------+----------------------------+
+--   |      source_branch_id |                 topic-uuid |
+--   +-----------------------+----------------------------+
+--   | source_causal_hash_id |                        100 |
+--   +-----------------------+----------------------------+
+--   |     target_project_id |                            |
+--   +-----------------------+----------------------------+
+--   |      target_branch_id |                            |
+--   +-----------------------+----------------------------+
+--   | target_causal_hash_id |                        200 |
+--   +-----------------------+----------------------------+
+create table merge_branch (
+  project_id uuid not null,
+  branch_id uuid not null,
+  local_source_project_id uuid,
+  local_source_branch_id uuid,
+  remote_host text,
+  remote_source_project_id uuid,
+  remote_source_branch_id uuid,
+  source_causal_hash_id integer references hash (id) on delete set null,
+  target_project_id uuid,
+  target_branch_id uuid,
+  target_causal_hash_id integer references hash (id) on delete set null,
+  primary key (project_id, branch_id),
+  foreign key (project_id, branch_id)
+    references project_branch (project_id, branch_id)
+    on delete cascade,
+  foreign key (source_project_id, source_branch_id)
+    references project_branch (project_id, branch_id)
+    on delete set null,
+  foreign key (target_project_id, target_branch_id)
+    references project_branch (project_id, branch_id)
+    on delete set null,
+  check (
+    (project_id = source_project_id or source_project_id is null) and
+    (project_id = target_project_id or target_project_id is null)
+  )
+);
+
+create table namespace_unique_type_guid (
+  namespace_hash_id integer not null references hash (id) on delete cascade,
+  type_name jsonb not null,
+  type_guid text not null
+);

--- a/codebase2/codebase-sqlite/unison-codebase-sqlite.cabal
+++ b/codebase2/codebase-sqlite/unison-codebase-sqlite.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -25,6 +25,7 @@ extra-source-files:
     sql/013-add-project-branch-reflog-table.sql
     sql/014-add-project-branch-causal-hash-id.sql
     sql/015-add-project-branch-last-accessed.sql
+    sql/016-add-merge-branch-tables.sql
     sql/create.sql
 
 source-repository head

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations.hs
@@ -85,7 +85,8 @@ migrations regionVar getDeclType termBuffer declBuffer rootCodebasePath =
       sqlMigration 15 Q.addSquashResultTableIfNotExists,
       sqlMigration 16 Q.cdToProjectRoot,
       (17 {- This migration takes a raw sqlite connection -}, \conn -> migrateSchema16To17 conn),
-      sqlMigration 18 Q.addProjectBranchLastAccessedColumn
+      sqlMigration 18 Q.addProjectBranchLastAccessedColumn,
+      sqlMigration 19 Q.addMergeBranchTables
     ]
   where
     runT :: Sqlite.Transaction () -> Sqlite.Connection -> IO ()

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
@@ -98,6 +98,7 @@ createSchema = do
   Q.addProjectBranchReflogTable
   Q.addProjectBranchCausalHashIdColumn
   Q.addProjectBranchLastAccessedColumn
+  Q.addMergeBranchTables
   (_, emptyCausalHashId) <- emptyCausalHash
   (_, ProjectBranch {projectId, branchId}) <- insertProjectAndBranch scratchProjectName scratchBranchName emptyCausalHashId
   Q.setCurrentProjectPath projectId branchId []

--- a/unison-cli/src/Unison/Cli/MergeTypes.hs
+++ b/unison-cli/src/Unison/Cli/MergeTypes.hs
@@ -7,13 +7,16 @@ module Unison.Cli.MergeTypes
   )
 where
 
+import U.Codebase.Sqlite.Project (Project)
+import U.Codebase.Sqlite.ProjectBranch (ProjectBranch)
+import Unison.Cli.Share.Projects.Types (RemoteProjectBranch)
 import Unison.Codebase.Editor.RemoteRepo (ReadShareLooseCode)
 import Unison.Project (ProjectAndBranch, ProjectBranchName, ProjectName)
 
 -- | What are we merging in?
 data MergeSource
-  = MergeSource'LocalProjectBranch !(ProjectAndBranch ProjectName ProjectBranchName)
-  | MergeSource'RemoteProjectBranch !(ProjectAndBranch ProjectName ProjectBranchName)
+  = MergeSource'LocalProjectBranch !(ProjectAndBranch Project ProjectBranch)
+  | MergeSource'RemoteProjectBranch !RemoteProjectBranch
   | MergeSource'RemoteLooseCode !ReadShareLooseCode
 
 type MergeTarget =

--- a/unison-cli/src/Unison/Cli/Pretty.hs
+++ b/unison-cli/src/Unison/Cli/Pretty.hs
@@ -205,8 +205,10 @@ prettyHash32 = prettyBase32Hex# . Hash32.toBase32Hex
 
 prettyMergeSource :: MergeSource -> Pretty
 prettyMergeSource = \case
-  MergeSource'LocalProjectBranch branch -> prettyProjectAndBranchName branch
-  MergeSource'RemoteProjectBranch branch -> "remote " <> prettyProjectAndBranchName branch
+  MergeSource'LocalProjectBranch branch ->
+    prettyProjectAndBranchName (ProjectAndBranch branch.project.name branch.branch.name)
+  MergeSource'RemoteProjectBranch branch ->
+    "remote " <> prettyProjectAndBranchName (ProjectAndBranch branch.projectName branch.branchName)
   MergeSource'RemoteLooseCode info -> prettyReadRemoteNamespace (ReadShare'LooseCode info)
 
 prettyMergeSourceOrTarget :: MergeSourceOrTarget -> Pretty

--- a/unison-cli/src/Unison/Cli/UniqueTypeGuidLookup.hs
+++ b/unison-cli/src/Unison/Cli/UniqueTypeGuidLookup.hs
@@ -51,15 +51,15 @@ loadUniqueTypeGuid pp name0 = do
             -- a new GUID because it's not clear whether alice's or bob's should be preferred.
             (Just aliceGuid, Just bobGuid) -> do
               case (aliceMaybeBranchId, bobMaybeBranchId) of
-                (Just aliceBranchId, Just bobBranchId) ->
-                  Queries.loadProjectBranchParent pp.project.projectId aliceBranchId >>= \case
-                    Just aliceParentBranchId ->
-                      if aliceParentBranchId == bobBranchId
-                        then pure (Just bobGuid)
-                        else
-                          Queries.loadProjectBranchParent pp.project.projectId bobBranchId <&> \case
-                            Just bobParentBranchId | bobParentBranchId == aliceBranchId -> Just aliceGuid
-                            _ -> Nothing
-                    Nothing -> pure Nothing
+                (Just aliceBranchId, Just bobBranchId) -> do
+                  aliceParentBranchId <- Queries.loadProjectBranchParent pp.project.projectId aliceBranchId
+                  if aliceParentBranchId == Just bobBranchId
+                    then pure (Just bobGuid)
+                    else do
+                      bobParentBranchId <- Queries.loadProjectBranchParent pp.project.projectId bobBranchId
+                      pure
+                        if bobParentBranchId == Just aliceBranchId
+                          then Just aliceGuid
+                          else Nothing
                 _ -> pure Nothing
     Just guid -> pure (Just guid)

--- a/unison-cli/src/Unison/Cli/UniqueTypeGuidLookup.hs
+++ b/unison-cli/src/Unison/Cli/UniqueTypeGuidLookup.hs
@@ -5,7 +5,9 @@ module Unison.Cli.UniqueTypeGuidLookup
   )
 where
 
+import Data.Map.Strict qualified as Map
 import U.Codebase.Branch qualified as Codebase.Branch
+import U.Codebase.Sqlite.Queries qualified as Queries
 import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Path qualified as Path
 import Unison.Codebase.ProjectPath (ProjectPath)
@@ -27,4 +29,37 @@ loadUniqueTypeGuid pp name0 = do
   let loadBranchAtPath :: ProjectPath -> Sqlite.Transaction (Maybe (Codebase.Branch.Branch Sqlite.Transaction))
       loadBranchAtPath = Codebase.getMaybeShallowBranchAtProjectPath
 
-  Codebase.loadUniqueTypeGuid loadBranchAtPath fullPP finalSegment
+  Codebase.loadUniqueTypeGuid loadBranchAtPath fullPP finalSegment >>= \case
+    Nothing ->
+      Queries.loadMergeBranchParents pp.project.projectId pp.branch.branchId >>= \case
+        Nothing -> pure Nothing
+        Just (bobMaybeBranchId, bobCausalHashId, aliceMaybeBranchId, aliceCausalHashId) -> do
+          aliceNamespaceHashId <- Queries.expectCausalValueHashId aliceCausalHashId
+          bobNamespaceHashId <- Queries.expectCausalValueHashId bobCausalHashId
+
+          aliceUniqueTypeGuids <- Queries.loadNamespaceUniqueTypeGuids aliceNamespaceHashId
+          bobUniqueTypeGuids <- Queries.loadNamespaceUniqueTypeGuids bobNamespaceHashId
+
+          case (Map.lookup name0 aliceUniqueTypeGuids, Map.lookup name0 bobUniqueTypeGuids) of
+            -- A few simple cases – reuse a GUID if it is sensible to do so
+            (Just aliceGuid, Just bobGuid) | aliceGuid == bobGuid -> pure (Just aliceGuid)
+            (Just aliceGuid, Nothing) -> pure (Just aliceGuid)
+            (Nothing, Just bobGuid) -> pure (Just bobGuid)
+            (Nothing, Nothing) -> pure Nothing
+            -- If alice and bob have different guids, and there is a parent-child relationship between them (i.e. alice
+            -- was directly branched off of bob or vice versa), then prefer the parent's GUID. Otherwise, just make up
+            -- a new GUID because it's not clear whether alice's or bob's should be preferred.
+            (Just aliceGuid, Just bobGuid) -> do
+              case (aliceMaybeBranchId, bobMaybeBranchId) of
+                (Just aliceBranchId, Just bobBranchId) ->
+                  Queries.loadProjectBranchParent pp.project.projectId aliceBranchId >>= \case
+                    Just aliceParentBranchId ->
+                      if aliceParentBranchId == bobBranchId
+                        then pure (Just bobGuid)
+                        else
+                          Queries.loadProjectBranchParent pp.project.projectId bobBranchId <&> \case
+                            Just bobParentBranchId | bobParentBranchId == aliceBranchId -> Just aliceGuid
+                            _ -> Nothing
+                    Nothing -> pure Nothing
+                _ -> pure Nothing
+    Just guid -> pure (Just guid)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Branch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Branch.hs
@@ -1,12 +1,14 @@
 -- | @branch@ input handler
 module Unison.Codebase.Editor.HandleInput.Branch
   ( CreateFrom (..),
+    CreateFromMergeSource (..),
     handleBranch,
     createBranch,
   )
 where
 
 import Control.Monad.Reader
+import Data.Map.Strict qualified as Map
 import Data.UUID.V4 qualified as UUID
 import Network.URI (URI)
 import U.Codebase.HashTags (CausalHash)
@@ -20,13 +22,14 @@ import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
 import Unison.Cli.MonadUtils qualified as Cli
 import Unison.Cli.ProjectUtils qualified as ProjectUtils
-import Unison.Cli.Share.Projects.Types (RemoteProjectBranch(..))
+import Unison.Cli.Share.Projects.Types (RemoteProjectBranch (..))
 import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Branch (Branch)
 import Unison.Codebase.Branch qualified as Branch
 import Unison.Codebase.Editor.Input qualified as Input
 import Unison.Codebase.Editor.Output qualified as Output
 import Unison.Codebase.ProjectPath qualified as PP
+import Unison.Name (Name)
 import Unison.Prelude
 import Unison.Project (ProjectAndBranch (..), ProjectBranchName, ProjectBranchNameKind (..), ProjectName, classifyProjectBranchName)
 import Unison.Sqlite qualified as Sqlite
@@ -36,16 +39,18 @@ data CreateFrom
   | CreateFrom'ParentBranch Sqlite.ProjectBranch
   | CreateFrom'Namespace (Branch IO)
   | CreateFrom'CausalHash CausalHash
-  | -- A merge failed (from local or remote branch), and we're making a branch for the user to resolve the merge on
-    CreateFrom'MergeParentsLocal
-      (Sqlite.ProjectBranch, CausalHash) -- source
-      (Sqlite.ProjectBranch, CausalHash) -- target
-      (Branch IO) -- merge branch
-  | CreateFrom'MergeParentsRemote
-      (RemoteProjectBranch, URI, CausalHash) -- source
-      (Sqlite.ProjectBranch, CausalHash) -- target
+  | -- A merge failed (from local branch, remote branch, or remote loose code), and we're making a branch for the user
+    -- to resolve the merge on
+    CreateFrom'MergeParents
+      (CreateFromMergeSource, CausalHash, Map Name Text {- unique type name to guid -}) -- source
+      (Sqlite.ProjectBranch, CausalHash, Map Name Text {- unique type name to guid -}) -- target
       (Branch IO) -- merge branch
   | CreateFrom'Nothingness
+
+data CreateFromMergeSource
+  = CreateFromMergeSource'Local Sqlite.ProjectBranch
+  | CreateFromMergeSource'Remote RemoteProjectBranch URI
+  | CreateFromMergeSource'LooseCode
 
 -- | Create a new project branch from an existing project branch or namespace.
 handleBranch :: Input.BranchSourceI -> ProjectAndBranch (Maybe ProjectName) ProjectBranchName -> Cli ()
@@ -130,12 +135,7 @@ createBranch description createFrom project getNewBranchName = do
         newBranchCausalHashId <- Q.expectCausalHashIdByCausalHash (Branch.headHash namespace)
         let parentBranchId = if parentBranch.projectId == projectId then Just parentBranch.branchId else Nothing
         pure (parentBranchId, newBranchCausalHashId)
-    CreateFrom'MergeParentsLocal _ (targetBranch, _) namespace -> do
-      liftIO $ Codebase.putBranch codebase namespace
-      Cli.runTransaction do
-        newBranchCausalHashId <- Q.expectCausalHashIdByCausalHash (Branch.headHash namespace)
-        pure (Just targetBranch.branchId, newBranchCausalHashId)
-    CreateFrom'MergeParentsRemote _ (targetBranch, _) namespace -> do
+    CreateFrom'MergeParents _ (targetBranch, _, _) namespace -> do
       liftIO $ Codebase.putBranch codebase namespace
       Cli.runTransaction do
         newBranchCausalHashId <- Q.expectCausalHashIdByCausalHash (Branch.headHash namespace)
@@ -168,26 +168,42 @@ createBranch description createFrom project getNewBranchName = do
                 parentBranchId = mayParentBranchId
               }
           case createFrom of
-            CreateFrom'MergeParentsLocal (sourceBranch, sourceCausalHash) (targetBranch, targetCausalHash) _ -> do
-              sourceCausalHashId <- Queries.expectCausalHashIdByCausalHash sourceCausalHash
-              targetCausalHashId <- Queries.expectCausalHashIdByCausalHash targetCausalHash
-              Queries.insertMergeBranchLocal
-                targetBranch.projectId
-                newBranchId
-                (sourceBranch.branchId, sourceCausalHashId)
-                (targetBranch.branchId, targetCausalHashId)
-              -- Create unique type to UUID mapping
-              wundefined
-            CreateFrom'MergeParentsRemote (sourceBranch, sourceHost, sourceCausalHash) (targetBranch, targetCausalHash) _ -> do
-              sourceCausalHashId <- Queries.expectCausalHashIdByCausalHash sourceCausalHash
-              targetCausalHashId <- Queries.expectCausalHashIdByCausalHash targetCausalHash
-              Queries.insertMergeBranchRemote
-                targetBranch.projectId
-                newBranchId
-                (sourceBranch.projectId, sourceBranch.branchId, sourceHost, sourceCausalHashId)
-                (targetBranch.branchId, targetCausalHashId)
-              -- Create unique type to UUID mapping
-              wundefined
+            CreateFrom'MergeParents
+              (source, sourceCausalHash, sourceUniqueTypeGuids)
+              (targetBranch, targetCausalHash, targetUniqueTypeGuids)
+              _ -> do
+                sourceCausalHashId <- Queries.expectCausalHashIdByCausalHash sourceCausalHash
+                targetCausalHashId <- Queries.expectCausalHashIdByCausalHash targetCausalHash
+                case source of
+                  CreateFromMergeSource'Local sourceBranch -> do
+                    Queries.insertMergeBranchLocal
+                      targetBranch.projectId
+                      newBranchId
+                      (sourceBranch.branchId, sourceCausalHashId)
+                      (targetBranch.branchId, targetCausalHashId)
+                  CreateFromMergeSource'Remote sourceBranch sourceHost -> do
+                    Queries.insertMergeBranchRemote
+                      targetBranch.projectId
+                      newBranchId
+                      (sourceBranch.projectId, sourceBranch.branchId, sourceHost, sourceCausalHashId)
+                      (targetBranch.branchId, targetCausalHashId)
+                  CreateFromMergeSource'LooseCode -> do
+                    Queries.insertMergeBranchLooseCode
+                      targetBranch.projectId
+                      newBranchId
+                      sourceCausalHashId
+                      (targetBranch.branchId, targetCausalHashId)
+                -- Create unique type to GUID mapping for source and target namespaces
+                let ensureUniqueTypeToGuidMapping uniqueTypeGuids causalHashId =
+                      when (not (Map.null uniqueTypeGuids)) do
+                        namespaceHashId <- Queries.expectCausalValueHashId causalHashId
+                        Queries.existsAnyNamespaceUniqueTypeGuidForNamespace namespaceHashId >>= \case
+                          True -> pure ()
+                          False ->
+                            for_ (Map.toList uniqueTypeGuids) \(name, guid) ->
+                              Queries.insertNamespaceUniqueTypeGuid namespaceHashId name guid
+                ensureUniqueTypeToGuidMapping sourceUniqueTypeGuids sourceCausalHashId
+                ensureUniqueTypeToGuidMapping targetUniqueTypeGuids targetCausalHashId
             _ -> pure ()
           pure (newBranchName, newBranchId)
 

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Branch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Branch.hs
@@ -8,6 +8,7 @@ where
 
 import Control.Monad.Reader
 import Data.UUID.V4 qualified as UUID
+import Network.URI (URI)
 import U.Codebase.HashTags (CausalHash)
 import U.Codebase.Sqlite.DbId
 import U.Codebase.Sqlite.Project qualified as Sqlite
@@ -19,6 +20,7 @@ import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
 import Unison.Cli.MonadUtils qualified as Cli
 import Unison.Cli.ProjectUtils qualified as ProjectUtils
+import Unison.Cli.Share.Projects.Types (RemoteProjectBranch(..))
 import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Branch (Branch)
 import Unison.Codebase.Branch qualified as Branch
@@ -34,8 +36,15 @@ data CreateFrom
   | CreateFrom'ParentBranch Sqlite.ProjectBranch
   | CreateFrom'Namespace (Branch IO)
   | CreateFrom'CausalHash CausalHash
-  | -- A merge failed, and we're making a branch for the user to resolve the merge on
-    CreateFrom'MergeParents Sqlite.ProjectBranch (Branch IO)
+  | -- A merge failed (from local or remote branch), and we're making a branch for the user to resolve the merge on
+    CreateFrom'MergeParentsLocal
+      (Sqlite.ProjectBranch, CausalHash) -- source
+      (Sqlite.ProjectBranch, CausalHash) -- target
+      (Branch IO) -- merge branch
+  | CreateFrom'MergeParentsRemote
+      (RemoteProjectBranch, URI, CausalHash) -- source
+      (Sqlite.ProjectBranch, CausalHash) -- target
+      (Branch IO) -- merge branch
   | CreateFrom'Nothingness
 
 -- | Create a new project branch from an existing project branch or namespace.
@@ -121,11 +130,16 @@ createBranch description createFrom project getNewBranchName = do
         newBranchCausalHashId <- Q.expectCausalHashIdByCausalHash (Branch.headHash namespace)
         let parentBranchId = if parentBranch.projectId == projectId then Just parentBranch.branchId else Nothing
         pure (parentBranchId, newBranchCausalHashId)
-    CreateFrom'MergeParents parentBranch namespace -> do
+    CreateFrom'MergeParentsLocal _ (targetBranch, _) namespace -> do
       liftIO $ Codebase.putBranch codebase namespace
       Cli.runTransaction do
         newBranchCausalHashId <- Q.expectCausalHashIdByCausalHash (Branch.headHash namespace)
-        pure (Just parentBranch.branchId, newBranchCausalHashId)
+        pure (Just targetBranch.branchId, newBranchCausalHashId)
+    CreateFrom'MergeParentsRemote _ (targetBranch, _) namespace -> do
+      liftIO $ Codebase.putBranch codebase namespace
+      Cli.runTransaction do
+        newBranchCausalHashId <- Q.expectCausalHashIdByCausalHash (Branch.headHash namespace)
+        pure (Just targetBranch.branchId, newBranchCausalHashId)
     CreateFrom'CausalHash causalHash -> do
       Cli.runTransaction do
         causalHashId <- Q.expectCausalHashIdByCausalHash causalHash
@@ -154,18 +168,26 @@ createBranch description createFrom project getNewBranchName = do
                 parentBranchId = mayParentBranchId
               }
           case createFrom of
-            CreateFrom'MergeParents parentBranch namespace ->
-              Queries.insertMergeBranch
-                parentBranch.projectId
+            CreateFrom'MergeParentsLocal (sourceBranch, sourceCausalHash) (targetBranch, targetCausalHash) _ -> do
+              sourceCausalHashId <- Queries.expectCausalHashIdByCausalHash sourceCausalHash
+              targetCausalHashId <- Queries.expectCausalHashIdByCausalHash targetCausalHash
+              Queries.insertMergeBranchLocal
+                targetBranch.projectId
                 newBranchId
-                (wundefined, wundefined)
-                wundefined
--- insertMergeBranch ::
---   ProjectId ->
---   ProjectBranchId ->
---   (ProjectBranchId, CausalHashId) ->
---   (ProjectBranchId, CausalHashId) ->
-  -- Transaction ()
+                (sourceBranch.branchId, sourceCausalHashId)
+                (targetBranch.branchId, targetCausalHashId)
+              -- Create unique type to UUID mapping
+              wundefined
+            CreateFrom'MergeParentsRemote (sourceBranch, sourceHost, sourceCausalHash) (targetBranch, targetCausalHash) _ -> do
+              sourceCausalHashId <- Queries.expectCausalHashIdByCausalHash sourceCausalHash
+              targetCausalHashId <- Queries.expectCausalHashIdByCausalHash targetCausalHash
+              Queries.insertMergeBranchRemote
+                targetBranch.projectId
+                newBranchId
+                (sourceBranch.projectId, sourceBranch.branchId, sourceHost, sourceCausalHashId)
+                (targetBranch.branchId, targetCausalHashId)
+              -- Create unique type to UUID mapping
+              wundefined
             _ -> pure ()
           pure (newBranchName, newBranchId)
 

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Branch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Branch.hs
@@ -34,6 +34,8 @@ data CreateFrom
   | CreateFrom'ParentBranch Sqlite.ProjectBranch
   | CreateFrom'Namespace (Branch IO)
   | CreateFrom'CausalHash CausalHash
+  | -- A merge failed, and we're making a branch for the user to resolve the merge on
+    CreateFrom'MergeParents Sqlite.ProjectBranch (Branch IO)
   | CreateFrom'Nothingness
 
 -- | Create a new project branch from an existing project branch or namespace.
@@ -115,17 +117,22 @@ createBranch description createFrom project getNewBranchName = do
       pure (Nothing, causalHashId)
     CreateFrom'NamespaceWithParent parentBranch namespace -> do
       liftIO $ Codebase.putBranch codebase namespace
-      Cli.runTransaction $ do
+      Cli.runTransaction do
         newBranchCausalHashId <- Q.expectCausalHashIdByCausalHash (Branch.headHash namespace)
         let parentBranchId = if parentBranch.projectId == projectId then Just parentBranch.branchId else Nothing
         pure (parentBranchId, newBranchCausalHashId)
+    CreateFrom'MergeParents parentBranch namespace -> do
+      liftIO $ Codebase.putBranch codebase namespace
+      Cli.runTransaction do
+        newBranchCausalHashId <- Q.expectCausalHashIdByCausalHash (Branch.headHash namespace)
+        pure (Just parentBranch.branchId, newBranchCausalHashId)
     CreateFrom'CausalHash causalHash -> do
-      Cli.runTransaction $ do
+      Cli.runTransaction do
         causalHashId <- Q.expectCausalHashIdByCausalHash causalHash
         pure (Nothing, causalHashId)
     CreateFrom'Namespace branch -> do
       liftIO $ Codebase.putBranch codebase branch
-      Cli.runTransaction $ do
+      Cli.runTransaction do
         newBranchCausalHashId <- Q.expectCausalHashIdByCausalHash (Branch.headHash branch)
         pure (Nothing, newBranchCausalHashId)
   (newBranchName, newBranchId) <-
@@ -146,6 +153,20 @@ createBranch description createFrom project getNewBranchName = do
                 name = newBranchName,
                 parentBranchId = mayParentBranchId
               }
+          case createFrom of
+            CreateFrom'MergeParents parentBranch namespace ->
+              Queries.insertMergeBranch
+                parentBranch.projectId
+                newBranchId
+                (wundefined, wundefined)
+                wundefined
+-- insertMergeBranch ::
+--   ProjectId ->
+--   ProjectBranchId ->
+--   (ProjectBranchId, CausalHashId) ->
+--   (ProjectBranchId, CausalHashId) ->
+  -- Transaction ()
+            _ -> pure ()
           pure (newBranchName, newBranchId)
 
   Cli.switchProject (ProjectAndBranch projectId newBranchId)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Merge2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Merge2.hs
@@ -396,7 +396,7 @@ doMerge info = do
             (_temporaryBranchId, temporaryBranchName) <-
               HandleInput.Branch.createBranch
                 info.description
-                ( HandleInput.Branch.CreateFrom'NamespaceWithParent
+                ( HandleInput.Branch.CreateFrom'MergeParents
                     info.alice.projectAndBranch.branch
                     (Branch.mergeNode stageTwoBranch parents.alice parents.bob)
                 )

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Merge2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Merge2.hs
@@ -388,9 +388,6 @@ doMerge info = do
         let stageOneBranch =
               defnsAndLibdepsToBranch0 env.codebase blob3.stageOne mergedLibdeps
 
-        let stageTwoBranch =
-              defnsAndLibdepsToBranch0 env.codebase blob3.stageTwo mergedLibdeps
-
         let parents =
               causals <&> \causal -> (causal.causalHash, Codebase.expectBranchForHash env.codebase causal.causalHash)
 
@@ -422,7 +419,7 @@ doMerge info = do
                           info.alice.causalHash,
                           makeUniqueTypeGuids hydratedDefns.alice.types
                         )
-                      mergeStuff = Branch.mergeNode stageTwoBranch parents.alice parents.bob
+                      mergeStuff = Branch.mergeNode stageOneBranch parents.alice parents.bob
                    in HandleInput.Branch.CreateFrom'MergeParents sourceStuff targetStuff mergeStuff
                 )
                 info.alice.projectAndBranch.project

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Merge2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Merge2.hs
@@ -400,19 +400,30 @@ doMerge info = do
             (_temporaryBranchId, temporaryBranchName) <-
               HandleInput.Branch.createBranch
                 info.description
-                ( let targetStuff = (info.alice.projectAndBranch.branch, info.alice.causalHash)
+                ( let makeUniqueTypeGuids :: Map Name (TypeReferenceId, Decl Symbol Ann) -> Map Name Text
+                      makeUniqueTypeGuids =
+                        Map.mapMaybe \case
+                          (_, decl) ->
+                            case (DataDeclaration.asDataDecl decl).modifier of
+                              DataDeclaration.Unique guid -> Just guid
+                              DataDeclaration.Structural -> Nothing
+                      sourceStuff =
+                        ( case info.bob.source of
+                            MergeSource'LocalProjectBranch bobBranch ->
+                              HandleInput.Branch.CreateFromMergeSource'Local bobBranch.branch
+                            MergeSource'RemoteProjectBranch bobBranch ->
+                              HandleInput.Branch.CreateFromMergeSource'Remote bobBranch Share.hardCodedUri
+                            MergeSource'RemoteLooseCode _ -> HandleInput.Branch.CreateFromMergeSource'LooseCode,
+                          info.bob.causalHash,
+                          makeUniqueTypeGuids hydratedDefns.bob.types
+                        )
+                      targetStuff =
+                        ( info.alice.projectAndBranch.branch,
+                          info.alice.causalHash,
+                          makeUniqueTypeGuids hydratedDefns.alice.types
+                        )
                       mergeStuff = Branch.mergeNode stageTwoBranch parents.alice parents.bob
-                   in case info.bob.source of
-                        MergeSource'LocalProjectBranch bobBranch ->
-                          let sourceStuff = (bobBranch.branch, info.bob.causalHash)
-                           in HandleInput.Branch.CreateFrom'MergeParentsLocal sourceStuff targetStuff mergeStuff
-                        MergeSource'RemoteProjectBranch bobBranch ->
-                          let sourceStuff = (bobBranch, Share.hardCodedUri, info.bob.causalHash)
-                           in HandleInput.Branch.CreateFrom'MergeParentsRemote sourceStuff targetStuff mergeStuff
-                        -- Ugh, we don't care about loose code. Just pretend we are creating a branch from a namespace.
-                        -- Unlikely to affect anyone as we are deleting loose code support entirely soon.
-                        MergeSource'RemoteLooseCode _ ->
-                          HandleInput.Branch.CreateFrom'NamespaceWithParent info.alice.projectAndBranch.branch mergeStuff
+                   in HandleInput.Branch.CreateFrom'MergeParents sourceStuff targetStuff mergeStuff
                 )
                 info.alice.projectAndBranch.project
                 (findTemporaryBranchName info.alice.projectAndBranch.project.projectId mergeSourceAndTarget)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Merge2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Merge2.hs
@@ -49,6 +49,7 @@ import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
 import Unison.Cli.MonadUtils qualified as Cli
 import Unison.Cli.ProjectUtils qualified as ProjectUtils
+import Unison.Cli.Share.Projects qualified as Share
 import Unison.Cli.UpdateUtils
   ( getNamespaceDependentsOf3,
     hydrateDefns,
@@ -359,10 +360,13 @@ doMerge info = do
                   { alice = into @Text aliceBranchNames,
                     bob =
                       case info.bob.source of
-                        MergeSource'LocalProjectBranch bobBranchNames -> into @Text bobBranchNames
-                        MergeSource'RemoteProjectBranch bobBranchNames
+                        MergeSource'LocalProjectBranch bobBranch -> into @Text (ProjectUtils.justTheNames bobBranch)
+                        MergeSource'RemoteProjectBranch bobBranch
                           | aliceBranchNames == bobBranchNames -> "remote " <> into @Text bobBranchNames
                           | otherwise -> into @Text bobBranchNames
+                          where
+                            bobBranchNames =
+                              ProjectAndBranch bobBranch.projectName bobBranch.branchName
                         MergeSource'RemoteLooseCode info ->
                           case Path.toName info.path of
                             Nothing -> "<root>"
@@ -396,9 +400,19 @@ doMerge info = do
             (_temporaryBranchId, temporaryBranchName) <-
               HandleInput.Branch.createBranch
                 info.description
-                ( HandleInput.Branch.CreateFrom'MergeParents
-                    info.alice.projectAndBranch.branch
-                    (Branch.mergeNode stageTwoBranch parents.alice parents.bob)
+                ( let targetStuff = (info.alice.projectAndBranch.branch, info.alice.causalHash)
+                      mergeStuff = Branch.mergeNode stageTwoBranch parents.alice parents.bob
+                   in case info.bob.source of
+                        MergeSource'LocalProjectBranch bobBranch ->
+                          let sourceStuff = (bobBranch.branch, info.bob.causalHash)
+                           in HandleInput.Branch.CreateFrom'MergeParentsLocal sourceStuff targetStuff mergeStuff
+                        MergeSource'RemoteProjectBranch bobBranch ->
+                          let sourceStuff = (bobBranch, Share.hardCodedUri, info.bob.causalHash)
+                           in HandleInput.Branch.CreateFrom'MergeParentsRemote sourceStuff targetStuff mergeStuff
+                        -- Ugh, we don't care about loose code. Just pretend we are creating a branch from a namespace.
+                        -- Unlikely to affect anyone as we are deleting loose code support entirely soon.
+                        MergeSource'RemoteLooseCode _ ->
+                          HandleInput.Branch.CreateFrom'NamespaceWithParent info.alice.projectAndBranch.branch mergeStuff
                 )
                 info.alice.projectAndBranch.project
                 (findTemporaryBranchName info.alice.projectAndBranch.project.projectId mergeSourceAndTarget)
@@ -498,7 +512,7 @@ doMergeLocalBranch branches = do
         bob =
           BobMergeInfo
             { causalHash = bobCausalHash,
-              source = MergeSource'LocalProjectBranch (ProjectUtils.justTheNames branches.bob)
+              source = MergeSource'LocalProjectBranch branches.bob
             },
         lca =
           LcaMergeInfo
@@ -604,8 +618,8 @@ findTemporaryBranchName projectId mergeSourceAndTarget = do
 
 mangleMergeSource :: MergeSource -> Text.Builder
 mangleMergeSource = \case
-  MergeSource'LocalProjectBranch (ProjectAndBranch _project branch) -> mangleBranchName branch
-  MergeSource'RemoteProjectBranch (ProjectAndBranch _project branch) -> "remote-" <> mangleBranchName branch
+  MergeSource'LocalProjectBranch (ProjectAndBranch _project branch) -> mangleBranchName branch.name
+  MergeSource'RemoteProjectBranch remoteBranch -> "remote-" <> mangleBranchName remoteBranch.branchName
   MergeSource'RemoteLooseCode info -> manglePath info.path
   where
     manglePath :: Path -> Text.Builder
@@ -703,9 +717,9 @@ makeMergedFileContents sourceAndTarget aliceContents bobContents =
       ">>>>>>> "
         <> ( case sourceAndTarget.bob of
                MergeSource'LocalProjectBranch bobProjectAndBranch ->
-                 Text.Builder.text (into @Text bobProjectAndBranch.branch)
-               MergeSource'RemoteProjectBranch bobProjectAndBranch ->
-                 "remote " <> Text.Builder.text (into @Text bobProjectAndBranch.branch)
+                 Text.Builder.text (into @Text bobProjectAndBranch.branch.name)
+               MergeSource'RemoteProjectBranch bobRemoteBranch ->
+                 "remote " <> Text.Builder.text (into @Text bobRemoteBranch.branchName)
                MergeSource'RemoteLooseCode info ->
                  case Path.toName info.path of
                    Nothing -> "<root>"

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Pull.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Pull.hs
@@ -115,8 +115,7 @@ handlePull unresolvedSourceAndTarget pullMode = do
                     { causalHash = remoteCausalHash,
                       source =
                         case source of
-                          ReadShare'ProjectBranch remoteBranch ->
-                            MergeSource'RemoteProjectBranch (ProjectAndBranch remoteBranch.projectName remoteBranch.branchName)
+                          ReadShare'ProjectBranch remoteBranch -> MergeSource'RemoteProjectBranch remoteBranch
                           ReadShare'LooseCode info -> MergeSource'RemoteLooseCode info
                     },
                 lca =

--- a/unison-merge/src/Unison/Merge/Mergeblob3.hs
+++ b/unison-merge/src/Unison/Merge/Mergeblob3.hs
@@ -20,7 +20,6 @@ import Data.Zip (unzip)
 import Unison.DataDeclaration (Decl)
 import Unison.DataDeclaration qualified as DataDeclaration
 import Unison.DeclNameLookup (DeclNameLookup (..), expectConstructorNames)
-import Unison.DeclNameLookup qualified as DeclNameLookup
 import Unison.Merge.EitherWay (EitherWay)
 import Unison.Merge.EitherWay qualified as EitherWay
 import Unison.Merge.Mergeblob2 (Mergeblob2 (..))
@@ -56,7 +55,6 @@ import Prelude hiding (unzip)
 data Mergeblob3 = Mergeblob3
   { libdeps :: Names,
     stageOne :: DefnsF (Map Name) Referent TypeReference,
-    stageTwo :: DefnsF (Map Name) Referent TypeReference,
     uniqueTypeGuids :: Map Name Text,
     -- `unparsedFile` (no mergetool) xor `unparsedSoloFiles` (yes mergetool) are ultimately given to the user
     unparsedFile :: Pretty ColorText,
@@ -136,7 +134,6 @@ makeMergeblob3 blob dependentsIds libdeps lcaLibdeps authors =
    in Mergeblob3
         { libdeps,
           stageOne = makeStageOne blob.declNameLookups conflictsNames blob.unconflicts dependents defnsByName.lca,
-          stageTwo = makeStageTwo blob.declNameLookups conflictsNames blob.unconflicts dependents defnsByName,
           uniqueTypeGuids = makeUniqueTypeGuids (ThreeWay.forgetLca blob.hydratedDefns),
           unparsedFile = makePrettyUnisonFile authors renderedConflicts renderedDependents,
           unparsedSoloFiles =
@@ -235,43 +232,6 @@ makeStageOne declNameLookups conflicts unconflicts dependents =
 makeStageOneV :: Unconflicts v -> Set Name -> Map Name v -> Map Name v
 makeStageOneV unconflicts namesToDelete =
   (`Map.withoutKeys` namesToDelete) . Unconflicts.apply unconflicts
-
-makeStageTwo ::
-  forall term typ.
-  TwoWay DeclNameLookup ->
-  TwoWay (DefnsF Set Name Name) ->
-  DefnsF Unconflicts term typ ->
-  TwoWay (DefnsF Set Name Name) ->
-  ThreeWay (DefnsF (Map Name) term typ) ->
-  DefnsF (Map Name) term typ
-makeStageTwo declNameLookups conflicts unconflicts dependents defns =
-  zipDefnsWith4 makeStageTwoV makeStageTwoV defns.lca aliceBiasedDependents unconflicts aliceConflicts
-  where
-    aliceConflicts :: DefnsF (Map Name) term typ
-    aliceConflicts =
-      zipDefnsWith
-        (\defns conflicts -> Map.restrictKeys defns (conflicts <> aliceConstructorsOfTypeConflicts))
-        Map.restrictKeys
-        defns.alice
-        conflicts.alice
-
-    aliceConstructorsOfTypeConflicts :: Set Name
-    aliceConstructorsOfTypeConflicts =
-      foldMap
-        (Set.fromList . DeclNameLookup.expectConstructorNames declNameLookups.alice)
-        conflicts.alice.types
-
-    aliceBiasedDependents :: DefnsF (Map Name) term typ
-    aliceBiasedDependents =
-      TwoWay.twoWay
-        (zipDefnsWith (Map.unionWith const) (Map.unionWith const))
-        (zipDefnsWith Map.restrictKeys Map.restrictKeys <$> ThreeWay.forgetLca defns <*> dependents)
-
-makeStageTwoV :: Map Name v -> Map Name v -> Unconflicts v -> Map Name v -> Map Name v
-makeStageTwoV lcaDefns dependents unconflicts conflicts =
-  Map.unionWith const dependents lcaDefns
-    & Unconflicts.apply unconflicts
-    & Map.unionWith const conflicts
 
 -- Given just named term/type reference ids, fill out all names that occupy the term and type namespaces. This is simply
 -- the given names plus all of the types' constructors.

--- a/unison-src/transcripts/merge.md
+++ b/unison-src/transcripts/merge.md
@@ -1748,6 +1748,105 @@ scratch/alice> names Bar
 scratch/main> project.delete scratch
 ```
 
+### Unique type GUID reuse – parent branch
+
+When on a merge branch, if the parser has to pick between two different GUIDs, and the two merge parents themselves have
+a branch parent-child relationship, it will prefer the parent's GUID. If they don't the parser will make a new GUID.
+
+``` ucm :hide
+scratch/main> builtins.mergeio lib.builtins
+```
+
+``` unison
+type Foo = Bar
+```
+
+``` ucm
+scratch/main> branch topic
+scratch/main> branch topic2
+scratch/main> add
+scratch/main> switch /topic
+```
+
+``` unison
+type Foo = Bar
+```
+
+``` ucm
+scratch/topic> add
+scratch/topic> switch /topic2
+```
+
+``` unison
+type Foo = Bar
+```
+
+``` ucm
+scratch/topic2> add
+scratch/main> switch /main
+```
+
+``` ucm :error
+scratch/main> merge /topic
+```
+
+``` ucm
+scratch/main> switch /merge-topic-into-main
+```
+
+``` unison
+type Foo = Bar
+```
+
+``` ucm
+scratch/merge-topic-into-main> update
+scratch/main> names Foo
+scratch/topic> names Foo
+scratch/merge-topic-into-main> names Foo
+```
+
+``` ucm :error
+scratch/topic> merge /main
+```
+
+``` ucm
+scratch/merge-main-into-topic>
+```
+
+``` unison
+type Foo = Bar
+```
+
+``` ucm
+scratch/merge-main-into-topic> update
+scratch/main> names Foo
+scratch/topic> names Foo
+scratch/merge-main-into-topic> names Foo
+```
+
+``` ucm :error
+scratch/topic> merge /topic2
+```
+
+``` ucm
+scratch/merge-topic2-into-topic>
+```
+
+``` unison
+type Foo = Bar
+```
+
+``` ucm
+scratch/merge-topic2-into-topic> update
+scratch/topic> names Foo
+scratch/topic2> names Foo
+scratch/merge-topic2-into-topic> names Foo
+```
+
+``` ucm :hide
+scratch/main> project.delete scratch
+```
+
 ### Using Alice's names for Bob's things
 
 Previously, we'd render Alice's stuff with her names and Bob's stuff with his. But because Alice is doing the merge,

--- a/unison-src/transcripts/merge.md
+++ b/unison-src/transcripts/merge.md
@@ -1786,6 +1786,8 @@ scratch/topic2> add
 scratch/main> switch /main
 ```
 
+Case 1: Merging child `/topic` into parent `/main` uses parent `/main`'s GUID
+
 ``` ucm :error
 scratch/main> merge /topic
 ```
@@ -1805,6 +1807,8 @@ scratch/topic> names Foo
 scratch/merge-topic-into-main> names Foo
 ```
 
+Case 2: Merging parent `/main` into child `/topic` also uses parent `/main`'s GUID
+
 ``` ucm :error
 scratch/topic> merge /main
 ```
@@ -1823,6 +1827,8 @@ scratch/main> names Foo
 scratch/topic> names Foo
 scratch/merge-main-into-topic> names Foo
 ```
+
+Case 3: Merging `/topic` into `/topic2` (neither of which is a parent of the other) uses a new third GUID
 
 ``` ucm :error
 scratch/topic> merge /topic2

--- a/unison-src/transcripts/merge.output.md
+++ b/unison-src/transcripts/merge.output.md
@@ -1881,8 +1881,7 @@ foo = "alice and bobs foo"
   do an `add` or `update`, here's how your codebase would
   change:
 
-    ⍟ These names already exist. You can `update` them to your
-      new definition:
+    ⍟ These new definitions are ok to `add`:
     
       foo : Text
 ```
@@ -3415,8 +3414,14 @@ type Bar = MkBar Foo
 ``` ucm :added-by-ucm
   Loading changes detected in scratch.u.
 
-  I found and typechecked the definitions in scratch.u. This
-  file has been previously added to the codebase.
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+
+    ⍟ These new definitions are ok to `add`:
+    
+      type Bar
+      type Foo
 ```
 
 ``` ucm

--- a/unison-src/transcripts/merge.output.md
+++ b/unison-src/transcripts/merge.output.md
@@ -3550,6 +3550,8 @@ scratch/topic2> add
 scratch/main> switch /main
 ```
 
+Case 1: Merging child `/topic` into parent `/main` uses parent `/main`'s GUID
+
 ``` ucm :error
 scratch/main> merge /topic
 
@@ -3638,6 +3640,8 @@ scratch/merge-topic-into-main> names Foo
   #j2e5n5ucie   Type   Foo
 ```
 
+Case 2: Merging parent `/main` into child `/topic` also uses parent `/main`'s GUID
+
 ``` ucm :error
 scratch/topic> merge /main
 
@@ -3724,6 +3728,8 @@ scratch/merge-main-into-topic> names Foo
   Hash          Kind   Names
   #j2e5n5ucie   Type   Foo
 ```
+
+Case 3: Merging `/topic` into `/topic2` (neither of which is a parent of the other) uses a new third GUID
 
 ``` ucm :error
 scratch/topic> merge /topic2

--- a/unison-src/transcripts/merge.output.md
+++ b/unison-src/transcripts/merge.output.md
@@ -3449,6 +3449,373 @@ scratch/alice> names Bar
 scratch/main> project.delete scratch
 ```
 
+### Unique type GUID reuse – parent branch
+
+When on a merge branch, if the parser has to pick between two different GUIDs, and the two merge parents themselves have
+a branch parent-child relationship, it will prefer the parent's GUID. If they don't the parser will make a new GUID.
+
+``` ucm :hide
+scratch/main> builtins.mergeio lib.builtins
+```
+
+``` unison
+type Foo = Bar
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+
+    ⍟ These new definitions are ok to `add`:
+    
+      type Foo
+```
+
+``` ucm
+scratch/main> branch topic
+
+  Done. I've created the topic branch based off of main.
+
+  Tip: To merge your work back into the main branch, first
+       `switch /main` then `merge /topic`.
+
+scratch/main> branch topic2
+
+  Done. I've created the topic2 branch based off of main.
+
+  Tip: To merge your work back into the main branch, first
+       `switch /main` then `merge /topic2`.
+
+scratch/main> add
+
+  ⍟ I've added these definitions:
+
+    type Foo
+
+scratch/main> switch /topic
+```
+
+``` unison
+type Foo = Bar
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+
+    ⍟ These new definitions are ok to `add`:
+    
+      type Foo
+```
+
+``` ucm
+scratch/topic> add
+
+  ⍟ I've added these definitions:
+
+    type Foo
+
+scratch/topic> switch /topic2
+```
+
+``` unison
+type Foo = Bar
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+
+    ⍟ These new definitions are ok to `add`:
+    
+      type Foo
+```
+
+``` ucm
+scratch/topic2> add
+
+  ⍟ I've added these definitions:
+
+    type Foo
+
+scratch/main> switch /main
+```
+
+``` ucm :error
+scratch/main> merge /topic
+
+  Loading branches...
+
+  Loading definitions...
+
+  Computing diffs...
+
+  Loading dependents of changes...
+
+  Loading and merging library dependencies...
+
+  Rendering Unison file...
+
+  I couldn't automatically merge scratch/topic into
+  scratch/main. However, I've added the definitions that need
+  attention to the top of scratch.u.
+
+  When you're done, you can run
+
+    merge.commit
+
+  to merge your changes back into main and delete the temporary
+  branch. Or, if you decide to cancel the merge instead, you can
+  run
+
+    delete.branch /merge-topic-into-main
+
+  to delete the temporary branch and switch back to main.
+```
+
+``` unison :added-by-ucm scratch.u
+-- scratch/main
+unique[qg9i3saca6l177670mmf60tc2lkc6fs0] type Foo = Bar
+
+-- scratch/topic
+unique[sfr163dp38r14s2j75i08e7eejljege9] type Foo = Bar
+
+```
+
+``` ucm
+scratch/main> switch /merge-topic-into-main
+```
+
+``` unison
+type Foo = Bar
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+
+    ⍟ These new definitions are ok to `add`:
+    
+      type Foo
+```
+
+``` ucm
+scratch/merge-topic-into-main> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+
+scratch/main> names Foo
+
+  'Foo':
+  Hash          Kind   Names
+  #j2e5n5ucie   Type   Foo
+
+scratch/topic> names Foo
+
+  'Foo':
+  Hash          Kind   Names
+  #j49bpadp1q   Type   Foo
+
+scratch/merge-topic-into-main> names Foo
+
+  'Foo':
+  Hash          Kind   Names
+  #j2e5n5ucie   Type   Foo
+```
+
+``` ucm :error
+scratch/topic> merge /main
+
+  Loading branches...
+
+  Loading definitions...
+
+  Computing diffs...
+
+  Loading dependents of changes...
+
+  Loading and merging library dependencies...
+
+  Rendering Unison file...
+
+  I couldn't automatically merge scratch/main into
+  scratch/topic. However, I've added the definitions that need
+  attention to the top of scratch.u.
+
+  When you're done, you can run
+
+    merge.commit
+
+  to merge your changes back into topic and delete the temporary
+  branch. Or, if you decide to cancel the merge instead, you can
+  run
+
+    delete.branch /merge-main-into-topic
+
+  to delete the temporary branch and switch back to topic.
+```
+
+``` unison :added-by-ucm scratch.u
+-- scratch/topic
+unique[sfr163dp38r14s2j75i08e7eejljege9] type Foo = Bar
+
+-- scratch/main
+unique[qg9i3saca6l177670mmf60tc2lkc6fs0] type Foo = Bar
+
+```
+
+``` ucm
+```
+
+``` unison
+type Foo = Bar
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+
+    ⍟ These new definitions are ok to `add`:
+    
+      type Foo
+```
+
+``` ucm
+scratch/merge-main-into-topic> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+
+scratch/main> names Foo
+
+  'Foo':
+  Hash          Kind   Names
+  #j2e5n5ucie   Type   Foo
+
+scratch/topic> names Foo
+
+  'Foo':
+  Hash          Kind   Names
+  #j49bpadp1q   Type   Foo
+
+scratch/merge-main-into-topic> names Foo
+
+  'Foo':
+  Hash          Kind   Names
+  #j2e5n5ucie   Type   Foo
+```
+
+``` ucm :error
+scratch/topic> merge /topic2
+
+  Loading branches...
+
+  Loading definitions...
+
+  Computing diffs...
+
+  Loading dependents of changes...
+
+  Loading and merging library dependencies...
+
+  Rendering Unison file...
+
+  I couldn't automatically merge scratch/topic2 into
+  scratch/topic. However, I've added the definitions that need
+  attention to the top of scratch.u.
+
+  When you're done, you can run
+
+    merge.commit
+
+  to merge your changes back into topic and delete the temporary
+  branch. Or, if you decide to cancel the merge instead, you can
+  run
+
+    delete.branch /merge-topic2-into-topic
+
+  to delete the temporary branch and switch back to topic.
+```
+
+``` unison :added-by-ucm scratch.u
+-- scratch/topic
+unique[sfr163dp38r14s2j75i08e7eejljege9] type Foo = Bar
+
+-- scratch/topic2
+unique[jhn3rdj2mr8k4g6domoj1qd1kdsshaa9] type Foo = Bar
+
+```
+
+``` ucm
+```
+
+``` unison
+type Foo = Bar
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+
+    ⍟ These new definitions are ok to `add`:
+    
+      type Foo
+```
+
+``` ucm
+scratch/merge-topic2-into-topic> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+
+scratch/topic> names Foo
+
+  'Foo':
+  Hash          Kind   Names
+  #j49bpadp1q   Type   Foo
+
+scratch/topic2> names Foo
+
+  'Foo':
+  Hash          Kind   Names
+  #c0h5g2udvs   Type   Foo
+
+scratch/merge-topic2-into-topic> names Foo
+
+  'Foo':
+  Hash          Kind   Names
+  #5td3ht8h1s   Type   Foo
+```
+
+``` ucm :hide
+scratch/main> project.delete scratch
+```
+
 ### Using Alice's names for Bob's things
 
 Previously, we'd render Alice's stuff with her names and Bob's stuff with his. But because Alice is doing the merge,


### PR DESCRIPTION
## Overview

Fixes #5643 

This PR fixes a bug in merge by tracking merge parents in SQLite in order to use those merge parents as a source of unique type GUIDs to reuse on merge branches.

## Details

When we merge two branches that result in a conflict on a unique type, the user's scratch file will get something like the following for them to resolve.

```
-- /main
unique[ab12...] type Foo = Foo

-- /topic
unique[xy34...] type Foo = Foo
```

The user can delete one of these conflicting definitions, or consolidate them, leaving the unique GUID in place, and the parser will use it when saving the resolved type to the merge branch.

But if the user deletes the GUID, leaving just the following, what GUID should the parser use?
```
type Foo = Foo
```

Before this PR, we would add a copy of the type from the merge target branch to the merge/conflict branch, leveraging existing "avoid unique type churn" code to reuse the GUID that's present on the underlying branch, breaking an otherwise nice invariant that the conflicted parts of the merge are in the scratch file, and only everything else is in the merge branch.

With this PR, instead of copying conflicted types into the merge target branch at the time the `merge` command is issued, we track the merge parents in the database, and are able to look them up at parse time to select a GUID for a previously-existing unique type if the user un-specifies it in the scratch file. We don't add a copy of conflicted types to the merge branch any more, only to the scratch file, so the merge branch and the scratch file are disjoint, and an `add` will be equivalent to an `update`.

So now with this PR, if we encounter an unadorned unique type in the scratch file on `update`, 
* if we are on a merge branch:
  * if a unique type by this name existed on one merge parent or the other, use the existing GUID
  * else if a unique type by this name existed on _both_ merge parents:
    * if one of the merge parents is a branch parent of the other, use its GUID (note we just check for parents, not ancestors in this version due to complexity)
*  if we're not on a merge branch, but we are on a branch that already has a unique type with the same name, use the existing GUID. (existing behavior)
* if none of the above conditions apply, we consider it a new unique type and make up a new GUID.

## Test coverage

One transcript already hit this code path, added a few others. Also tested manually that #5643 is fixed.
