### PR TITLE
Trigger FZF on no-args `ls`

### DIFF
--- a/docs/sharing-code.markdown
+++ b/docs/sharing-code.markdown
@@ -8,13 +8,13 @@ data Causal m e
   | Merge { currentHash :: Hash, head :: e, tails :: Map Hash (m (Causal e)) }
 
 -- just one level of name, like Foo or Bar, but not Foo.Bar
-newtype NameSegment = NameSegment { toText :: Text } 
+newtype NameSegment = NameSegment { toText :: Text }
 newtype Path = Path { toList :: [NameSegment] }
 
 data Namespace m = Namespace
 	{ terms :: Relation NameSegment Referent
   , types :: Relation NameSegment Reference
-  , children :: Relation NameSegment (Codetree m) 
+  , children :: Relation NameSegment (Codetree m)
   }
 
 data Codetree m = Codetree (Causal m Namespace)
@@ -28,10 +28,10 @@ data RemoteRef = GithubRef { username :: Text, repo :: Text, treeish :: Text }
 
 newtype EditMap = EditMap { toMap :: Map GUID (Causal Edits) }
 data Edits = Edits
-	{ terms :: Relation Reference TermEdit 
+	{ terms :: Relation Reference TermEdit
 	, types :: Relation Reference TypeEdit
 	}
-	
+
 -- maps local paths to remote paths
 data RemoteStatus = Map Path RemoteSpec
 ```
@@ -53,9 +53,9 @@ Questions:
 
 * Do we want to distinguish between `/` paths and `.` separators in names?
 
-  * Should a type `A` be at the same level as 
+  * Should a type `A` be at the same level as
 
-  * On one hand, you probably don't need to separate a type `A` from its constructor `A.A`.  You wouldn't be able to export the constructor without the type which resides a level up in the namespace.  
+  * On one hand, you probably don't need to separate a type `A` from its constructor `A.A`.  You wouldn't be able to export the constructor without the type which resides a level up in the namespace.
 
   * Maybe the type `A` should organically be organized as `A/A`, and its constructor also as `A/A`.  This is reminiscent of having a separate module per type in Haskell, except that a reorganization could be done more easily:
 
@@ -63,13 +63,13 @@ Questions:
     /mycode> mv ClassA* ClassA/
     /mycode> mv ClassB* ClassB/
     /mycode> cd ClassA
-    /mycode/ClassA> ls
+    /mycode/ClassA> ls .
     ```
 
-    
+
 
   * ```
-    
+
     ```
 
 ## NameTree representation
@@ -94,9 +94,9 @@ data NameTree a = Causal (Relation Name (NameTree a))
 ```
 or
 ```haskell
-data NameTree a 
-	= Leaf a 
-	| Branch (Relation Name (NameTree a)) 
+data NameTree a
+	= Leaf a
+	| Branch (Relation Name (NameTree a))
 	| SharePoint (Causal (NameTree a))
 ```
 
@@ -113,10 +113,10 @@ Branches: https://api.github.com/repos/unisonweb/unison/branches
 A directory:
 
 ```
-url: 
+url:
 https://api.github.com/repos/unisonweb/unison/contents/unison-src/demo?ref=master
 
-html_url: 
+html_url:
 https://github.com/unisonweb/unison/tree/master/unison-src/demo
 
 git_url

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -1220,7 +1220,7 @@ findShallow =
     I.Visible
     (Parameters [("namespace", namespaceArg)] (Optional [] Nothing))
     ( P.wrapColumn2
-        [ ("`list`", "Lists definitions and namespaces within the selected namespace."),
+        [ ("`list`", "lists definitions and namespaces within the selected namespace."),
           ("`list foo`", "lists the 'foo' namespace."),
           ("`list .foo`", "lists the '.foo' namespace.")
         ]

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -1218,9 +1218,9 @@ findShallow =
     "list"
     ["ls", "dir"]
     I.Visible
-    (Parameters [] $ Optional [("namespace", namespaceArg)] Nothing)
+    (Parameters [("namespace", namespaceArg)] (Optional [] Nothing))
     ( P.wrapColumn2
-        [ ("`list`", "lists definitions and namespaces at the current level of the current namespace."),
+        [ ("`list`", "Lists definitions and namespaces within the selected namespace."),
           ("`list foo`", "lists the 'foo' namespace."),
           ("`list .foo`", "lists the '.foo' namespace.")
         ]

--- a/unison-src/transcripts/errors/no-abspath-in-ucm.md
+++ b/unison-src/transcripts/errors/no-abspath-in-ucm.md
@@ -1,5 +1,5 @@
 ``` ucm :error
 scratch/main> builtins.merge
 -- As of 0.5.25, we no longer allow loose code paths for UCM commands.
-.> ls
+.> ls .
 ```

--- a/unison-src/transcripts/errors/no-abspath-in-ucm.output.md
+++ b/unison-src/transcripts/errors/no-abspath-in-ucm.output.md
@@ -1,6 +1,6 @@
 :4:1:
   |
-4 | .> ls
+4 | .> ls .
   | ^^
 unexpected ".>"
 expecting "  ", " <newline>", '@', comment (delimited with “--”), end of input, or newline

--- a/unison-src/transcripts/idempotent/alias-term.md
+++ b/unison-src/transcripts/idempotent/alias-term.md
@@ -9,7 +9,7 @@ project/main> alias.term lib.builtins.bug foo
 
   Done.
 
-project/main> ls
+project/main> ls .
 
   1. foo  (a -> b)
   2. lib/ (650 terms, 94 types)
@@ -26,7 +26,7 @@ project/main> alias.term lib.builtins.todo foo
 ```
 
 ``` ucm
-project/main> ls
+project/main> ls .
 
   1. foo  (a -> b)
   2. lib/ (650 terms, 94 types)
@@ -39,7 +39,7 @@ project/main> debug.alias.term.force lib.builtins.todo foo
 
   Done.
 
-project/main> ls
+project/main> ls .
 
   1. foo  (a -> b)
   2. foo  (a -> b)

--- a/unison-src/transcripts/idempotent/alias-type.md
+++ b/unison-src/transcripts/idempotent/alias-type.md
@@ -9,7 +9,7 @@ project/main> alias.type lib.builtins.Nat Foo
 
   Done.
 
-project/main> ls
+project/main> ls .
 
   1. Foo  (builtin type)
   2. lib/ (650 terms, 94 types)
@@ -26,7 +26,7 @@ project/main> alias.type lib.builtins.Int Foo
 ```
 
 ``` ucm
-project/main> ls
+project/main> ls .
 
   1. Foo  (builtin type)
   2. lib/ (650 terms, 94 types)
@@ -39,7 +39,7 @@ project/main> debug.alias.type.force lib.builtins.Int Foo
 
   Done.
 
-project/main> ls
+project/main> ls .
 
   1. Foo  (builtin type)
   2. Foo  (builtin type)

--- a/unison-src/transcripts/idempotent/empty-namespaces.md
+++ b/unison-src/transcripts/idempotent/empty-namespaces.md
@@ -13,7 +13,7 @@ scratch/main> delete.namespace mynamespace
 The deleted namespace shouldn't appear in `ls` output.
 
 ``` ucm :error
-scratch/main> ls
+scratch/main> ls .
 
   nothing to show
 ```

--- a/unison-src/transcripts/idempotent/emptyCodebase.md
+++ b/unison-src/transcripts/idempotent/emptyCodebase.md
@@ -7,7 +7,7 @@ Not even `Nat` or `+`\!
 BEHOLD\!\!\!
 
 ``` ucm :error
-scratch/main> ls
+scratch/main> ls .
 
   nothing to show
 ```

--- a/unison-src/transcripts/idempotent/fix1327.md
+++ b/unison-src/transcripts/idempotent/fix1327.md
@@ -12,7 +12,7 @@ bar = 5
   change:
 
     ⍟ These new definitions are ok to `add`:
-    
+
       bar : ##Nat
       foo : ##Nat
 ```
@@ -29,7 +29,7 @@ scratch/main> add
     bar : ##Nat
     foo : ##Nat
 
-scratch/main> ls
+scratch/main> ls .
 
   1. bar (##Nat)
   2. foo (##Nat)

--- a/unison-src/transcripts/idempotent/fix1327.md
+++ b/unison-src/transcripts/idempotent/fix1327.md
@@ -12,7 +12,7 @@ bar = 5
   change:
 
     ⍟ These new definitions are ok to `add`:
-
+    
       bar : ##Nat
       foo : ##Nat
 ```

--- a/unison-src/transcripts/idempotent/fix1532.md
+++ b/unison-src/transcripts/idempotent/fix1532.md
@@ -20,7 +20,7 @@ bar.z = x + y
   change:
 
     ⍟ These new definitions are ok to `add`:
-    
+
       bar.z : Nat
       foo.x : Nat
       foo.y : Nat
@@ -39,7 +39,7 @@ scratch/main> add
 Let's see what we have created...
 
 ``` ucm
-scratch/main> ls
+scratch/main> ls .
 
   1. bar/     (1 term)
   2. builtin/ (476 terms, 76 types)
@@ -58,7 +58,7 @@ scratch/main> delete.namespace foo
 
   Dependency   Referenced In
   x            1. bar.z
-               
+
   y            2. bar.z
 
   If you want to proceed anyways and leave those definitions

--- a/unison-src/transcripts/idempotent/fix1532.md
+++ b/unison-src/transcripts/idempotent/fix1532.md
@@ -20,7 +20,7 @@ bar.z = x + y
   change:
 
     ⍟ These new definitions are ok to `add`:
-
+    
       bar.z : Nat
       foo.x : Nat
       foo.y : Nat
@@ -58,7 +58,7 @@ scratch/main> delete.namespace foo
 
   Dependency   Referenced In
   x            1. bar.z
-
+               
   y            2. bar.z
 
   If you want to proceed anyways and leave those definitions

--- a/unison-src/transcripts/idempotent/help.md
+++ b/unison-src/transcripts/idempotent/help.md
@@ -517,7 +517,7 @@ scratch/main> help
                                               `@unison/base`
 
   list (or ls, dir)
-  `list`       Lists definitions and namespaces within the
+  `list`       lists definitions and namespaces within the
                selected namespace.
   `list foo`   lists the 'foo' namespace.
   `list .foo`  lists the '.foo' namespace.

--- a/unison-src/transcripts/idempotent/help.md
+++ b/unison-src/transcripts/idempotent/help.md
@@ -517,8 +517,8 @@ scratch/main> help
                                               `@unison/base`
 
   list (or ls, dir)
-  `list`       lists definitions and namespaces at the current
-               level of the current namespace.
+  `list`       Lists definitions and namespaces within the
+               selected namespace.
   `list foo`   lists the 'foo' namespace.
   `list .foo`  lists the '.foo' namespace.
 

--- a/unison-src/transcripts/idempotent/input-parse-errors.md
+++ b/unison-src/transcripts/idempotent/input-parse-errors.md
@@ -27,7 +27,7 @@ scratch/main> add .
       |  ^
     unexpected end of input
     expecting '`' or operator (valid characters: !$%&*+-/:<=>\^|~)
-
+    
 
   You can run `help add` for more information on using `add`.
 
@@ -46,7 +46,6 @@ scratch/main> ls .
 
 scratch/main> add 2
 
-  ⊡ Ignored previously added definitions: x
 ```
 
 todo:
@@ -83,7 +82,7 @@ scratch/main> update arg
 
 aliasTerm
 
-```
+``` 
 scratch/main> alias.term ##Nat.+ Nat.+
 ```
 
@@ -92,7 +91,7 @@ aliasType,
 
 todo:
 
-```
+``` 
 
 aliasMany,
 api,

--- a/unison-src/transcripts/idempotent/input-parse-errors.md
+++ b/unison-src/transcripts/idempotent/input-parse-errors.md
@@ -27,11 +27,11 @@ scratch/main> add .
       |  ^
     unexpected end of input
     expecting '`' or operator (valid characters: !$%&*+-/:<=>\^|~)
-    
+
 
   You can run `help add` for more information on using `add`.
 
-scratch/main> ls
+scratch/main> ls .
 
   1. lib/ (476 terms, 76 types)
   2. x    (Nat)
@@ -39,7 +39,7 @@ scratch/main> ls
 scratch/main> add 1
 
 
-scratch/main> ls
+scratch/main> ls .
 
   1. lib/ (476 terms, 76 types)
   2. x    (Nat)
@@ -83,7 +83,7 @@ scratch/main> update arg
 
 aliasTerm
 
-``` 
+```
 scratch/main> alias.term ##Nat.+ Nat.+
 ```
 
@@ -92,7 +92,7 @@ aliasType,
 
 todo:
 
-``` 
+```
 
 aliasMany,
 api,

--- a/unison-src/transcripts/idempotent/move-all.md
+++ b/unison-src/transcripts/idempotent/move-all.md
@@ -23,7 +23,7 @@ unique type Foo.T = T
   change:
 
     ⍟ These new definitions are ok to `add`:
-    
+
       type Foo
       type Foo.T
       Foo         : Nat
@@ -55,7 +55,7 @@ unique type Foo.T = T1 | T2
 
     ⍟ These names already exist. You can `update` them to your
       new definition:
-    
+
       type Foo.T
       Foo.termInA : Nat
         (also named Foo)
@@ -77,7 +77,7 @@ scratch/main> move Foo Bar
 
   Done.
 
-scratch/main> ls
+scratch/main> ls .
 
   1. Bar      (Nat)
   2. Bar      (type)
@@ -99,11 +99,11 @@ scratch/main> history Bar
   ⊙ 1. #hk3a3lsc2e
 
     + Adds / updates:
-    
+
       T T.T1 T.T2 termInA
-    
+
     - Deletes:
-    
+
       T.T
 
   □ 2. #vqc50q3b3v (start of history)
@@ -123,7 +123,7 @@ bonk = 5
   change:
 
     ⍟ These new definitions are ok to `add`:
-    
+
       bonk : Nat
 ```
 
@@ -142,7 +142,7 @@ z/main> move bonk zonk
 
   Done.
 
-z/main> ls
+z/main> ls .
 
   1. builtin/ (476 terms, 76 types)
   2. zonk     (Nat)
@@ -162,7 +162,7 @@ bonk.zonk = 5
   change:
 
     ⍟ These new definitions are ok to `add`:
-    
+
       bonk.zonk : Nat
         (also named zonk)
 ```
@@ -182,7 +182,7 @@ a/main> move bonk zonk
 
   Done.
 
-a/main> ls
+a/main> ls .
 
   1. builtin/ (476 terms, 76 types)
   2. zonk/    (1 term)

--- a/unison-src/transcripts/idempotent/move-all.md
+++ b/unison-src/transcripts/idempotent/move-all.md
@@ -23,7 +23,7 @@ unique type Foo.T = T
   change:
 
     ⍟ These new definitions are ok to `add`:
-
+    
       type Foo
       type Foo.T
       Foo         : Nat
@@ -55,7 +55,7 @@ unique type Foo.T = T1 | T2
 
     ⍟ These names already exist. You can `update` them to your
       new definition:
-
+    
       type Foo.T
       Foo.termInA : Nat
         (also named Foo)
@@ -99,11 +99,11 @@ scratch/main> history Bar
   ⊙ 1. #hk3a3lsc2e
 
     + Adds / updates:
-
+    
       T T.T1 T.T2 termInA
-
+    
     - Deletes:
-
+    
       T.T
 
   □ 2. #vqc50q3b3v (start of history)
@@ -123,7 +123,7 @@ bonk = 5
   change:
 
     ⍟ These new definitions are ok to `add`:
-
+    
       bonk : Nat
 ```
 
@@ -162,7 +162,7 @@ bonk.zonk = 5
   change:
 
     ⍟ These new definitions are ok to `add`:
-
+    
       bonk.zonk : Nat
         (also named zonk)
 ```

--- a/unison-src/transcripts/idempotent/move-namespace.md
+++ b/unison-src/transcripts/idempotent/move-namespace.md
@@ -28,7 +28,7 @@ scratch/main> move.namespace . .root.at.path
 
   Done.
 
-scratch/main> ls
+scratch/main> ls .
 
   1. root/ (1 term)
 
@@ -73,7 +73,7 @@ scratch/main> move.namespace .root.at.path .
 
   Done.
 
-scratch/main> ls
+scratch/main> ls .
 
   1. foo (##Nat)
 
@@ -125,7 +125,7 @@ unique type a.T = T
   change:
 
     ⍟ These new definitions are ok to `add`:
-    
+
       type a.T
       a.termInA : Nat
 ```
@@ -153,7 +153,7 @@ unique type a.T = T1 | T2
 
     ⍟ These names already exist. You can `update` them to your
       new definition:
-    
+
       type a.T
       a.termInA : Nat
 ```
@@ -188,11 +188,11 @@ scratch/happy> history b
   ⊙ 1. #ugqniosnp0
 
     + Adds / updates:
-    
+
       T T.T1 T.T2 termInA
-    
+
     - Deletes:
-    
+
       T.T
 
   □ 2. #a7r726o5ut (start of history)
@@ -219,7 +219,7 @@ b.termInB = 10
   change:
 
     ⍟ These new definitions are ok to `add`:
-    
+
       a.termInA : Nat
       b.termInB : Nat
 ```
@@ -247,7 +247,7 @@ b.termInB = 11
 
     ⍟ These names already exist. You can `update` them to your
       new definition:
-    
+
       a.termInA : Nat
       b.termInB : Nat
 ```
@@ -284,7 +284,7 @@ scratch/history> history b
   ⊙ 1. #j0cjjqepb3
 
     + Adds / updates:
-    
+
       termInA
 
   □ 2. #m8smmmgjso (start of history)
@@ -322,7 +322,7 @@ b.termInB = 10
   change:
 
     ⍟ These new definitions are ok to `add`:
-    
+
       a.termInA : Nat
       b.termInB : Nat
 ```
@@ -350,7 +350,7 @@ b.termInB = 11
 
     ⍟ These names already exist. You can `update` them to your
       new definition:
-    
+
       a.termInA : Nat
       b.termInB : Nat
 ```

--- a/unison-src/transcripts/idempotent/move-namespace.md
+++ b/unison-src/transcripts/idempotent/move-namespace.md
@@ -125,7 +125,7 @@ unique type a.T = T
   change:
 
     ⍟ These new definitions are ok to `add`:
-
+    
       type a.T
       a.termInA : Nat
 ```
@@ -153,7 +153,7 @@ unique type a.T = T1 | T2
 
     ⍟ These names already exist. You can `update` them to your
       new definition:
-
+    
       type a.T
       a.termInA : Nat
 ```
@@ -188,11 +188,11 @@ scratch/happy> history b
   ⊙ 1. #ugqniosnp0
 
     + Adds / updates:
-
+    
       T T.T1 T.T2 termInA
-
+    
     - Deletes:
-
+    
       T.T
 
   □ 2. #a7r726o5ut (start of history)
@@ -219,7 +219,7 @@ b.termInB = 10
   change:
 
     ⍟ These new definitions are ok to `add`:
-
+    
       a.termInA : Nat
       b.termInB : Nat
 ```
@@ -247,7 +247,7 @@ b.termInB = 11
 
     ⍟ These names already exist. You can `update` them to your
       new definition:
-
+    
       a.termInA : Nat
       b.termInB : Nat
 ```
@@ -284,7 +284,7 @@ scratch/history> history b
   ⊙ 1. #j0cjjqepb3
 
     + Adds / updates:
-
+    
       termInA
 
   □ 2. #m8smmmgjso (start of history)
@@ -322,7 +322,7 @@ b.termInB = 10
   change:
 
     ⍟ These new definitions are ok to `add`:
-
+    
       a.termInA : Nat
       b.termInB : Nat
 ```
@@ -350,7 +350,7 @@ b.termInB = 11
 
     ⍟ These names already exist. You can `update` them to your
       new definition:
-
+    
       a.termInA : Nat
       b.termInB : Nat
 ```

--- a/unison-src/transcripts/idempotent/undo.md
+++ b/unison-src/transcripts/idempotent/undo.md
@@ -40,18 +40,18 @@ scratch/main> history
   ⊙ 1. #a43uem9vjp
 
     + Adds / updates:
-
+    
       y
-
+    
     = Copies:
-
+    
       Original name New name(s)
       x             y
 
   ⊙ 2. #5gbhpddvrn
 
     + Adds / updates:
-
+    
       x
 
   □ 3. #q0sddm3uvt (start of history)
@@ -78,7 +78,7 @@ scratch/main> history
   ⊙ 1. #5gbhpddvrn
 
     + Adds / updates:
-
+    
       x
 
   □ 2. #q0sddm3uvt (start of history)
@@ -126,18 +126,18 @@ scratch/branch1> history
   ⊙ 1. #a43uem9vjp
 
     + Adds / updates:
-
+    
       y
-
+    
     = Copies:
-
+    
       Original name New name(s)
       x             y
 
   ⊙ 2. #5gbhpddvrn
 
     + Adds / updates:
-
+    
       x
 
   □ 3. #q0sddm3uvt (start of history)
@@ -174,7 +174,7 @@ scratch/branch1> history
   ⊙ 1. #5gbhpddvrn
 
     + Adds / updates:
-
+    
       x
 
   □ 2. #q0sddm3uvt (start of history)

--- a/unison-src/transcripts/idempotent/undo.md
+++ b/unison-src/transcripts/idempotent/undo.md
@@ -17,7 +17,7 @@ scratch/main> add
 
     x : Nat
 
-scratch/main> ls
+scratch/main> ls .
 
   1. lib/ (476 terms, 76 types)
   2. x    (Nat)
@@ -26,7 +26,7 @@ scratch/main> alias.term x y
 
   Done.
 
-scratch/main> ls
+scratch/main> ls .
 
   1. lib/ (476 terms, 76 types)
   2. x    (Nat)
@@ -40,18 +40,18 @@ scratch/main> history
   ⊙ 1. #a43uem9vjp
 
     + Adds / updates:
-    
+
       y
-    
+
     = Copies:
-    
+
       Original name New name(s)
       x             y
 
   ⊙ 2. #5gbhpddvrn
 
     + Adds / updates:
-    
+
       x
 
   □ 3. #q0sddm3uvt (start of history)
@@ -65,7 +65,7 @@ scratch/main> undo
     Original  Changes
     1. x      2. y (added)
 
-scratch/main> ls
+scratch/main> ls .
 
   1. lib/ (476 terms, 76 types)
   2. x    (Nat)
@@ -78,7 +78,7 @@ scratch/main> history
   ⊙ 1. #5gbhpddvrn
 
     + Adds / updates:
-    
+
       x
 
   □ 2. #q0sddm3uvt (start of history)
@@ -103,7 +103,7 @@ scratch/branch1> add
 
     x : Nat
 
-scratch/branch1> ls
+scratch/branch1> ls .
 
   1. lib/ (476 terms, 76 types)
   2. x    (Nat)
@@ -112,7 +112,7 @@ scratch/branch1> alias.term x y
 
   Done.
 
-scratch/branch1> ls
+scratch/branch1> ls .
 
   1. lib/ (476 terms, 76 types)
   2. x    (Nat)
@@ -126,18 +126,18 @@ scratch/branch1> history
   ⊙ 1. #a43uem9vjp
 
     + Adds / updates:
-    
+
       y
-    
+
     = Copies:
-    
+
       Original name New name(s)
       x             y
 
   ⊙ 2. #5gbhpddvrn
 
     + Adds / updates:
-    
+
       x
 
   □ 3. #q0sddm3uvt (start of history)
@@ -161,7 +161,7 @@ scratch/branch1> undo
     Original  Changes
     1. x      2. y (added)
 
-scratch/branch1> ls
+scratch/branch1> ls .
 
   1. lib/ (476 terms, 76 types)
   2. x    (Nat)
@@ -174,7 +174,7 @@ scratch/branch1> history
   ⊙ 1. #5gbhpddvrn
 
     + Adds / updates:
-    
+
       x
 
   □ 2. #q0sddm3uvt (start of history)

--- a/unison-src/transcripts/project-outputs/docs/sharing-code.output.md
+++ b/unison-src/transcripts/project-outputs/docs/sharing-code.output.md
@@ -8,13 +8,13 @@ data Causal m e
   | Merge { currentHash :: Hash, head :: e, tails :: Map Hash (m (Causal e)) }
 
 -- just one level of name, like Foo or Bar, but not Foo.Bar
-newtype NameSegment = NameSegment { toText :: Text } 
+newtype NameSegment = NameSegment { toText :: Text }
 newtype Path = Path { toList :: [NameSegment] }
 
 data Namespace m = Namespace
 	{ terms :: Relation NameSegment Referent
   , types :: Relation NameSegment Reference
-  , children :: Relation NameSegment (Codetree m) 
+  , children :: Relation NameSegment (Codetree m)
   }
 
 data Codetree m = Codetree (Causal m Namespace)
@@ -28,10 +28,10 @@ data RemoteRef = GithubRef { username :: Text, repo :: Text, treeish :: Text }
 
 newtype EditMap = EditMap { toMap :: Map GUID (Causal Edits) }
 data Edits = Edits
-	{ terms :: Relation Reference TermEdit 
+	{ terms :: Relation Reference TermEdit
 	, types :: Relation Reference TypeEdit
 	}
-	
+
 -- maps local paths to remote paths
 data RemoteStatus = Map Path RemoteSpec
 ```
@@ -46,29 +46,29 @@ A couple of important points:
 Questions:
 
   - Do we want to distinguish between `/` paths and `.` separators in names?
-    
+
       - Should a type `A` be at the same level as
-    
+
       - On one hand, you probably don't need to separate a type `A` from its constructor `A.A`.  You wouldn't be able to export the constructor without the type which resides a level up in the namespace.
-    
+
       - Maybe the type `A` should organically be organized as `A/A`, and its constructor also as `A/A`.  This is reminiscent of having a separate module per type in Haskell, except that a reorganization could be done more easily:
-        
-        ``` 
+
+        ```
         /mycode> mv ClassA* ClassA/
         /mycode> mv ClassB* ClassB/
         /mycode> cd ClassA
-        /mycode/ClassA> ls
+        /mycode/ClassA> ls .
         ```
-    
-      - ``` 
-        
+
+      - ```
+
         ```
 
 ## NameTree representation
 
 examples:
 
-``` 
+```
 <empty>
 
 /A   (type)
@@ -86,9 +86,9 @@ data NameTree a = Causal (Relation Name (NameTree a))
 or
 
 ``` haskell
-data NameTree a 
-	= Leaf a 
-	| Branch (Relation Name (NameTree a)) 
+data NameTree a
+	= Leaf a
+	| Branch (Relation Name (NameTree a))
 	| SharePoint (Causal (NameTree a))
 ```
 
@@ -100,11 +100,11 @@ Branches: https://api.github.com/repos/unisonweb/unison/branches
 
 A directory:
 
-``` 
-url: 
+```
+url:
 https://api.github.com/repos/unisonweb/unison/contents/unison-src/demo?ref=master
 
-html_url: 
+html_url:
 https://github.com/unisonweb/unison/tree/master/unison-src/demo
 
 git_url
@@ -113,7 +113,7 @@ https://api.github.com/repos/unisonweb/unison/git/trees/f8d91c6cc2ee1bc8f2bfc759
 
 A file:
 
-``` 
+```
 url:
 https://api.github.com/repos/unisonweb/unison/contents/unison-src/Base.u?ref=master
 

--- a/unison-src/transcripts/project-outputs/docs/sharing-code.output.md
+++ b/unison-src/transcripts/project-outputs/docs/sharing-code.output.md
@@ -46,29 +46,29 @@ A couple of important points:
 Questions:
 
   - Do we want to distinguish between `/` paths and `.` separators in names?
-
+    
       - Should a type `A` be at the same level as
-
+    
       - On one hand, you probably don't need to separate a type `A` from its constructor `A.A`.  You wouldn't be able to export the constructor without the type which resides a level up in the namespace.
-
+    
       - Maybe the type `A` should organically be organized as `A/A`, and its constructor also as `A/A`.  This is reminiscent of having a separate module per type in Haskell, except that a reorganization could be done more easily:
-
-        ```
+        
+        ``` 
         /mycode> mv ClassA* ClassA/
         /mycode> mv ClassB* ClassB/
         /mycode> cd ClassA
         /mycode/ClassA> ls .
         ```
-
-      - ```
-
+    
+      - ``` 
+        
         ```
 
 ## NameTree representation
 
 examples:
 
-```
+``` 
 <empty>
 
 /A   (type)
@@ -100,7 +100,7 @@ Branches: https://api.github.com/repos/unisonweb/unison/branches
 
 A directory:
 
-```
+``` 
 url:
 https://api.github.com/repos/unisonweb/unison/contents/unison-src/demo?ref=master
 
@@ -113,7 +113,7 @@ https://api.github.com/repos/unisonweb/unison/git/trees/f8d91c6cc2ee1bc8f2bfc759
 
 A file:
 
-```
+``` 
 url:
 https://api.github.com/repos/unisonweb/unison/contents/unison-src/Base.u?ref=master
 


### PR DESCRIPTION
## Overview

Makes the argument for `ls` required, which means it will trigger `fzf` if not provided.

## Interesting/controversial decisions

There's some bike-shedding about whether this is the right place to tweak for allowing a quick exploration of your codebase; but feedback has been good so far, so we'll try this out and go from there.


## Test coverage

Transcripts

## Loose ends

Currently there's a wart where if there are _no_ namespaces available it will print:

```
  ⚠️

  Sorry, I was expecting an argument for the namespace, and I couldn't find any to suggest to you. 😅

```

Rather than:

```
  nothing to show
```

Which isn't the best experience, but since creating a new project automatically installs `base`; basically nobody should be encountering this.