### PR TITLE
FZF Edit namespace

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1467,4 +1467,3 @@ resolveBranchId2 = \case
     pp <- ProjectUtils.resolveBranchRelativePath brp
     Cli.Env {codebase} <- ask
     fromMaybe Branch.empty <$> liftIO (Codebase.getBranchAtProjectPath codebase pp)
-

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/EditNamespace.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/EditNamespace.hs
@@ -21,7 +21,6 @@ import Unison.Codebase.Editor.DisplayObject (DisplayObject)
 import Unison.Codebase.Editor.DisplayObject qualified as DisplayObject
 import Unison.Codebase.Editor.HandleInput.ShowDefinition (showDefinitions)
 import Unison.Codebase.Editor.Input (OutputLocation (..))
-import Unison.Codebase.Path (Path)
 import Unison.Codebase.Path qualified as Path
 import Unison.DataDeclaration (Decl)
 import Unison.HashQualified qualified as HQ
@@ -44,7 +43,7 @@ import Unison.Type (Type)
 import Unison.Util.Monoid (foldMapM)
 import Unison.Util.Set qualified as Set
 
-handleEditNamespace :: OutputLocation -> [Path] -> Cli ()
+handleEditNamespace :: OutputLocation -> [Path.Path'] -> Cli ()
 handleEditNamespace outputLoc paths0 = do
   Cli.Env {codebase} <- ask
   currentBranch <- Cli.getCurrentBranch0
@@ -56,7 +55,7 @@ handleEditNamespace outputLoc paths0 = do
   let paths =
         if null paths0
           then [mempty]
-          else paths0
+          else Path.fromPath' <$> paths0
 
   -- Make a names object that contains the union of all names in the supplied paths (each prefixed with the associated
   -- path of course). Special case: if the path is the empty path, then ignore `lib`.

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -234,7 +234,7 @@ data Input
   | CloneI ProjectAndBranchNames (Maybe ProjectAndBranchNames)
   | ReleaseDraftI Semver
   | UpgradeI !NameSegment !NameSegment
-  | EditNamespaceI [Path.Path]
+  | EditNamespaceI [Path.Path']
   | -- New merge algorithm: merge the given project branch into the current one.
     MergeI (ProjectAndBranch (Maybe ProjectName) ProjectBranchName)
   | LibInstallI

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -2342,13 +2342,13 @@ editNamespace =
     { patternName = "edit.namespace",
       aliases = [],
       visibility = I.Visible,
-      params = Parameters [] . Optional [] $ Just ("namespace to load definitions from", namespaceArg),
+      params = Parameters [] $ OnePlus ("namespace to load definitions from", namespaceArg),
       help =
         P.lines
-          [ "`edit.namespace` will load all terms and types contained within the current namespace into your scratch file. This includes definitions in namespaces, but excludes libraries.",
+          [ "`edit.namespace .` will load all terms and types contained within the current namespace into your scratch file. This includes definitions in namespaces, but excludes libraries.",
             "`edit.namespace ns1 ns2 ...` loads the terms and types contained within the provided namespaces."
           ],
-      parse = fmap Input.EditNamespaceI . traverse handlePathArg
+      parse = fmap Input.EditNamespaceI . traverse handlePath'Arg
     }
 
 newBranchNameArg :: ParameterType

--- a/unison-src/transcripts/idempotent/edit-namespace.md
+++ b/unison-src/transcripts/idempotent/edit-namespace.md
@@ -72,7 +72,7 @@ project/main> add
 `edit.namespace` edits the whole namespace (minus the top-level `lib`).
 
 ``` ucm
-project/main> edit.namespace
+project/main> edit.namespace .
 
   ☝️
 

--- a/unison-src/transcripts/idempotent/fix-5357.md
+++ b/unison-src/transcripts/idempotent/fix-5357.md
@@ -56,7 +56,7 @@ scratch/main> add
     lib.base.ignore : a -> ()
       (also named util.ignore)
 
-scratch/main> edit.namespace
+scratch/main> edit.namespace .
 
   ☝️
 

--- a/unison-src/transcripts/idempotent/help.md
+++ b/unison-src/transcripts/idempotent/help.md
@@ -285,7 +285,7 @@ scratch/main> help
   Like `edit`, but also includes all transitive dependents in the current project.
 
   edit.namespace
-  `edit.namespace` will load all terms and types contained within the current namespace into your scratch file. This includes definitions in namespaces, but excludes libraries.
+  `edit.namespace .` will load all terms and types contained within the current namespace into your scratch file. This includes definitions in namespaces, but excludes libraries.
   `edit.namespace ns1 ns2 ...` loads the terms and types contained within the provided namespaces.
 
   edit.new

--- a/unison-src/transcripts/pretty-print-libraries.md
+++ b/unison-src/transcripts/pretty-print-libraries.md
@@ -4,10 +4,10 @@ We clone releases and not dev branches to avoid external changes, and also to re
 
 ```ucm
 scratch/main> clone @unison/base/releases/3.19.0
-@unison/base/releases/3.19.0> edit.namespace
+@unison/base/releases/3.19.0> edit.namespace .
 ```
 
 ```ucm
 scratch/main> clone @unison/http/releases/3.3.2
-@unison/http/releases/3.3.2> edit.namespace
+@unison/http/releases/3.3.2> edit.namespace .
 ```

--- a/unison-src/transcripts/pretty-print-libraries.output.md
+++ b/unison-src/transcripts/pretty-print-libraries.output.md
@@ -7,7 +7,7 @@ scratch/main> clone @unison/base/releases/3.19.0
 
   Cloned @unison/base/releases/3.19.0.
 
-@unison/base/releases/3.19.0> edit.namespace
+@unison/base/releases/3.19.0> edit.namespace .
 
   ☝️
 
@@ -83169,7 +83169,7 @@ scratch/main> clone @unison/http/releases/3.3.2
 
   Cloned @unison/http/releases/3.3.2.
 
-@unison/http/releases/3.3.2> edit.namespace
+@unison/http/releases/3.3.2> edit.namespace .
 
   ☝️
 


### PR DESCRIPTION
## Overview

Changes `edit.namespace` to trigger fzf when provided no args; as requested by @SystemFw :)

## Implementation notes

Simply makes the namespace argument 'required'. To regain old behaviour one can simply pass `edit.namespace .`

## Test coverage

Transcripts
