### PR TITLE
segment racket dependencies by arch

### DIFF
--- a/.github/workflows/bundle-ucm.yaml
+++ b/.github/workflows/bundle-ucm.yaml
@@ -183,7 +183,7 @@ jobs:
             ~/Library/Racket/${{env.racket_version}}
           # This isn't right because unison.zip is going to include different dates each time.
           # Maybe we can unpack it and hash the contents.
-          key: ${{ runner.os }}-racket-${{env.racket_version}}-${{hashFiles('scheme-libs/racket/unison.zip')}}
+          key: ${{matrix.os}}-racket-${{env.racket_version}}-${{hashFiles('scheme-libs/racket/unison.zip')}}
       - name: set up environment
         run: |
           case "$RUNNER_ARCH" in


### PR DESCRIPTION
Report from @ceedubs:
> @dolio @pchiusano we went to try out the ability optimizations in Unison Cloud but realized that they haven't had a successful pre-release. Seemingly because of a racket incompatibility for macos? https://github.com/unisonweb/unison/actions/workflows/pre-release.yaml

I noticed this cache sharing data between platforms, which seems like an accident.