### PR TITLE
Better fallbacks when fzf isn't installed

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,6 +11,7 @@
     * [`UNISON_READONLY`](#unison_readonly)
     * [`UNISON_ENTITY_VALIDATION`](#unison_entity_validation)
     * [`UNISON_SYNC_VERSION`](#unison_sync_version)
+    * [`UNISON_FZF_PATH`](#unison_fzf_path)
     * [Local Codebase Server](#local-codebase-server)
 * [Codebase Configuration](#codebase-configuration)
 
@@ -125,6 +126,24 @@ Allows regressing to sync version 1 when interacting with Share.
 ```sh
 $ UNISON_SYNC_VERSION="1" ucm
 ```
+
+### `UNISON_FZF_PATH`
+
+Allows configuring which binary to use when triggering fuzzy searches using `fzf`.
+If unset, we default to searching for a binary named `fzf` in your `$PATH`.
+
+E.g.
+
+```sh
+$ UNISON_FZF_PATH="/opt/homebrew/bin/fzf" ucm
+```
+
+If you wish to disable `fzf` entirely, you can set `UNISON_FZF_PATH` to "NONE".
+
+```sh
+$ UNISON_FZF_PATH="NONE" ucm
+```
+
 
 ### `UNISON_PULL_WORKERS`
 

--- a/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
+++ b/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
@@ -48,6 +48,7 @@ import Unison.Codebase.Transcript.Parser qualified as Transcript
 import Unison.Codebase.Verbosity (Verbosity, isSilent)
 import Unison.Codebase.Verbosity qualified as Verbosity
 import Unison.CommandLine
+import Unison.CommandLine.FuzzySelect qualified as Fuzzy
 import Unison.CommandLine.InputPattern (aliases, patternName)
 import Unison.CommandLine.InputPatterns qualified as IP
 import Unison.CommandLine.OutputMessages (notifyNumbered, notifyUser)
@@ -65,6 +66,7 @@ import Unison.Syntax.Parser qualified as Parser
 import Unison.Util.Pretty qualified as Pretty
 import Unison.Util.TQueue qualified as Q
 import UnliftIO qualified
+import UnliftIO.Environment (setEnv)
 import UnliftIO.STM
 import Prelude hiding (readFile, writeFile)
 
@@ -95,7 +97,12 @@ withRunner ::
   FilePath ->
   (Runner -> m r) ->
   m r
-withRunner isTest verbosity ucmVersion nrtp action =
+withRunner isTest verbosity ucmVersion nrtp action = do
+  -- If we're in a transcript test, configure the environment to use a non-existent fzf binary
+  -- so that errors are consistent.
+  -- This also prevents automated transcript tests from mistakenly opening fzf and waiting for user input.
+  when isTest $ do
+    liftIO $ setEnv Fuzzy.fzfPathEnvVar "NONE"
   withRuntimes nrtp \runtime sbRuntime nRuntime ->
     action \transcriptName transcriptSrc (codebaseDir, codebase) ->
       Server.startServer

--- a/unison-cli/src/Unison/CommandLine.hs
+++ b/unison-cli/src/Unison/CommandLine.hs
@@ -20,7 +20,6 @@ import Data.List (isPrefixOf, isSuffixOf)
 import Data.List.NonEmpty (NonEmpty ((:|)), nonEmpty)
 import Data.Map qualified as Map
 import Data.Text qualified as Text
-import Data.Text.IO qualified as Text
 import Data.Vector qualified as Vector
 import System.FilePath (takeFileName)
 import Text.Numeral (defaultInflection)
@@ -41,6 +40,7 @@ import Unison.CommandLine.InputPattern qualified as InputPattern
 import Unison.CommandLine.InputPatterns qualified as IP
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
+import Unison.PrettyTerminal qualified as PrettyTerm
 import Unison.Symbol (Symbol)
 import Unison.Util.Pretty qualified as P
 import Prelude hiding (readFile, writeFile)
@@ -166,18 +166,31 @@ parseInput codebase projPath currentProjectRoot numberedArgs patterns segments =
 
   case segments of
     [] -> throwE NoCommand
-    command : args -> case Map.lookup command patterns of
-      Just pat@(InputPattern {params, parse}) -> do
-        (expandedArgs, remainingParams) <-
-          except . first (ExpansionFailure command pat) $ expandArguments numberedArgs params args
-        lift (fzfResolve codebase projPath getCurrentBranch0 remainingParams)
-          >>= either
-            (throwE . FZFResolveFailure pat)
-            ( traverse \resolvedArgs ->
-                let allArgs = expandedArgs <> resolvedArgs
-                 in except . bimap (SubParseFailure command pat) (Left command : allArgs,) $ parse allArgs
-            )
-      Nothing -> throwE $ UnknownCommand command
+    command : args -> do
+      pat@(InputPattern {params, parse}) <- case Map.lookup command patterns of
+        Just pat -> pure pat
+        Nothing -> throwE $ UnknownCommand command
+      let mkResult finalArgs = except . bimap (SubParseFailure command pat) (Left command : finalArgs,) $ parse finalArgs
+      (expandedArgs, remainingParams) <-
+        except . first (ExpansionFailure command pat) $ expandArguments numberedArgs params args
+
+      if Fuzzy.isFZFInstalled
+        then do
+          argResult <- lift (fzfResolve codebase projPath getCurrentBranch0 remainingParams)
+          case argResult of
+            -- If there are no completion options, indicate that with an error.
+            Left err@(NoFZFOptions {}) -> throwError $ FZFResolveFailure pat err
+            -- If there's no resolver, just parse the args we have.
+            Left (NoFZFResolverForArgumentType {}) ->
+              Just <$> mkResult expandedArgs
+            Right mayResolvedArgs -> case mayResolvedArgs of
+              -- If fzf was cancelled, indicate that
+              Nothing -> pure $ Nothing
+              -- otherwise, parse the args we resolved
+              Just resolvedArgs -> Just <$> mkResult (expandedArgs <> resolvedArgs)
+        else do
+          -- fzf isn't installed, just try to parse the args we have and probably get an error from the parser
+          Just <$> mkResult expandedArgs
 
 -- Expand a numeric argument like `1` or a range like `3-9`
 expandNumber :: NumberedArgs -> String -> Maybe NumberedArgs
@@ -230,7 +243,7 @@ fzfResolve codebase ppCtx getCurrentBranch InputPattern.Parameters {requiredPara
       currentBranch <- Branch.withoutTransitiveLibs <$> liftIO getCurrentBranch
       options <- liftIO $ getOptions codebase ppCtx currentBranch
       when (null options) . throwError $ NoFZFOptions argDesc
-      liftIO $ Text.putStrLn (FZFResolvers.fuzzySelectHeader argDesc)
+      liftIO $ PrettyTerm.putPrettyLn' (FZFResolvers.fuzzySelectHeader argDesc)
       results <- liftIO (Fuzzy.fuzzySelect Fuzzy.defaultOptions {Fuzzy.allowMultiSelect = allowMulti} id options)
       -- If the user triggered the fuzzy finder, but selected nothing, abort the command rather than continuing
       -- execution with no arguments.

--- a/unison-cli/src/Unison/CommandLine/FZFResolvers.hs
+++ b/unison-cli/src/Unison/CommandLine/FZFResolvers.hs
@@ -49,6 +49,7 @@ import Unison.Syntax.HashQualified qualified as HQ (toText)
 import Unison.Syntax.NameSegment qualified as NameSegment
 import Unison.Util.Monoid (foldMapM)
 import Unison.Util.Monoid qualified as Monoid
+import Unison.Util.Pretty qualified as P
 import Unison.Util.Relation qualified as Relation
 
 type OptionFetcher = Codebase IO Symbol Ann -> PP.ProjectPath -> Branch0 IO -> IO [Text]
@@ -195,11 +196,14 @@ projectBranchOptionsWithinCurrentProject codebase projCtx _searchBranch0 = do
 --
 -- >>> fuzzySelectHeader "alias name"
 -- "Select an alias name:"
-fuzzySelectHeader :: Text -> Text
-fuzzySelectHeader argDesc = "Select " <> aOrAn argDesc <> " " <> argDesc <> ":"
+fuzzySelectHeader :: Text -> P.Pretty P.ColorText
+fuzzySelectHeader argDesc =
+  P.lines
+    [ "Select " <> aOrAn <> " " <> P.cyan (P.text argDesc) <> P.text " or press <esc> to cancel" <> ":"
+    ]
   where
-    aOrAn :: Text -> Text
-    aOrAn txt =
-      Text.uncons txt & \case
+    aOrAn :: P.Pretty P.ColorText
+    aOrAn =
+      Text.uncons argDesc & \case
         Just (c, _) | c `elem` ("aeiou" :: [Char]) -> "an"
         _ -> "a"

--- a/unison-cli/src/Unison/CommandLine/FuzzySelect.hs
+++ b/unison-cli/src/Unison/CommandLine/FuzzySelect.hs
@@ -5,6 +5,7 @@
 module Unison.CommandLine.FuzzySelect
   ( fuzzySelect,
     isFZFInstalled,
+    fzfPathEnvVar,
     Options (..),
     defaultOptions,
   )
@@ -15,6 +16,7 @@ import Data.Set qualified as Set
 import Data.Text qualified as Text
 import Data.Text.IO qualified as Text
 import GHC.IO.Handle (hDuplicateTo)
+import System.Environment (lookupEnv)
 import System.IO (BufferMode (NoBuffering), hPutStrLn, stderr)
 import System.IO.Unsafe (unsafePerformIO)
 import Unison.Prelude
@@ -24,9 +26,22 @@ import UnliftIO.Exception (bracket)
 import UnliftIO.IO (hGetBuffering, hSetBuffering, stdin)
 import UnliftIO.Process qualified as Proc
 
+-- | An environment variable that can be set to override the default fzf executable.
+fzfPathEnvVar :: String
+fzfPathEnvVar = "UNISON_FZF_PATH"
+
+fzfExecutable :: IO (Maybe FilePath)
+fzfExecutable = do
+  envPath <- lookupEnv fzfPathEnvVar
+  case (envPath) of
+    Just path
+      | Text.toUpper (Text.pack path) == "NONE" -> pure Nothing
+      | otherwise -> pure (Just path)
+    Nothing -> findExecutable "fzf"
+
 isFZFInstalled :: Bool
 isFZFInstalled =
-  unsafePerformIO (isJust <$> findExecutable "fzf")
+  unsafePerformIO (isJust <$> fzfExecutable)
 {-# NOINLINE isFZFInstalled #-}
 
 -- | Fuzzy Selection options
@@ -70,7 +85,7 @@ fuzzySelect opts intoSearchText choices =
     . runExceptT
     $ do
       fzfPath <-
-        liftIO (findExecutable "fzf") >>= \case
+        liftIO fzfExecutable >>= \case
           Nothing -> throwError "I couldn't find the `fzf` executable on your path, consider installing `fzf` to enable fuzzy searching."
           Just fzfPath -> pure fzfPath
       let fzfArgs :: [String] =

--- a/unison-cli/src/Unison/CommandLine/FuzzySelect.hs
+++ b/unison-cli/src/Unison/CommandLine/FuzzySelect.hs
@@ -4,6 +4,7 @@
 --     Shells out to fzf for the actual selection.
 module Unison.CommandLine.FuzzySelect
   ( fuzzySelect,
+    isFZFInstalled,
     Options (..),
     defaultOptions,
   )
@@ -15,12 +16,18 @@ import Data.Text qualified as Text
 import Data.Text.IO qualified as Text
 import GHC.IO.Handle (hDuplicateTo)
 import System.IO (BufferMode (NoBuffering), hPutStrLn, stderr)
+import System.IO.Unsafe (unsafePerformIO)
 import Unison.Prelude
 import UnliftIO qualified
 import UnliftIO.Directory (findExecutable)
 import UnliftIO.Exception (bracket)
 import UnliftIO.IO (hGetBuffering, hSetBuffering, stdin)
 import UnliftIO.Process qualified as Proc
+
+isFZFInstalled :: Bool
+isFZFInstalled =
+  unsafePerformIO (isJust <$> findExecutable "fzf")
+{-# NOINLINE isFZFInstalled #-}
 
 -- | Fuzzy Selection options
 data Options = Options

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -2346,7 +2346,8 @@ editNamespace =
       params = Parameters [] $ OnePlus ("namespace to load definitions from", namespaceArg),
       help =
         P.lines
-          [ "`edit.namespace .` will load all terms and types contained within the current namespace into your scratch file. This includes definitions in namespaces, but excludes libraries.",
+          [ "`edit.namespace` loads all terms and types contained within the namespace you select into your scratch file. This includes definitions in namespaces, but excludes libraries (requires fzf).",
+            "`edit.namespace .` loads all terms and types contained within the current namespace into your scratch file. This includes definitions in namespaces, but excludes libraries.",
             "`edit.namespace ns1 ns2 ...` loads the terms and types contained within the provided namespaces."
           ],
       parse = fmap Input.EditNamespaceI . traverse handlePath'Arg

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -1220,9 +1220,10 @@ findShallow =
     I.Visible
     (Parameters [("namespace", namespaceArg)] (Optional [] Nothing))
     ( P.wrapColumn2
-        [ ("`list`", "lists definitions and namespaces within the selected namespace."),
-          ("`list foo`", "lists the 'foo' namespace."),
-          ("`list .foo`", "lists the '.foo' namespace.")
+        [ ("`list`", "lists definitions and namespaces in a namespace you select (requires fzf)."),
+          ("`list .`", "lists definitions and namespaces in the project root."),
+          ("`list .foo`", "lists definitions and namespaces in the '.foo' namespace."),
+          ("`list foo`", "lists definitions and namespaces in the 'foo' namespace.")
         ]
     )
     ( fmap Input.FindShallowI . \case

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -871,7 +871,6 @@ notifyUser dir = \case
       --       defs in the codebase.  In some cases it's fine for bindings to
       --       shadow codebase names, but you don't want it to capture them in
       --       the decompiled output.
-
         let prettyBindings =
               P.bracket . P.lines $
                 P.wrap "The watch expression(s) reference these definitions:"
@@ -1480,7 +1479,7 @@ notifyUser dir = \case
   DebugDisplayFuzzyOptions argDesc fuzzyOptions ->
     pure $
       P.lines
-        [P.text (FZFResolvers.fuzzySelectHeader argDesc), P.indentN 2 $ P.bulleted (P.string <$> fuzzyOptions)]
+        [(FZFResolvers.fuzzySelectHeader argDesc), P.indentN 2 $ P.bulleted (P.string <$> fuzzyOptions)]
   DebugFuzzyOptionsIncorrectArgs _ -> pure $ P.string "Too many arguments were provided."
   DebugFuzzyOptionsNoCommand command -> pure $ "The command “" <> P.string command <> "” doesn’t exist."
   DebugFuzzyOptionsNoResolver -> pure "No resolver found for fuzzy options in this slot."

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -871,6 +871,7 @@ notifyUser dir = \case
       --       defs in the codebase.  In some cases it's fine for bindings to
       --       shadow codebase names, but you don't want it to capture them in
       --       the decompiled output.
+
         let prettyBindings =
               P.bracket . P.lines $
                 P.wrap "The watch expression(s) reference these definitions:"

--- a/unison-src/transcripts/idempotent/fuzzy-options.md
+++ b/unison-src/transcripts/idempotent/fuzzy-options.md
@@ -28,7 +28,11 @@ scratch/empty> view
 
   ⚠️
 
-  Sorry, I was expecting an argument for the definition to view, and I couldn't find any to suggest to you. 😅
+  Sorry, I wasn’t sure how to process your request:
+
+    I expected at least one argument, but received none.
+
+  You can run `help view` for more information on using `view`.
 ```
 
 ``` unison :hide

--- a/unison-src/transcripts/idempotent/fuzzy-options.md
+++ b/unison-src/transcripts/idempotent/fuzzy-options.md
@@ -3,11 +3,21 @@
 If an argument is required but doesn't have a fuzzy resolver, the command should just print the help.
 
 ``` ucm :error
--- The second argument of move.term is a 'new-name' and doesn't have a fuzzy resolver
+-- The second argument of move.term is a 'new-name' and doesn't have a fuzzy resolver,
+
+-- So it should print the arg parsing error.
 
 scratch/main> move.term
 
-  `move.term foo bar` renames `foo` to `bar`.
+  ⚠️
+
+  Sorry, I wasn’t sure how to process your request:
+
+    `rename.term` takes two arguments, like `rename.term oldname
+    newname`.
+
+  You can run `help move.term` for more information on using
+  `move.term`.
 ```
 
 If a fuzzy resolver doesn't have any options available it should print a message instead of
@@ -39,7 +49,7 @@ scratch/main> add
 
 scratch/main> debug.fuzzy-options view _
 
-  Select a definition to view:
+  Select a definition to view or press <esc> to cancel:
     * optionOne
     * nested.optionTwo
 ```
@@ -54,6 +64,6 @@ scratch/main> add
 
 scratch/main> debug.fuzzy-options find-in _
 
-  Select a namespace:
+  Select a namespace or press <esc> to cancel:
     * nested
 ```

--- a/unison-src/transcripts/idempotent/help.md
+++ b/unison-src/transcripts/idempotent/help.md
@@ -285,7 +285,8 @@ scratch/main> help
   Like `edit`, but also includes all transitive dependents in the current project.
 
   edit.namespace
-  `edit.namespace .` will load all terms and types contained within the current namespace into your scratch file. This includes definitions in namespaces, but excludes libraries.
+  `edit.namespace` loads all terms and types contained within the namespace you select into your scratch file. This includes definitions in namespaces, but excludes libraries (requires fzf).
+  `edit.namespace .` loads all terms and types contained within the current namespace into your scratch file. This includes definitions in namespaces, but excludes libraries.
   `edit.namespace ns1 ns2 ...` loads the terms and types contained within the provided namespaces.
 
   edit.new
@@ -517,10 +518,14 @@ scratch/main> help
                                               `@unison/base`
 
   list (or ls, dir)
-  `list`       lists definitions and namespaces within the
-               selected namespace.
-  `list foo`   lists the 'foo' namespace.
-  `list .foo`  lists the '.foo' namespace.
+  `list`       lists definitions and namespaces in a namespace
+               you select (requires fzf).
+  `list .`     lists definitions and namespaces in the project
+               root.
+  `list .foo`  lists definitions and namespaces in the '.foo'
+               namespace.
+  `list foo`   lists definitions and namespaces in the 'foo'
+               namespace.
 
   load
   `load`                 parses, typechecks, and evaluates the

--- a/unison-src/transcripts/idempotent/upgrade-happy-path.md
+++ b/unison-src/transcripts/idempotent/upgrade-happy-path.md
@@ -41,14 +41,14 @@ proj/main> debug.tab-complete upgrade ol
 
 proj/main> debug.fuzzy-options upgrade _
 
-  Select a dependency to upgrade:
+  Select a dependency to upgrade or press <esc> to cancel:
     * builtin
     * new
     * old
 
 proj/main> debug.fuzzy-options upgrade old _
 
-  Select a dependency to upgrade to:
+  Select a dependency to upgrade to or press <esc> to cancel:
     * builtin
     * new
     * old

--- a/unison-src/transcripts/project-outputs/docs/configuration.output.md
+++ b/unison-src/transcripts/project-outputs/docs/configuration.output.md
@@ -10,6 +10,7 @@
       - [`UNISON_READONLY`](#unison_readonly)
       - [`UNISON_ENTITY_VALIDATION`](#unison_entity_validation)
       - [`UNISON_SYNC_VERSION`](#unison_sync_version)
+      - [`UNISON_FZF_PATH`](#unison_fzf_path)
       - [Local Codebase Server](#local-codebase-server)
   - [Codebase Configuration](#codebase-configuration)
 
@@ -123,6 +124,23 @@ Allows regressing to sync version 1 when interacting with Share.
 
 ``` sh
 $ UNISON_SYNC_VERSION="1" ucm
+```
+
+### `UNISON_FZF_PATH`
+
+Allows configuring which binary to use when triggering fuzzy searches using `fzf`.
+If unset, we default to searching for a binary named `fzf` in your `$PATH`.
+
+E.g.
+
+``` sh
+$ UNISON_FZF_PATH="/opt/homebrew/bin/fzf" ucm
+```
+
+If you wish to disable `fzf` entirely, you can set `UNISON_FZF_PATH` to "NONE".
+
+``` sh
+$ UNISON_FZF_PATH="NONE" ucm
 ```
 
 ### `UNISON_PULL_WORKERS`


### PR DESCRIPTION
## Overview

1. Previously, if fzf was invoked but not installed it would print an error indicating fzf wasn't installed. Now it will detect that fzf is unavailable in advance and fall-back to passing arguments as-provided to the command, triggering the command's error message instead, or if the command is configured to handle missing args like `ls`, it will proceed with default behaviour.
2. Add a note about how to exit `fzf` using `<esc>` to the fzf prompt
3. Add pretty colouring to the fzf prompt
4. Update the help messaging for `ls` and `edit.namespace`


<img width="417" alt="image" src="https://github.com/user-attachments/assets/6f51e24b-7ece-4c98-bf53-c73e282ef970" />



## Test coverage

Local testing and transcripts

