### PR TITLE
perf: fetch unique type guids from merge parents more efficiently

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -139,7 +139,7 @@ module U.Codebase.Sqlite.Queries
     insertMergeBranchLocal,
     insertMergeBranchRemote,
     insertMergeBranchLooseCode,
-    loadNamespaceUniqueTypeGuids,
+    loadNamespaceUniqueTypeGuid,
     existsAnyNamespaceUniqueTypeGuidForNamespace,
     insertNamespaceUniqueTypeGuid,
 
@@ -4478,31 +4478,23 @@ insertMergeBranchLooseCode
         )
       |]
 
-loadNamespaceUniqueTypeGuids :: BranchHashId -> Transaction (Map Name Text)
-loadNamespaceUniqueTypeGuids namespaceHashId = do
-  rows <-
-    queryListRow
-      [sql|
-        SELECT type_name, type_guid
-        FROM namespace_unique_type_guid
-        WHERE namespace_hash_id = :namespaceHashId
-      |]
-
-  let f :: ByteString -> Name
-      f bytes =
-        case Aeson.decodeStrict @[Text] bytes of
-          Just (segment : segments) ->
-            Name.fromSegments (NameSegment segment NonEmpty.:| map NameSegment segments)
-          _ ->
-            error $
-              reportBug
-                "E955495"
-                ( "busted name in namespace_unique_type_guid (namespace hash id = "
-                    ++ show namespaceHashId
-                    ++ ")"
-                )
-
-  pure (Map.fromList (over (Lens.mapped . Lens._1) f rows))
+loadNamespaceUniqueTypeGuid :: BranchHashId -> Name -> Transaction (Maybe Text)
+loadNamespaceUniqueTypeGuid namespaceHashId name = do
+  queryMaybeCol
+    [sql|
+      SELECT type_guid
+      FROM namespace_unique_type_guid
+      WHERE namespace_hash_id = :namespaceHashId
+        AND type_name = :segments
+    |]
+  where
+    segments :: LazyByteString
+    segments =
+      name
+        & Name.segments
+        & List.NonEmpty.toList
+        & map NameSegment.toUnescapedText
+        & Aeson.encode @[Text]
 
 existsAnyNamespaceUniqueTypeGuidForNamespace :: BranchHashId -> Transaction Bool
 existsAnyNamespaceUniqueTypeGuidForNamespace namespaceHashId =

--- a/unison-cli/src/Unison/Cli/UniqueTypeGuidLookup.hs
+++ b/unison-cli/src/Unison/Cli/UniqueTypeGuidLookup.hs
@@ -5,8 +5,8 @@ module Unison.Cli.UniqueTypeGuidLookup
   )
 where
 
-import Data.Map.Strict qualified as Map
 import U.Codebase.Branch qualified as Codebase.Branch
+import U.Codebase.Sqlite.DbId qualified as Sqlite
 import U.Codebase.Sqlite.Queries qualified as Queries
 import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Path qualified as Path
@@ -33,33 +33,50 @@ loadUniqueTypeGuid pp name0 = do
     Nothing ->
       Queries.loadMergeBranchParents pp.project.projectId pp.branch.branchId >>= \case
         Nothing -> pure Nothing
-        Just (bobMaybeBranchId, bobCausalHashId, aliceMaybeBranchId, aliceCausalHashId) -> do
-          aliceNamespaceHashId <- Queries.expectCausalValueHashId aliceCausalHashId
-          bobNamespaceHashId <- Queries.expectCausalValueHashId bobCausalHashId
-
-          aliceUniqueTypeGuids <- Queries.loadNamespaceUniqueTypeGuids aliceNamespaceHashId
-          bobUniqueTypeGuids <- Queries.loadNamespaceUniqueTypeGuids bobNamespaceHashId
-
-          case (Map.lookup name0 aliceUniqueTypeGuids, Map.lookup name0 bobUniqueTypeGuids) of
-            -- A few simple cases – reuse a GUID if it is sensible to do so
-            (Just aliceGuid, Just bobGuid) | aliceGuid == bobGuid -> pure (Just aliceGuid)
-            (Just aliceGuid, Nothing) -> pure (Just aliceGuid)
-            (Nothing, Just bobGuid) -> pure (Just bobGuid)
-            (Nothing, Nothing) -> pure Nothing
-            -- If alice and bob have different guids, and there is a parent-child relationship between them (i.e. alice
-            -- was directly branched off of bob or vice versa), then prefer the parent's GUID. Otherwise, just make up
-            -- a new GUID because it's not clear whether alice's or bob's should be preferred.
-            (Just aliceGuid, Just bobGuid) -> do
-              case (aliceMaybeBranchId, bobMaybeBranchId) of
-                (Just aliceBranchId, Just bobBranchId) -> do
-                  aliceParentBranchId <- Queries.loadProjectBranchParent pp.project.projectId aliceBranchId
-                  if aliceParentBranchId == Just bobBranchId
-                    then pure (Just bobGuid)
-                    else do
-                      bobParentBranchId <- Queries.loadProjectBranchParent pp.project.projectId bobBranchId
-                      pure
-                        if bobParentBranchId == Just aliceBranchId
-                          then Just aliceGuid
-                          else Nothing
-                _ -> pure Nothing
+        Just (bobMaybeBranchId, bobCausalHashId, aliceMaybeBranchId, aliceCausalHashId) ->
+          loadUniqueTypeGuidFromMergeParents
+            pp
+            name0
+            bobMaybeBranchId
+            bobCausalHashId
+            aliceMaybeBranchId
+            aliceCausalHashId
     Just guid -> pure (Just guid)
+
+loadUniqueTypeGuidFromMergeParents ::
+  ProjectPath ->
+  Name ->
+  Maybe Sqlite.ProjectBranchId ->
+  Sqlite.CausalHashId ->
+  Maybe Sqlite.ProjectBranchId ->
+  Sqlite.CausalHashId ->
+  Sqlite.Transaction (Maybe Text)
+loadUniqueTypeGuidFromMergeParents pp name0 bobMaybeBranchId bobCausalHashId aliceMaybeBranchId aliceCausalHashId = do
+  aliceNamespaceHashId <- Queries.expectCausalValueHashId aliceCausalHashId
+  bobNamespaceHashId <- Queries.expectCausalValueHashId bobCausalHashId
+
+  maybeAliceGuid <- Queries.loadNamespaceUniqueTypeGuid aliceNamespaceHashId name0
+  maybeBobGuid <- Queries.loadNamespaceUniqueTypeGuid bobNamespaceHashId name0
+
+  case (maybeAliceGuid, maybeBobGuid) of
+    -- A few simple cases – reuse a GUID if it is sensible to do so
+    (Just aliceGuid, Just bobGuid) | aliceGuid == bobGuid -> pure (Just aliceGuid)
+    (Just aliceGuid, Nothing) -> pure (Just aliceGuid)
+    (Nothing, Just bobGuid) -> pure (Just bobGuid)
+    (Nothing, Nothing) -> pure Nothing
+    -- If alice and bob have different guids, and there is a parent-child relationship between them (i.e. alice was
+    -- directly branched off of bob or vice versa), then prefer the parent's GUID. Otherwise, just make up a new
+    -- GUID because it's not clear whether alice's or bob's should be preferred.
+    (Just aliceGuid, Just bobGuid) -> do
+      case (aliceMaybeBranchId, bobMaybeBranchId) of
+        (Just aliceBranchId, Just bobBranchId) -> do
+          aliceParentBranchId <- Queries.loadProjectBranchParent pp.project.projectId aliceBranchId
+          if aliceParentBranchId == Just bobBranchId
+            then pure (Just bobGuid)
+            else do
+              bobParentBranchId <- Queries.loadProjectBranchParent pp.project.projectId bobBranchId
+              pure
+                if bobParentBranchId == Just aliceBranchId
+                  then Just aliceGuid
+                  else Nothing
+        _ -> pure Nothing


### PR DESCRIPTION
## Overview

This PR fixes a small oversight in the parser logic that resolves a unique type name to guid while on a merge branch (using merge parents' guids): since we only query for names one at a time, we don't need to read the entire mapping out once per lookup.