### PR TITLE
identify renames in merges

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Merge2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Merge2.hs
@@ -299,11 +299,12 @@ doMerge info = do
             Merge.Alice reason -> done (Output.IncoherentDeclDuringMerge mergeTarget reason)
             Merge.Bob reason -> done (Output.IncoherentDeclDuringMerge mergeSource reason)
 
-        liftIO (debugFunctions.debugDiffs blob1.diffsFromLCA)
-
-        liftIO (debugFunctions.debugCombinedDiff blob1.diff)
-
-        liftIO (debugFunctions.debugHumanDiffs blob1.humanDiffsFromLCA)
+        liftIO do
+          debugFunctions.debugDiffs blob1.diffsFromLCA
+          debugFunctions.debugRenames blob1.renames
+          debugFunctions.debugSimpleRenames blob1.simpleRenames
+          debugFunctions.debugCombinedDiff blob1.diff
+          debugFunctions.debugHumanDiffs blob1.humanDiffsFromLCA
 
         blob2 <-
           Merge.makeMergeblob2 blob1 & onLeft \err ->
@@ -757,7 +758,9 @@ data DebugFunctions = DebugFunctions
     debugPartitionedDiff ::
       Merge.TwoWay (DefnsF (Map Name) TermReferenceId TypeReferenceId) ->
       DefnsF Merge.Unconflicts Referent TypeReference ->
-      IO ()
+      IO (),
+    debugRenames :: Merge.TwoWay (DefnsF [] Merge.Rename Merge.Rename) -> IO (),
+    debugSimpleRenames :: Merge.TwoWay (Defns Merge.SimpleRenames Merge.SimpleRenames) -> IO ()
   }
 
 realDebugFunctions :: DebugFunctions
@@ -769,12 +772,14 @@ realDebugFunctions =
       debugCombinedDiff = realDebugCombinedDiff,
       debugHumanDiffs = realDebugHumanDiffs,
       debugInitialDependents = realDebugInitialDependents,
-      debugPartitionedDiff = realDebugPartitionedDiff
+      debugPartitionedDiff = realDebugPartitionedDiff,
+      debugRenames = realDebugRenames,
+      debugSimpleRenames = realDebugSimpleRenames
     }
 
 fakeDebugFunctions :: DebugFunctions
 fakeDebugFunctions =
-  DebugFunctions mempty mempty mempty mempty mempty mempty mempty
+  DebugFunctions mempty mempty mempty mempty mempty mempty mempty mempty mempty
 
 realDebugCausals :: Merge.TwoOrThreeWay (V2.CausalBranch Transaction) -> IO ()
 realDebugCausals causals = do
@@ -1127,6 +1132,55 @@ realDebugPartitionedDiff conflicts unconflicts = do
                 <> name
                 <> " "
                 <> renderRef ref
+
+realDebugRenames :: Merge.TwoWay (DefnsF [] Merge.Rename Merge.Rename) -> IO ()
+realDebugRenames renames = do
+  Text.putStrLn (Text.bold "\n=== Alice renames ===")
+  renderRenames renames.alice
+  Text.putStrLn (Text.bold "\n=== Bob renames ===")
+  renderRenames renames.bob
+  where
+    renderRenames :: DefnsF [] Merge.Rename Merge.Rename -> IO ()
+    renderRenames renames = do
+      for_ renames.terms \rename ->
+        Text.putStrLn (Text.italic "term" <> " " <> renderRename rename)
+      for_ renames.types \rename ->
+        Text.putStrLn (Text.italic "type" <> " " <> renderRename rename)
+
+    renderRename :: Merge.Rename -> Text
+    renderRename rename =
+      Text.unwords $
+        catMaybes
+          [ case Set.toList rename.unchanged of
+              [] -> Nothing
+              unchanged -> Just (Text.unwords (map Name.toText unchanged)),
+            case Set.toList rename.deletes of
+              [] -> Nothing
+              deletes -> Just (Text.unwords (map (\name -> Text.red ("-" <> Name.toText name)) deletes)),
+            case Set.toList rename.adds of
+              [] -> Nothing
+              adds -> Just (Text.unwords (map (\name -> Text.green ("+" <> Name.toText name)) adds))
+          ]
+
+realDebugSimpleRenames :: Merge.TwoWay (Defns Merge.SimpleRenames Merge.SimpleRenames) -> IO ()
+realDebugSimpleRenames renames = do
+  Text.putStrLn (Text.bold "\n=== Alice simple renames ===")
+  renderRenames renames.alice
+  Text.putStrLn (Text.bold "\n=== Bob simple renames ===")
+  renderRenames renames.bob
+  where
+    renderRenames :: Defns Merge.SimpleRenames Merge.SimpleRenames -> IO ()
+    renderRenames renames = do
+      renames.terms.forwards
+        & Map.toList
+        & map (\(old, new) -> Text.italic "term" <> " " <> Name.toText old <> " → " <> Name.toText new)
+        & Text.unlines
+        & Text.putStr
+      renames.types.forwards
+        & Map.toList
+        & map (\(old, new) -> Text.italic "type" <> " " <> Name.toText old <> " → " <> Name.toText new)
+        & Text.unlines
+        & Text.putStr
 
 referentLabel :: Referent -> Text
 referentLabel ref

--- a/unison-merge/src/Unison/Merge.hs
+++ b/unison-merge/src/Unison/Merge.hs
@@ -28,6 +28,8 @@ module Unison.Merge
     EitherWayI (..),
     HumanDiffOp (..),
     LibdepDiffOp (..),
+    Rename (..),
+    SimpleRenames (..),
     Synhashed (..),
     ThreeWay (..),
     TwoOrThreeWay (..),
@@ -58,6 +60,7 @@ import Unison.Merge.Mergeblob3 (Mergeblob3 (..), makeMergeblob3)
 import Unison.Merge.Mergeblob4 (Mergeblob4 (..), makeMergeblob4)
 import Unison.Merge.Mergeblob5 (Mergeblob5 (..), makeMergeblob5)
 import Unison.Merge.PartialDeclNameLookup (PartialDeclNameLookup (..))
+import Unison.Merge.Rename (Rename (..), SimpleRenames (..))
 import Unison.Merge.Synhashed (Synhashed (..))
 import Unison.Merge.ThreeWay (ThreeWay (..))
 import Unison.Merge.TwoOrThreeWay (TwoOrThreeWay (..))

--- a/unison-merge/src/Unison/Merge/Diff.hs
+++ b/unison-merge/src/Unison/Merge/Diff.hs
@@ -239,7 +239,6 @@ partitionPropagated =
       | propagated -> Right (Synhashed.value <$> refs)
       | otherwise -> Left (DiffOp'Update refs)
 
-
 -- | Post-process a diff to identify relationships humans might care about, such as whether a given addition could be
 -- interpreted as an alias of an existing definition, or whether an add and deletion could be a rename.
 humanizeDiffs ::

--- a/unison-merge/src/Unison/Merge/Diff.hs
+++ b/unison-merge/src/Unison/Merge/Diff.hs
@@ -1,5 +1,6 @@
 module Unison.Merge.Diff
-  ( nameBasedNamespaceDiff,
+  ( synhashDefns,
+    diffSynhashedDefns,
     humanizeDiffs,
   )
 where
@@ -37,7 +38,7 @@ import Unison.Parser.Ann (Ann)
 import Unison.Prelude hiding (catMaybes)
 import Unison.PrettyPrintEnv (PrettyPrintEnv (..))
 import Unison.PrettyPrintEnv qualified as PPE
-import Unison.PrettyPrintEnvDecl qualified as PPED
+import Unison.PrettyPrintEnvDecl (PrettyPrintEnvDecl (..))
 import Unison.Reference (Reference' (..), TermReference, TermReferenceId, TypeReferenceId)
 import Unison.Referent (Referent)
 import Unison.Referent qualified as Referent
@@ -51,37 +52,142 @@ import Unison.Util.Defns qualified as Defns
 import Unison.Util.Relation (Relation)
 import Unison.Util.Relation qualified as Rel
 
--- | @nameBasedNamespaceDiff db declNameLookups defns@ returns Alice's and Bob's name-based namespace diffs, each in the
--- form:
---
--- > terms :: Map Name (DiffOp (Synhashed Referent))
--- > types :: Map Name (DiffOp (Synhashed TypeReference))
---
--- where each name is paired with its diff-op (added, deleted, or updated), relative to the LCA between Alice and Bob's
--- branches. If the hash of a name did not change, it will not appear in the map.
-nameBasedNamespaceDiff ::
+------------------------------------------------------------------------------------------------------------------------
+-- Syntactic hashing
+
+-- | @synhashDefns declNameLookups ppes defns hydratedDefns@ computes syntactic hashes of @defns@.
+synhashDefns ::
   (HasCallStack) =>
-  TwoWay DeclNameLookup ->
-  PartialDeclNameLookup ->
-  ThreeWay PPED.PrettyPrintEnvDecl ->
+  (TwoWay DeclNameLookup, PartialDeclNameLookup) ->
+  ThreeWay PrettyPrintEnvDecl ->
   ThreeWay (Defns (BiMultimap Referent Name) (BiMultimap TypeReference Name)) ->
   Defns (Map TermReferenceId (Term Symbol Ann)) (Map TypeReferenceId (Decl Symbol Ann)) ->
+  ThreeWay (DefnsF2 (Map Name) Synhashed Referent TypeReference)
+synhashDefns (declNameLookups, lcaDeclNameLookup) ppes defns hydratedDefns =
+  ThreeWay
+    { alice = synhashDefns0 ppe hydratedDefns declNameLookups.alice defns.alice,
+      bob = synhashDefns0 ppe hydratedDefns declNameLookups.bob defns.bob,
+      lca = synhashLcaDefns ppe lcaDeclNameLookup defns.lca hydratedDefns
+    }
+  where
+    ppe :: PPE.PrettyPrintEnv
+    ppe =
+      ppes.alice.unsuffixifiedPPE
+        `PPE.addFallback` ppes.bob.unsuffixifiedPPE
+        `PPE.addFallback` ppes.lca.unsuffixifiedPPE
+
+synhashLcaDefns ::
+  (HasCallStack) =>
+  PrettyPrintEnv ->
+  PartialDeclNameLookup ->
+  Defns (BiMultimap Referent Name) (BiMultimap TypeReference Name) ->
+  Defns (Map TermReferenceId (Term Symbol Ann)) (Map TypeReferenceId (Decl Symbol Ann)) ->
+  DefnsF2 (Map Name) Synhashed Referent TypeReference
+synhashLcaDefns ppe declNameLookup defns hydratedDefns =
+  synhashDefnsWith hashReferent hashType defns
+  where
+    -- For the LCA only, if we don't have a name for every constructor, or we don't have a name for a decl, that's okay,
+    -- just use a dummy syntactic hash (e.g. where we return `Hash mempty` below in two places).
+    --
+    -- This is safe and correct; Alice/Bob can't have such a decl (it violates a merge precondition), so there's no risk
+    -- that we accidentally get an equal hash and classify a real update as unchanged.
+
+    hashReferent :: Name -> Referent -> Hash
+    hashReferent name = \case
+      Referent.Con (ConstructorReference ref _) _ ->
+        case Map.lookup name declNameLookup.constructorToDecl of
+          Nothing -> Hash mempty -- see note above
+          Just declName -> hashType declName ref
+      Referent.Ref ref -> synhashTermReference ppe hydratedDefns.terms ref
+
+    hashType :: Name -> TypeReference -> Hash
+    hashType name = \case
+      ReferenceBuiltin builtin -> Synhash.synhashBuiltinDecl builtin
+      ReferenceDerived ref ->
+        case sequence (declNameLookup.declToConstructors Map.! name) of
+          Nothing -> Hash mempty -- see note above
+          Just names -> synhashDerivedDecl ppe hydratedDefns.types names name ref
+
+synhashDefns0 ::
+  (HasCallStack) =>
+  PrettyPrintEnv ->
+  Defns (Map TermReferenceId (Term Symbol Ann)) (Map TypeReferenceId (Decl Symbol Ann)) ->
+  DeclNameLookup ->
+  Defns (BiMultimap Referent Name) (BiMultimap TypeReference Name) ->
+  DefnsF2 (Map Name) Synhashed Referent TypeReference
+synhashDefns0 ppe hydratedDefns declNameLookup =
+  synhashDefnsWith hashReferent hashType
+  where
+    hashReferent :: Name -> Referent -> Hash
+    hashReferent name = \case
+      -- We say that a referent constructor *in the namespace* (distinct from a referent that is in a term body) has a
+      -- synhash that is simply equal to the synhash of its type declaration. This is because the type declaration and
+      -- constructors are changed in lock-step: it is not possible to change one, but not the other.
+      --
+      -- For example, if Alice updates `type Foo = Bar Nat` to `type Foo = Bar Nat Nat`, we want different synhashes on
+      -- both the type (Foo) and the constructor (Foo.Bar).
+      Referent.Con (ConstructorReference ref _) _ -> hashType (DeclNameLookup.expectDeclName declNameLookup name) ref
+      Referent.Ref ref -> synhashTermReference ppe hydratedDefns.terms ref
+
+    hashType :: Name -> TypeReference -> Hash
+    hashType name = \case
+      ReferenceBuiltin builtin -> Synhash.synhashBuiltinDecl builtin
+      ReferenceDerived ref ->
+        synhashDerivedDecl ppe hydratedDefns.types (DeclNameLookup.expectConstructorNames declNameLookup name) name ref
+
+synhashDerivedDecl ::
+  (HasCallStack) =>
+  PrettyPrintEnv ->
+  Map TypeReferenceId (Decl Symbol Ann) ->
+  [Name] ->
+  Name ->
+  TypeReferenceId ->
+  Hash
+synhashDerivedDecl ppe declsById names name ref =
+  declsById
+    & expectDecl ref
+    & DataDeclaration.setConstructorNames (map Name.toVar names)
+    & Synhash.synhashDerivedDecl ppe name
+
+synhashTermReference :: (HasCallStack) => PrettyPrintEnv -> Map TermReferenceId (Term Symbol Ann) -> TermReference -> Hash
+synhashTermReference ppe termsById = \case
+  ReferenceBuiltin builtin -> Synhash.synhashBuiltinTerm builtin
+  ReferenceDerived ref -> Synhash.synhashDerivedTerm ppe (expectTerm ref termsById)
+
+synhashDefnsWith ::
+  (HasCallStack) =>
+  (Name -> term -> Hash) ->
+  (Name -> typ -> Hash) ->
+  Defns (BiMultimap term Name) (BiMultimap typ Name) ->
+  DefnsF2 (Map Name) Synhashed term typ
+synhashDefnsWith hashTerm hashType = do
+  bimap
+    (Map.mapWithKey hashTerm1 . BiMultimap.range)
+    (Map.mapWithKey hashType1 . BiMultimap.range)
+  where
+    hashTerm1 name term =
+      Synhashed (hashTerm name term) term
+
+    hashType1 name typ =
+      Synhashed (hashType name typ) typ
+
+------------------------------------------------------------------------------------------------------------------------
+-- Diffing syntactic hashes
+
+-- | @diffSynhashedDefns defns@, given the output of @synhashDefns@, computes the two two-way diffs (each consisting of
+-- the "core" diffs, i.e. adds/delete/updates, alongside the propagated updates, i.e. updates that have the same synhash
+-- but different Unison hashes).
+diffSynhashedDefns ::
+  ThreeWay (DefnsF2 (Map Name) Synhashed Referent TypeReference) ->
   ( -- Core diffs, i.e. adds, deletes, and updates which have different synhashes.
     TwoWay (DefnsF3 (Map Name) DiffOp Synhashed Referent TypeReference),
     -- Propagated updates, i.e. updates which have the same synhash but different Unison hashes.
     TwoWay (DefnsF2 (Map Name) Updated Referent TypeReference)
   )
-nameBasedNamespaceDiff declNameLookups lcaDeclNameLookup ppeds defns hydratedDefns =
-  Zip.unzip $
-    diffHashedNamespaceDefns (synhashLcaDefns synhashPPE lcaDeclNameLookup defns.lca hydratedDefns)
-      <$> (synhashDefns synhashPPE hydratedDefns <$> declNameLookups <*> ThreeWay.forgetLca defns)
-  where
-    synhashPPE :: PPE.PrettyPrintEnv
-    synhashPPE =
-      let ThreeWay {lca = lcaPPE, alice = alicePPE, bob = bobPPE} = PPED.unsuffixifiedPPE <$> ppeds
-       in alicePPE `PPE.addFallback` bobPPE `PPE.addFallback` lcaPPE
+diffSynhashedDefns defns =
+  Zip.unzip (diffSynhashedDefns0 defns.lca <$> ThreeWay.forgetLca defns)
 
-diffHashedNamespaceDefns ::
+diffSynhashedDefns0 ::
   (Eq term, Eq typ) =>
   DefnsF2 (Map Name) Synhashed term typ ->
   DefnsF2 (Map Name) Synhashed term typ ->
@@ -90,7 +196,7 @@ diffHashedNamespaceDefns ::
     -- Propagated updates, i.e. updates which have the same synhash but different Unison hashes.
     DefnsF2 (Map Name) Updated term typ
   )
-diffHashedNamespaceDefns old new =
+diffSynhashedDefns0 old new =
   unzipDefns (zipDefnsWith f f old new)
   where
     f ::
@@ -99,39 +205,40 @@ diffHashedNamespaceDefns old new =
       Map Name (Synhashed ref) ->
       (Map Name (DiffOp (Synhashed ref)), Map Name (Updated ref))
     f old new =
-      partitionPropagated (computeDiff old new)
+      partitionPropagated (diffSynhashedDefns1 old new)
 
-    -- Compute the diff by comparing old-and-new values, resulting in either an add, delete, update (propagated or not),
-    -- or dropping the thing entirely (because old and new have the same hash).
-    computeDiff ::
-      (Eq ref) =>
-      Map Name (Synhashed ref) ->
-      Map Name (Synhashed ref) ->
-      Map Name (DiffOp2 (Synhashed ref))
-    computeDiff =
-      Map.merge
-        (Map.mapMissing (\_ -> DiffOp2'Delete))
-        (Map.mapMissing (\_ -> DiffOp2'Add))
-        ( let f old new = do
-                let equalSynhashes = old == new
-                -- Drop things that haven't changed
-                when equalSynhashes do
-                  guard (Synhashed.value old /= Synhashed.value new)
-                Just (DiffOp2'Update Updated {old, new} equalSynhashes)
-           in Map.zipWithMaybeMatched \_ -> f
-        )
+-- Compute the diff by comparing old-and-new values, resulting in either an add, delete, update (propagated or not),
+-- or dropping the thing entirely (because old and new have the same hash).
+diffSynhashedDefns1 ::
+  forall ref.
+  (Eq ref) =>
+  Map Name (Synhashed ref) ->
+  Map Name (Synhashed ref) ->
+  Map Name (DiffOp2 (Synhashed ref))
+diffSynhashedDefns1 =
+  Map.merge
+    (Map.mapMissing \_ -> DiffOp2'Delete)
+    (Map.mapMissing \_ -> DiffOp2'Add)
+    (Map.zipWithMaybeMatched \_ -> f)
+  where
+    f :: Synhashed ref -> Synhashed ref -> Maybe (DiffOp2 (Synhashed ref))
+    f old new = do
+      let equalSynhashes = old == new
+      -- Drop things that haven't changed
+      when equalSynhashes do
+        guard (Synhashed.value old /= Synhashed.value new)
+      Just (DiffOp2'Update Updated {old, new} equalSynhashes)
 
-    -- Partition add/delete/update/propagated-update into add/delete/update + propagated-update
-    partitionPropagated ::
-      Map Name (DiffOp2 (Synhashed ref)) ->
-      (Map Name (DiffOp (Synhashed ref)), Map Name (Updated ref))
-    partitionPropagated =
-      Map.mapEither \case
-        DiffOp2'Add ref -> Left (DiffOp'Add ref)
-        DiffOp2'Delete ref -> Left (DiffOp'Delete ref)
-        DiffOp2'Update refs propagated
-          | propagated -> Right (Synhashed.value <$> refs)
-          | otherwise -> Left (DiffOp'Update refs)
+-- Partition add/delete/update/propagated-update into add/delete/update + propagated-update
+partitionPropagated :: Map Name (DiffOp2 (Synhashed ref)) -> (Map Name (DiffOp (Synhashed ref)), Map Name (Updated ref))
+partitionPropagated =
+  Map.mapEither \case
+    DiffOp2'Add ref -> Left (DiffOp'Add ref)
+    DiffOp2'Delete ref -> Left (DiffOp'Delete ref)
+    DiffOp2'Update refs propagated
+      | propagated -> Right (Synhashed.value <$> refs)
+      | otherwise -> Left (DiffOp'Update refs)
+
 
 -- | Post-process a diff to identify relationships humans might care about, such as whether a given addition could be
 -- interpreted as an alias of an existing definition, or whether an add and deletion could be a rename.
@@ -201,104 +308,6 @@ humanizeDiffs names3 =
               Nothing -> HumanDiffOp'Delete ref
               Just newNames -> HumanDiffOp'RenamedTo ref (NESet.fromList newNames)
           DiffOp'Update Updated {old, new} -> HumanDiffOp'Update Updated {old, new}
-
-------------------------------------------------------------------------------------------------------------------------
--- Syntactic hashing
-
-synhashLcaDefns ::
-  (HasCallStack) =>
-  PrettyPrintEnv ->
-  PartialDeclNameLookup ->
-  Defns (BiMultimap Referent Name) (BiMultimap TypeReference Name) ->
-  Defns (Map TermReferenceId (Term Symbol Ann)) (Map TypeReferenceId (Decl Symbol Ann)) ->
-  DefnsF2 (Map Name) Synhashed Referent TypeReference
-synhashLcaDefns ppe declNameLookup defns hydratedDefns =
-  synhashDefnsWith hashReferent hashType defns
-  where
-    -- For the LCA only, if we don't have a name for every constructor, or we don't have a name for a decl, that's okay,
-    -- just use a dummy syntactic hash (e.g. where we return `Hash mempty` below in two places).
-    --
-    -- This is safe and correct; Alice/Bob can't have such a decl (it violates a merge precondition), so there's no risk
-    -- that we accidentally get an equal hash and classify a real update as unchanged.
-
-    hashReferent :: Name -> Referent -> Hash
-    hashReferent name = \case
-      Referent.Con (ConstructorReference ref _) _ ->
-        case Map.lookup name declNameLookup.constructorToDecl of
-          Nothing -> Hash mempty -- see note above
-          Just declName -> hashType declName ref
-      Referent.Ref ref -> synhashTermReference ppe hydratedDefns.terms ref
-
-    hashType :: Name -> TypeReference -> Hash
-    hashType name = \case
-      ReferenceBuiltin builtin -> Synhash.synhashBuiltinDecl builtin
-      ReferenceDerived ref ->
-        case sequence (declNameLookup.declToConstructors Map.! name) of
-          Nothing -> Hash mempty -- see note above
-          Just names -> synhashDerivedDecl ppe hydratedDefns.types names name ref
-
-synhashDefns ::
-  (HasCallStack) =>
-  PrettyPrintEnv ->
-  Defns (Map TermReferenceId (Term Symbol Ann)) (Map TypeReferenceId (Decl Symbol Ann)) ->
-  DeclNameLookup ->
-  Defns (BiMultimap Referent Name) (BiMultimap TypeReference Name) ->
-  DefnsF2 (Map Name) Synhashed Referent TypeReference
-synhashDefns ppe hydratedDefns declNameLookup =
-  synhashDefnsWith hashReferent hashType
-  where
-    hashReferent :: Name -> Referent -> Hash
-    hashReferent name = \case
-      -- We say that a referent constructor *in the namespace* (distinct from a referent that is in a term body) has a
-      -- synhash that is simply equal to the synhash of its type declaration. This is because the type declaration and
-      -- constructors are changed in lock-step: it is not possible to change one, but not the other.
-      --
-      -- For example, if Alice updates `type Foo = Bar Nat` to `type Foo = Bar Nat Nat`, we want different synhashes on
-      -- both the type (Foo) and the constructor (Foo.Bar).
-      Referent.Con (ConstructorReference ref _) _ -> hashType (DeclNameLookup.expectDeclName declNameLookup name) ref
-      Referent.Ref ref -> synhashTermReference ppe hydratedDefns.terms ref
-
-    hashType :: Name -> TypeReference -> Hash
-    hashType name = \case
-      ReferenceBuiltin builtin -> Synhash.synhashBuiltinDecl builtin
-      ReferenceDerived ref ->
-        synhashDerivedDecl ppe hydratedDefns.types (DeclNameLookup.expectConstructorNames declNameLookup name) name ref
-
-synhashDerivedDecl ::
-  (HasCallStack) =>
-  PrettyPrintEnv ->
-  Map TypeReferenceId (Decl Symbol Ann) ->
-  [Name] ->
-  Name ->
-  TypeReferenceId ->
-  Hash
-synhashDerivedDecl ppe declsById names name ref =
-  declsById
-    & expectDecl ref
-    & DataDeclaration.setConstructorNames (map Name.toVar names)
-    & Synhash.synhashDerivedDecl ppe name
-
-synhashTermReference :: (HasCallStack) => PrettyPrintEnv -> Map TermReferenceId (Term Symbol Ann) -> TermReference -> Hash
-synhashTermReference ppe termsById = \case
-  ReferenceBuiltin builtin -> Synhash.synhashBuiltinTerm builtin
-  ReferenceDerived ref -> Synhash.synhashDerivedTerm ppe (expectTerm ref termsById)
-
-synhashDefnsWith ::
-  (HasCallStack) =>
-  (Name -> term -> Hash) ->
-  (Name -> typ -> Hash) ->
-  Defns (BiMultimap term Name) (BiMultimap typ Name) ->
-  DefnsF2 (Map Name) Synhashed term typ
-synhashDefnsWith hashTerm hashType = do
-  bimap
-    (Map.mapWithKey hashTerm1 . BiMultimap.range)
-    (Map.mapWithKey hashType1 . BiMultimap.range)
-  where
-    hashTerm1 name term =
-      Synhashed (hashTerm name term) term
-
-    hashType1 name typ =
-      Synhashed (hashType name typ) typ
 
 ------------------------------------------------------------------------------------------------------------------------
 -- Looking up terms and decls that we expect to be there

--- a/unison-merge/src/Unison/Merge/Mergeblob0.hs
+++ b/unison-merge/src/Unison/Merge/Mergeblob0.hs
@@ -25,9 +25,8 @@ makeMergeblob0 ::
   ThreeWay (Map NameSegment libdep) ->
   Mergeblob0 libdep
 makeMergeblob0 nametrees libdeps =
-  let defns = flattenNametrees <$> nametrees
-   in Mergeblob0
-        { defns,
-          libdeps,
-          nametrees
-        }
+  Mergeblob0
+    { defns = flattenNametrees <$> nametrees,
+      libdeps,
+      nametrees
+    }

--- a/unison-merge/src/Unison/Merge/Mergeblob0.hs
+++ b/unison-merge/src/Unison/Merge/Mergeblob0.hs
@@ -4,28 +4,20 @@ module Unison.Merge.Mergeblob0
   )
 where
 
-import Data.Map.Merge.Strict qualified as Map
-import Data.Set qualified as Set
-import Data.Set.NonEmpty (NESet)
-import Data.Set.NonEmpty qualified as Set.NonEmpty
 import Unison.Merge.ThreeWay (ThreeWay)
-import Unison.Merge.ThreeWay qualified as ThreeWay
-import Unison.Merge.TwoWay (TwoWay)
 import Unison.Name (Name)
 import Unison.NameSegment (NameSegment)
 import Unison.Prelude
 import Unison.Reference (TypeReference)
 import Unison.Referent (Referent)
 import Unison.Util.BiMultimap (BiMultimap)
-import Unison.Util.BiMultimap qualified as BiMultimap
-import Unison.Util.Defns (Defns, DefnsF, zipDefnsWith)
+import Unison.Util.Defns (Defns, DefnsF)
 import Unison.Util.Nametree (Nametree, flattenNametrees)
 
 data Mergeblob0 libdep = Mergeblob0
   { defns :: ThreeWay (Defns (BiMultimap Referent Name) (BiMultimap TypeReference Name)),
     libdeps :: ThreeWay (Map NameSegment libdep),
-    nametrees :: ThreeWay (Nametree (DefnsF (Map NameSegment) Referent TypeReference)),
-    renames :: TwoWay (Defns (Map Referent Rename) (Map TypeReference Rename))
+    nametrees :: ThreeWay (Nametree (DefnsF (Map NameSegment) Referent TypeReference))
   }
 
 makeMergeblob0 ::
@@ -37,35 +29,5 @@ makeMergeblob0 nametrees libdeps =
    in Mergeblob0
         { defns,
           libdeps,
-          nametrees,
-          renames = makeRenames defns
+          nametrees
         }
-
--- Invariant: it is not the case the both sets are empty
-data Rename = Rename
-  { deletes :: Set Name,
-    adds :: Set Name
-  }
-
-makeRenames ::
-  ThreeWay (Defns (BiMultimap Referent Name) (BiMultimap TypeReference Name)) ->
-  TwoWay (Defns (Map Referent Rename) (Map TypeReference Rename))
-makeRenames defns =
-  zipDefnsWith f f defns.lca <$> ThreeWay.forgetLca defns
-  where
-    f :: (Ord ref) => BiMultimap ref Name -> BiMultimap ref Name -> Map ref Rename
-    f old new =
-      Map.merge
-        Map.dropMissing
-        Map.dropMissing
-        (Map.zipWithMaybeMatched g)
-        (BiMultimap.domain old)
-        (BiMultimap.domain new)
-
-    g :: ref -> NESet Name -> NESet Name -> Maybe Rename
-    g _ old new =
-      let deletes = Set.NonEmpty.difference old new
-          adds = Set.NonEmpty.difference new old
-       in if Set.null deletes && Set.null adds
-            then Nothing
-            else Just Rename {deletes, adds}

--- a/unison-merge/src/Unison/Merge/Mergeblob0.hs
+++ b/unison-merge/src/Unison/Merge/Mergeblob0.hs
@@ -4,20 +4,28 @@ module Unison.Merge.Mergeblob0
   )
 where
 
+import Data.Map.Merge.Strict qualified as Map
+import Data.Set qualified as Set
+import Data.Set.NonEmpty (NESet)
+import Data.Set.NonEmpty qualified as Set.NonEmpty
 import Unison.Merge.ThreeWay (ThreeWay)
+import Unison.Merge.ThreeWay qualified as ThreeWay
+import Unison.Merge.TwoWay (TwoWay)
 import Unison.Name (Name)
 import Unison.NameSegment (NameSegment)
 import Unison.Prelude
 import Unison.Reference (TypeReference)
 import Unison.Referent (Referent)
 import Unison.Util.BiMultimap (BiMultimap)
-import Unison.Util.Defns (Defns, DefnsF)
+import Unison.Util.BiMultimap qualified as BiMultimap
+import Unison.Util.Defns (Defns, DefnsF, zipDefnsWith)
 import Unison.Util.Nametree (Nametree, flattenNametrees)
 
 data Mergeblob0 libdep = Mergeblob0
   { defns :: ThreeWay (Defns (BiMultimap Referent Name) (BiMultimap TypeReference Name)),
     libdeps :: ThreeWay (Map NameSegment libdep),
-    nametrees :: ThreeWay (Nametree (DefnsF (Map NameSegment) Referent TypeReference))
+    nametrees :: ThreeWay (Nametree (DefnsF (Map NameSegment) Referent TypeReference)),
+    renames :: TwoWay (Defns (Map Referent Rename) (Map TypeReference Rename))
   }
 
 makeMergeblob0 ::
@@ -25,8 +33,39 @@ makeMergeblob0 ::
   ThreeWay (Map NameSegment libdep) ->
   Mergeblob0 libdep
 makeMergeblob0 nametrees libdeps =
-  Mergeblob0
-    { defns = flattenNametrees <$> nametrees,
-      libdeps,
-      nametrees
-    }
+  let defns = flattenNametrees <$> nametrees
+   in Mergeblob0
+        { defns,
+          libdeps,
+          nametrees,
+          renames = makeRenames defns
+        }
+
+-- Invariant: it is not the case the both sets are empty
+data Rename = Rename
+  { deletes :: Set Name,
+    adds :: Set Name
+  }
+
+makeRenames ::
+  ThreeWay (Defns (BiMultimap Referent Name) (BiMultimap TypeReference Name)) ->
+  TwoWay (Defns (Map Referent Rename) (Map TypeReference Rename))
+makeRenames defns =
+  zipDefnsWith f f defns.lca <$> ThreeWay.forgetLca defns
+  where
+    f :: (Ord ref) => BiMultimap ref Name -> BiMultimap ref Name -> Map ref Rename
+    f old new =
+      Map.merge
+        Map.dropMissing
+        Map.dropMissing
+        (Map.zipWithMaybeMatched g)
+        (BiMultimap.domain old)
+        (BiMultimap.domain new)
+
+    g :: ref -> NESet Name -> NESet Name -> Maybe Rename
+    g _ old new =
+      let deletes = Set.NonEmpty.difference old new
+          adds = Set.NonEmpty.difference new old
+       in if Set.null deletes && Set.null adds
+            then Nothing
+            else Just Rename {deletes, adds}

--- a/unison-merge/src/Unison/Merge/Mergeblob1.hs
+++ b/unison-merge/src/Unison/Merge/Mergeblob1.hs
@@ -16,7 +16,7 @@ import Unison.DeclNameLookup (DeclNameLookup)
 import Unison.LabeledDependency qualified as LD
 import Unison.Merge.CombineDiffs (CombinedDiffOp, combineDiffs)
 import Unison.Merge.DeclCoherencyCheck (IncoherentDeclReason, checkDeclCoherency, lenientCheckDeclCoherency)
-import Unison.Merge.Diff (humanizeDiffs, nameBasedNamespaceDiff)
+import Unison.Merge.Diff (diffSynhashedDefns, humanizeDiffs, synhashDefns)
 import Unison.Merge.DiffOp (DiffOp)
 import Unison.Merge.EitherWay (EitherWay (..))
 import Unison.Merge.HumanDiffOp (HumanDiffOp)
@@ -24,7 +24,8 @@ import Unison.Merge.Libdeps (applyLibdepsDiff, diffLibdeps, getTwoFreshLibdepNam
 import Unison.Merge.Mergeblob0 (Mergeblob0 (..))
 import Unison.Merge.PartialDeclNameLookup (PartialDeclNameLookup)
 import Unison.Merge.PartitionCombinedDiffs (partitionCombinedDiffs)
-import Unison.Merge.Synhashed (Synhashed)
+import Unison.Merge.Rename (Rename, SimpleRenames, makeRenames, makeSimpleRenames)
+import Unison.Merge.Synhashed (Synhashed (..))
 import Unison.Merge.ThreeWay (ThreeWay)
 import Unison.Merge.ThreeWay qualified as ThreeWay
 import Unison.Merge.TwoWay (TwoWay (..))
@@ -46,6 +47,7 @@ import Unison.Term qualified as Term
 import Unison.Type (Type)
 import Unison.Type qualified as Type
 import Unison.Util.BiMultimap (BiMultimap)
+import Unison.Util.BiMultimap qualified as BiMultimap
 import Unison.Util.Defns (Defns (..), DefnsF, DefnsF2, DefnsF3)
 
 data Mergeblob1 libdep = Mergeblob1
@@ -66,6 +68,8 @@ data Mergeblob1 libdep = Mergeblob1
     lcaLibdeps :: Map NameSegment libdep,
     libdeps :: Map NameSegment libdep,
     libdepsDiffs :: TwoWay (Map NameSegment (DiffOp libdep)),
+    renames :: TwoWay (DefnsF [] Rename Rename),
+    simpleRenames :: TwoWay (Defns SimpleRenames SimpleRenames),
     unconflicts :: DefnsF Unconflicts Referent TypeReference
   }
 
@@ -135,11 +139,10 @@ makeMergeblob1 blob names3 hydratedDefns = do
   let lcaDeclNameLookup =
         lenientCheckDeclCoherency blob.nametrees.lca numConstructors
 
-  -- Diff LCA->Alice and LCA->Bob
-  let (diffsFromLCA, propagatedUpdates) =
-        nameBasedNamespaceDiff
-          declNameLookups
-          lcaDeclNameLookup
+  -- Synhash all the defns
+  let synhashedDefns =
+        synhashDefns
+          (declNameLookups, lcaDeclNameLookup)
           ppeds3
           blob.defns
           Defns
@@ -153,10 +156,22 @@ makeMergeblob1 blob names3 hydratedDefns = do
                   hydratedDefns
             }
 
-  -- Combine the LCA->Alice and LCA->Bob diffs together
-  let diff = combineDiffs diffsFromLCA
+  let renames =
+        makeRenames (bimap BiMultimap.fromRange BiMultimap.fromRange <$> synhashedDefns)
 
-  let humanDiffsFromLCA = humanizeDiffs names3 diffsFromLCA propagatedUpdates
+  let simpleRenames =
+        makeSimpleRenames <$> renames
+
+  -- Diff LCA->Alice and LCA->Bob
+  let (diffsFromLCA, propagatedUpdates) =
+        diffSynhashedDefns synhashedDefns
+
+  -- Combine the LCA->Alice and LCA->Bob diffs together
+  let diff =
+        combineDiffs diffsFromLCA
+
+  let humanDiffsFromLCA =
+        humanizeDiffs names3 diffsFromLCA propagatedUpdates
 
   -- Partition the combined diff into the conflicted things and the unconflicted things
   let (conflicts, unconflicts) =
@@ -184,5 +199,7 @@ makeMergeblob1 blob names3 hydratedDefns = do
         lcaLibdeps = blob.libdeps.lca,
         libdeps,
         libdepsDiffs,
+        renames,
+        simpleRenames,
         unconflicts
       }

--- a/unison-merge/src/Unison/Merge/Rename.hs
+++ b/unison-merge/src/Unison/Merge/Rename.hs
@@ -1,0 +1,98 @@
+module Unison.Merge.Rename
+  ( Rename (..),
+    makeRenames,
+    SimpleRenames (..),
+    makeSimpleRenames,
+  )
+where
+
+import Control.Lens
+import Data.List qualified as List
+import Data.Map.Merge.Strict qualified as Map
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
+import Data.Set.NonEmpty (NESet)
+import Data.Set.NonEmpty qualified as Set.NonEmpty
+import Unison.Merge.Synhashed (Synhashed (..))
+import Unison.Merge.ThreeWay (ThreeWay)
+import Unison.Merge.ThreeWay qualified as ThreeWay
+import Unison.Merge.TwoWay (TwoWay (..))
+import Unison.Name (Name)
+import Unison.Prelude
+import Unison.Reference (TypeReference)
+import Unison.Referent (Referent)
+import Unison.ReferentPrime qualified as Referent'
+import Unison.Util.BiMultimap (BiMultimap)
+import Unison.Util.BiMultimap qualified as BiMultimap
+import Unison.Util.Defns (Defns (..), DefnsF, zipDefnsWith)
+
+-- | A "rename" is a venn partition of two non-empty sets of names: both set differences and the set intersection.
+--
+-- Invariant: the sets are all disjoint
+-- Invariant: it is not the case that adds and deletes are both empty
+data Rename = Rename
+  { adds :: Set Name,
+    deletes :: Set Name,
+    unchanged :: Set Name
+  }
+
+makeRenames ::
+  ThreeWay (Defns (BiMultimap (Synhashed Referent) Name) (BiMultimap (Synhashed TypeReference) Name)) ->
+  TwoWay (DefnsF [] Rename Rename)
+makeRenames defns =
+  zipDefnsWith (f termNamingsToRename) (f \_ -> namingsToRename) defns.lca <$> ThreeWay.forgetLca defns
+  where
+    f ::
+      (Ord ref) =>
+      (ref -> NESet Name -> NESet Name -> Maybe Rename) ->
+      BiMultimap ref Name ->
+      BiMultimap ref Name ->
+      [Rename]
+    f g old new =
+      Map.elems $
+        Map.merge
+          Map.dropMissing
+          Map.dropMissing
+          (Map.zipWithMaybeMatched g)
+          (BiMultimap.domain old)
+          (BiMultimap.domain new)
+
+termNamingsToRename :: Synhashed Referent -> NESet Name -> NESet Name -> Maybe Rename
+termNamingsToRename ref old new
+  -- Throw away constructors; we don't really capture their renamings in the same way as types an terms, as the
+  -- synhash of a constructor is just the synhash of its type.
+  | Referent'.isConstructor ref.value = Nothing
+  | otherwise = namingsToRename old new
+
+namingsToRename :: NESet Name -> NESet Name -> Maybe Rename
+namingsToRename old new =
+  if Set.null adds && Set.null deletes
+    then Nothing
+    else Just Rename {adds, deletes, unchanged}
+  where
+    adds = Set.NonEmpty.difference new old
+    deletes = Set.NonEmpty.difference old new
+    unchanged = Set.NonEmpty.intersection old new
+
+-- | A "simple" rename is one that moves one name to another, where neither the before- nor after-name have any aliases.
+data SimpleRenames = SimpleRenames
+  { forwards :: !(Map Name Name),
+    backwards :: !(Map Name Name)
+  }
+
+makeSimpleRenames :: DefnsF [] Rename Rename -> Defns SimpleRenames SimpleRenames
+makeSimpleRenames =
+  bimap makeSimpleRenames1 makeSimpleRenames1
+
+makeSimpleRenames1 :: [Rename] -> SimpleRenames
+makeSimpleRenames1 =
+  List.foldl' f (SimpleRenames Map.empty Map.empty)
+  where
+    f :: SimpleRenames -> Rename -> SimpleRenames
+    f acc rename =
+      case (Set.size rename.adds, Set.size rename.deletes, Set.size rename.unchanged) of
+        (1, 1, 0) ->
+          let old = Set.findMin rename.deletes
+              new = Set.findMin rename.adds
+           in SimpleRenames (Map.insert old new acc.forwards) (Map.insert new old acc.backwards)
+        _ -> acc

--- a/unison-merge/unison-merge.cabal
+++ b/unison-merge/unison-merge.cabal
@@ -36,6 +36,7 @@ library
       Unison.Merge.Mergeblob5
       Unison.Merge.PartialDeclNameLookup
       Unison.Merge.PartitionCombinedDiffs
+      Unison.Merge.Rename
       Unison.Merge.Synhash
       Unison.Merge.Synhashed
       Unison.Merge.ThreeWay


### PR DESCRIPTION
## Overview

This PR adds some supporting code in the merge algorithm to identify "rename" structures, which are simply the 3 sets (`Current \ LCA`, `LCA \ Current`, `Current ∩ LCA`) with the property that `Current \ LCA` or `LCA \ Current` (or both) is non-empty.

It also contains code that refines this structure to just identify the "simple renames", which is when a thing is renamed and has no other aliases (either before or after). This is where we intend to start the rename handling in merge, and we can expand to handle more cases incrementally.

Renames here are determined by comparing syntactic hashes, not Unison hashes, so update propagation doesn't interfere with rename detection (that is, you can rename something that's received a propagated update and it will just work).

This PR doesn't change the merge algorithm behavior yet, it just internally identifies the renames and prints them when `merge` is run under `UNISON_DEBUG=merge`.