### PR TITLE
add more terms/types fields to branch object

### DIFF
--- a/lib/unison-util-relation/src/Unison/Util/BiMultimap.hs
+++ b/lib/unison-util-relation/src/Unison/Util/BiMultimap.hs
@@ -61,8 +61,8 @@ import Prelude hiding (filter)
 --
 -- "Left-unique" means that for all @(x, y)@ in the relation, @y@ is related only to @x@.
 data BiMultimap a b = BiMultimap
-  { toMultimap :: !(Map a (NESet b)),
-    toMapR :: !(Map b a)
+  { toMultimap :: (Map a (NESet b)), -- intentionally lazy in case it's not used after `fromRange`
+    toMapR :: (Map b a)
   }
   deriving (Eq, Ord, Show)
 

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -248,7 +248,7 @@ getShallowProjectRootByNames (ProjectAndBranch projectName branchName) = runMayb
 
 expectProjectBranchRoot :: (MonadIO m) => Codebase m v a -> Db.ProjectId -> Db.ProjectBranchId -> m (Branch m)
 expectProjectBranchRoot codebase projectId branchId = do
-  causalHash <- runTransaction codebase $ do
+  causalHash <- runTransaction codebase do
     causalHashId <- Q.expectProjectBranchHead projectId branchId
     Q.expectCausalHash causalHashId
   expectBranchForHash codebase causalHash

--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -79,13 +79,14 @@ module Unison.Codebase.Branch
     -- ** Term/type queries
     deepTerms,
     deepTypes,
-    deepDefns,
     deepPaths,
     deepReferents,
     deepTermReferences,
     deepTermReferenceIds,
     deepTypeReferences,
     deepTypeReferenceIds,
+    asUnconflicted,
+    UnconflictedBranchView (..),
     consBranchSnapshot,
   )
 where
@@ -99,16 +100,17 @@ import U.Codebase.HashTags (CausalHash)
 import Unison.Codebase.Branch.Raw (Raw)
 import Unison.Codebase.Branch.Type
   ( Branch (..),
-    Branch0,
+    Branch0 (asUnconflicted),
     NamespaceHash,
     Star,
+    UnconflictedBranchView (..),
     UnwrappedBranch,
     branch0,
     children,
-    deepDefns,
     deepPaths,
     deepTerms,
     deepTypes,
+    deleteLibdeps,
     edits,
     head,
     headHash,
@@ -180,11 +182,6 @@ withoutTransitiveLibs b0 =
 deleteLibdep :: NameSegment -> Branch0 m -> Branch0 m
 deleteLibdep dep =
   over (children . ix NameSegment.libSegment . head_ . children) (Map.delete dep)
-
--- | @deleteLibdeps branch@ deletes all libdeps from @branch@.
-deleteLibdeps :: Branch0 m -> Branch0 m
-deleteLibdeps =
-  over children (Map.delete NameSegment.libSegment)
 
 deepReferents :: Branch0 m -> Set Referent
 deepReferents = R.dom . deepTerms

--- a/parser-typechecker/src/Unison/Codebase/Branch/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch/Type.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Unison.Codebase.Branch.Type
   ( NamespaceHash,
@@ -8,7 +7,8 @@ module Unison.Codebase.Branch.Type
     headHash,
     namespaceHash,
     Branch (..),
-    Branch0,
+    Branch0 (asUnconflicted),
+    UnconflictedBranchView (..),
     branch0,
     Unison.Codebase.Branch.Type.terms,
     Unison.Codebase.Branch.Type.types,
@@ -19,8 +19,8 @@ module Unison.Codebase.Branch.Type
     isEmpty0,
     deepTerms,
     deepTypes,
-    deepDefns,
     deepPaths,
+    deleteLibdeps,
     Star,
     UnwrappedBranch,
   )
@@ -29,10 +29,13 @@ where
 import Control.Lens hiding (children, cons, transform, uncons)
 import Control.Monad.State (State)
 import Control.Monad.State qualified as State
+import Data.Bitraversable (bitraverse)
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map qualified as Map
 import Data.Sequence qualified as Seq
 import Data.Set qualified as Set
+import Data.Set.NonEmpty (NESet)
+import Data.Set.NonEmpty qualified as Set.NonEmpty
 import U.Codebase.HashTags (CausalHash, PatchHash (..))
 import Unison.Codebase.Causal.Type (Causal)
 import Unison.Codebase.Causal.Type qualified as Causal
@@ -46,10 +49,15 @@ import Unison.Name qualified as Name
 import Unison.NameSegment (NameSegment)
 import Unison.NameSegment qualified as NameSegment
 import Unison.Prelude hiding (empty)
-import Unison.Reference (Reference, TypeReference)
+import Unison.Reference (TypeReference)
 import Unison.Referent (Referent)
+import Unison.Util.BiMultimap (BiMultimap)
+import Unison.Util.BiMultimap qualified as BiMultimap
+import Unison.Util.Conflicted (Conflicted (..))
+import Unison.Util.Defn (Defn (..), DefnF)
 import Unison.Util.Defns (Defns (..), DefnsF)
 import Unison.Util.Monoid qualified as Monoid
+import Unison.Util.Nametree (Nametree, unflattenNametrees)
 import Unison.Util.Relation (Relation)
 import Unison.Util.Relation qualified as R
 import Unison.Util.Relation qualified as Relation
@@ -90,7 +98,7 @@ namespaceHash (Branch c) = Causal.valueHash c
 -- Use either the lensy accessors or the field getters.
 data Branch0 m = Branch0
   { _terms :: Star Referent NameSegment,
-    _types :: Star Reference NameSegment,
+    _types :: Star TypeReference NameSegment,
     -- | Note the 'Branch' here, not 'Branch0'.
     -- Every level in the tree has a history.
     _children :: Map NameSegment (Branch m),
@@ -100,8 +108,15 @@ data Branch0 m = Branch0
     _isEmpty0 :: Bool,
     -- names for this branch and its children
     _deepTerms :: Relation Referent Name,
-    _deepTypes :: Relation Reference Name,
-    _deepPaths :: Set Path
+    _deepTypes :: Relation TypeReference Name,
+    _deepPaths :: Set Path,
+    asUnconflicted ::
+      Either
+        ( Defn
+            (Conflicted Name Referent)
+            (Conflicted Name TypeReference)
+        )
+        UnconflictedBranchView
   }
 
 instance Eq (Branch0 m) where
@@ -110,6 +125,21 @@ instance Eq (Branch0 m) where
       && _types a == _types b
       && _children a == _children b
       && (fmap fst . _edits) a == (fmap fst . _edits) b
+
+-- | A view of a branch's definition (everything outside of `lib`) that is unconflicted: each name refers to one thing.
+-- The data contained within is all just different expressions of the same contents, for various use cases. The
+-- intention is to use laziness to avoid recomputing data structures whenever possible.
+data UnconflictedBranchView = UnconflictedBranchView
+  { defns :: Defns (BiMultimap Referent Name) (BiMultimap TypeReference Name),
+    nametree :: Nametree (DefnsF (Map NameSegment) Referent TypeReference)
+  }
+
+makeUnconflictedBranchView :: DefnsF (Map Name) Referent TypeReference -> UnconflictedBranchView
+makeUnconflictedBranchView defns0 =
+  UnconflictedBranchView {defns, nametree}
+  where
+    defns = bimap BiMultimap.fromRange BiMultimap.fromRange defns0
+    nametree = unflattenNametrees defns0
 
 history :: Iso' (Branch m) (UnwrappedBranch m)
 history = iso _history Branch
@@ -130,6 +160,7 @@ terms =
     \branch terms ->
       branch {_terms = terms}
         & deriveDeepTerms
+        & deriveAsUnconflicted
         & deriveIsEmpty
 
 types :: Lens' (Branch0 m) (Star TypeReference NameSegment)
@@ -139,6 +170,7 @@ types =
     \branch types ->
       branch {_types = types}
         & deriveDeepTypes
+        & deriveAsUnconflicted
         & deriveIsEmpty
 
 isEmpty0 :: Branch0 m -> Bool
@@ -149,13 +181,6 @@ deepTerms = _deepTerms
 
 deepTypes :: Branch0 m -> Relation TypeReference Name
 deepTypes = _deepTypes
-
-deepDefns :: Branch0 m -> DefnsF (Relation Name) Referent TypeReference
-deepDefns branch =
-  Defns
-    { terms = Relation.swap (deepTerms branch),
-      types = Relation.swap (deepTypes branch)
-    }
 
 deepPaths :: Branch0 m -> Set Path
 deepPaths = _deepPaths
@@ -187,10 +212,12 @@ branch0 terms types children edits =
       -- These are all overwritten immediately
       _deepTerms = R.empty,
       _deepTypes = R.empty,
-      _deepPaths = Set.empty
+      _deepPaths = Set.empty,
+      asUnconflicted = undefined
     }
     & deriveDeepTerms
     & deriveDeepTypes
+    & deriveAsUnconflicted
     & deriveDeepPaths
     & deriveIsEmpty
 
@@ -248,6 +275,43 @@ deriveDeepTypes branch =
           children <- deepChildrenHelper e
           go (work <> children) (types <> acc)
 
+-- | Derive the 'asUnconflicted' field of a branch.
+deriveAsUnconflicted :: Branch0 m -> Branch0 m
+deriveAsUnconflicted branch =
+  branch {asUnconflicted = makeUnconflictedBranchView <$> narrowDefns defns}
+  where
+    branchWithoutLibdeps = deleteLibdeps branch
+    defns =
+      Defns
+        { terms = Relation.swap (deepTerms branchWithoutLibdeps),
+          types = Relation.swap (deepTypes branchWithoutLibdeps)
+        }
+
+-- | "Narrow" a namespace that may contain conflicted names, resulting in either a failure (if we find a conflicted
+-- name), or the narrowed nametree without conflicted names.
+narrowDefns ::
+  forall term typ.
+  (Ord term, Ord typ) =>
+  DefnsF (Relation Name) term typ ->
+  Either
+    (DefnF (Conflicted Name) term typ)
+    (DefnsF (Map Name) term typ)
+narrowDefns =
+  bitraverse
+    (go (\name -> TermDefn . Conflicted name))
+    (go (\name -> TypeDefn . Conflicted name))
+  where
+    go :: forall ref x. (Ord ref) => (Name -> NESet ref -> x) -> Relation Name ref -> Either x (Map Name ref)
+    go conflicted =
+      Map.traverseWithKey unconflicted . Relation.domain
+      where
+        unconflicted :: Name -> Set ref -> Either x ref
+        unconflicted name refs0
+          | Set.NonEmpty.size refs == 1 = Right (Set.NonEmpty.findMin refs)
+          | otherwise = Left (conflicted name refs)
+          where
+            refs = Set.NonEmpty.unsafeFromSet refs0
+
 -- | Derive the 'deepPaths' field of a branch.
 deriveDeepPaths :: forall m. Branch0 m -> Branch0 m
 deriveDeepPaths branch =
@@ -294,3 +358,8 @@ deepChildrenHelper (reversePrefix, libDepth, b0) = do
         State.modify' (Set.insert h)
         pure result
   Monoid.foldMapM go (Map.toList (nonEmptyChildren b0))
+
+-- | @deleteLibdeps branch@ deletes all libdeps from @branch@.
+deleteLibdeps :: Branch0 m -> Branch0 m
+deleteLibdeps =
+  over children (Map.delete NameSegment.libSegment)

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -154,7 +154,9 @@ sqliteCodebase debugName root localOrRemote lockOption migrationStrategy action 
   -- The two work in tandem, so the rootBranchCache keeps relevant branches alive, and the branchLoadCache
   -- stores ALL the subnamespaces of those branches, deduping them when loading from the DB.
   rootBranchCache <- Cache.semispaceCache 10
-  getDeclType <- CodebaseOps.makeCachedTransaction 2048 CodebaseOps.getDeclType
+  rootBranchCacheTx <- Cache.semispaceCache 10
+  declTypeCache <- Cache.semispaceCache 2048
+  let getDeclType = CodebaseOps.makeCachedTransaction declTypeCache CodebaseOps.getDeclType
   -- The v1 codebase interface has operations to read and write individual definitions
   -- whereas the v2 codebase writes them as complete components.  These two fields buffer
   -- the individual definitions until a complete component has been written.
@@ -191,9 +193,13 @@ sqliteCodebase debugName root localOrRemote lockOption migrationStrategy action 
             printBuffer "Terms:" terms
 
       flip finally finalizer do
-        getTerm <- CodebaseOps.makeMaybeCachedTransaction 8192 (CodebaseOps.getTerm getDeclType)
-        getTypeOfTermImpl <- CodebaseOps.makeMaybeCachedTransaction 8192 (CodebaseOps.getTypeOfTermImpl)
-        getTypeDeclaration <- CodebaseOps.makeMaybeCachedTransaction 1024 CodebaseOps.getTypeDeclaration
+        termCache <- Cache.semispaceCache 8192
+        let getTerm = CodebaseOps.makeMaybeCachedTransaction termCache (CodebaseOps.getTerm getDeclType)
+        typeOfTermCache <- Cache.semispaceCache 8192
+        let getTypeOfTermImpl = CodebaseOps.makeMaybeCachedTransaction typeOfTermCache CodebaseOps.getTypeOfTermImpl
+        typeDeclarationCache <- Cache.semispaceCache 1024
+        let getTypeDeclaration = CodebaseOps.makeMaybeCachedTransaction typeDeclarationCache CodebaseOps.getTypeDeclaration
+        let getBranchForHashTx = CodebaseOps.makeMaybeCachedTransaction rootBranchCacheTx (CodebaseOps.getBranchForHash branchLoadCache getDeclType)
 
         let getTermComponentWithTypes :: Hash -> Sqlite.Transaction (Maybe [(Term Symbol Ann, Type Symbol Ann)])
             getTermComponentWithTypes =
@@ -226,14 +232,13 @@ sqliteCodebase debugName root localOrRemote lockOption migrationStrategy action 
             -- if this blows up on cromulent hashes, then switch from `hashToHashId`
             -- to one that returns Maybe.
             getBranchForHash :: CausalHash -> m (Maybe (Branch m))
-            getBranchForHash =
-              Cache.applyDefined rootBranchCache \h -> do
-                fmap (Branch.transform runTransaction) <$> runTransaction (CodebaseOps.getBranchForHash branchLoadCache getDeclType h)
+            getBranchForHash hash =
+              runTransaction (fmap (Branch.transform runTransaction) <$> (getBranchForHashTx hash))
 
             putBranch :: Branch m -> m ()
             putBranch branch =
               withRunInIO \runInIO ->
-                runInIO $ do
+                runInIO do
                   Cache.insert rootBranchCache (Branch.headHash branch) branch
                   runTransaction (CodebaseOps.putBranch (Branch.transform (Sqlite.unsafeIO . runInIO) branch))
 
@@ -282,6 +287,7 @@ sqliteCodebase debugName root localOrRemote lockOption migrationStrategy action 
                   putTypeDeclarationComponent,
                   getTermComponentWithTypes,
                   getBranchForHash,
+                  getBranchForHashTx,
                   putBranch,
                   getWatch,
                   termsOfTypeImpl,

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -16,6 +16,7 @@ import Data.Either.Extra ()
 import Data.Map qualified as Map
 import System.FileLock (SharedExclusive (Exclusive), withTryFileLock)
 import U.Codebase.HashTags (CausalHash)
+import U.Codebase.Sqlite.Operations qualified as Operations
 import Unison.Codebase (Codebase, CodebasePath)
 import Unison.Codebase qualified as Codebase1
 import Unison.Codebase.Branch (Branch (..))
@@ -199,6 +200,8 @@ sqliteCodebase debugName root localOrRemote lockOption migrationStrategy action 
         let getTypeOfTermImpl = CodebaseOps.makeMaybeCachedTransaction typeOfTermCache CodebaseOps.getTypeOfTermImpl
         typeDeclarationCache <- Cache.semispaceCache 1024
         let getTypeDeclaration = CodebaseOps.makeMaybeCachedTransaction typeDeclarationCache CodebaseOps.getTypeDeclaration
+        declNumConstructorsCache <- Cache.semispaceCache 1024
+        let expectDeclNumConstructors = CodebaseOps.makeCachedTransaction declNumConstructorsCache Operations.expectDeclNumConstructors
         let getBranchForHashTx = CodebaseOps.makeMaybeCachedTransaction rootBranchCacheTx (CodebaseOps.getBranchForHash branchLoadCache getDeclType)
 
         let getTermComponentWithTypes :: Hash -> Sqlite.Transaction (Maybe [(Term Symbol Ann, Type Symbol Ann)])
@@ -281,6 +284,7 @@ sqliteCodebase debugName root localOrRemote lockOption migrationStrategy action 
                   getTypeOfTermImpl,
                   getTypeDeclaration,
                   getDeclType,
+                  expectDeclNumConstructors,
                   putTerm,
                   putTermComponent,
                   putTypeDeclaration,

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations/MigrateSchema16To17.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations/MigrateSchema16To17.hs
@@ -32,6 +32,7 @@ import Unison.Prelude
 import Unison.Sqlite qualified as Sqlite
 import Unison.Sqlite.Connection qualified as Connection
 import Unison.Syntax.NameSegment qualified as NameSegment
+import Unison.Util.Cache qualified as Cache
 import UnliftIO qualified
 import UnliftIO qualified as UnsafeIO
 
@@ -209,7 +210,8 @@ makeLegacyProjectFromLooseCode = do
   |]
   rootCh <- Q.expectCausalHash rootChId
   branchCache <- Sqlite.unsafeIO BranchCache.newBranchCache
-  getDeclType <- Sqlite.unsafeIO $ CodebaseOps.makeCachedTransaction 2048 CodebaseOps.getDeclType
+  declTypeCache <- Sqlite.unsafeIO (Cache.semispaceCache 2048)
+  let getDeclType = CodebaseOps.makeCachedTransaction declTypeCache CodebaseOps.getDeclType
   rootBranch <-
     CodebaseOps.getBranchForHash branchCache getDeclType rootCh `whenNothingM` do
       Sqlite.unsafeIO . UnliftIO.throwIO $ MissingRootBranch

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
@@ -61,7 +61,7 @@ import Unison.Names (Names (Names))
 import Unison.Names qualified as Names
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
-import Unison.Reference (Reference)
+import Unison.Reference (Reference, TypeReferenceId)
 import Unison.Reference qualified as Reference
 import Unison.Referent qualified as Referent
 import Unison.ShortHash (ShortHash)

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
@@ -732,27 +732,24 @@ regenerateNameLookup getDeclType bh = do
       ensureNameLookupForBranchHash getDeclType Nothing bh
     False -> ensureNameLookupForBranchHash getDeclType Nothing bh
 
--- | Given a transaction, return a transaction that first checks a semispace cache of the given size.
+-- | Given a transaction, return a transaction that first checks a given semispace cache.
 --
 -- The transaction should probably be read-only, as we (of course) don't hit SQLite on a cache hit.
-makeCachedTransaction :: (Ord a, MonadIO m) => Word -> (a -> Sqlite.Transaction b) -> m (a -> Sqlite.Transaction b)
-makeCachedTransaction size action = do
-  cache <- Cache.semispaceCache size
-  pure \x -> do
-    conn <- Sqlite.unsafeGetConnection
-    Sqlite.unsafeIO (Cache.apply cache (\x -> Sqlite.unsafeUnTransaction (action x) conn) x)
+makeCachedTransaction :: (Ord a) => Cache.Cache a b -> (a -> Sqlite.Transaction b) -> a -> Sqlite.Transaction b
+makeCachedTransaction cache action x = do
+  conn <- Sqlite.unsafeGetConnection
+  Sqlite.unsafeIO (Cache.apply cache (\x -> Sqlite.unsafeUnTransaction (action x) conn) x)
 
 -- | Like 'makeCachedTransaction', but for when the transaction returns a Maybe; only cache the Justs.
 makeMaybeCachedTransaction ::
-  (Ord a, MonadIO m) =>
-  Word ->
+  (Ord a) =>
+  Cache.Cache a b ->
   (a -> Sqlite.Transaction (Maybe b)) ->
-  m (a -> Sqlite.Transaction (Maybe b))
-makeMaybeCachedTransaction size action = do
-  cache <- Cache.semispaceCache size
-  pure \x -> do
-    conn <- Sqlite.unsafeGetConnection
-    Sqlite.unsafeIO (Cache.applyDefined cache (\x -> Sqlite.unsafeUnTransaction (action x) conn) x)
+  a ->
+  Sqlite.Transaction (Maybe b)
+makeMaybeCachedTransaction cache action x = do
+  conn <- Sqlite.unsafeGetConnection
+  Sqlite.unsafeIO (Cache.applyDefined cache (\x -> Sqlite.unsafeUnTransaction (action x) conn) x)
 
 -- | Creates a project by name if one doesn't already exist, creates a branch in that project, then returns the project and branch ids. Fails if a branch by that name already exists in the project.
 insertProjectAndBranch :: ProjectName -> ProjectBranchName -> Db.CausalHashId -> Sqlite.Transaction (Project, ProjectBranch)

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
@@ -61,7 +61,7 @@ import Unison.Names (Names (Names))
 import Unison.Names qualified as Names
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
-import Unison.Reference (Reference, TypeReferenceId)
+import Unison.Reference (Reference)
 import Unison.Reference qualified as Reference
 import Unison.Referent qualified as Referent
 import Unison.ShortHash (ShortHash)

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -55,6 +55,8 @@ data Codebase m v a = Codebase
     -- getTermComponent :: Hash -> m (Maybe [Term v a]),
     getTermComponentWithTypes :: Hash -> Sqlite.Transaction (Maybe [(Term v a, Type v a)]),
     getBranchForHash :: CausalHash -> m (Maybe (Branch m)),
+    -- | Like `getBranchForHash`, but in Transaction... this should entirely replace `getBranchForHash` (some day)
+    getBranchForHashTx :: CausalHash -> Sqlite.Transaction (Maybe (Branch Sqlite.Transaction)),
     -- | Put a branch into the codebase, which includes its children, its patches, and the branch itself, if they don't
     -- already exist.
     --

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -43,6 +43,7 @@ data Codebase m v a = Codebase
     getTypeDeclaration :: TypeReferenceId -> Sqlite.Transaction (Maybe (Decl v a)),
     -- | Get the type of a given decl.
     getDeclType :: TypeReference -> Sqlite.Transaction CT.ConstructorType,
+    expectDeclNumConstructors :: TypeReferenceId -> Sqlite.Transaction Int,
     -- | Enqueue the put of a user-defined term (with its type) into the codebase, if it doesn't already exist. The
     -- implementation may choose to delay the put until all of the term's (and its type's) references are stored as
     -- well.

--- a/unison-cli/src/Unison/Cli/UpdateUtils.hs
+++ b/unison-cli/src/Unison/Cli/UpdateUtils.hs
@@ -61,9 +61,9 @@ import Unison.UnisonFile (TypecheckedUnisonFile)
 import Unison.Util.BiMultimap (BiMultimap)
 import Unison.Util.BiMultimap qualified as BiMultimap
 import Unison.Util.Conflicted (Conflicted (..))
-import Unison.Util.Defn (Defn (..), DefnF)
+import Unison.Util.Defn (Defn (..))
 import Unison.Util.Defns (Defns (..), DefnsF, DefnsF2)
-import Unison.Util.Nametree (Nametree (..), traverseNametreeWithName, unflattenNametrees)
+import Unison.Util.Nametree (Nametree (..), traverseNametreeWithName)
 import Unison.Util.Pretty (Pretty)
 import Unison.Util.Pretty qualified as Pretty
 import Unison.Util.Relation (Relation)

--- a/unison-cli/src/Unison/Cli/UpdateUtils.hs
+++ b/unison-cli/src/Unison/Cli/UpdateUtils.hs
@@ -11,9 +11,6 @@ module Unison.Cli.UpdateUtils
     getNamespaceDependentsOf2,
     getNamespaceDependentsOf3,
 
-    -- * Narrowing definitions
-    narrowDefns,
-
     -- * Hydrating definitions
     hydrateDefns,
 
@@ -64,7 +61,7 @@ import Unison.UnisonFile (TypecheckedUnisonFile)
 import Unison.Util.BiMultimap (BiMultimap)
 import Unison.Util.BiMultimap qualified as BiMultimap
 import Unison.Util.Conflicted (Conflicted (..))
-import Unison.Util.Defn (Defn (..))
+import Unison.Util.Defn (Defn (..), DefnF)
 import Unison.Util.Defns (Defns (..), DefnsF, DefnsF2)
 import Unison.Util.Nametree (Nametree (..), traverseNametreeWithName, unflattenNametrees)
 import Unison.Util.Pretty (Pretty)
@@ -185,38 +182,6 @@ getNamespaceDependentsOf3 defns dependencies = do
   let toTypeScope = Set.mapMaybe Reference.toId . BiMultimap.dom
   let scope = bifoldMap toTermScope toTypeScope defns
   Operations.transitiveDependentsWithinScope scope (bifold dependencies)
-
-------------------------------------------------------------------------------------------------------------------------
--- Narrowing definitions
-
--- | "Narrow" a namespace that may contain conflicted names, resulting in either a failure (if we find a conflicted
--- name), or the narrowed nametree without conflicted names.
-narrowDefns ::
-  forall term typ.
-  (Ord term, Ord typ) =>
-  DefnsF (Relation Name) term typ ->
-  Either
-    ( Defn
-        (Conflicted Name term)
-        (Conflicted Name typ)
-    )
-    (Nametree (DefnsF (Map NameSegment) term typ))
-narrowDefns =
-  fmap unflattenNametrees
-    . bitraverse
-      (go (\name -> TermDefn . Conflicted name))
-      (go (\name -> TypeDefn . Conflicted name))
-  where
-    go :: forall ref x. (Ord ref) => (Name -> NESet ref -> x) -> Relation Name ref -> Either x (Map Name ref)
-    go conflicted =
-      Map.traverseWithKey unconflicted . Relation.domain
-      where
-        unconflicted :: Name -> Set ref -> Either x ref
-        unconflicted name refs0
-          | Set.NonEmpty.size refs == 1 = Right (Set.NonEmpty.findMin refs)
-          | otherwise = Left (conflicted name refs)
-          where
-            refs = Set.NonEmpty.unsafeFromSet refs0
 
 ------------------------------------------------------------------------------------------------------------------------
 -- Hydrating definitions

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
@@ -21,7 +21,7 @@ import Unison.Cli.Monad (Cli, Env (..))
 import Unison.Cli.Monad qualified as Cli
 import Unison.Cli.MonadUtils qualified as Cli
 import Unison.Cli.Pretty qualified as Pretty
-import Unison.Cli.UpdateUtils (getNamespaceDependentsOf2, hydrateDefns, narrowDefns, parseAndTypecheck)
+import Unison.Cli.UpdateUtils (getNamespaceDependentsOf2, hydrateDefns, parseAndTypecheck)
 import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Branch (Branch0)
 import Unison.Codebase.Branch qualified as Branch
@@ -47,7 +47,6 @@ import Unison.PrettyPrintEnvDecl qualified as PPED
 import Unison.PrettyPrintEnvDecl.Names qualified as PPED
 import Unison.Reference (TypeReference, TypeReferenceId)
 import Unison.Reference qualified as Reference (fromId)
-import Unison.Referent (Referent)
 import Unison.Referent qualified as Referent
 import Unison.Sqlite (Transaction)
 import Unison.Symbol (Symbol)
@@ -56,11 +55,9 @@ import Unison.Syntax.Name qualified as Name
 import Unison.UnisonFile qualified as UF
 import Unison.UnisonFile.Names qualified as UF
 import Unison.UnisonFile.Type (TypecheckedUnisonFile)
-import Unison.Util.BiMultimap (BiMultimap)
 import Unison.Util.BiMultimap qualified as BiMultimap
 import Unison.Util.Defns (Defns (..), DefnsF, defnsAreEmpty)
 import Unison.Util.Monoid qualified as Monoid
-import Unison.Util.Nametree (flattenNametrees)
 import Unison.Util.Pretty (ColorText, Pretty)
 import Unison.Util.Pretty qualified as Pretty
 import Unison.Util.Relation qualified as Relation
@@ -78,18 +75,14 @@ handleUpdate2 = do
   let namesIncludingLibdeps = Branch.toNames currentBranch0
 
   -- Assert that the namespace doesn't have any conflicted names
-  nametree <-
-    narrowDefns (Branch.deepDefns currentBranch0ExcludingLibdeps)
+  unconflictedView <-
+    Branch.asUnconflicted currentBranch0ExcludingLibdeps
       & onLeft (Cli.returnEarly . Output.ConflictedDefn "update")
-
-  let defns :: Defns (BiMultimap Referent Name) (BiMultimap TypeReference Name)
-      defns =
-        flattenNametrees nametree
 
   -- Get the number of constructors for every type declaration
   numConstructors <-
     Cli.runTransaction do
-      defns.types
+      unconflictedView.defns.types
         & BiMultimap.dom
         & Set.toList
         & Foldable.foldlM
@@ -103,7 +96,7 @@ handleUpdate2 = do
 
   -- Assert that the namespace doesn't have any incoherent decls
   declNameLookup <-
-    Merge.checkDeclCoherency nametree numConstructors
+    Merge.checkDeclCoherency unconflictedView.nametree numConstructors
       & onLeft (Cli.returnEarly . Output.IncoherentDeclDuringUpdate)
 
   finalOutput <-
@@ -117,7 +110,7 @@ handleUpdate2 = do
             -- Get all dependents of things being updated
             dependents0 <-
               getNamespaceDependentsOf2
-                (flattenNametrees nametree)
+                unconflictedView.defns
                 (getExistingReferencesNamed termAndDeclNames (Branch.toNames currentBranch0ExcludingLibdeps))
 
             -- Throw away the dependents that are shadowed by the file itself

--- a/unison-core/src/Unison/Util/Defn.hs
+++ b/unison-core/src/Unison/Util/Defn.hs
@@ -1,5 +1,6 @@
 module Unison.Util.Defn
   ( Defn (..),
+    DefnF,
   )
 where
 
@@ -28,3 +29,6 @@ instance Bitraversable Defn where
   bitraverse f g = \case
     TermDefn x -> TermDefn <$> f x
     TypeDefn y -> TypeDefn <$> g y
+
+type DefnF f term typ =
+  Defn (f term) (f typ)


### PR DESCRIPTION
## Overview

In working on the `update` update, I realized it would probably be good to start stashing more `deepTerms` / `deepTypes` variants in a `Branch` object itself, so that work can be shared across (for example) an initial `load` (which produces slurp output) and a follow-up `update` that acts on it.

This work isn't complete: I'd like to put more in the branch object, such as a mapping from decl name to constructor names and vice-versa. I'd also like to make `merge` more efficient by reusing these data structures whenever possible rather than compute them from scratch. But it's a start :)