### PR TITLE
Include root namespace as option in fzf namespace args

### DIFF
--- a/unison-cli/src/Unison/CommandLine/FZFResolvers.hs
+++ b/unison-cli/src/Unison/CommandLine/FZFResolvers.hs
@@ -47,6 +47,7 @@ import Unison.Prelude
 import Unison.Symbol (Symbol)
 import Unison.Syntax.HashQualified qualified as HQ (toText)
 import Unison.Syntax.NameSegment qualified as NameSegment
+import Unison.Util.List (safeHead)
 import Unison.Util.Monoid (foldMapM)
 import Unison.Util.Monoid qualified as Monoid
 import Unison.Util.Pretty qualified as P
@@ -97,7 +98,15 @@ namespaceOptions _codebase _projCtx searchBranch0 = do
     & Branch.deepPaths
     & Set.delete mempty {- The current path just renders as an empty string which isn't a valid arg -}
     & Set.toList
+    -- Sort libs last, then by path depth, then lexicographically
+    & List.sortOn
+      ( \path ->
+          let pathList = Path.toList path
+           in (safeHead pathList == Just NameSegment.libSegment, length pathList, pathList)
+      )
     & map (Path.toText . intoPath')
+    -- Add the root namespace to the path list
+    & (Path.toText Path.Root' :)
     & pure
 
 -- | Lists all dependencies of the current project.

--- a/unison-src/transcripts/idempotent/fuzzy-options.md
+++ b/unison-src/transcripts/idempotent/fuzzy-options.md
@@ -69,5 +69,6 @@ scratch/main> add
 scratch/main> debug.fuzzy-options find-in _
 
   Select a namespace or press <esc> to cancel:
+    * .
     * nested
 ```


### PR DESCRIPTION
## Overview

With the new change to require an argument for `ls` and `edit.namespace` it's helpful to also include `.` in the fzf options.

## Implementation notes

* Sorts namespace args according to:
  * libs last
  * Then, shallow paths first
  * Then, lexicographically
  * Then, add the root namespace as the first option


## Test coverage

Tested manually, and also looked through the commands that use `namespaceArg` as a fzf resolver and AFAICT they should all accept `.`
