### PR TITLE
Fix a bug in one of the new peephole optimizations

### DIFF
--- a/unison-runtime/src/Unison/Runtime/ANF/Optimize.hs
+++ b/unison-runtime/src/Unison/Runtime/ANF/Optimize.hs
@@ -283,9 +283,10 @@ peephole arities grp@(Rec bs entry) =
           | directAllowed bn ->
               TLets Direct vs ccs bn bd <$ dirty
         HandlerApp rw -> rw <$ dirty
-        HandlerResume _ f as lh h bs rs -> do
-          dirty
-          pure . TName lh h bs . THnd rs lh Nothing $ TApp (Nameable f) as
+        HandlerResume lz f as lh h bs rs
+          | all (/= lz) h, all (/= lz) bs -> do
+              dirty
+              pure . TName lh h bs . THnd rs lh Nothing $ TApp (Nameable f) as
         HandledThunk r n expr
           | Just arity <- Map.lookup r arities,
             n < arity ->

--- a/unison-runtime/src/Unison/Runtime/ANF/Optimize.hs
+++ b/unison-runtime/src/Unison/Runtime/ANF/Optimize.hs
@@ -284,7 +284,8 @@ peephole arities grp@(Rec bs entry) =
               TLets Direct vs ccs bn bd <$ dirty
         HandlerApp rw -> rw <$ dirty
         HandlerResume lz f as lh h bs rs
-          | all (/= lz) h, all (/= lz) bs -> do
+          | all (/= lz) h,
+            all (/= lz) bs -> do
               dirty
               pure . TName lh h bs . THnd rs lh Nothing $ TApp (Nameable f) as
         HandledThunk r n expr


### PR DESCRIPTION
The `HandlerResume` case was not checking that the lazy binding it was eliminating was actually unused except for being forced in a handle block. _Now_ I think it is basically impossible to write such code, because the erroneous case was caused by failing to cover all the cases in an ability matching block. However, there was an example in an older version of `codec` that was written before exhaustiveness checking was implemented.

I've fixed the optimization to check the condition even though it shouldn't happen on any newly written code.

This also means that I don't know how to add a regression test, because I don't know how to write code like this anymore.