### PR TITLE
windows 2019 -> 2022

### DIFF
--- a/.github/workflows/bundle-ucm.yaml
+++ b/.github/workflows/bundle-ucm.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-13, macos-14, windows-2019]
+        os: [ubuntu-24.04, macos-13, macos-14, windows-2022]
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -151,7 +151,7 @@ jobs:
           webhook-type: incoming-webhook
           payload: |
               text: "package-racket-lib failed on ${{ github.ref }}. See details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} cc <@UF924D5S7>"
-  
+
   build-dist-unison-runtime:
     needs: package-racket-lib
     name: build unison-runtime
@@ -162,7 +162,7 @@ jobs:
           - ubuntu-24.04
           - macos-13
           - macos-14
-          - windows-2019
+          - windows-2022
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -230,7 +230,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-13, macos-14, windows-2019]
+        os: [ubuntu-24.04, macos-13, macos-14, windows-2022]
     steps:
       - name: set up environment
         run: |

--- a/.github/workflows/ci-build-jit-binary.yaml
+++ b/.github/workflows/ci-build-jit-binary.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-13, windows-2019]
+        os: [ubuntu-24.04, macos-13, windows-2022]
     runs-on: ${{matrix.os}}
     steps:
       - name: set up environment

--- a/.github/workflows/ci-test-jit.yaml
+++ b/.github/workflows/ci-test-jit.yaml
@@ -25,7 +25,7 @@ jobs:
         os:
           - ubuntu-24.04
           - macos-13
-          # - windows-2019
+          # - windows-2022
     runs-on: ${{matrix.os}}
     steps:
       - name: set up environment

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
           # While iterating on this file, you can disable one or more of these to speed things up
           - ubuntu-24.04
           - macos-13
-          - windows-2019
+          - windows-2022
           # - windows-2022
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -199,7 +199,7 @@ jobs:
           # While iterating on this file, you can disable one or more of these to speed things up
           - ubuntu-24.04
           - macos-13
-          - windows-2019
+          - windows-2022
           # - windows-2022
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -282,7 +282,7 @@ jobs:
           # While iterating on this file, you can disable one or more of these to speed things up
           - ubuntu-24.04
           - macos-13
-          # - windows-2019
+          # - windows-2022
           # - windows-2022
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,20 +4,20 @@ pull_request_rules:
       - check-success=check-contributor
       - check-success=build ucm (ubuntu-20.04)
       - check-success=build ucm (macos-13)
-      - check-success=build ucm (windows-2019)
+      - check-success=build ucm (windows-2022)
       - check-success=run transcripts (ubuntu-20.04)
       - check-success=run transcripts (macos-13)
-      - check-success=run transcripts (windows-2019)
+      - check-success=run transcripts (windows-2022)
       - check-success=run interpreter tests (ubuntu-20.04)
       - check-success=run interpreter tests (macos-13)
-      # - check-success=run interpreter tests (windows-2019)
+      # - check-success=run interpreter tests (windows-2022)
       - check-success=generate jit source
       - check-success=build jit binary / build jit binary (ubuntu-20.04)
       - check-success=build jit binary / build jit binary (macos-13)
-      - check-success=build jit binary / build jit binary (windows-2019)
+      - check-success=build jit binary / build jit binary (windows-2022)
       - check-success=test jit / test jit (ubuntu-20.04)
       - check-success=test jit / test jit (macos-13)
-      # - check-success=test jit / test jit (windows-2019)
+      # - check-success=test jit / test jit (windows-2022)
       - label=ready-to-merge
       - "#approved-reviews-by>=1"
     actions:


### PR DESCRIPTION
2025 was another option but I wasn't sure how much to jump through time.

This is because GitHub is deprecating windows 2019 runners.

Fixes #5733
Closes #5734 by way of #5735 if this passes CI