### PR TITLE
hide ucm output in jit tests

### DIFF
--- a/unison-cli-integration/integration-tests/IntegrationTests/transcript.output.md
+++ b/unison-cli-integration/integration-tests/IntegrationTests/transcript.output.md
@@ -8,7 +8,7 @@ scratch/main> load ./unison-src/transcripts-using-base/base.u
 scratch/main> add
 ```
 
-``` unison
+``` unison :hide
 use lib.builtins
 
 unique type MyBool = MyTrue | MyFalse
@@ -39,10 +39,9 @@ main = do
   Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
+  do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `add`:
+    ⍟ These new definitions are ok to `update`:
     
       structural ability Break
       type MyBool
@@ -53,12 +52,7 @@ main = do
 ``` ucm
 scratch/main> add
 
-  ⍟ I've added these definitions:
-
-    structural ability Break
-    type MyBool
-    main   : '{IO, Exception} ()
-    resume : Request {g, Break} x -> x
+  Done.
 
 scratch/main> compile main ./unison-cli-integration/integration-tests/IntegrationTests/main
 ```

--- a/unison-src/builtin-tests/jit-tests.output.md
+++ b/unison-src/builtin-tests/jit-tests.output.md
@@ -16,39 +16,23 @@ scratch/main> delete.project runtime-tests
 scratch/main> clone @unison/runtime-tests/releases/0.0.3 runtime-tests/selected
 ```
 
-``` ucm
+``` ucm :hide
 runtime-tests/selected> run.native tests
 
-  ()
-
 runtime-tests/selected> run.native tests.jit.only
-
-  ()
 ```
 
 Per Dan:
 It's testing a flaw in how we were sending code from a scratch file to the native runtime, when that happened multiple times.
 Related to the verifiable refs and recursive functions.
 
-``` unison
+``` unison :hide
 foo = do
   go : Nat ->{Exception} ()
   go = cases
     0 -> ()
     n -> go (decrement n)
   go 1000
-```
-
-``` ucm :added-by-ucm
-  Loading changes detected in scratch.u.
-
-  I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
-
-    ⍟ These new definitions are ok to `add`:
-    
-      foo : '{Exception} ()
 ```
 
 ``` ucm

--- a/unison-src/builtin-tests/jit-tests.tpl.md
+++ b/unison-src/builtin-tests/jit-tests.tpl.md
@@ -13,7 +13,7 @@ scratch/main> delete.project runtime-tests
 scratch/main> clone ${runtime_tests_version} runtime-tests/selected
 ```
 
-``` ucm
+``` ucm :hide
 runtime-tests/selected> run.native tests
 runtime-tests/selected> run.native tests.jit.only
 ```
@@ -21,7 +21,7 @@ runtime-tests/selected> run.native tests.jit.only
 Per Dan:
 It's testing a flaw in how we were sending code from a scratch file to the native runtime, when that happened multiple times.
 Related to the verifiable refs and recursive functions.
-``` unison
+``` unison :hide
 foo = do
   go : Nat ->{Exception} ()
   go = cases


### PR DESCRIPTION
Hides the output messages to not present as a transcript change as in #5732,  #5734