### PR TITLE
Fix a variable capture during optimization.

### DIFF
--- a/unison-core/src/Unison/ABT/Normalized.hs
+++ b/unison-core/src/Unison/ABT/Normalized.hs
@@ -14,7 +14,9 @@ module Unison.ABT.Normalized
     Term (.., TAbs, TTm, TAbss),
     Align (..),
     alpha,
+    freshen,
     renames,
+    renamesAvoiding,
     rename,
     transform,
     visit,
@@ -105,7 +107,7 @@ class (Bifoldable f, Bifunctor f) => Align f where
 
 alphaErr ::
   (Align f) => (Var v) => Map v v -> Term f v -> Term f v -> Either (Term f v, Term f v) a
-alphaErr un tml tmr = Left (tml, renames0 count un tmr)
+alphaErr un tml tmr = Left (tml, renamesAndFreshen0 count un tmr)
   where
     count = Map.fromListWith (+) . flip zip [1, 1 ..] $ toList un
 
@@ -135,21 +137,30 @@ pattern TAbss vs bd <-
 
 {-# COMPLETE TAbss #-}
 
--- Simultaneous variable renaming implementation.
+-- Simultaneous variable renaming and freshening implementation.
 --
--- subvs0 counts the number of variables being renamed to a particular
--- variable
+-- subvs0 is a count of the number of conflicts associated with a
+-- variable. There are two sources of conflicts.
+--
+--   1. A variable is being renamed _to_ the given variable
+--   2. We want to avoid capturing the variable for other reasons
+--
+-- So, if you initially call `renamesAndFreshen0` with a higher count
+-- for `v` then there are variables being renamed to `v`, all bound
+-- occurrences of `v` will be freshened regardless of whether any
+-- actual renamings are left.
 --
 -- rnv0 is the variable renaming map.
-renames0 ::
-  (Var v, Ord v, Bifunctor f, Bifoldable f) =>
+renamesAndFreshen0 ::
+  (Var v, Bifunctor f, Bifoldable f) =>
   Map v Int ->
   Map v v ->
   Term f v ->
   Term f v
-renames0 subvs0 rnv0 tm = case tm of
+renamesAndFreshen0 subvs0 rnv0 tm = case tm of
   TAbs u body
-    | not $ Map.null rnv' -> TAbs u' (renames0 subvs' rnv' body)
+    | not $ Map.null subvs' ->
+        TAbs u' (renamesAndFreshen0 subvs' rnv' body)
     where
       rnv' = Map.alter (const $ adjustment) u rnv
       bfvs = freeVars body
@@ -167,14 +178,16 @@ renames0 subvs0 rnv0 tm = case tm of
             (Just u', Map.insertWith (+) u' 1 subvs)
         | otherwise = (Nothing, subvs)
   TTm body
-    | not $ Map.null rnv ->
-        TTm $ bimap (\u -> Map.findWithDefault u u rnv) (renames0 subvs rnv) body
+    | not $ Map.null subvs ->
+        TTm $ bimap lkup (renamesAndFreshen0 subvs rnv) body
   _ -> tm
   where
     fvs = freeVars tm
 
     -- throw out irrelevant renamings
     rnv = Map.restrictKeys rnv0 fvs
+
+    lkup u = Map.findWithDefault u u rnv
 
     -- decrement the variable usage counts for the renamings we threw away
     subvs = Map.foldl' decrement subvs0 $ Map.withoutKeys rnv0 fvs
@@ -183,13 +196,39 @@ renames0 subvs0 rnv0 tm = case tm of
       | n <= 1 = Nothing
       | otherwise = Just (n - 1)
 
--- Simultaneous variable renaming.
-renames ::
-  (Var v, Ord v, Bifunctor f, Bifoldable f) =>
+-- Freshens the bound variables in a term to avoid capturing variables
+-- in the set.
+freshen ::
+  (Var v, Bifunctor f, Bifoldable f) =>
+  Set v ->
+  Term f v ->
+  Term f v
+freshen avoid = renamesAndFreshen0 subvs Map.empty
+  where
+    subvs = Map.fromSet (const 1) avoid
+
+-- Renames some variables while also avoiding a given set of variables
+-- for any bindings in the term.
+renamesAvoiding ::
+  (Var v, Bifunctor f, Bifoldable f) =>
+  Set v ->
   Map v v ->
   Term f v ->
   Term f v
-renames rnv tm = renames0 subvs rnv tm
+renamesAvoiding avoid rnv = renamesAndFreshen0 subvs rnv
+  where
+    suba = Map.fromSet (const 1) avoid
+    subr = Map.fromListWith (+) . fmap (,1) $ Map.elems rnv
+
+    subvs = Map.unionWith (+) suba subr
+
+-- Simultaneous variable renaming.
+renames ::
+  (Var v, Bifunctor f, Bifoldable f) =>
+  Map v v ->
+  Term f v ->
+  Term f v
+renames rnv tm = renamesAndFreshen0 subvs rnv tm
   where
     subvs = Map.fromListWith (+) . fmap (,1) $ Map.elems rnv
 
@@ -199,7 +238,7 @@ rename ::
   v ->
   Term f v ->
   Term f v
-rename old new = renames0 (Map.singleton new 1) (Map.singleton old new)
+rename old new = renamesAndFreshen0 (Map.singleton new 1) (Map.singleton old new)
 
 transform ::
   (Var v, Bifunctor g, Bifoldable f, Bifoldable g) =>

--- a/unison-runtime/src/Unison/Runtime/ANF/Optimize.hs
+++ b/unison-runtime/src/Unison/Runtime/ANF/Optimize.hs
@@ -224,6 +224,8 @@ inline self (arities, inls0) grp@(Rec bs entry) =
   where
     inls = maybe id (Map.insert self) (entryInfo grp) inls0
 
+    avoid = Set.fromList $ fst <$> bs
+
     go0 nrm@(Lambda ccs body) =
       memo nrm $ Lambda ccs <$> go (30 :: Int) body
 
@@ -245,17 +247,23 @@ inline self (arities, inls0) grp@(Rec bs entry) =
     don'tInline TailInl isTail = not isTail
     don'tInline AnywhereInl _ = False
 
+    -- Note: we use `renameAvoiding` because by adding `entryInfo` to
+    -- the inlining map, we may be inlining terms with free variables
+    -- referring to the floated handler code. This happens over
+    -- multiple inlining steps, so we freshen anything else we inline
+    -- to not be capable of capturing the variables from the entry
+    -- code.
     tweak isTail args arity (InlInfo clazz (ABTN.TAbss vs body))
       | don'tInline clazz isTail = Nothing
       -- exactly saturated
       | length args == arity,
         rn <- Map.fromList (zip vs args) =
-          Just $ ABTN.renames rn body
+          Just $ ABTN.renamesAvoiding avoid rn body
       -- oversaturated, only makes sense if body is a call
       | length args > arity,
         (pre, post) <- splitAt arity args,
         rn <- Map.fromList (zip vs pre),
-        TApp f pre <- ABTN.renames rn body =
+        TApp f pre <- ABTN.renamesAvoiding avoid rn body =
           Just $ TApp f (pre ++ post)
       | otherwise = Nothing
 


### PR DESCRIPTION
As part of optimizing code to get handlers in shape for the affine handler transformation, we do inlining. One of these is a somewhat special inlining, where we take handler code, which looks like this:

```
  handler =
    let rec
      matcher <vs> = cases
        { ... } -> ... handler ...
    in ... matcher ...
```

And we (effectively) inline the _body_ of the let rec into the recursive reference to `handler` inside of `matcher`. This avoids indirection and makes it easier to recognize things.

However, the variable `matcher` is free in the body, and cannot easily be renamed. So, it is important that `matcher` is not captured by the context into which it's inlined.

However, the variable names aren't really this distinct. They are like `_anf5`, and such variables are also used when normalizing terms to have no complex subexpressions (etc.). If the recursive `handler` call is not direct, but via _another_ function that gets inlined, it may be that that other function uses redundant variables, because the `_anf` numbering starts at 0 for each term.

So, this change uses a beefed up form of renaming when doing inlining, which also freshens the term to avoid binding certain variables. This is used to ensure that the inlining, never captures the `matcher` variable.

Fixes #5737