### PR TITLE
try bumping racket version to 8.17 to fix CI errors in windows-2022

### DIFF
--- a/.github/workflows/bundle-ucm.yaml
+++ b/.github/workflows/bundle-ucm.yaml
@@ -13,7 +13,7 @@ on:
         required: true
 
 env:
-  racket_version: "8.14"
+  racket_version: "8.17"
 
 defaults:
   run:
@@ -104,14 +104,6 @@ jobs:
       - name: set up environment
         run: |
           echo "ucm=${{ runner.temp }}/unison" >> $GITHUB_ENV
-          case "$RUNNER_ARCH" in
-            X86) racket_arch=x86 ;;
-            X64) racket_arch=x64 ;;
-            ARM) racket_arch=arm32 ;;
-            ARM64) racket_arch=arm64 ;;
-            *) echo "Unsupported architecture: ${{runner.arch}}"; exit 1 ;;
-          esac
-          echo "racket_arch=$racket_arch" >> $GITHUB_ENV
       - name: download racket `unison` source
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -125,11 +117,9 @@ jobs:
         run: |
           chmod +x ${{ env.ucm }}
           ${{ env.ucm }} transcript unison-src/transcripts-manual/gen-racket-libs.md
-      - uses: Bogdanp/setup-racket@0094a9d8bd157633293a2210f373bb542687fa6d # v1.11
+      - name: install racket
+        uses: unisonweb/actions/racket/install@a944f9bc3fb62b5b7eaf99a813f90db0df3b36f2
         with:
-          architecture: ${{ env.racket_arch }}
-          distribution: "full"
-          variant: "CS"
           version: ${{env.racket_version}}
       - name: create racket lib
         run: |
@@ -184,21 +174,10 @@ jobs:
           # This isn't right because unison.zip is going to include different dates each time.
           # Maybe we can unpack it and hash the contents.
           key: ${{matrix.os}}-racket-${{env.racket_version}}-${{hashFiles('scheme-libs/racket/unison.zip')}}
-      - name: set up environment
-        run: |
-          case "$RUNNER_ARCH" in
-            X86) racket_arch=x86 ;;
-            X64) racket_arch=x64 ;;
-            ARM) racket_arch=arm32 ;;
-            ARM64) racket_arch=arm64 ;;
-            *) echo "Unsupported architecture: ${{runner.arch}}"; exit 1 ;;
-          esac
-          echo "racket_arch=$racket_arch" >> $GITHUB_ENV
-      - uses: Bogdanp/setup-racket@0094a9d8bd157633293a2210f373bb542687fa6d # v1.11
+      - name: install racket
+        if: steps.cache-jit-binaries.outputs.cache-hit != 'true'
+        uses: unisonweb/actions/racket/install@a944f9bc3fb62b5b7eaf99a813f90db0df3b36f2
         with:
-          architecture: ${{ env.racket_arch }}
-          distribution: "full"
-          variant: "CS"
           version: ${{env.racket_version}}
       - name: install unison racket lib
         if: steps.cache-racket-deps.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-build-jit-binary.yaml
+++ b/.github/workflows/ci-build-jit-binary.yaml
@@ -10,7 +10,7 @@ defaults:
 env:
   jit_src: unison-jit-src/
   jit_dist: unison-jit-dist/
-  racket_version: "8.14"
+  racket_version: "8.17"
 
 jobs:
   build-jit-binary:
@@ -73,7 +73,7 @@ jobs:
 
       - name: install racket
         if: steps.cache-jit-binaries.outputs.cache-hit != 'true'
-        uses: unisonweb/actions/racket/install@buildjet-cache
+        uses: unisonweb/actions/racket/install@a944f9bc3fb62b5b7eaf99a813f90db0df3b36f2
         with:
           version: ${{env.racket_version}}
 


### PR DESCRIPTION
e.g. https://github.com/unisonweb/unison/actions/runs/15520801591/job/43699212220

if this seems to build successfully, then check w/ @dolio to see if there's any anticipated reason why we shouldn't use racket 8.17 over 8.14