### PR TITLE
Laxify code-server port binding

### DIFF
--- a/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
+++ b/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
@@ -106,6 +106,7 @@ withRunner isTest verbosity ucmVersion nrtp action = do
   withRuntimes nrtp \runtime sbRuntime nRuntime ->
     action \transcriptName transcriptSrc (codebaseDir, codebase) ->
       Server.startServer
+        isTest
         Backend.BackendEnv {Backend.useNamesIndex = False}
         Server.defaultCodebaseServerOpts
         runtime

--- a/unison-cli/src/Unison/LSP.hs
+++ b/unison-cli/src/Unison/LSP.hs
@@ -95,7 +95,7 @@ spawnLsp lspFormattingConfig codebase runtime signal =
       case Errno <$> ioe_errno ioerr of
         Just errNo
           | errNo == eADDRINUSE -> do
-              Text.hPutStrLn UnliftIO.stderr $ "Note: Port " <> Text.pack lspPort <> " is already bound by another process or another UCM. The LSP server will not be started."
+              Text.hPutStrLn UnliftIO.stderr $ "⚠️  Port " <> Text.pack lspPort <> " is already bound by another process or another UCM. The LSP server will not be started."
         _ -> do
           Text.hPutStrLn UnliftIO.stderr $ "LSP server failed to start."
     -- Where to send logs that occur before a client connects

--- a/unison-cli/src/Unison/Main.hs
+++ b/unison-cli/src/Unison/Main.hs
@@ -324,7 +324,8 @@ main version = do
               -- Windows when we move to GHC 9.*
               -- https://gitlab.haskell.org/ghc/ghc/-/merge_requests/1224
               void . Ki.fork scope $ LSP.spawnLsp lspFormattingConfig theCodebase runtime changeSignal
-              Server.startServer (Backend.BackendEnv {Backend.useNamesIndex = False}) codebaseServerOpts sbRuntime theCodebase $ \mayBaseUrl -> do
+              let isTest = False
+              Server.startServer isTest (Backend.BackendEnv {Backend.useNamesIndex = False}) codebaseServerOpts sbRuntime theCodebase $ \mayBaseUrl -> do
                 case exitOption of
                   DoNotExit -> do
                     case isHeadless of

--- a/unison-share-api/src/Unison/Server/CodebaseServer.hs
+++ b/unison-share-api/src/Unison/Server/CodebaseServer.hs
@@ -36,6 +36,7 @@ import Network.Wai.Handler.Warp
     setHost,
     setPort,
   )
+import Network.Wai.Handler.Warp qualified as Warp
 import Network.Wai.Middleware.Cors (cors, corsMethods, corsOrigins, simpleCorsResourcePolicy)
 import Servant
   ( Handler,
@@ -471,31 +472,41 @@ startServer env opts rt codebase onStart = do
     Nothing -> withPort settings baseUrl app' 5858
     Just p -> withPort settings baseUrl app' p
   where
-    withPort settings baseUrl app' p = do
+    withPort settings baseUrl app' preferredPort = do
       started <- mkWaiter
+      portVar <- UnliftIO.newTVarIO preferredPort
       let settings' = setBeforeMainLoop (notify started ()) settings
       let runServer = do
             UnliftIO.try (runSettings settings' app') >>= \case
               Left ioerror | IOError.isAlreadyInUseError ioerror -> do
+                (actualPort, socket) <- Warp.openFreePort
+                UnliftIO.atomically $ UnliftIO.writeTVar portVar actualPort
                 Text.hPutStrLn UnliftIO.stderr $
                   Text.unlines
-                    [ "Note: Port "
-                        <> Text.pack (show p)
-                        <> " is already bound by another process or another UCM. The UCM server will not be started."
+                    [ "⚠️  Port "
+                        <> Text.pack (show preferredPort)
+                        <> " is already bound by another process or another UCM.",
+                      "   The UCM server will be started on port "
+                        <> Text.pack (show actualPort)
+                        <> " instead.",
+                      "   Tools which expect the server on a specific port may not behave as intended."
                     ]
+                Warp.runSettingsSocket settings' socket app'
               Left e -> do
                 Text.hPutStrLn UnliftIO.stderr $
                   Text.unlines
-                    [ "UCM server failure: " <> Text.pack (show e),
-                      "The UCM server will not be restarted."
+                    [ "⚠️  UCM server failure: " <> Text.pack (show e),
+                      "   The UCM server will not be restarted."
                     ]
               Right _ -> do
-                throwIO $ ErrorCall "The UCM server exited unexpectedly, it will not be restarted."
+                throwIO $ ErrorCall "⚠️  The UCM server exited unexpectedly, it will not be restarted."
       Async.withAsync runServer \serverHandle -> do
         -- Wait until either the server has started or the server has failed to start, then proceed with the callback, passing the base URL if the server started, and Nothing otherwise.
         UnliftIO.race (UnliftIO.wait serverHandle) (waitFor started) >>= \case
           Left _ -> onStart Nothing
-          Right _ -> onStart (Just $ baseUrl p)
+          Right _ -> do
+            runningPort <- UnliftIO.readTVarIO portVar
+            onStart (Just $ baseUrl runningPort)
 
 serveIndex :: FilePath -> Handler RawHtml
 serveIndex path = do

--- a/unison-share-api/src/Unison/Server/CodebaseServer.hs
+++ b/unison-share-api/src/Unison/Server/CodebaseServer.hs
@@ -449,13 +449,14 @@ defaultCodebaseServerOpts =
 
 -- The auth token required for accessing the server is passed to the function k
 startServer ::
+  Bool ->
   BackendEnv ->
   CodebaseServerOpts ->
   Rt.Runtime Symbol ->
   Codebase IO Symbol Ann ->
   (Maybe BaseUrl -> IO a) ->
   IO a
-startServer env opts rt codebase onStart = do
+startServer isTest env opts rt codebase onStart = do
   -- the `canonicalizePath` resolves symlinks
   exePath <- canonicalizePath =<< getExecutablePath
   envUI <- canonicalizePath $ fromMaybe (FilePath.takeDirectory exePath </> "ui") (codebaseUIPath opts)
@@ -481,16 +482,17 @@ startServer env opts rt codebase onStart = do
               Left ioerror | IOError.isAlreadyInUseError ioerror -> do
                 (actualPort, socket) <- Warp.openFreePort
                 UnliftIO.atomically $ UnliftIO.writeTVar portVar actualPort
-                Text.hPutStrLn UnliftIO.stderr $
-                  Text.unlines
-                    [ "⚠️  Port "
-                        <> Text.pack (show preferredPort)
-                        <> " is already bound by another process or another UCM.",
-                      "   The UCM server will be started on port "
-                        <> Text.pack (show actualPort)
-                        <> " instead.",
-                      "   Tools which expect the server on a specific port may not behave as intended."
-                    ]
+                when (not isTest) $
+                  Text.hPutStrLn UnliftIO.stderr $
+                    Text.unlines
+                      [ "⚠️  Port "
+                          <> Text.pack (show preferredPort)
+                          <> " is already bound by another process or another UCM.",
+                        "   The UCM server will be started on port "
+                          <> Text.pack (show actualPort)
+                          <> " instead.",
+                        "   Tools which expect the server on a specific port may not behave as intended."
+                      ]
                 Warp.runSettingsSocket settings' socket app'
               Left e -> do
                 Text.hPutStrLn UnliftIO.stderr $


### PR DESCRIPTION
## Overview

Fixes #5736 

<img width="943" alt="image" src="https://github.com/user-attachments/assets/d6609b56-0c84-4c6e-ab8c-b41e73fb8969" />


Currently, having a UCM open will bind ports for the codeserver, meaning if you want another ucm for transcripts or a separate codebase, it can't bind the codeserver to the default port.

At best, this means `ui` doesn't work, at worst it will cause your transcripts to fail to run for no good reason.

After this change it will simply warn you the default port is taken and bind a different port instead; allowing both `ui` and transcripts to work.

## Implementation notes

* If we get a port binding failure on the codeserver, acquire a random free port for the codeserver and print a warning message.
* If in transcripts, we silence the error message since it's only important that the transcript itself knows what port to run API transcript fetches against (and it does)

## Interesting/controversial decisions

Do we want something like this for the LSP port too? I don't think so, since I don't think anyone is going to manually update their LSP port in their editor every time 🤷🏼 

## Test coverage

I tested running transcripts locally both with `transcripts` and `ucm transcript` while I had a separate UCM open.
