### PR TITLE
update unison racket lib if not already installed

### DIFF
--- a/.github/workflows/bundle-ucm.yaml
+++ b/.github/workflows/bundle-ucm.yaml
@@ -181,7 +181,9 @@ jobs:
           version: ${{env.racket_version}}
       - name: install unison racket lib
         if: steps.cache-racket-deps.outputs.cache-hit != 'true'
-        run: raco pkg install --auto scheme-libs/racket/unison.zip
+        run: |
+          raco pkg install --auto --skip-installed scheme-libs/racket/unison.zip || \
+            raco pkg update --auto scheme-libs/racket/unison.zip
       - name: install libb2 (macos)
         if: runner.os == 'macOS'
         run: |


### PR DESCRIPTION
It would be better to understand why it's already installed; it looks like it's written to only install if the cache isn't restored.
if the cache isn't restored, how could it already be installed?

however, the cache exists in multiple possible places, populated by multiple possible workflows (namely, this one, and the `unisonweb/actions/racket/install` action — though I removed(?) the user cache line from the `unisonweb/actions/racket/install` action and it didn't seem to help.

so maybe this will fix it without fully understanding it :(