### PR TITLE
bugfix: use old branch ppe when rendering deleted things

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Load.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Load.hs
@@ -95,7 +95,6 @@ loadUnisonFile sourceName text = do
   Cli.respond $ Output.LoadingFile sourceName
   oldBranch0 <- Cli.getCurrentBranch0
   let oldNames = Branch.toNames oldBranch0
-  let oldPpe = PPE.suffixifiedPPE (PPED.makePPED (PPE.hqNamer 10 oldNames) (PPE.suffixifyByHash oldNames))
   unisonFile <- parseAndTypecheckUnisonFile oldNames sourceName text
   let sr = Slurp.slurpFile unisonFile mempty Slurp.CheckOp oldNames
   let newNames = UF.addNamesFromTypeCheckedUnisonFile unisonFile oldNames
@@ -119,8 +118,9 @@ loadUnisonFile sourceName text = do
         Just updateBranchParentCausalHash -> do
           Cli.Env {codebase} <- ask
           updateBranchParent <- liftIO (Codebase.expectBranchForHash codebase updateBranchParentCausalHash)
-          let updateBranchParentNames = Branch.toNames (Branch.deleteLibdeps (Branch.head updateBranchParent))
-          let updateBranchNames =
+          let updateBranchParent0 = Branch.head updateBranchParent
+          let updateBranchParentLocalNames = Branch.toNames (Branch.deleteLibdeps updateBranchParent0)
+          let updateBranchLocalNames =
                 Names.shadowing
                   (UF.typecheckedToNames unisonFile)
                   (Branch.toNames (Branch.deleteLibdeps oldBranch0))
@@ -175,8 +175,8 @@ loadUnisonFile sourceName text = do
                               (Referent.Con _ _, Referent.Con _ _) ->
                                 pure Nothing
                     )
-                    (Relation.domain updateBranchParentNames.terms)
-                    (Relation.domain updateBranchNames.terms)
+                    (Relation.domain updateBranchParentLocalNames.terms)
+                    (Relation.domain updateBranchLocalNames.terms)
 
           slurpTypes :: Map Name (SlurpEntry (DeclOrBuiltin Symbol Ann)) <-
             let getOldDecl :: TypeReference -> Sqlite.Transaction (DeclOrBuiltin Symbol Ann)
@@ -210,8 +210,8 @@ loadUnisonFile sourceName text = do
                                   Nothing -> Nothing
                                   Just _ -> Just SlurpEntry'Unchanged
                     )
-                    (Relation.domain updateBranchParentNames.types)
-                    (Relation.domain updateBranchNames.types)
+                    (Relation.domain updateBranchParentLocalNames.types)
+                    (Relation.domain updateBranchLocalNames.types)
 
           let slurpEntries =
                 Defns
@@ -219,6 +219,12 @@ loadUnisonFile sourceName text = do
                     types = slurpTypes
                   }
 
+          let updateBranchParentNames = Branch.toNames updateBranchParent0
+          let oldPpe =
+                PPE.suffixifiedPPE $
+                  PPED.makePPED
+                    (PPE.hqNamer 10 updateBranchParentNames)
+                    (PPE.suffixifyByHash updateBranchParentNames)
           Cli.respond (Output.Typechecked2 oldPpe newPpe slurpEntries)
     else do
       Cli.respond (Output.Typechecked sourceName newPpe sr unisonFile)

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -965,7 +965,7 @@ notifyUser dir = \case
             pure . P.wrap $
               "I loaded " <> P.text sourceName <> " and didn't find anything."
           else pure mempty
-  Typechecked2 _oldPpe newPpe slurpEntries -> do
+  Typechecked2 oldPpe newPpe slurpEntries -> do
     let newTypes0 :: [(Name, DeclOrBuiltin Symbol Ann)]
         updatedTypes0 :: [(Name, DeclOrBuiltin Symbol Ann, DeclOrBuiltin Symbol Ann)]
         deletedTypes0 :: [(Name, DeclOrBuiltin Symbol Ann)]
@@ -1041,7 +1041,7 @@ notifyUser dir = \case
 
     let renderedDeletedTerms :: Pretty
         renderedDeletedTerms =
-          P.column2 (map (\(name, ty) -> renderTerm newPpe (P.red . ("- " <>)) name ty) deletedTerms)
+          P.column2 (map (\(name, ty) -> renderTerm oldPpe (P.red . ("- " <>)) name ty) deletedTerms)
 
     pure $
       P.sepNonEmpty


### PR DESCRIPTION
## Overview

Small oversight: when rendering deleted things on an `update` branch, use the original branch's PPE, so types that are being updated don't cause old types to lose their names and render as hashes. I tested this change manually.

Before:

<img width="451" alt="Screenshot 2025-06-20 at 8 50 59 AM" src="https://github.com/user-attachments/assets/c3b2b9e5-24c9-43b0-8179-d80f6bf958aa" />

After:

<img width="451" alt="Screenshot 2025-06-20 at 8 50 41 AM" src="https://github.com/user-attachments/assets/c2b7d3c9-8867-43bc-9086-860cf8d88762" />