### PR TITLE
silence `load` output for programmatically-generated `update` file activity

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
@@ -7,7 +7,7 @@ module Unison.Codebase.Editor.HandleInput.Update2
   )
 where
 
-import Control.Lens (mapped, (.=))
+import Control.Lens (mapped, (.=), (?=))
 import Control.Monad.Reader.Class (ask)
 import Data.Bifoldable (bifoldMap)
 import Data.Foldable qualified as Foldable
@@ -236,10 +236,12 @@ handleUpdate2 = do
                           pure ()
 
                       scratchFilePath <- fst <$> Cli.expectLatestFile
+                      #latestFile ?= (scratchFilePath, True)
                       liftIO $ env.writeSource (Text.pack scratchFilePath) (Text.pack $ Pretty.toPlain 80 prettyUnisonFile) True
                       done Output.UpdateTypecheckingFailure
                     else do
                       scratchFilePath <- fst <$> Cli.expectLatestFile
+                      #latestFile ?= (scratchFilePath, True)
                       liftIO $ env.writeSource (Text.pack scratchFilePath) (Text.pack $ Pretty.toPlain 80 prettyUnisonFile) True
                       done Output.UpdateTypecheckingFailure
 


### PR DESCRIPTION
## Overview

This PR tweaks `update` to work like `edit`: set some global state that causes the next file event to be ignored.