### PR TITLE
update failed `update` output

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
@@ -214,11 +214,14 @@ handleUpdate2 = do
                       if onUpdateBranchAlready
                         then do
                           Cli.updateProjectBranchRoot_ pp.branch "update" (const nextNamespace)
+                          scratchFilePath <- fst <$> Cli.expectLatestFile
+                          liftIO $ env.writeSource (Text.pack scratchFilePath) (Text.pack $ Pretty.toPlain 80 prettyUnisonFile) True
+                          done Output.UpdateTypecheckingFailure
                         else do
                           uniqueTypeGuidsByName <-
                             Cli.runTransaction (makeUniqueTypeGuids (BiMultimap.range unconflictedView.defns.types))
 
-                          (_temporaryBranchId, _temporaryBranchName) <-
+                          (_updateBranchId, updateBranchName) <-
                             HandleInput.Branch.createBranch
                               ("update " <> into @Text (ProjectAndBranch pp.project.name pp.branch.name))
                               ( HandleInput.Branch.CreateFrom'Update
@@ -233,12 +236,10 @@ handleUpdate2 = do
                                       & unsafeFrom @Text
                                   )
                               )
-                          pure ()
-
-                      scratchFilePath <- fst <$> Cli.expectLatestFile
-                      #latestFile ?= (scratchFilePath, True)
-                      liftIO $ env.writeSource (Text.pack scratchFilePath) (Text.pack $ Pretty.toPlain 80 prettyUnisonFile) True
-                      done Output.UpdateTypecheckingFailure
+                          scratchFilePath <- fst <$> Cli.expectLatestFile
+                          #latestFile ?= (scratchFilePath, True)
+                          liftIO $ env.writeSource (Text.pack scratchFilePath) (Text.pack $ Pretty.toPlain 80 prettyUnisonFile) True
+                          done (Output.UpdateTypecheckingFailure2 scratchFilePath pp.branch.name updateBranchName)
                     else do
                       scratchFilePath <- fst <$> Cli.expectLatestFile
                       #latestFile ?= (scratchFilePath, True)

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -424,6 +424,7 @@ data Output
   | HappyCoding
   | ProjectHasNoReleases ProjectName
   | UpdateTypecheckingFailure
+  | UpdateTypecheckingFailure2 !FilePath !ProjectBranchName !ProjectBranchName
   | UpdateIncompleteConstructorSet UpdateOrUpgrade Name (Map ConstructorId Name) (Maybe Int)
   | UpgradeFailure !ProjectBranchName !ProjectBranchName !FilePath !NameSegment !NameSegment
   | UpgradeSuccess !NameSegment !NameSegment !(Maybe NameSegment)
@@ -509,6 +510,7 @@ type SourceFileContents = Text
 isFailure :: Output -> Bool
 isFailure o = case o of
   UpdateTypecheckingFailure {} -> True
+  UpdateTypecheckingFailure2 {} -> True
   UpdateIncompleteConstructorSet {} -> True
   AmbiguousCloneLocal {} -> True
   AmbiguousCloneRemote {} -> True

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1963,6 +1963,26 @@ notifyUser dir = \case
         <> "Once the file is compiling, try"
         <> makeExample' IP.update
         <> "again."
+  UpdateTypecheckingFailure2 scratchFile0 baseBranch updateBranch -> do
+    scratchFile <- renderFileName scratchFile0
+    pure $
+      P.wrap
+        ( "Some definitions don't typecheck with your changes. I've update the file"
+            <> scratchFile
+            <> "with the definitions that need fixing. Once the file is compiling, try"
+            <> makeExample' IP.update
+            <> "again."
+        )
+        <> P.newline
+        <> P.newline
+        <> P.wrap
+          ( "I've also switched you to a new branch"
+              <> prettyProjectBranchName updateBranch
+              <> "for this work. On"
+              <> P.group (makeExample' IP.update <> ",")
+              <> "it will be merged back into"
+              <> P.group (prettyProjectBranchName baseBranch <> ".")
+          )
   UpdateIncompleteConstructorSet operation typeName _ctorMap _expectedCount ->
     let operationName = case operation of E.UOUUpdate -> "update"; E.UOUUpgrade -> "upgrade"
      in pure $


### PR DESCRIPTION
## Overview

Depends on #5768 

This PR just tweaks the output on a failed `update`.

Before:

<img width="789" alt="Screenshot 2025-06-20 at 9 41 27 AM" src="https://github.com/user-attachments/assets/f752e5bb-2558-407f-a207-92010d1a9a96" />

After:

<img width="789" alt="Screenshot 2025-06-20 at 9 46 11 AM" src="https://github.com/user-attachments/assets/1ca6256c-3728-4080-ad40-62496daa0997" />