### PR TITLE
bugfix: make getProjectBranchRootCausal not fail if branch doesn't exist

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -131,6 +131,7 @@ module U.Codebase.Sqlite.Queries
     renameProjectBranch,
     deleteProjectBranch,
     setProjectBranchHead,
+    loadProjectBranchHead,
     expectProjectBranchHead,
     setMostRecentBranch,
     loadMostRecentBranch,
@@ -3968,14 +3969,21 @@ setProjectBranchHead description projectId branchId causalHashId = do
         reason = description
       }
 
+loadProjectBranchHead :: ProjectId -> ProjectBranchId -> Transaction (Maybe CausalHashId)
+loadProjectBranchHead projectId branchId =
+  queryMaybeCol (loadProjectBranchHeadSql projectId branchId)
+
 expectProjectBranchHead :: (HasCallStack) => ProjectId -> ProjectBranchId -> Transaction CausalHashId
 expectProjectBranchHead projectId branchId =
-  queryOneCol
-    [sql|
-      SELECT causal_hash_id
-      FROM project_branch
-      WHERE project_id = :projectId AND branch_id = :branchId
-    |]
+  queryOneCol (loadProjectBranchHeadSql projectId branchId)
+
+loadProjectBranchHeadSql :: ProjectId -> ProjectBranchId -> Sql
+loadProjectBranchHeadSql projectId branchId =
+  [sql|
+    SELECT causal_hash_id
+    FROM project_branch
+    WHERE project_id = :projectId AND branch_id = :branchId
+  |]
 
 data LoadRemoteBranchFlag
   = IncludeSelfRemote

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -272,10 +272,10 @@ getShallowProjectBranchRoot pb = do
   getProjectBranchRootCausal pb >>= traverse V2Causal.value
 
 getProjectBranchRootCausal :: ProjectBranch -> Sqlite.Transaction (Maybe (V2Branch.CausalBranch Sqlite.Transaction))
-getProjectBranchRootCausal ProjectBranch {projectId, branchId} = do
-  causalHashId <- Q.expectProjectBranchHead projectId branchId
-  causalHash <- Q.expectCausalHash causalHashId
-  Operations.loadCausalBranchByCausalHash causalHash
+getProjectBranchRootCausal ProjectBranch {projectId, branchId} = runMaybeT do
+  causalHashId <- MaybeT $ Q.loadProjectBranchHead projectId branchId
+  causalHash <- lift $ Q.expectCausalHash causalHashId
+  MaybeT $ Operations.loadCausalBranchByCausalHash causalHash
 
 expectProjectBranchRootCausal :: ProjectBranch -> Sqlite.Transaction (V2Branch.CausalBranch Sqlite.Transaction)
 expectProjectBranchRootCausal ProjectBranch {projectId, branchId} = do

--- a/unison-cli/src/Unison/Cli/MonadUtils.hs
+++ b/unison-cli/src/Unison/Cli/MonadUtils.hs
@@ -442,7 +442,7 @@ updateProjectBranchRoot projectBranch reason f = do
         liftIO (env.lspCheckForChanges projectPathIds)
     pure result
 
-setProjectBranchRootToCausalHash :: ProjectBranch -> Text -> CausalHash -> Cli ()
+setProjectBranchRootToCausalHash :: (HasCallStack) => ProjectBranch -> Text -> CausalHash -> Cli ()
 setProjectBranchRootToCausalHash projectBranch reason targetCH = do
   Cli.time "setProjectBranchRootToCausalHash" do
     Cli.runTransaction $ do


### PR DESCRIPTION
## Overview

This PR amends `getProjectBranchRootCausal`, which returns a `Maybe`, to return `Nothing` when the give project/branch doesn't exist, rather than throw a runtime exception.