### PR TITLE
bugfix: make `back` not fail on deleted branch

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -118,6 +118,7 @@ module U.Codebase.Sqlite.Queries
     deleteProject,
 
     -- ** project branches
+    projectBranchExists,
     projectBranchExistsByName,
     loadProjectBranchByName,
     loadProjectBranchByNames,
@@ -3659,6 +3660,19 @@ renameProject projectId name =
       UPDATE project
       SET name = :name
       WHERE id = :projectId
+    |]
+
+-- | Does a project branch exist?
+projectBranchExists :: ProjectId -> ProjectBranchId -> Transaction Bool
+projectBranchExists projectId branchId =
+  queryOneCol
+    [sql|
+      SELECT EXISTS (
+        SELECT 1
+        FROM project_branch
+        WHERE project_id = :projectId
+          AND branch_id = :branchId
+      )
     |]
 
 -- | Does a project branch exist by this name?

--- a/unison-cli/src/Unison/Cli/Monad.hs
+++ b/unison-cli/src/Unison/Cli/Monad.hs
@@ -422,10 +422,7 @@ popd = do
             False -> loop paths
   state <- State.get
   runTransaction (loop (List.NonEmpty.tail (projectPathStack state))) >>= \case
-    Nothing -> do
-      -- blow out deleted branches from stack, if any.
-      #projectPathStack %= \(path List.NonEmpty.:| _) -> (path List.NonEmpty.:| [])
-      pure False
+    Nothing -> pure False
     Just (path, paths) -> do
       #projectPathStack .= (path List.NonEmpty.:| paths)
       env <- ask

--- a/unison-cli/src/Unison/Cli/Monad.hs
+++ b/unison-cli/src/Unison/Cli/Monad.hs
@@ -406,18 +406,28 @@ switchProject pab@(ProjectAndBranch projectId branchId) = do
     Codebase.preloadProjectBranch env.codebase pab
     env.lspCheckForChanges newPP
 
--- | Pop the latest path off the stack, if it's not the only path in the stack.
+-- | Pop the latest path off the stack, if it's not the only path in the stack, and keep popping until we either get to
+-- a project branch that still exists (i.e. wasn't deleted), or we get to a singleton stack.
 --
--- Returns whether anything was popped.
+-- Returns whether the current path has changed.
 popd :: Cli Bool
 popd = do
+  let loop = \case
+        [] -> pure Nothing
+        path : paths ->
+          Q.projectBranchExists path.project path.branch >>= \case
+            True -> do
+              Codebase.setCurrentProjectPath path
+              pure (Just (path, paths))
+            False -> loop paths
   state <- State.get
-  case List.NonEmpty.uncons (projectPathStack state) of
-    (_, Nothing) -> pure False
-    (_, Just paths) -> do
-      let path = List.NonEmpty.head paths
-      runTransaction (Codebase.setCurrentProjectPath path)
-      State.put state {projectPathStack = paths}
+  runTransaction (loop (List.NonEmpty.tail (projectPathStack state))) >>= \case
+    Nothing -> do
+      -- blow out deleted branches from stack, if any.
+      #projectPathStack %= \(path List.NonEmpty.:| _) -> (path List.NonEmpty.:| [])
+      pure False
+    Just (path, paths) -> do
+      #projectPathStack .= (path List.NonEmpty.:| paths)
       env <- ask
       liftIO (env.lspCheckForChanges path)
       pure True


### PR DESCRIPTION
## Overview

This PR amends `back` so that it doesn't fail when you try to go `back` to a deleted branch. It'll now just discard deleted stuff until it finds something that exists. I tested this change manually.