### PR TITLE
add list-fuzzy / lsf command

### DIFF
--- a/unison-cli-integration/integration-tests/IntegrationTests/transcript.output.md
+++ b/unison-cli-integration/integration-tests/IntegrationTests/transcript.output.md
@@ -8,7 +8,7 @@ scratch/main> load ./unison-src/transcripts-using-base/base.u
 scratch/main> add
 ```
 
-``` unison :hide
+``` unison
 use lib.builtins
 
 unique type MyBool = MyTrue | MyFalse

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -1189,13 +1189,29 @@ findShallow =
     "list"
     ["ls", "dir"]
     I.Visible
+    (Parameters [] $ Optional [("namespace", namespaceArg)] Nothing)
+    ( P.wrapColumn2
+        [ (makeExample findShallow [], "lists definitions and namespaces in the current namespace."),
+          (makeExample findShallow ["foo"], "lists the 'foo' namespace."),
+          (makeExample findShallow [".foo"], "lists the '.foo' namespace.")
+        ]
+    )
+    ( fmap Input.FindShallowI . \case
+        [] -> pure Path.Current'
+        path : _ -> handlePath'Arg path
+    )
+
+findFuzzy :: InputPattern
+findFuzzy =
+  InputPattern
+    "list-fuzzy"
+    ["lsf"]
+    I.Visible
     (Parameters [("namespace", namespaceArg)] (Optional [] Nothing))
     ( P.wrapColumn2
-        [ ("`list`", "lists definitions and namespaces in a namespace you select (requires fzf)."),
-          ("`list .`", "lists definitions and namespaces in the project root."),
-          ("`list .foo`", "lists definitions and namespaces in the '.foo' namespace."),
-          ("`list foo`", "lists definitions and namespaces in the 'foo' namespace.")
-        ]
+        [(makeExample' findFuzzy, "lists definitions and namespaces in a namespace you select (requires fzf).")]
+        <> P.newline
+        <> P.wrap ("If you pass arguments to" <> makeExample' findFuzzy <> "it will behave the same as as" <> makeExample' findShallow)
     )
     ( fmap Input.FindShallowI . \case
         [] -> pure Path.Current'
@@ -3542,6 +3558,7 @@ validInputs =
       findIn,
       findAll,
       findInAll,
+      findFuzzy,
       findGlobal,
       findShallow,
       findVerbose,

--- a/unison-src/transcripts/idempotent/help.md
+++ b/unison-src/transcripts/idempotent/help.md
@@ -518,14 +518,16 @@ scratch/main> help
                                               `@unison/base`
 
   list (or ls, dir)
-  `list`       lists definitions and namespaces in a namespace
-               you select (requires fzf).
-  `list .`     lists definitions and namespaces in the project
-               root.
-  `list .foo`  lists definitions and namespaces in the '.foo'
+  `list`       lists definitions and namespaces in the current
                namespace.
-  `list foo`   lists definitions and namespaces in the 'foo'
-               namespace.
+  `list foo`   lists the 'foo' namespace.
+  `list .foo`  lists the '.foo' namespace.
+
+  list-fuzzy (or lsf)
+  `list-fuzzy`  lists definitions and namespaces in a namespace
+                you select (requires fzf).
+  If you pass arguments to `list-fuzzy` it will behave the same
+  as as `list`
 
   load
   `load`                 parses, typechecks, and evaluates the


### PR DESCRIPTION
`list-fuzzy` or `lsf` will open `fzf` to search among paths within the current branch, which can be useful for browsing a project or library.