### PR TITLE
Add tab-completion and fzf completion for file arguments

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -632,7 +632,9 @@ loop e = do
                   ( \_ (paramName, IP.ParameterType {fzfResolver}) arg ->
                       if arg == "_"
                         then case fzfResolver of
-                          Just IP.FZFResolver {getOptions} -> do
+                          Just IP.DefaultFZFFileSearch -> do
+                            (,[]) <$> Cli.respond (DebugDisplayFuzzyOptions paramName ["<files>"])
+                          Just (IP.FetchOptions getOptions) -> do
                             pp <- Cli.getCurrentProjectPath
                             results <- liftIO $ getOptions codebase pp currentBranch
                             (,[]) <$> Cli.respond (DebugDisplayFuzzyOptions paramName (Text.unpack <$> results))

--- a/unison-cli/src/Unison/CommandLine.hs
+++ b/unison-cli/src/Unison/CommandLine.hs
@@ -239,12 +239,19 @@ fzfResolve codebase ppCtx getCurrentBranch InputPattern.Parameters {requiredPara
         fzfResolver
     fuzzyFillArg ::
       Bool -> Text -> InputPattern.FZFResolver -> MaybeT (ExceptT FZFResolveFailure IO) (NonEmpty InputPattern.Argument)
-    fuzzyFillArg allowMulti argDesc InputPattern.FZFResolver {getOptions} = MaybeT do
+    fuzzyFillArg allowMulti argDesc fzfResolver = MaybeT do
       currentBranch <- Branch.withoutTransitiveLibs <$> liftIO getCurrentBranch
-      options <- liftIO $ getOptions codebase ppCtx currentBranch
-      when (null options) . throwError $ NoFZFOptions argDesc
-      liftIO $ PrettyTerm.putPrettyLn' (FZFResolvers.fuzzySelectHeader argDesc)
-      results <- liftIO (Fuzzy.fuzzySelect Fuzzy.defaultOptions {Fuzzy.allowMultiSelect = allowMulti} id options)
+      results <- case fzfResolver of
+        InputPattern.FetchOptions getOptions -> do
+          options <- liftIO $ getOptions codebase ppCtx currentBranch
+          when (null options) . throwError $ NoFZFOptions argDesc
+          liftIO $ PrettyTerm.putPrettyLn' (FZFResolvers.fuzzySelectHeader argDesc)
+          let selections = Fuzzy.SelectFromChoices id options
+          liftIO (Fuzzy.fuzzySelect Fuzzy.defaultOptions {Fuzzy.allowMultiSelect = allowMulti} selections)
+        InputPattern.DefaultFZFFileSearch -> do
+          liftIO $ PrettyTerm.putPrettyLn' (FZFResolvers.fuzzySelectHeader argDesc)
+          let selections = Fuzzy.SelectFiles
+          liftIO (Fuzzy.fuzzySelect Fuzzy.defaultOptions {Fuzzy.allowMultiSelect = allowMulti} selections)
       -- If the user triggered the fuzzy finder, but selected nothing, abort the command rather than continuing
       -- execution with no arguments.
       pure $ fmap (Left . Text.unpack <$>) . nonEmpty =<< results

--- a/unison-cli/src/Unison/CommandLine/Completion.hs
+++ b/unison-cli/src/Unison/CommandLine/Completion.hs
@@ -16,6 +16,7 @@ module Unison.CommandLine.Completion
     fixupCompletion,
     haskelineTabComplete,
     sharePathCompletion,
+    filenameCompletion,
   )
 where
 
@@ -78,12 +79,12 @@ haskelineTabComplete patterns codebase authedHTTPClient ppCtx = Line.completeWor
   if null prev
     then pure . exactComplete word $ Map.keys patterns
     else -- User has finished a command name; use completions for that command
-    case words $ reverse prev of
-      h : t -> fromMaybe (pure []) $ do
-        p <- Map.lookup h patterns
-        paramType <- IP.paramType (IP.params p) (length t)
-        pure $ IP.suggestions paramType word codebase authedHTTPClient ppCtx
-      _ -> pure []
+      case words $ reverse prev of
+        h : t -> fromMaybe (pure []) $ do
+          p <- Map.lookup h patterns
+          paramType <- IP.paramType (IP.params p) (length t)
+          pure $ IP.suggestions paramType word codebase authedHTTPClient ppCtx
+        _ -> pure []
 
 -- | Things which we may want to complete for.
 data CompletionType
@@ -439,3 +440,13 @@ instance Aeson.FromJSON SearchResult where
     handle <- obj Aeson..: "handle"
     tag <- obj Aeson..: "tag"
     pure $ SearchResult {..}
+
+filenameCompletion ::
+  (MonadIO m) =>
+  String ->
+  m [Completion]
+filenameCompletion query = do
+  -- Haskeline uses a zipper-style cursor format, so it expects the prefix to be reversed.
+  let prefix = reverse query
+  (_leftovers, results) <- Line.completeFilename (prefix, "")
+  pure results

--- a/unison-cli/src/Unison/CommandLine/Completion.hs
+++ b/unison-cli/src/Unison/CommandLine/Completion.hs
@@ -79,12 +79,12 @@ haskelineTabComplete patterns codebase authedHTTPClient ppCtx = Line.completeWor
   if null prev
     then pure . exactComplete word $ Map.keys patterns
     else -- User has finished a command name; use completions for that command
-      case words $ reverse prev of
-        h : t -> fromMaybe (pure []) $ do
-          p <- Map.lookup h patterns
-          paramType <- IP.paramType (IP.params p) (length t)
-          pure $ IP.suggestions paramType word codebase authedHTTPClient ppCtx
-        _ -> pure []
+    case words $ reverse prev of
+      h : t -> fromMaybe (pure []) $ do
+        p <- Map.lookup h patterns
+        paramType <- IP.paramType (IP.params p) (length t)
+        pure $ IP.suggestions paramType word codebase authedHTTPClient ppCtx
+      _ -> pure []
 
 -- | Things which we may want to complete for.
 data CompletionType

--- a/unison-cli/src/Unison/CommandLine/FZFResolvers.hs
+++ b/unison-cli/src/Unison/CommandLine/FZFResolvers.hs
@@ -55,9 +55,9 @@ import Unison.Util.Relation qualified as Relation
 
 type OptionFetcher = Codebase IO Symbol Ann -> PP.ProjectPath -> Branch0 IO -> IO [Text]
 
-data FZFResolver = FZFResolver
-  { getOptions :: OptionFetcher
-  }
+data FZFResolver
+  = FetchOptions OptionFetcher
+  | DefaultFZFFileSearch
 
 instance Show FZFResolver where
   show _ = "<FZFResolver>"
@@ -126,7 +126,7 @@ projectDependencyOptions _codebase _projCtx searchBranch0 = do
 -- Returned Path's will match the provided 'Position' type.
 fuzzySelectFromList :: [Text] -> FZFResolver
 fuzzySelectFromList options =
-  (FZFResolver {getOptions = \_codebase _projCtx _branch -> pure options})
+  (FetchOptions (\_codebase _projCtx _branch -> pure options))
 
 -- | Combine multiple option fetchers into one resolver.
 multiResolver :: [OptionFetcher] -> FZFResolver
@@ -134,25 +134,25 @@ multiResolver resolvers =
   let getOptions :: Codebase IO Symbol Ann -> PP.ProjectPath -> Branch0 IO -> IO [Text]
       getOptions codebase projCtx searchBranch0 = do
         List.nubOrd <$> foldMapM (\f -> f codebase projCtx searchBranch0) resolvers
-   in (FZFResolver {getOptions})
+   in (FetchOptions getOptions)
 
 definitionResolver :: FZFResolver
-definitionResolver = FZFResolver {getOptions = definitionOptions}
+definitionResolver = FetchOptions definitionOptions
 
 typeDefinitionResolver :: FZFResolver
-typeDefinitionResolver = FZFResolver {getOptions = typeDefinitionOptions}
+typeDefinitionResolver = FetchOptions typeDefinitionOptions
 
 termDefinitionResolver :: FZFResolver
-termDefinitionResolver = FZFResolver {getOptions = termDefinitionOptions}
+termDefinitionResolver = FetchOptions termDefinitionOptions
 
 namespaceResolver :: FZFResolver
-namespaceResolver = FZFResolver {getOptions = namespaceOptions}
+namespaceResolver = FetchOptions namespaceOptions
 
 namespaceOrDefinitionResolver :: FZFResolver
 namespaceOrDefinitionResolver = multiResolver [definitionOptions, namespaceOptions]
 
 projectDependencyResolver :: FZFResolver
-projectDependencyResolver = FZFResolver {getOptions = projectDependencyOptions}
+projectDependencyResolver = FetchOptions projectDependencyOptions
 
 -- | A project name, branch name, or both.
 projectAndOrBranchArg :: FZFResolver
@@ -162,13 +162,13 @@ projectOrBranchResolver :: FZFResolver
 projectOrBranchResolver = multiResolver [projectBranchOptions, namespaceOptions]
 
 projectBranchResolver :: FZFResolver
-projectBranchResolver = FZFResolver {getOptions = projectBranchOptions}
+projectBranchResolver = FetchOptions projectBranchOptions
 
 projectBranchWithinCurrentProjectResolver :: FZFResolver
-projectBranchWithinCurrentProjectResolver = FZFResolver {getOptions = projectBranchOptionsWithinCurrentProject}
+projectBranchWithinCurrentProjectResolver = FetchOptions projectBranchOptionsWithinCurrentProject
 
 projectNameResolver :: FZFResolver
-projectNameResolver = FZFResolver {getOptions = projectNameOptions}
+projectNameResolver = FetchOptions projectNameOptions
 
 -- | All possible local project names
 -- E.g. '@unison/base'

--- a/unison-cli/src/Unison/CommandLine/FuzzySelect.hs
+++ b/unison-cli/src/Unison/CommandLine/FuzzySelect.hs
@@ -7,11 +7,13 @@ module Unison.CommandLine.FuzzySelect
     isFZFInstalled,
     fzfPathEnvVar,
     Options (..),
+    FuzzySelections (..),
     defaultOptions,
   )
 where
 
-import Control.Monad.Except (runExceptT, throwError)
+import Control.Monad.Except (throwError)
+import Control.Monad.Trans.Except
 import Data.Set qualified as Set
 import Data.Text qualified as Text
 import Data.Text.IO qualified as Text
@@ -20,6 +22,7 @@ import System.Environment (lookupEnv)
 import System.IO (BufferMode (NoBuffering), hPutStrLn, stderr)
 import System.IO.Unsafe (unsafePerformIO)
 import Unison.Prelude
+import Unison.Util.Monoid qualified as Monoid
 import UnliftIO qualified
 import UnliftIO.Directory (findExecutable)
 import UnliftIO.Exception (bracket)
@@ -57,28 +60,33 @@ defaultOptions =
     }
 
 -- | Convert options into command-line args for fzf
-optsToArgs :: Options -> [String]
-optsToArgs opts =
+optsToArgs :: Options -> Bool -> [String]
+optsToArgs opts useNumberings =
   defaultArgs <> case opts of
     Options {allowMultiSelect = True} -> ["-m"]
     _ -> []
   where
     defaultArgs =
-      -- Don't show or match on the first column of input.
+      -- When using numberings, don't show or match on the first column of input.
       -- This allows us to prepend each line with a number, and use that number to determine
       -- which values from the input list were selected.
-      [ "--with-nth",
-        "2..",
-        -- Use only half the screen (it's nice to see what you were working on when searching)
-        "--height=50%",
-        -- But if 50% of the screen is too small, ensure show at least 10 results.
-        "--min-height=10"
-      ]
+      Monoid.whenM
+        useNumberings
+        ["--with-nth", "2.."]
+        <> [ -- Use only half the screen (it's nice to see what you were working on when searching)
+             "--height=50%",
+             -- But if 50% of the screen is too small, ensure show at least 10 results.
+             "--min-height=10"
+           ]
+
+data FuzzySelections a where
+  SelectFromChoices :: (a -> Text) -> [a] -> FuzzySelections a
+  SelectFiles :: FuzzySelections Text
 
 -- | Allows prompting the user to interactively fuzzy-select a result from a list of options, currently shells out to `fzf` under the hood.
 -- If fzf is missing, or an error (other than ctrl-c) occurred, returns Nothing.
-fuzzySelect :: forall a. Options -> (a -> Text) -> [a] -> IO (Maybe [a])
-fuzzySelect opts intoSearchText choices =
+fuzzySelect :: forall a. Options -> FuzzySelections a -> IO (Maybe [a])
+fuzzySelect opts selections =
   UnliftIO.handleAny handleException
     . handleError
     . restoreBuffering
@@ -88,12 +96,36 @@ fuzzySelect opts intoSearchText choices =
         liftIO fzfExecutable >>= \case
           Nothing -> throwError "I couldn't find the `fzf` executable on your path, consider installing `fzf` to enable fuzzy searching."
           Just fzfPath -> pure fzfPath
-      let fzfArgs :: [String] =
-            optsToArgs opts
-      let numberedChoices :: [(Int, a)] =
-            zip [0 ..] choices
-      let searchTexts :: [Text] =
-            (\(n, ch) -> tShow (n) <> " " <> intoSearchText ch) <$> numberedChoices
+      case selections of
+        SelectFromChoices intoSearchText choices -> do
+          let fzfArgs :: [String] =
+                optsToArgs opts True
+          let numberedChoices :: [(Int, a)] =
+                zip [0 ..] choices
+          let searchTexts :: [Text] =
+                (\(n, ch) -> tShow (n) <> " " <> intoSearchText ch) <$> numberedChoices
+
+          result <- fzfWithChoices fzfPath fzfArgs searchTexts
+          -- Since we prefixed every search term with its number earlier, we know each result
+          -- is prefixed with a number, we need to parse it and use it to select the matching
+          -- value from our input list.
+          pure $ case result of
+            Left _ -> Nothing
+            Right selections ->
+              selections
+                & mapMaybe (readMaybe @Int . Text.unpack . Text.takeWhile (/= ' '))
+                & Set.fromList
+                & ( \selectedNumbers ->
+                      numberedChoices
+                        & mapMaybe (\(n, a) -> if n `Set.member` selectedNumbers then Just a else Nothing)
+                  )
+                & Just
+        SelectFiles -> do
+          let fzfArgs :: [String] = optsToArgs opts False
+          eitherToMaybe <$> fzfFileSelector fzfPath fzfArgs
+  where
+    fzfWithChoices :: FilePath -> [String] -> [Text] -> ExceptT Text IO (Either SomeException [Text])
+    fzfWithChoices fzfPath fzfArgs searchTexts = do
       let fzfProc :: Proc.CreateProcess =
             (Proc.proc fzfPath fzfArgs)
               { Proc.std_in = Proc.CreatePipe,
@@ -104,28 +136,27 @@ fuzzySelect opts intoSearchText choices =
       -- Generally no-buffering is helpful for highly interactive processes.
       hSetBuffering stdin NoBuffering
       hSetBuffering stdin' NoBuffering
-      result <- liftIO . UnliftIO.tryAny $ do
+      liftIO . UnliftIO.tryAny $ do
         -- Dump the search terms into fzf's stdin
         traverse_ (Text.hPutStrLn stdin') searchTexts
         -- Wire up the interactive terminal to fzf now that the inputs have been loaded.
         hDuplicateTo stdin stdin'
         void $ Proc.waitForProcess procHandle
         Text.lines <$> liftIO (Text.hGetContents stdout')
-      -- Since we prefixed every search term with its number earlier, we know each result
-      -- is prefixed with a number, we need to parse it and use it to select the matching
-      -- value from our input list.
-      pure $ case result of
-        Left _ -> Nothing
-        Right selections ->
-          selections
-            & mapMaybe (readMaybe @Int . Text.unpack . Text.takeWhile (/= ' '))
-            & Set.fromList
-            & ( \selectedNumbers ->
-                  numberedChoices
-                    & mapMaybe (\(n, a) -> if n `Set.member` selectedNumbers then Just a else Nothing)
-              )
-            & Just
-  where
+    fzfFileSelector :: FilePath -> [String] -> ExceptT Text IO (Either SomeException [Text])
+    fzfFileSelector fzfPath fzfArgs = do
+      let fzfProc :: Proc.CreateProcess =
+            (Proc.proc fzfPath fzfArgs)
+              { Proc.std_in = Proc.Inherit,
+                Proc.std_out = Proc.CreatePipe,
+                Proc.delegate_ctlc = True
+              }
+      (_stdin', Just stdout', _, procHandle) <- Proc.createProcess fzfProc
+      -- Generally no-buffering is helpful for highly interactive processes.
+      hSetBuffering stdin NoBuffering
+      liftIO . UnliftIO.tryAny $ do
+        void $ Proc.waitForProcess procHandle
+        Text.lines <$> liftIO (Text.hGetContents stdout')
     handleException :: SomeException -> IO (Maybe [a])
     handleException err = traceShowM err *> hPutStrLn stderr "Oops, something went wrong. No input selected." *> pure Nothing
     handleError :: IO (Either Text (Maybe [a])) -> IO (Maybe [a])

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -3746,7 +3746,7 @@ filePathArg :: ParameterType
 filePathArg =
   ParameterType
     { typeName = "file-path",
-      suggestions = noCompletions,
+      suggestions = \prefix _ _ _ -> filenameCompletion prefix,
       fzfResolver = Nothing,
       isStructured = False
     }

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -1815,7 +1815,7 @@ debugFormat =
     "debug.format"
     []
     I.Hidden
-    (Parameters [] $ Optional [("source-file", filePathArg)] Nothing)
+    (Parameters [] $ Optional [("source file", filePathArg)] Nothing)
     ( P.lines
         [ P.wrap $ "This command can be used to test ucm's file formatter on the latest typechecked file.",
           makeExample' debugFormat
@@ -2016,7 +2016,7 @@ syncToFile =
       aliases = [],
       visibility = I.Visible,
       params =
-        Parameters [("file-path", filePathArg)] $
+        Parameters [("destination sync file", filePathArg)] $
           Optional [("branch", projectAndBranchNamesArg suggestionsConfig)] Nothing,
       help =
         ( P.wrapColumn2
@@ -2048,7 +2048,7 @@ syncFromFile =
       aliases = [],
       visibility = I.Visible,
       params =
-        Parameters [("file-path", filePathArg), ("destination branch", projectAndBranchNamesArg suggestionsConfig)] $
+        Parameters [("file to sync from", filePathArg), ("destination branch", projectAndBranchNamesArg suggestionsConfig)] $
           Optional [] Nothing,
       help =
         ( P.wrapColumn2
@@ -2077,9 +2077,9 @@ syncFromCodebase =
       visibility = I.Visible,
       params =
         Parameters
-          [ ("codebase-location", filePathArg),
-            ("branch-to-sync", projectAndBranchNamesArg suggestionsConfig),
-            ("destination-branch", projectAndBranchNamesArg suggestionsConfig)
+          [ ("codebase location", directoryPathArg),
+            ("branch to sync", projectAndBranchNamesArg suggestionsConfig),
+            ("destination branch", projectAndBranchNamesArg suggestionsConfig)
           ]
           $ Optional [] Nothing,
       help =
@@ -2867,7 +2867,7 @@ docsToHtml =
     "docs.to-html"
     []
     I.Visible
-    (Parameters [("namespace", branchRelativePathArg), ("output directory", filePathArg)] $ Optional [] Nothing)
+    (Parameters [("namespace", branchRelativePathArg), ("output directory", directoryPathArg)] $ Optional [] Nothing)
     ( P.wrapColumn2
         [ ( makeExample docsToHtml [".path.to.ns", "doc-dir"],
             "Render all docs contained within the namespace `.path.to.ns`, no matter how deep, to html files in `doc-dir` in the directory UCM was run from."
@@ -3746,6 +3746,15 @@ filePathArg :: ParameterType
 filePathArg =
   ParameterType
     { typeName = "file-path",
+      suggestions = \prefix _ _ _ -> filenameCompletion prefix,
+      fzfResolver = Just I.DefaultFZFFileSearch,
+      isStructured = False
+    }
+
+directoryPathArg :: ParameterType
+directoryPathArg =
+  ParameterType
+    { typeName = "directory-path",
       suggestions = \prefix _ _ _ -> filenameCompletion prefix,
       fzfResolver = Nothing,
       isStructured = False


### PR DESCRIPTION
## Overview

It was strange that I couldn't tab-complete scratch-files or sync files; now I can.

I just default to the standard fzf no-args behaviour for file searching, it'll respect the user's fzf configuration for file-finding :)

## Implementation notes

* Sets up Haskeline's builtin file-completion handler
* Sets up fzf's default file search behaviour
* Adds a new directory arg type just because fzf's file searcher doesn't search for directories.

## Test coverage

* Hard-coded the fzf resolver debugger in transcripts to just return `<files>` so it's still deterministic.
* Tested manually with the sync commands and `load`

