### PR TITLE
Revert hpack version comment from 0.37.0 to 0.36.0

### DIFF
--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 

--- a/unison-runtime/unison-runtime.cabal
+++ b/unison-runtime/unison-runtime.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -21,15 +21,15 @@ flag arraychecks
   manual: True
   default: False
 
+flag codeserialchecks
+  manual: True
+  default: False
+
 flag dumpcore
   manual: True
   default: False
 
 flag optchecks
-  manual: True
-  default: False
-
-flag codeserialchecks
   manual: True
   default: False
 
@@ -166,7 +166,7 @@ library
     build-depends:
         inspection-testing
   if flag(codeserialchecks)
-    cpp-options: -DCODE_SERIAL_CHECK
+    ghc-options: -DCODE_SERIAL_CHECK
   if flag(dumpcore)
     ghc-options: -ddump-simpl -ddump-stg-final -ddump-to-file -dsuppress-coercions -dsuppress-idinfo -dsuppress-module-prefixes -ddump-str-signatures -ddump-simpl-stats
 
@@ -253,5 +253,7 @@ test-suite runtime-tests
     cpp-options: -DOPT_CHECK
     build-depends:
         inspection-testing
+  if flag(codeserialchecks)
+    ghc-options: -DCODE_SERIAL_CHECK
   if flag(dumpcore)
     ghc-options: -ddump-simpl -ddump-stg-final -ddump-to-file -dsuppress-coercions -dsuppress-idinfo -dsuppress-module-prefixes -ddump-str-signatures -ddump-simpl-stats


### PR DESCRIPTION
These were changed by #5522. It doesn't seem like it should be a consequential
change, but the nix build seems to be treating the following as a fatal error
that breaks the build:

```
unison-runtime.cabal was generated with a newer version of hpack, please upgrade and try again.
```