### PR TITLE
Adds tab-completion for Share project/branches/releases on clone/pull/push/lib.install

### DIFF
--- a/unison-cli/src/Unison/CommandLine/Completion.hs
+++ b/unison-cli/src/Unison/CommandLine/Completion.hs
@@ -77,12 +77,12 @@ haskelineTabComplete patterns codebase authedHTTPClient ppCtx = Line.completeWor
   if null prev
     then pure . exactComplete word $ Map.keys patterns
     else -- User has finished a command name; use completions for that command
-      case words $ reverse prev of
-        h : t -> fromMaybe (pure []) $ do
-          p <- Map.lookup h patterns
-          paramType <- IP.paramType (IP.params p) (length t)
-          pure $ IP.suggestions paramType word codebase authedHTTPClient ppCtx
-        _ -> pure []
+    case words $ reverse prev of
+      h : t -> fromMaybe (pure []) $ do
+        p <- Map.lookup h patterns
+        paramType <- IP.paramType (IP.params p) (length t)
+        pure $ IP.suggestions paramType word codebase authedHTTPClient ppCtx
+      _ -> pure []
 
 -- | Things which we may want to complete for.
 data CompletionType

--- a/unison-cli/src/Unison/CommandLine/Completion.hs
+++ b/unison-cli/src/Unison/CommandLine/Completion.hs
@@ -476,6 +476,9 @@ completeShareBranchHelper authHTTPClient query = do
           pure $
             Monoid.whenM (Text.isPrefixOf branchOrContributorPrefix "releases") [handle <> "/" <> proj <> "/releases/"]
               <> results
+    [handle, proj, "releases", ""] -> do
+      searchProjectReleases authHTTPClient handle proj ""
+        <&> (handle <> "/" <> proj <> "/releases/latest" :)
     [handle, proj, "releases", branch]
       | Text.isPrefixOf branch "latest" -> pure [handle <> "/" <> proj <> "/releases/latest"]
       | otherwise -> do
@@ -496,14 +499,14 @@ searchProjectBranches ::
   m [Text]
 searchProjectBranches (AuthenticatedHttpClient httpManager) handle proj contributor query = do
   fromMaybe [] <$> runMaybeT do
-    let searchKind = case contributor of
-          Just {} -> "contributor"
-          Nothing -> "core"
+    let (searchKind, contributorFilter) = case contributor of
+          Just contributor -> ("contributor", "&contributor-handle=" <> contributor)
+          Nothing -> ("core", "")
     let cleanedHandle = Text.dropWhile (== '@') handle
     let uri =
           (Share.codeserverToURI Codeserver.defaultCodeserver)
             { URI.uriPath = "/users/" <> Text.unpack cleanedHandle <> "/projects/" <> Text.unpack proj <> "/branches",
-              URI.uriQuery = Text.unpack $ "?name-prefix=" <> query <> "&kind=" <> searchKind
+              URI.uriQuery = Text.unpack $ "?name-prefix=" <> query <> "&kind=" <> searchKind <> contributorFilter
             }
     Debug.debugM Debug.Temp "searchProjectBranches: uri: " (Text.pack $ show uri)
     req <- MaybeT $ pure (HTTP.requestFromURI uri)

--- a/unison-cli/src/Unison/CommandLine/Completion.hs
+++ b/unison-cli/src/Unison/CommandLine/Completion.hs
@@ -11,6 +11,9 @@ module Unison.CommandLine.Completion
     prefixCompleteType,
     noCompletions,
     prefixCompleteNamespace,
+    fixupCompletion,
+    haskelineTabComplete,
+    shareProjectCompletion,
     -- Unused for now, but may be useful later
     prettyCompletion,
     fixupCompletion,
@@ -21,11 +24,11 @@ module Unison.CommandLine.Completion
 where
 
 import Control.Lens
+import Data.Aeson (FromJSON)
 import Data.Aeson qualified as Aeson
 import Data.List (isPrefixOf)
 import Data.List qualified as List
 import Data.List.Extra (nubOrdOn)
-import Data.List.NonEmpty qualified as List.NonEmpty
 import Data.List.NonEmpty qualified as NE
 import Data.Map qualified as Map
 import Data.Set.NonEmpty (NESet)
@@ -50,16 +53,11 @@ import Unison.Codebase.ProjectPath qualified as PP
 import Unison.Codebase.SqliteCodebase.Conversions qualified as Cv
 import Unison.CommandLine.InputPattern qualified as IP
 import Unison.HashQualifiedPrime qualified as HQ'
-import Unison.Name qualified as Name
 import Unison.NameSegment.Internal (NameSegment (NameSegment))
 import Unison.Prelude
-import Unison.Server.Local.Endpoints.NamespaceListing (NamespaceListing (NamespaceListing))
-import Unison.Server.Local.Endpoints.NamespaceListing qualified as Server
-import Unison.Server.Types qualified as Server
 import Unison.Share.Codeserver qualified as Codeserver
 import Unison.Share.Types qualified as Share
 import Unison.Sqlite qualified as Sqlite
-import Unison.Syntax.Name qualified as Name
 import Unison.Syntax.NameSegment qualified as NameSegment
 import Unison.Util.Monoid qualified as Monoid
 import Unison.Util.Pretty qualified as P
@@ -79,12 +77,12 @@ haskelineTabComplete patterns codebase authedHTTPClient ppCtx = Line.completeWor
   if null prev
     then pure . exactComplete word $ Map.keys patterns
     else -- User has finished a command name; use completions for that command
-    case words $ reverse prev of
-      h : t -> fromMaybe (pure []) $ do
-        p <- Map.lookup h patterns
-        paramType <- IP.paramType (IP.params p) (length t)
-        pure $ IP.suggestions paramType word codebase authedHTTPClient ppCtx
-      _ -> pure []
+      case words $ reverse prev of
+        h : t -> fromMaybe (pure []) $ do
+          p <- Map.lookup h patterns
+          paramType <- IP.paramType (IP.params p) (length t)
+          pure $ IP.suggestions paramType word codebase authedHTTPClient ppCtx
+        _ -> pure []
 
 -- | Things which we may want to complete for.
 data CompletionType
@@ -336,98 +334,44 @@ fixupCompletion q cs@(h : t) =
         then [c {Line.replacement = q} | c <- cs]
         else cs
 
-sharePathCompletion ::
+shareProjectCompletion ::
   (MonadIO m) =>
   AuthenticatedHttpClient ->
   String ->
   m [Completion]
-sharePathCompletion = shareCompletion (NESet.singleton NamespaceCompletion)
+shareProjectCompletion authHTTPClient str =
+  searchProjects authHTTPClient (Text.pack str)
+    <&> fmap (\projectRef -> prettyCompletionWithQueryPrefix True str (Text.unpack projectRef))
 
-shareCompletion ::
-  (MonadIO m) =>
-  NESet CompletionType ->
-  AuthenticatedHttpClient ->
-  String ->
-  m [Completion]
-shareCompletion completionTypes authHTTPClient str =
-  fromMaybe [] <$> runMaybeT do
-    case Path.toList <$> Path.parsePath str of
-      Left _err -> empty
-      Right [] -> empty
-      Right [userPrefix] -> do
-        userHandles <- searchUsers authHTTPClient (NameSegment.toEscapedText userPrefix)
-        pure $
-          userHandles
-            & filter (\userHandle -> NameSegment.toEscapedText userPrefix `Text.isPrefixOf` userHandle)
-            <&> \handle -> prettyCompletionWithQueryPrefix False (Text.unpack (NameSegment.toEscapedText userPrefix)) (Text.unpack handle)
-      Right (userHandle : path0) -> do
-        let (path, pathSuffix) =
-              case unsnoc path0 of
-                Just (path, pathSuffix) -> (Path.fromList path, NameSegment.toEscapedText pathSuffix)
-                Nothing -> (mempty, "")
-        NamespaceListing {namespaceListingChildren} <- MaybeT $ fetchShareNamespaceInfo authHTTPClient (NameSegment.toEscapedText userHandle) path
-        namespaceListingChildren
-          & fmap
-            ( \case
-                Server.Subnamespace nn ->
-                  let name = Server.namespaceName nn
-                   in (NamespaceCompletion, name)
-                Server.TermObject nt ->
-                  let name = HQ'.toTextWith Name.toText $ Server.termName nt
-                   in (NamespaceCompletion, name)
-                Server.TypeObject nt ->
-                  let name = HQ'.toTextWith Name.toText $ Server.typeName nt
-                   in (TermCompletion, name)
-                Server.PatchObject np ->
-                  let name = Server.patchName np
-                   in (NamespaceCompletion, name)
-            )
-          & filter (\(typ, name) -> typ `NESet.member` completionTypes && pathSuffix `Text.isPrefixOf` name)
-          & fmap
-            ( \(_, name) ->
-                let queryPath = userHandle : Path.toList path
-                    result =
-                      (queryPath ++ [NameSegment.unsafeParseText name])
-                        & List.NonEmpty.fromList
-                        & Name.fromSegments
-                        & Name.toText
-                        & Text.unpack
-                 in prettyCompletionWithQueryPrefix False str result
-            )
-          & pure
-
-fetchShareNamespaceInfo :: (MonadIO m) => AuthenticatedHttpClient -> Text -> Path.Path -> m (Maybe NamespaceListing)
-fetchShareNamespaceInfo (AuthenticatedHttpClient httpManager) userHandle path = runMaybeT do
-  let uri =
-        (Share.codeserverToURI Codeserver.defaultCodeserver)
-          { URI.uriPath = Text.unpack $ "/codebases/" <> userHandle <> "/browse",
-            URI.uriQuery =
-              if not . null $ Path.toList path
-                then Text.unpack $ "?relativeTo=" <> tShow path
-                else ""
-          }
-  req <- MaybeT $ pure (HTTP.requestFromURI uri)
-  fullResp <- liftIO $ UnliftIO.tryAny $ HTTP.httpLbs req httpManager
-  resp <- either (const empty) pure $ fullResp
-  MaybeT . pure . Aeson.decode @Server.NamespaceListing $ HTTP.responseBody resp
-
-searchUsers :: (MonadIO m) => AuthenticatedHttpClient -> Text -> m [Text]
-searchUsers _ "" = pure []
-searchUsers (AuthenticatedHttpClient httpManager) userHandlePrefix =
-  fromMaybe [] <$> runMaybeT do
-    let uri =
-          (Share.codeserverToURI Codeserver.defaultCodeserver)
-            { URI.uriPath = "/search",
-              URI.uriQuery = Text.unpack $ "?query=" <> userHandlePrefix
-            }
-    req <- MaybeT $ pure (HTTP.requestFromURI uri)
-    fullResp <- liftIO $ UnliftIO.tryAny $ HTTP.httpLbs req httpManager
-    resp <- either (const empty) pure $ fullResp
-    results <- (MaybeT . pure . Aeson.decode @[SearchResult] $ HTTP.responseBody resp)
-    pure $
-      results
-        & filter (\SearchResult {tag} -> tag == "User")
-        & fmap handle
+-- | Searches for matching projects on the codeserver.
+-- Query is flexible, e.g.
+--
+-- - "base"
+-- - "@unison"
+-- - "@unison/b"
+-- - "postgres"
+-- - "database"
+searchProjects :: (MonadIO m) => AuthenticatedHttpClient -> Text -> m [Text]
+searchProjects _ "" = pure []
+searchProjects (AuthenticatedHttpClient httpManager) query =
+  runSearch "slug-infix" >>= \case
+    -- Fall back to the web search if slug-infix returns no results
+    [] -> runSearch "web-search"
+    results -> pure results
+  where
+    runSearch :: (MonadIO m) => Text -> m [Text]
+    runSearch psk = do
+      fromMaybe [] <$> runMaybeT do
+        let uri =
+              (Share.codeserverToURI Codeserver.defaultCodeserver)
+                { URI.uriPath = "/search",
+                  URI.uriQuery = Text.unpack $ "?kinds=project&project-search-kind=" <> psk <> "&query=" <> query
+                }
+        req <- MaybeT $ pure (HTTP.requestFromURI uri)
+        fullResp <- liftIO $ UnliftIO.tryAny $ HTTP.httpLbs req httpManager
+        resp <- either (const empty) pure $ fullResp
+        (MaybeT . pure . Aeson.decode @[ProjectSearchResult] $ HTTP.responseBody resp)
+          <&> fmap projectRef
 
 data SearchResult = SearchResult
   { handle :: Text,
@@ -440,6 +384,13 @@ instance Aeson.FromJSON SearchResult where
     handle <- obj Aeson..: "handle"
     tag <- obj Aeson..: "tag"
     pure $ SearchResult {..}
+
+instance FromJSON ProjectSearchResult where
+  parseJSON = Aeson.withObject "ProjectSearchResult" \obj -> do
+    projectRef <- obj Aeson..: "projectRef"
+    summary <- obj Aeson..: "summary"
+    visibility <- obj Aeson..: "visibility"
+    pure $ ProjectSearchResult {..}
 
 filenameCompletion ::
   (MonadIO m) =>

--- a/unison-cli/src/Unison/CommandLine/Completion.hs
+++ b/unison-cli/src/Unison/CommandLine/Completion.hs
@@ -13,7 +13,8 @@ module Unison.CommandLine.Completion
     prefixCompleteNamespace,
     fixupCompletion,
     haskelineTabComplete,
-    shareProjectCompletion,
+    completeShareUser,
+    completeShareProject,
     filenameCompletion,
     -- Unused for now, but may be useful later
     prettyCompletion,
@@ -31,11 +32,13 @@ import Data.Map qualified as Map
 import Data.Set.NonEmpty (NESet)
 import Data.Set.NonEmpty qualified as NESet
 import Data.Text qualified as Text
+import Data.These (These (..))
 import Network.HTTP.Client qualified as HTTP
 import Network.URI qualified as URI
 import System.Console.Haskeline qualified as Line
 import System.Console.Haskeline.Completion (Completion)
 import System.Console.Haskeline.Completion qualified as Haskeline
+import Text.Megaparsec qualified as MP
 import Text.Megaparsec qualified as P
 import U.Codebase.Branch qualified as V2Branch
 import U.Codebase.Causal qualified as V2Causal
@@ -49,9 +52,11 @@ import Unison.Codebase.Path.Parse qualified as Path
 import Unison.Codebase.ProjectPath qualified as PP
 import Unison.Codebase.SqliteCodebase.Conversions qualified as Cv
 import Unison.CommandLine.InputPattern qualified as IP
+import Unison.Debug qualified as Debug
 import Unison.HashQualifiedPrime qualified as HQ'
 import Unison.NameSegment.Internal (NameSegment (NameSegment))
 import Unison.Prelude
+import Unison.Project qualified as Project
 import Unison.Share.Codeserver qualified as Codeserver
 import Unison.Share.Types qualified as Share
 import Unison.Sqlite qualified as Sqlite
@@ -331,15 +336,6 @@ fixupCompletion q cs@(h : t) =
         then [c {Line.replacement = q} | c <- cs]
         else cs
 
-shareProjectCompletion ::
-  (MonadIO m) =>
-  AuthenticatedHttpClient ->
-  String ->
-  m [Completion]
-shareProjectCompletion authHTTPClient str =
-  searchProjects authHTTPClient (Text.pack str)
-    <&> fmap (\projectRef -> prettyCompletionWithQueryPrefix True str (Text.unpack projectRef))
-
 -- | Searches for matching projects on the codeserver.
 -- Query is flexible, e.g.
 --
@@ -348,29 +344,179 @@ shareProjectCompletion authHTTPClient str =
 -- - "@unison/b"
 -- - "postgres"
 -- - "database"
-searchProjects :: (MonadIO m) => AuthenticatedHttpClient -> Text -> m [Text]
-searchProjects _ "" = pure []
-searchProjects (AuthenticatedHttpClient httpManager) query =
-  runSearch "slug-infix" >>= \case
+_searchProjects :: (MonadIO m) => AuthenticatedHttpClient -> Text -> m [Text]
+_searchProjects _ "" = pure []
+_searchProjects (AuthenticatedHttpClient httpManager) query = do
+  infixResults <- runSearch "slug-infix"
+  Debug.debugM Debug.Temp "shareProjectCompletion: slug-infix results: " infixResults
+  case infixResults of
     -- Fall back to the web search if slug-infix returns no results
-    [] -> runSearch "web-search"
+    [] -> do
+      webSearchResults <- runSearch "web-search"
+      Debug.debugM Debug.Temp "shareProjectCompletion: web-search results: " webSearchResults
+      pure webSearchResults
     results -> pure results
   where
+    searchKinds
+      -- If the query contains a '/', we assume it's a project search.
+      | Text.isInfixOf "/" query = "projects"
+      | otherwise = "users"
     runSearch :: (MonadIO m) => Text -> m [Text]
     runSearch psk = do
       fromMaybe [] <$> runMaybeT do
         let uri =
               (Share.codeserverToURI Codeserver.defaultCodeserver)
                 { URI.uriPath = "/search",
-                  URI.uriQuery = Text.unpack $ "?project-search-kind=" <> psk <> "&query=" <> query
+                  URI.uriQuery = Text.unpack $ "?kinds=" <> searchKinds <> "&project-search-kind=" <> psk <> "&query=" <> query
                 }
         req <- MaybeT $ pure (HTTP.requestFromURI uri)
         fullResp <- liftIO $ UnliftIO.tryAny $ HTTP.httpLbs req httpManager
         resp <- either (const empty) pure $ fullResp
         (MaybeT . pure . Aeson.decode @[SearchResult] $ HTTP.responseBody resp)
           <&> fmap \case
-            SearchResultUserLike handle -> handle
-            SearchResultProject ref -> ref
+            SearchResultUserLike handle -> "@" <> handle <> "/"
+            SearchResultProject ref -> ref <> "/"
+
+data SearchKind = UserKind | ProjectKind
+  deriving (Show, Eq)
+
+completeShareUser ::
+  (MonadIO m) =>
+  AuthenticatedHttpClient ->
+  String ->
+  m [Completion]
+completeShareUser authHTTPClient query =
+  completeShareUserHelper authHTTPClient (Text.pack query)
+    <&> fmap \handle ->
+      Line.Completion
+        { Line.replacement = Text.unpack handle,
+          Line.display = Text.unpack handle,
+          Line.isFinished = False
+        }
+
+completeShareUserHelper ::
+  (MonadIO m) =>
+  AuthenticatedHttpClient ->
+  Text ->
+  m [Text]
+completeShareUserHelper authHTTPClient query = do
+  results <- runShareOmniSearch authHTTPClient (NESet.singleton UserKind) query Nothing
+  results
+    & mapMaybe \case
+      SearchResultUserLike handle -> Just $ "@" <> handle
+      SearchResultProject _ -> Nothing
+    & pure
+
+completeShareProject ::
+  (MonadIO m) =>
+  AuthenticatedHttpClient ->
+  String ->
+  m [Completion]
+completeShareProject authHTTPClient query =
+  completeShareProjectHelper authHTTPClient (Text.pack query)
+    <&> fmap \ref ->
+      Line.Completion
+        { Line.replacement = Text.unpack ref,
+          Line.display = Text.unpack ref,
+          Line.isFinished = False
+        }
+
+completeShareProjectHelper ::
+  (MonadIO m) =>
+  AuthenticatedHttpClient ->
+  Text ->
+  m [Text]
+completeShareProjectHelper authHTTPClient query
+  | Text.isInfixOf "/" query = do
+      results <- runShareOmniSearch authHTTPClient (NESet.singleton ProjectKind) query (Just "slug-prefix")
+      results
+        & mapMaybe \case
+          SearchResultUserLike _ -> Nothing
+          SearchResultProject ref -> Just ref
+        & pure
+  | otherwise =
+      completeShareUserHelper authHTTPClient query
+        <&> fmap \handle -> handle <> "/"
+
+completeShareBranchHelper ::
+  (MonadIO m) =>
+  AuthenticatedHttpClient ->
+  Text ->
+  m [Text]
+completeShareBranchHelper authHTTPClient query = do
+  -- This function is not implemented yet, but it would be similar to the user and project completion functions.
+  -- It would search for branches in the share server based on the provided query.
+  -- For now, we return an empty list.
+  pure []
+
+searchProjectBranches ::
+  (MonadIO m) =>
+  AuthenticatedHttpClient ->
+  Text ->
+  m [Text]
+searchProjectBranches authHTTPClient userHandle projectSlug branchPrefix = do
+  case MP.parseMaybe (Project.projectAndBranchNamesParser Project.ProjectBranchSpecifier'NameOrLatestRelease) query of
+    Nothing -> pure []
+    Just (This proj) -> _
+    Just (That (Project.ProjectBranchNameOrLatestRelease'LatestRelease)) -> do
+      _
+    Just (That (Project.ProjectBranchNameOrLatestRelease'Name pbPrefix)) -> do
+      -- Here we would search for branches in the project specified by `proj`.
+      -- For now, we return an empty list.
+      pure []
+    Just (These proj branch) -> do
+      -- Here we would search for branches in the project specified by `proj` and `branch`.
+      -- For now, we return an empty list.
+      pure []
+  where
+    runSearch = do
+      fromMaybe [] <$> runMaybeT do
+        let uri =
+              (Share.codeserverToURI Codeserver.defaultCodeserver)
+                { URI.uriPath = "/search",
+                  URI.uriQuery = Text.unpack $ "?kinds=" <> searchKinds <> "&query=" <> query <> psk
+                }
+        req <- MaybeT $ pure (HTTP.requestFromURI uri)
+        fullResp <- liftIO $ UnliftIO.tryAny $ HTTP.httpLbs req httpManager
+        resp <- either (const empty) pure $ fullResp
+        results <- (MaybeT . pure . Aeson.decode @[SearchResult] $ HTTP.responseBody resp)
+        Debug.debugM Debug.Temp "runShareOmniSearch: results: " results
+        pure results
+
+-- completeShareBranchHelper ::
+--   (MonadIO m) =>
+--   AuthenticatedHttpClient ->
+--   Text ->
+--   m [Text]
+-- completeShareBranchHelper authHTTPClient query = do
+--   _
+
+runShareOmniSearch :: (MonadIO m) => AuthenticatedHttpClient -> NESet SearchKind -> Text -> Maybe Text -> m [SearchResult]
+runShareOmniSearch (AuthenticatedHttpClient httpManager) kinds query mayPsk = do
+  fromMaybe [] <$> runMaybeT do
+    let uri =
+          (Share.codeserverToURI Codeserver.defaultCodeserver)
+            { URI.uriPath = "/search",
+              URI.uriQuery = Text.unpack $ "?kinds=" <> searchKinds <> "&query=" <> query <> psk
+            }
+    req <- MaybeT $ pure (HTTP.requestFromURI uri)
+    fullResp <- liftIO $ UnliftIO.tryAny $ HTTP.httpLbs req httpManager
+    resp <- either (const empty) pure $ fullResp
+    results <- (MaybeT . pure . Aeson.decode @[SearchResult] $ HTTP.responseBody resp)
+    Debug.debugM Debug.Temp "runShareOmniSearch: results: " results
+    pure results
+  where
+    psk :: Text
+    psk =
+      case mayPsk of
+        Just p -> "&project-search-kind=" <> p
+        Nothing -> ""
+    searchKinds :: Text
+    searchKinds =
+      toList kinds
+        & Monoid.intercalateMap "," \case
+          UserKind -> "users"
+          ProjectKind -> "projects"
 
 data UserLike = UserLike
   { handle :: Text

--- a/unison-cli/src/Unison/CommandLine/Completion.hs
+++ b/unison-cli/src/Unison/CommandLine/Completion.hs
@@ -76,12 +76,12 @@ haskelineTabComplete patterns codebase authedHTTPClient ppCtx = Line.completeWor
   if null prev
     then pure . exactComplete word $ Map.keys patterns
     else -- User has finished a command name; use completions for that command
-      case words $ reverse prev of
-        h : t -> fromMaybe (pure []) $ do
-          p <- Map.lookup h patterns
-          paramType <- IP.paramType (IP.params p) (length t)
-          pure $ IP.suggestions paramType word codebase authedHTTPClient ppCtx
-        _ -> pure []
+    case words $ reverse prev of
+      h : t -> fromMaybe (pure []) $ do
+        p <- Map.lookup h patterns
+        paramType <- IP.paramType (IP.params p) (length t)
+        pure $ IP.suggestions paramType word codebase authedHTTPClient ppCtx
+      _ -> pure []
 
 -- | Things which we may want to complete for.
 data CompletionType

--- a/unison-cli/src/Unison/CommandLine/Completion.hs
+++ b/unison-cli/src/Unison/CommandLine/Completion.hs
@@ -14,12 +14,9 @@ module Unison.CommandLine.Completion
     fixupCompletion,
     haskelineTabComplete,
     shareProjectCompletion,
+    filenameCompletion,
     -- Unused for now, but may be useful later
     prettyCompletion,
-    fixupCompletion,
-    haskelineTabComplete,
-    sharePathCompletion,
-    filenameCompletion,
   )
 where
 
@@ -365,32 +362,37 @@ searchProjects (AuthenticatedHttpClient httpManager) query =
         let uri =
               (Share.codeserverToURI Codeserver.defaultCodeserver)
                 { URI.uriPath = "/search",
-                  URI.uriQuery = Text.unpack $ "?kinds=project&project-search-kind=" <> psk <> "&query=" <> query
+                  URI.uriQuery = Text.unpack $ "?project-search-kind=" <> psk <> "&query=" <> query
                 }
         req <- MaybeT $ pure (HTTP.requestFromURI uri)
         fullResp <- liftIO $ UnliftIO.tryAny $ HTTP.httpLbs req httpManager
         resp <- either (const empty) pure $ fullResp
-        (MaybeT . pure . Aeson.decode @[ProjectSearchResult] $ HTTP.responseBody resp)
-          <&> fmap projectRef
+        (MaybeT . pure . Aeson.decode @[SearchResult] $ HTTP.responseBody resp)
+          <&> fmap \case
+            SearchResultUserLike handle -> handle
+            SearchResultProject ref -> ref
 
-data SearchResult = SearchResult
-  { handle :: Text,
-    tag :: Text
+data UserLike = UserLike
+  { handle :: Text
   }
   deriving (Show)
 
-instance Aeson.FromJSON SearchResult where
-  parseJSON = Aeson.withObject "SearchResult" \obj -> do
-    handle <- obj Aeson..: "handle"
-    tag <- obj Aeson..: "tag"
-    pure $ SearchResult {..}
+instance FromJSON SearchResult where
+  parseJSON = Aeson.withObject "SearchResultUserLike" \obj -> do
+    obj Aeson..: "tag" >>= \case
+      ("user" :: Text) -> SearchResultUserLike <$> (obj Aeson..: "handle")
+      "org" -> do
+        user <- obj Aeson..: "user"
+        SearchResultUserLike <$> (user Aeson..: "handle")
+      "project" -> do
+        ref <- obj Aeson..: "projectRef"
+        pure $ SearchResultProject ref
+      _ -> fail "Expected 'user' or 'org' or 'project' tag"
 
-instance FromJSON ProjectSearchResult where
-  parseJSON = Aeson.withObject "ProjectSearchResult" \obj -> do
-    projectRef <- obj Aeson..: "projectRef"
-    summary <- obj Aeson..: "summary"
-    visibility <- obj Aeson..: "visibility"
-    pure $ ProjectSearchResult {..}
+data SearchResult
+  = SearchResultUserLike Text
+  | SearchResultProject Text
+  deriving (Show)
 
 filenameCompletion ::
   (MonadIO m) =>

--- a/unison-cli/src/Unison/CommandLine/Completion.hs
+++ b/unison-cli/src/Unison/CommandLine/Completion.hs
@@ -15,7 +15,7 @@ module Unison.CommandLine.Completion
     haskelineTabComplete,
     completeShareUser,
     completeShareProject,
-    completeShareBranch,
+    completeShareBranchOrRelease,
     filenameCompletion,
     -- Unused for now, but may be useful later
     prettyCompletion,
@@ -372,8 +372,8 @@ _searchProjects (AuthenticatedHttpClient httpManager) query = do
         resp <- either (const empty) pure $ fullResp
         (MaybeT . pure . Aeson.decode @[SearchResult] $ HTTP.responseBody resp)
           <&> fmap \case
-            SearchResultUserLike handle -> "@" <> handle <> "/"
-            SearchResultProject ref -> ref <> "/"
+            SearchResultUserLike handle -> "@" <> ensureTrailingSlash handle
+            SearchResultProject ref -> ensureTrailingSlash ref
 
 data SearchKind = UserKind | ProjectKind
   deriving (Show, Eq)
@@ -434,21 +434,24 @@ completeShareProjectHelper authHTTPClient query
         & pure
   | otherwise =
       completeShareUserHelper authHTTPClient query
-        <&> fmap \handle -> handle <> "/"
+        <&> fmap \handle -> ensureTrailingSlash handle
 
-completeShareBranch ::
+completeShareBranchOrRelease ::
   (MonadIO m) =>
   AuthenticatedHttpClient ->
   String ->
   m [Completion]
-completeShareBranch authHTTPClient query =
-  completeShareBranchHelper authHTTPClient (Text.pack query)
-    <&> fmap \branch ->
-      Line.Completion
-        { Line.replacement = Text.unpack branch,
-          Line.display = Text.unpack branch,
-          Line.isFinished = False
-        }
+completeShareBranchOrRelease authHTTPClient query = do
+  r <- completeShareBranchHelper authHTTPClient (Text.pack query)
+  Debug.debugM Debug.Temp "results" r
+  pure $
+    r
+      & fmap \branch ->
+        Line.Completion
+          { Line.replacement = Text.unpack branch,
+            Line.display = Text.unpack branch,
+            Line.isFinished = False
+          }
 
 completeShareBranchHelper ::
   (MonadIO m) =>
@@ -462,39 +465,88 @@ completeShareBranchHelper authHTTPClient query = do
       -- TODO: Add support for inferring the remote project branch.
       pure []
     -- @handle/proj/branch
-    [handle, proj, branch] ->
-      searchProjectBranches authHTTPClient handle proj branch
-    -- Anything else
-    _ -> completeShareProjectHelper authHTTPClient query
+    [handle, proj, branchOrContributorPrefix]
+      | Text.isPrefixOf "@" branchOrContributorPrefix -> do
+          -- Search contributors instead.
+          completeShareUserHelper authHTTPClient branchOrContributorPrefix
+            <&> fmap \contributorHandle ->
+              handle <> "/" <> proj <> "/" <> ensureTrailingSlash contributorHandle
+      | otherwise -> do
+          results <- searchProjectBranches authHTTPClient handle proj Nothing branchOrContributorPrefix
+          pure $
+            Monoid.whenM (Text.isPrefixOf branchOrContributorPrefix "releases") [handle <> "/" <> proj <> "/releases/"]
+              <> results
+    [handle, proj, "releases", branch]
+      | Text.isPrefixOf branch "latest" -> pure [handle <> "/" <> proj <> "/releases/latest"]
+      | otherwise -> do
+          searchProjectReleases authHTTPClient handle proj branch
+    [handle, proj, contributor, branch] ->
+      searchProjectBranches authHTTPClient handle proj (Just contributor) branch
+    _ ->
+      completeShareProjectHelper authHTTPClient query
+        <&> fmap ensureTrailingSlash
 
 searchProjectBranches ::
   (MonadIO m) =>
   AuthenticatedHttpClient ->
   Text ->
   Text ->
+  Maybe Text ->
   Text ->
   m [Text]
-searchProjectBranches (AuthenticatedHttpClient httpManager) handle proj query = do
+searchProjectBranches (AuthenticatedHttpClient httpManager) handle proj contributor query = do
   fromMaybe [] <$> runMaybeT do
+    let searchKind = case contributor of
+          Just {} -> "contributor"
+          Nothing -> "core"
+    let cleanedHandle = Text.dropWhile (== '@') handle
     let uri =
           (Share.codeserverToURI Codeserver.defaultCodeserver)
-            { URI.uriPath = "/users/" <> Text.unpack handle <> "/projects/" <> Text.unpack proj <> "/branches",
-              URI.uriQuery = Text.unpack $ "?name-prefix=" <> query
+            { URI.uriPath = "/users/" <> Text.unpack cleanedHandle <> "/projects/" <> Text.unpack proj <> "/branches",
+              URI.uriQuery = Text.unpack $ "?name-prefix=" <> query <> "&kind=" <> searchKind
             }
+    Debug.debugM Debug.Temp "searchProjectBranches: uri: " (Text.pack $ show uri)
     req <- MaybeT $ pure (HTTP.requestFromURI uri)
-    fullResp <- liftIO $ UnliftIO.tryAny $ HTTP.httpLbs req httpManager
+    let req' = req {HTTP.responseTimeout = HTTP.responseTimeoutMicro 5000000} -- 5 seconds
+    -- Set a timeout on the request
+    fullResp <- liftIO $ UnliftIO.tryAny $ HTTP.httpLbs req' httpManager
     resp <- either (const empty) pure $ fullResp
-    (MaybeT . pure . Aeson.decode @[BranchListResult] $ HTTP.responseBody resp)
-      <&> fmap \BranchListResult {branchRef, projectSlug, projectOwnerHandle} ->
-        "@" <> projectOwnerHandle <> "/" <> projectSlug <> "/" <> branchRef
+    (MaybeT . pure . Aeson.decode @(PagedResponse BranchResult) $ HTTP.responseBody resp)
+      <&> \(PagedResponse {items}) ->
+        items <&> \BranchResult {branchRef, projectSlug, projectOwnerHandle} ->
+          projectOwnerHandle <> "/" <> projectSlug <> "/" <> branchRef
 
--- completeShareBranchHelper ::
---   (MonadIO m) =>
---   AuthenticatedHttpClient ->
---   Text ->
---   m [Text]
--- completeShareBranchHelper authHTTPClient query = do
---   _
+searchProjectReleases ::
+  (MonadIO m) =>
+  AuthenticatedHttpClient ->
+  Text ->
+  Text ->
+  Text ->
+  m [Text]
+searchProjectReleases (AuthenticatedHttpClient httpManager) handle proj query = do
+  fromMaybe [] <$> runMaybeT do
+    let cleanedHandle = Text.dropWhile (== '@') handle
+    let uri =
+          (Share.codeserverToURI Codeserver.defaultCodeserver)
+            { URI.uriPath = "/users/" <> Text.unpack cleanedHandle <> "/projects/" <> Text.unpack proj <> "/releases",
+              URI.uriQuery = Text.unpack $ "?version-prefix=" <> query
+            }
+    Debug.debugM Debug.Temp "searchProjectRelease: uri: " (Text.pack $ show uri)
+    req <- MaybeT $ pure (HTTP.requestFromURI uri)
+    let req' = req {HTTP.responseTimeout = HTTP.responseTimeoutMicro 5000000} -- 5 seconds
+    -- Set a timeout on the request
+    fullResp <- liftIO $ UnliftIO.tryAny $ HTTP.httpLbs req' httpManager
+    resp <- either (const empty) pure $ fullResp
+    (MaybeT . pure . Aeson.decode @(PagedResponse ReleaseResult) $ HTTP.responseBody resp)
+      <&> \(PagedResponse {items}) ->
+        items <&> \ReleaseResult {projectRef, version} ->
+          projectRef <> "/releases/" <> version
+
+ensureTrailingSlash :: Text -> Text
+ensureTrailingSlash ref =
+  case Text.stripSuffix "/" ref of
+    Nothing -> ref <> "/"
+    Just stripped -> stripped <> "/"
 
 runShareOmniSearch :: (MonadIO m) => AuthenticatedHttpClient -> NESet SearchKind -> Text -> Maybe Text -> m [SearchResult]
 runShareOmniSearch (AuthenticatedHttpClient httpManager) kinds query mayPsk = do
@@ -502,10 +554,12 @@ runShareOmniSearch (AuthenticatedHttpClient httpManager) kinds query mayPsk = do
     let uri =
           (Share.codeserverToURI Codeserver.defaultCodeserver)
             { URI.uriPath = "/search",
-              URI.uriQuery = Text.unpack $ "?kinds=" <> searchKinds <> "&query=" <> query <> psk
+              URI.uriQuery = Text.unpack $ "?user-search-kind=handle-prefix&kinds=" <> searchKinds <> "&query=" <> query <> psk
             }
+    Debug.debugM Debug.Temp "runShareOmniSearch: uri: " (Text.pack $ show uri)
     req <- MaybeT $ pure (HTTP.requestFromURI uri)
-    fullResp <- liftIO $ UnliftIO.tryAny $ HTTP.httpLbs req httpManager
+    let req' = req {HTTP.responseTimeout = HTTP.responseTimeoutMicro 5000000} -- 5 seconds
+    fullResp <- liftIO $ UnliftIO.tryAny $ HTTP.httpLbs req' httpManager
     resp <- either (const empty) pure $ fullResp
     results <- (MaybeT . pure . Aeson.decode @[SearchResult] $ HTTP.responseBody resp)
     Debug.debugM Debug.Temp "runShareOmniSearch: results: " results
@@ -545,20 +599,43 @@ data SearchResult
   | SearchResultProject Text
   deriving (Show)
 
-data BranchListResult = BranchListResult
+data PagedResponse a = PagedResponse
+  { items :: [a]
+  }
+  deriving (Show)
+
+instance (FromJSON a) => FromJSON (PagedResponse a) where
+  parseJSON = Aeson.withObject "PagedResponse" \obj -> do
+    items <- obj Aeson..: "items"
+    pure $ PagedResponse items
+
+data BranchResult = BranchResult
   { branchRef :: Text,
     projectSlug :: Text,
     projectOwnerHandle :: Text
   }
+  deriving (Show)
 
-instance FromJSON BranchListResult where
-  parseJSON = Aeson.withObject "BranchListResult" \obj -> do
+instance FromJSON BranchResult where
+  parseJSON = Aeson.withObject "BranchResult" \obj -> do
     branchRef <- obj Aeson..: "branchRef"
     project <- obj Aeson..: "project"
     projectSlug <- project Aeson..: "slug"
     owner <- project Aeson..: "owner"
     projectOwnerHandle <- owner Aeson..: "handle"
-    pure $ BranchListResult branchRef projectSlug projectOwnerHandle
+    pure $ BranchResult branchRef projectSlug projectOwnerHandle
+
+data ReleaseResult = ReleaseResult
+  { projectRef :: Text,
+    version :: Text
+  }
+  deriving (Show)
+
+instance FromJSON ReleaseResult where
+  parseJSON = Aeson.withObject "ReleaseResult" \obj -> do
+    projectRef <- obj Aeson..: "projectRef"
+    version <- obj Aeson..: "version"
+    pure $ ReleaseResult projectRef version
 
 filenameCompletion ::
   (MonadIO m) =>

--- a/unison-cli/src/Unison/CommandLine/Completion.hs
+++ b/unison-cli/src/Unison/CommandLine/Completion.hs
@@ -15,6 +15,7 @@ module Unison.CommandLine.Completion
     haskelineTabComplete,
     completeShareUser,
     completeShareProject,
+    completeShareBranch,
     filenameCompletion,
     -- Unused for now, but may be useful later
     prettyCompletion,
@@ -32,13 +33,11 @@ import Data.Map qualified as Map
 import Data.Set.NonEmpty (NESet)
 import Data.Set.NonEmpty qualified as NESet
 import Data.Text qualified as Text
-import Data.These (These (..))
 import Network.HTTP.Client qualified as HTTP
 import Network.URI qualified as URI
 import System.Console.Haskeline qualified as Line
 import System.Console.Haskeline.Completion (Completion)
 import System.Console.Haskeline.Completion qualified as Haskeline
-import Text.Megaparsec qualified as MP
 import Text.Megaparsec qualified as P
 import U.Codebase.Branch qualified as V2Branch
 import U.Codebase.Causal qualified as V2Causal
@@ -56,7 +55,6 @@ import Unison.Debug qualified as Debug
 import Unison.HashQualifiedPrime qualified as HQ'
 import Unison.NameSegment.Internal (NameSegment (NameSegment))
 import Unison.Prelude
-import Unison.Project qualified as Project
 import Unison.Share.Codeserver qualified as Codeserver
 import Unison.Share.Types qualified as Share
 import Unison.Sqlite qualified as Sqlite
@@ -438,50 +436,57 @@ completeShareProjectHelper authHTTPClient query
       completeShareUserHelper authHTTPClient query
         <&> fmap \handle -> handle <> "/"
 
+completeShareBranch ::
+  (MonadIO m) =>
+  AuthenticatedHttpClient ->
+  String ->
+  m [Completion]
+completeShareBranch authHTTPClient query =
+  completeShareBranchHelper authHTTPClient (Text.pack query)
+    <&> fmap \branch ->
+      Line.Completion
+        { Line.replacement = Text.unpack branch,
+          Line.display = Text.unpack branch,
+          Line.isFinished = False
+        }
+
 completeShareBranchHelper ::
   (MonadIO m) =>
   AuthenticatedHttpClient ->
   Text ->
   m [Text]
 completeShareBranchHelper authHTTPClient query = do
-  -- This function is not implemented yet, but it would be similar to the user and project completion functions.
-  -- It would search for branches in the share server based on the provided query.
-  -- For now, we return an empty list.
-  pure []
+  case Text.splitOn "/" query of
+    -- /branch
+    ["", _branchQuery] ->
+      -- TODO: Add support for inferring the remote project branch.
+      pure []
+    -- @handle/proj/branch
+    [handle, proj, branch] ->
+      searchProjectBranches authHTTPClient handle proj branch
+    -- Anything else
+    _ -> completeShareProjectHelper authHTTPClient query
 
 searchProjectBranches ::
   (MonadIO m) =>
   AuthenticatedHttpClient ->
   Text ->
+  Text ->
+  Text ->
   m [Text]
-searchProjectBranches authHTTPClient userHandle projectSlug branchPrefix = do
-  case MP.parseMaybe (Project.projectAndBranchNamesParser Project.ProjectBranchSpecifier'NameOrLatestRelease) query of
-    Nothing -> pure []
-    Just (This proj) -> _
-    Just (That (Project.ProjectBranchNameOrLatestRelease'LatestRelease)) -> do
-      _
-    Just (That (Project.ProjectBranchNameOrLatestRelease'Name pbPrefix)) -> do
-      -- Here we would search for branches in the project specified by `proj`.
-      -- For now, we return an empty list.
-      pure []
-    Just (These proj branch) -> do
-      -- Here we would search for branches in the project specified by `proj` and `branch`.
-      -- For now, we return an empty list.
-      pure []
-  where
-    runSearch = do
-      fromMaybe [] <$> runMaybeT do
-        let uri =
-              (Share.codeserverToURI Codeserver.defaultCodeserver)
-                { URI.uriPath = "/search",
-                  URI.uriQuery = Text.unpack $ "?kinds=" <> searchKinds <> "&query=" <> query <> psk
-                }
-        req <- MaybeT $ pure (HTTP.requestFromURI uri)
-        fullResp <- liftIO $ UnliftIO.tryAny $ HTTP.httpLbs req httpManager
-        resp <- either (const empty) pure $ fullResp
-        results <- (MaybeT . pure . Aeson.decode @[SearchResult] $ HTTP.responseBody resp)
-        Debug.debugM Debug.Temp "runShareOmniSearch: results: " results
-        pure results
+searchProjectBranches (AuthenticatedHttpClient httpManager) handle proj query = do
+  fromMaybe [] <$> runMaybeT do
+    let uri =
+          (Share.codeserverToURI Codeserver.defaultCodeserver)
+            { URI.uriPath = "/users/" <> Text.unpack handle <> "/projects/" <> Text.unpack proj <> "/branches",
+              URI.uriQuery = Text.unpack $ "?name-prefix=" <> query
+            }
+    req <- MaybeT $ pure (HTTP.requestFromURI uri)
+    fullResp <- liftIO $ UnliftIO.tryAny $ HTTP.httpLbs req httpManager
+    resp <- either (const empty) pure $ fullResp
+    (MaybeT . pure . Aeson.decode @[BranchListResult] $ HTTP.responseBody resp)
+      <&> fmap \BranchListResult {branchRef, projectSlug, projectOwnerHandle} ->
+        "@" <> projectOwnerHandle <> "/" <> projectSlug <> "/" <> branchRef
 
 -- completeShareBranchHelper ::
 --   (MonadIO m) =>
@@ -539,6 +544,21 @@ data SearchResult
   = SearchResultUserLike Text
   | SearchResultProject Text
   deriving (Show)
+
+data BranchListResult = BranchListResult
+  { branchRef :: Text,
+    projectSlug :: Text,
+    projectOwnerHandle :: Text
+  }
+
+instance FromJSON BranchListResult where
+  parseJSON = Aeson.withObject "BranchListResult" \obj -> do
+    branchRef <- obj Aeson..: "branchRef"
+    project <- obj Aeson..: "project"
+    projectSlug <- project Aeson..: "slug"
+    owner <- project Aeson..: "owner"
+    projectOwnerHandle <- owner Aeson..: "handle"
+    pure $ BranchListResult branchRef projectSlug projectOwnerHandle
 
 filenameCompletion ::
   (MonadIO m) =>

--- a/unison-cli/src/Unison/CommandLine/Completion.hs
+++ b/unison-cli/src/Unison/CommandLine/Completion.hs
@@ -51,7 +51,6 @@ import Unison.Codebase.Path.Parse qualified as Path
 import Unison.Codebase.ProjectPath qualified as PP
 import Unison.Codebase.SqliteCodebase.Conversions qualified as Cv
 import Unison.CommandLine.InputPattern qualified as IP
-import Unison.Debug qualified as Debug
 import Unison.HashQualifiedPrime qualified as HQ'
 import Unison.NameSegment.Internal (NameSegment (NameSegment))
 import Unison.Prelude
@@ -77,12 +76,12 @@ haskelineTabComplete patterns codebase authedHTTPClient ppCtx = Line.completeWor
   if null prev
     then pure . exactComplete word $ Map.keys patterns
     else -- User has finished a command name; use completions for that command
-    case words $ reverse prev of
-      h : t -> fromMaybe (pure []) $ do
-        p <- Map.lookup h patterns
-        paramType <- IP.paramType (IP.params p) (length t)
-        pure $ IP.suggestions paramType word codebase authedHTTPClient ppCtx
-      _ -> pure []
+      case words $ reverse prev of
+        h : t -> fromMaybe (pure []) $ do
+          p <- Map.lookup h patterns
+          paramType <- IP.paramType (IP.params p) (length t)
+          pure $ IP.suggestions paramType word codebase authedHTTPClient ppCtx
+        _ -> pure []
 
 -- | Things which we may want to complete for.
 data CompletionType
@@ -334,50 +333,10 @@ fixupCompletion q cs@(h : t) =
         then [c {Line.replacement = q} | c <- cs]
         else cs
 
--- | Searches for matching projects on the codeserver.
--- Query is flexible, e.g.
---
--- - "base"
--- - "@unison"
--- - "@unison/b"
--- - "postgres"
--- - "database"
-_searchProjects :: (MonadIO m) => AuthenticatedHttpClient -> Text -> m [Text]
-_searchProjects _ "" = pure []
-_searchProjects (AuthenticatedHttpClient httpManager) query = do
-  infixResults <- runSearch "slug-infix"
-  Debug.debugM Debug.Temp "shareProjectCompletion: slug-infix results: " infixResults
-  case infixResults of
-    -- Fall back to the web search if slug-infix returns no results
-    [] -> do
-      webSearchResults <- runSearch "web-search"
-      Debug.debugM Debug.Temp "shareProjectCompletion: web-search results: " webSearchResults
-      pure webSearchResults
-    results -> pure results
-  where
-    searchKinds
-      -- If the query contains a '/', we assume it's a project search.
-      | Text.isInfixOf "/" query = "projects"
-      | otherwise = "users"
-    runSearch :: (MonadIO m) => Text -> m [Text]
-    runSearch psk = do
-      fromMaybe [] <$> runMaybeT do
-        let uri =
-              (Share.codeserverToURI Codeserver.defaultCodeserver)
-                { URI.uriPath = "/search",
-                  URI.uriQuery = Text.unpack $ "?kinds=" <> searchKinds <> "&project-search-kind=" <> psk <> "&query=" <> query
-                }
-        req <- MaybeT $ pure (HTTP.requestFromURI uri)
-        fullResp <- liftIO $ UnliftIO.tryAny $ HTTP.httpLbs req httpManager
-        resp <- either (const empty) pure $ fullResp
-        (MaybeT . pure . Aeson.decode @[SearchResult] $ HTTP.responseBody resp)
-          <&> fmap \case
-            SearchResultUserLike handle -> "@" <> ensureTrailingSlash handle
-            SearchResultProject ref -> ensureTrailingSlash ref
-
 data SearchKind = UserKind | ProjectKind
   deriving (Show, Eq)
 
+-- | Completes a user handle by searching Share.
 completeShareUser ::
   (MonadIO m) =>
   AuthenticatedHttpClient ->
@@ -392,6 +351,7 @@ completeShareUser authHTTPClient query =
           Line.isFinished = False
         }
 
+-- | E.g. "@uni" -> "@unison"
 completeShareUserHelper ::
   (MonadIO m) =>
   AuthenticatedHttpClient ->
@@ -405,6 +365,10 @@ completeShareUserHelper authHTTPClient query = do
       SearchResultProject _ -> Nothing
     & pure
 
+-- | Does progressive tab-completion, so if you're working on the user-segment it'll complete that, then if you mash tab
+-- it'll proceed to project completion.
+-- E.g. "@uni" -> "@unison/"
+-- Then "@unison/" -> "@unison/base"
 completeShareProject ::
   (MonadIO m) =>
   AuthenticatedHttpClient ->
@@ -436,22 +400,28 @@ completeShareProjectHelper authHTTPClient query
       completeShareUserHelper authHTTPClient query
         <&> fmap \handle -> ensureTrailingSlash handle
 
+-- | Does progressive tab-completion, so if you're working on the user-segment it'll complete that, then if you mash tab
+-- it'll proceed to project completion, then branch or release completion.
+-- E.g. "@uni" -> "@unison/"
+-- Then "@unison/" -> "@unison/base/"
+-- Then "@unison/base/" -> "@unison/base/main"
+-- or "@unison/base/@cont" -> "@unison/base/@contributor/"
+-- or "@unison/base/@contributor/" -> "@unison/base/@contributor/feature"
+-- or "@unison/base/releases/lat" -> "@unison/base/releases/latest"
+-- or "@unison/base/releases/1." -> "@unison/base/releases/1.2.3"
 completeShareBranchOrRelease ::
   (MonadIO m) =>
   AuthenticatedHttpClient ->
   String ->
   m [Completion]
 completeShareBranchOrRelease authHTTPClient query = do
-  r <- completeShareBranchHelper authHTTPClient (Text.pack query)
-  Debug.debugM Debug.Temp "results" r
-  pure $
-    r
-      & fmap \branch ->
-        Line.Completion
-          { Line.replacement = Text.unpack branch,
-            Line.display = Text.unpack branch,
-            Line.isFinished = False
-          }
+  completeShareBranchHelper authHTTPClient (Text.pack query)
+    <&> fmap \branch ->
+      Line.Completion
+        { Line.replacement = Text.unpack branch,
+          Line.display = Text.unpack branch,
+          Line.isFinished = False
+        }
 
 completeShareBranchHelper ::
   (MonadIO m) =>
@@ -489,6 +459,7 @@ completeShareBranchHelper authHTTPClient query = do
       completeShareProjectHelper authHTTPClient query
         <&> fmap ensureTrailingSlash
 
+-- | Search share for branches within the provided handle and project
 searchProjectBranches ::
   (MonadIO m) =>
   AuthenticatedHttpClient ->
@@ -508,7 +479,6 @@ searchProjectBranches (AuthenticatedHttpClient httpManager) handle proj contribu
             { URI.uriPath = "/users/" <> Text.unpack cleanedHandle <> "/projects/" <> Text.unpack proj <> "/branches",
               URI.uriQuery = Text.unpack $ "?name-prefix=" <> query <> "&kind=" <> searchKind <> contributorFilter
             }
-    Debug.debugM Debug.Temp "searchProjectBranches: uri: " (Text.pack $ show uri)
     req <- MaybeT $ pure (HTTP.requestFromURI uri)
     let req' = req {HTTP.responseTimeout = HTTP.responseTimeoutMicro 5000000} -- 5 seconds
     -- Set a timeout on the request
@@ -519,6 +489,7 @@ searchProjectBranches (AuthenticatedHttpClient httpManager) handle proj contribu
         items <&> \BranchResult {branchRef, projectSlug, projectOwnerHandle} ->
           projectOwnerHandle <> "/" <> projectSlug <> "/" <> branchRef
 
+-- | Search share for releases within the provided handle and project
 searchProjectReleases ::
   (MonadIO m) =>
   AuthenticatedHttpClient ->
@@ -534,7 +505,6 @@ searchProjectReleases (AuthenticatedHttpClient httpManager) handle proj query = 
             { URI.uriPath = "/users/" <> Text.unpack cleanedHandle <> "/projects/" <> Text.unpack proj <> "/releases",
               URI.uriQuery = Text.unpack $ "?version-prefix=" <> query
             }
-    Debug.debugM Debug.Temp "searchProjectRelease: uri: " (Text.pack $ show uri)
     req <- MaybeT $ pure (HTTP.requestFromURI uri)
     let req' = req {HTTP.responseTimeout = HTTP.responseTimeoutMicro 5000000} -- 5 seconds
     -- Set a timeout on the request
@@ -551,6 +521,7 @@ ensureTrailingSlash ref =
     Nothing -> ref <> "/"
     Just stripped -> stripped <> "/"
 
+-- | Search Share for users and projects based on the provided query and search kinds.
 runShareOmniSearch :: (MonadIO m) => AuthenticatedHttpClient -> NESet SearchKind -> Text -> Maybe Text -> m [SearchResult]
 runShareOmniSearch (AuthenticatedHttpClient httpManager) kinds query mayPsk = do
   fromMaybe [] <$> runMaybeT do
@@ -559,14 +530,11 @@ runShareOmniSearch (AuthenticatedHttpClient httpManager) kinds query mayPsk = do
             { URI.uriPath = "/search",
               URI.uriQuery = Text.unpack $ "?user-search-kind=handle-prefix&kinds=" <> searchKinds <> "&query=" <> query <> psk
             }
-    Debug.debugM Debug.Temp "runShareOmniSearch: uri: " (Text.pack $ show uri)
     req <- MaybeT $ pure (HTTP.requestFromURI uri)
     let req' = req {HTTP.responseTimeout = HTTP.responseTimeoutMicro 5000000} -- 5 seconds
     fullResp <- liftIO $ UnliftIO.tryAny $ HTTP.httpLbs req' httpManager
     resp <- either (const empty) pure $ fullResp
-    results <- (MaybeT . pure . Aeson.decode @[SearchResult] $ HTTP.responseBody resp)
-    Debug.debugM Debug.Temp "runShareOmniSearch: results: " results
-    pure results
+    (MaybeT . pure . Aeson.decode @[SearchResult] $ HTTP.responseBody resp)
   where
     psk :: Text
     psk =

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -1680,7 +1680,7 @@ pullImpl name aliases pullMode addendum = do
           params =
             Parameters [] $
               Optional
-                [ ("remote namespace to pull", remoteNamespaceArg),
+                [ ("remote namespace to pull", remoteProjectArg),
                   ( "destination branch",
                     projectBranchNameArg
                       ProjectBranchSuggestionsConfig
@@ -1848,7 +1848,7 @@ push =
     I.Visible
     ( Parameters [] $
         Optional
-          [("remote destination", remoteNamespaceArg), ("local target", namespaceOrProjectBranchArg suggestionsConfig)]
+          [("remote destination", remoteProjectArg), ("local target", namespaceOrProjectBranchArg suggestionsConfig)]
           Nothing
     )
     ( P.lines
@@ -1904,7 +1904,7 @@ pushCreate =
     I.Visible
     ( Parameters [] $
         Optional
-          [("remote destination", remoteNamespaceArg), ("local target", namespaceOrProjectBranchArg suggestionsConfig)]
+          [("remote destination", remoteProjectArg), ("local target", namespaceOrProjectBranchArg suggestionsConfig)]
           Nothing
     )
     ( P.lines
@@ -1957,7 +1957,7 @@ pushForce =
     I.Visible
     ( Parameters [] $
         Optional
-          [("remote destination", remoteNamespaceArg), ("local source", namespaceOrProjectBranchArg suggestionsConfig)]
+          [("remote destination", remoteProjectArg), ("local source", namespaceOrProjectBranchArg suggestionsConfig)]
           Nothing
     )
     (P.wrap "Like `push`, but forcibly overwrites the remote namespace.")
@@ -1990,7 +1990,7 @@ pushExhaustive =
     I.Hidden
     ( Parameters [] $
         Optional
-          [("remote destination", remoteNamespaceArg), ("local target", namespaceOrProjectBranchArg suggestionsConfig)]
+          [("remote destination", remoteProjectArg), ("local target", namespaceOrProjectBranchArg suggestionsConfig)]
           Nothing
     )
     ( P.lines
@@ -3777,12 +3777,11 @@ directoryPathArg =
       isStructured = False
     }
 
--- | Refers to a namespace on some remote code host.
-remoteNamespaceArg :: ParameterType
-remoteNamespaceArg =
+remoteProjectArg :: ParameterType
+remoteProjectArg =
   ParameterType
-    { typeName = "remote-namespace",
-      suggestions = noCompletions,
+    { typeName = "remote-project",
+      suggestions = \input _cb http _p -> shareProjectCompletion http input,
       fzfResolver = Nothing,
       isStructured = True
     }

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -1600,7 +1600,7 @@ libInstallInputPattern =
     { patternName = "lib.install",
       aliases = ["install.lib"],
       visibility = I.Visible,
-      params = Parameters [("library name", noCompletionsArg)] $ Optional [] Nothing,
+      params = Parameters [("library name", remoteProjectBranchOrReleaseArg)] $ Optional [] Nothing,
       help =
         P.lines
           [ P.wrap $
@@ -1680,7 +1680,7 @@ pullImpl name aliases pullMode addendum = do
           params =
             Parameters [] $
               Optional
-                [ ("remote namespace to pull", remoteProjectBranchArg),
+                [ ("remote namespace to pull", remoteProjectBranchOrReleaseArg),
                   ( "destination branch",
                     projectBranchNameArg
                       ProjectBranchSuggestionsConfig
@@ -1848,7 +1848,7 @@ push =
     I.Visible
     ( Parameters [] $
         Optional
-          [("remote destination", remoteProjectBranchArg), ("local target", namespaceOrProjectBranchArg suggestionsConfig)]
+          [("remote destination", remoteProjectBranchOrReleaseArg), ("local target", namespaceOrProjectBranchArg suggestionsConfig)]
           Nothing
     )
     ( P.lines
@@ -1904,7 +1904,7 @@ pushCreate =
     I.Visible
     ( Parameters [] $
         Optional
-          [("remote destination", remoteProjectBranchArg), ("local target", namespaceOrProjectBranchArg suggestionsConfig)]
+          [("remote destination", remoteProjectBranchOrReleaseArg), ("local target", namespaceOrProjectBranchArg suggestionsConfig)]
           Nothing
     )
     ( P.lines
@@ -1957,7 +1957,7 @@ pushForce =
     I.Visible
     ( Parameters [] $
         Optional
-          [("remote destination", remoteProjectBranchArg), ("local source", namespaceOrProjectBranchArg suggestionsConfig)]
+          [("remote destination", remoteProjectBranchOrReleaseArg), ("local source", namespaceOrProjectBranchArg suggestionsConfig)]
           Nothing
     )
     (P.wrap "Like `push`, but forcibly overwrites the remote namespace.")
@@ -1990,7 +1990,7 @@ pushExhaustive =
     I.Hidden
     ( Parameters [] $
         Optional
-          [("remote destination", remoteProjectBranchArg), ("local target", namespaceOrProjectBranchArg suggestionsConfig)]
+          [("remote destination", remoteProjectBranchOrReleaseArg), ("local target", namespaceOrProjectBranchArg suggestionsConfig)]
           Nothing
     )
     ( P.lines
@@ -3366,7 +3366,7 @@ clone =
       aliases = [],
       visibility = I.Visible,
       params =
-        Parameters [("source branch", projectAndBranchNamesArg suggestionsConfig)] $
+        Parameters [("source branch", remoteProjectBranchOrReleaseArg)] $
           Optional [("target branch", newBranchNameArg)] Nothing,
       help =
         P.wrapColumn2
@@ -3398,13 +3398,6 @@ clone =
             <*> fmap pure (handleProjectAndBranchNamesArg localNames)
         args -> wrongArgsLength "one or two arguments" args
     }
-  where
-    suggestionsConfig =
-      ProjectBranchSuggestionsConfig
-        { showProjectCompletions = True,
-          projectInclusion = AllProjects,
-          branchInclusion = ExcludeCurrentBranch
-        }
 
 releaseDraft :: InputPattern
 releaseDraft =
@@ -3786,11 +3779,11 @@ _remoteProjectArg =
       isStructured = True
     }
 
-remoteProjectBranchArg :: ParameterType
-remoteProjectBranchArg =
+remoteProjectBranchOrReleaseArg :: ParameterType
+remoteProjectBranchOrReleaseArg =
   ParameterType
     { typeName = "remote-project-branch",
-      suggestions = \input _cb http _p -> completeShareBranch http input,
+      suggestions = \input _cb http _p -> completeShareBranchOrRelease http input,
       fzfResolver = Nothing,
       isStructured = True
     }

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -3781,7 +3781,7 @@ remoteProjectArg :: ParameterType
 remoteProjectArg =
   ParameterType
     { typeName = "remote-project",
-      suggestions = \input _cb http _p -> shareProjectCompletion http input,
+      suggestions = \input _cb http _p -> completeShareProject http input,
       fzfResolver = Nothing,
       isStructured = True
     }

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -3782,7 +3782,7 @@ remoteNamespaceArg :: ParameterType
 remoteNamespaceArg =
   ParameterType
     { typeName = "remote-namespace",
-      suggestions = \input _cb http _p -> sharePathCompletion http input,
+      suggestions = noCompletions,
       fzfResolver = Nothing,
       isStructured = True
     }

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -1680,7 +1680,7 @@ pullImpl name aliases pullMode addendum = do
           params =
             Parameters [] $
               Optional
-                [ ("remote namespace to pull", remoteProjectArg),
+                [ ("remote namespace to pull", remoteProjectBranchArg),
                   ( "destination branch",
                     projectBranchNameArg
                       ProjectBranchSuggestionsConfig
@@ -1848,7 +1848,7 @@ push =
     I.Visible
     ( Parameters [] $
         Optional
-          [("remote destination", remoteProjectArg), ("local target", namespaceOrProjectBranchArg suggestionsConfig)]
+          [("remote destination", remoteProjectBranchArg), ("local target", namespaceOrProjectBranchArg suggestionsConfig)]
           Nothing
     )
     ( P.lines
@@ -1904,7 +1904,7 @@ pushCreate =
     I.Visible
     ( Parameters [] $
         Optional
-          [("remote destination", remoteProjectArg), ("local target", namespaceOrProjectBranchArg suggestionsConfig)]
+          [("remote destination", remoteProjectBranchArg), ("local target", namespaceOrProjectBranchArg suggestionsConfig)]
           Nothing
     )
     ( P.lines
@@ -1957,7 +1957,7 @@ pushForce =
     I.Visible
     ( Parameters [] $
         Optional
-          [("remote destination", remoteProjectArg), ("local source", namespaceOrProjectBranchArg suggestionsConfig)]
+          [("remote destination", remoteProjectBranchArg), ("local source", namespaceOrProjectBranchArg suggestionsConfig)]
           Nothing
     )
     (P.wrap "Like `push`, but forcibly overwrites the remote namespace.")
@@ -1990,7 +1990,7 @@ pushExhaustive =
     I.Hidden
     ( Parameters [] $
         Optional
-          [("remote destination", remoteProjectArg), ("local target", namespaceOrProjectBranchArg suggestionsConfig)]
+          [("remote destination", remoteProjectBranchArg), ("local target", namespaceOrProjectBranchArg suggestionsConfig)]
           Nothing
     )
     ( P.lines
@@ -3777,11 +3777,20 @@ directoryPathArg =
       isStructured = False
     }
 
-remoteProjectArg :: ParameterType
-remoteProjectArg =
+_remoteProjectArg :: ParameterType
+_remoteProjectArg =
   ParameterType
     { typeName = "remote-project",
       suggestions = \input _cb http _p -> completeShareProject http input,
+      fzfResolver = Nothing,
+      isStructured = True
+    }
+
+remoteProjectBranchArg :: ParameterType
+remoteProjectBranchArg =
+  ParameterType
+    { typeName = "remote-project-branch",
+      suggestions = \input _cb http _p -> completeShareBranch http input,
       fzfResolver = Nothing,
       isStructured = True
     }


### PR DESCRIPTION
## Overview

Does what it says on the tin; e.g.


https://github.com/user-attachments/assets/5b0c9376-5415-4704-854f-e80977572c79


Supports completing users, projects, branches, contributors and releases.

## Implementation notes

This just calls Share's omnisearch under the hood.

## Interesting/controversial decisions

Currently this just manually builds the query URLs rather than using a Servant client or w/e;

For critical things the servant client still makes sense, but for things like there where the worst case is just that tab-completion doesn't work it's not a big deal, doing the servant-client version would require moving a ton of APIs from Share to the unison package, and would require stabilizing them them into a versioned UCM API; all of which is just kinda annoying to do.

If we find it's breaking often we can move it in the future, but I don't expect that to be the case.

## Test coverage

I don't want automated tests to rely on share availability, so I just tested it manually.

## Loose ends

It would be really cool to somehow rig up fzf to this at some point, not quite sure what that'd look like though.