### PR TITLE
Fix inverted "should Validate"

### DIFF
--- a/unison-cli/src/Unison/Cli/DownloadUtils.hs
+++ b/unison-cli/src/Unison/Cli/DownloadUtils.hs
@@ -77,7 +77,7 @@ downloadProjectBranchFromShare useSquashed branch =
             Cli.respond (Output.DownloadedEntities numDownloaded)
         SyncV2 -> do
           let branchRef = SyncV2.BranchRef (into @Text (ProjectAndBranch branch.projectName remoteProjectBranchName))
-          let shouldValidate = not $ Codeserver.isCustomCodeserver Codeserver.defaultCodeserver
+          let shouldValidate = Codeserver.isCustomCodeserver Codeserver.defaultCodeserver
           result <- SyncV2.syncFromCodeserver shouldValidate Share.hardCodedBaseUrl branchRef causalHashJwt
           void result & onLeft \err0 -> do
             done case err0 of


### PR DESCRIPTION
## Overview

Looks like the original intent here was to validate code from everywhere EXCEPT Unison Share, but oops, it's doing the opposite 🙊 

This gives ~1.3x speedup on syncing down from Share.

## Implementation notes

Remove a stray `not`.

## Interesting/controversial decisions

When is it actually safe to skip hash validation?
After this change we'll still validate on pulls from everywhere except Share prod, as well as on file-syncs and codebase-syncs.

## Test coverage

Did timings locally. Validation has been running for ages without any failures, so probably safe to disable; Share still validates everything on ingress.

