### PR TITLE
Change slurp output to just say "New definitions:"

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/SlurpResult.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/SlurpResult.hs
@@ -207,7 +207,7 @@ pretty isPast ppe sr =
       okToAdd =
         ok
           (P.green "I've added these definitions:")
-          (P.green "These new definitions are ok to `update`:")
+          (P.green "New definitions:")
       notOks _past _present sr | isOk sr = mempty
       notOks past present sr =
         let header =

--- a/unison-src/transcripts-manual/docs.to-html.output.md
+++ b/unison-src/transcripts-manual/docs.to-html.output.md
@@ -21,7 +21,7 @@ some.outside = 3
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       some.ns.direct                   : Nat
       some.ns.direct.doc               : Doc2

--- a/unison-src/transcripts-round-trip/main.output.md
+++ b/unison-src/transcripts-round-trip/main.output.md
@@ -24,7 +24,7 @@ x = ()
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       x : ()
 ```

--- a/unison-src/transcripts-using-base/_base.output.md
+++ b/unison-src/transcripts-using-base/_base.output.md
@@ -57,7 +57,7 @@ testAutoClean _ =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       testAutoClean : '{IO} [Result]
 ```

--- a/unison-src/transcripts-using-base/binary-encoding-nats.output.md
+++ b/unison-src/transcripts-using-base/binary-encoding-nats.output.md
@@ -59,7 +59,7 @@ testABunchOfNats _ =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type EncDec
       BE16             : EncDec

--- a/unison-src/transcripts-using-base/codeops.output.md
+++ b/unison-src/transcripts-using-base/codeops.output.md
@@ -157,7 +157,7 @@ swapped name link =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural type Three a b c
       Code.get       : Link.Term ->{IO, Throw Text} Code
@@ -286,7 +286,7 @@ badLoad _ =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural ability Zap
       badLoad : '{IO} [Result]
@@ -388,7 +388,7 @@ codeTests =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       codeTests : '{IO} [Result]
 ```
@@ -473,7 +473,7 @@ vtests _ =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       validateTest : Link.Term ->{IO} Result
       vtests       : '{IO} [Result]

--- a/unison-src/transcripts-using-base/doc.output.md
+++ b/unison-src/transcripts-using-base/doc.output.md
@@ -34,7 +34,7 @@ unique type time.DayOfWeek = Sun | Mon | Tue | Wed | Thu | Fri | Sat
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type time.DayOfWeek
       ImportantConstant     : Nat
@@ -80,7 +80,7 @@ scratch/main> load ./unison-src/transcripts-using-base/doc.md.files/syntax.u
   ./unison-src/transcripts-using-base/doc.md.files/syntax.u. If
   you do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       basicFormatting     : Doc2
       doc.guide           : Doc2

--- a/unison-src/transcripts-using-base/failure-tests.output.md
+++ b/unison-src/transcripts-using-base/failure-tests.output.md
@@ -24,7 +24,7 @@ test2 = do
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       test1 : '{IO, Exception} [Result]
       test2 : '{IO, Exception} [Result]

--- a/unison-src/transcripts-using-base/fix-2805.output.md
+++ b/unison-src/transcripts-using-base/fix-2805.output.md
@@ -11,7 +11,7 @@ main _ = "Hello " ++ Optional.getOrBug "definitely passed an arg" (List.head !ge
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       main : '{IO, Exception} Text
 ```

--- a/unison-src/transcripts-using-base/fix2158-1.output.md
+++ b/unison-src/transcripts-using-base/fix2158-1.output.md
@@ -17,7 +17,7 @@ Async.parMap f as =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural ability Async t g
       Async.parMap : (a ->{g, Async t g} b)

--- a/unison-src/transcripts-using-base/fix2358.output.md
+++ b/unison-src/transcripts-using-base/fix2358.output.md
@@ -14,7 +14,7 @@ timingApp2 _ =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       timingApp2 : '{IO, Exception} ()
 ```

--- a/unison-src/transcripts-using-base/fix2944.output.md
+++ b/unison-src/transcripts-using-base/fix2944.output.md
@@ -12,7 +12,7 @@ ability Foo where
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ability Foo
 ```
@@ -40,7 +40,7 @@ bar = {{
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar : Doc2
 ```

--- a/unison-src/transcripts-using-base/fix3166.output.md
+++ b/unison-src/transcripts-using-base/fix3166.output.md
@@ -37,7 +37,7 @@ increment n = 1 + n
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       Stream.fromList    : [a] -> '{Stream a} ()
       Stream.map         : (a -> b)
@@ -86,7 +86,7 @@ foo _ =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural ability E
       foo : '{E} (Nat -> Nat)
@@ -128,7 +128,7 @@ hmm =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural ability Over
       delegated : ∀ _. _ -> Nat -> Nat

--- a/unison-src/transcripts-using-base/fix3542.output.md
+++ b/unison-src/transcripts-using-base/fix3542.output.md
@@ -19,7 +19,7 @@ arrayList v n = do
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       arrayList : Nat -> Nat -> '{Exception, Scope s} [Nat]
 

--- a/unison-src/transcripts-using-base/fix3939.output.md
+++ b/unison-src/transcripts-using-base/fix3939.output.md
@@ -11,7 +11,7 @@ meh = 9
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       meh     : Nat
       meh.doc : Doc2

--- a/unison-src/transcripts-using-base/fix4746.output.md
+++ b/unison-src/transcripts-using-base/fix4746.output.md
@@ -41,7 +41,7 @@ run s =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ability Issue t
       run   : '{Issue t} () -> '{Stream Text} ()

--- a/unison-src/transcripts-using-base/fix5178.output.md
+++ b/unison-src/transcripts-using-base/fix5178.output.md
@@ -10,7 +10,7 @@ foo = {{
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       foo : Doc2
 ```

--- a/unison-src/transcripts-using-base/hashing.output.md
+++ b/unison-src/transcripts-using-base/hashing.output.md
@@ -80,7 +80,7 @@ ex5 = crypto.hmac Sha2_256 mysecret f |> hex
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ex1      : Text
       ex2      : Text
@@ -384,7 +384,7 @@ test> hmac_sha2_512.tests.ex2 =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ex'                     : HashAlgorithm
                                 -> Text
@@ -447,7 +447,7 @@ test> md5.tests.ex3 =
 
     ⊡ Previously added definitions will be ignored: ex
     
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       md5.tests.ex1 : [Result]
       md5.tests.ex2 : [Result]

--- a/unison-src/transcripts-using-base/mvar.output.md
+++ b/unison-src/transcripts-using-base/mvar.output.md
@@ -56,7 +56,7 @@ testMvars _ =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       eitherCk  : (a ->{g} Boolean) -> Either e a ->{g} Boolean
       testMvars : '{IO} [Result]

--- a/unison-src/transcripts-using-base/nat-coersion.output.md
+++ b/unison-src/transcripts-using-base/nat-coersion.output.md
@@ -38,7 +38,7 @@ test = 'let
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       test    : '{IO} [Result]
       testNat : Nat

--- a/unison-src/transcripts-using-base/net.output.md
+++ b/unison-src/transcripts-using-base/net.output.md
@@ -102,7 +102,7 @@ testDefaultPort _ =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       testDefaultHost  : '{IO} [Result]
       testDefaultPort  : '{IO} [Result]
@@ -187,7 +187,7 @@ testTcpConnect = 'let
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       clientThread   : MVar Nat -> MVar Text -> '{IO} ()
       serverThread   : MVar Nat -> Text -> '{IO} ()

--- a/unison-src/transcripts-using-base/random-deserial.output.md
+++ b/unison-src/transcripts-using-base/random-deserial.output.md
@@ -61,7 +61,7 @@ serialTests = do
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       availableCases : '{IO, Exception} [Text]
       directory      : Text

--- a/unison-src/transcripts-using-base/ref-promise.output.md
+++ b/unison-src/transcripts-using-base/ref-promise.output.md
@@ -32,7 +32,7 @@ casTest = do
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       casTest : '{IO} [Result]
 ```
@@ -95,7 +95,7 @@ promiseConcurrentTest = do
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       promiseConcurrentTest : '{IO} [Result]
       promiseSequentialTest : '{IO} [Result]
@@ -147,7 +147,7 @@ atomicUpdate ref f =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       atomicUpdate : Ref {IO} a -> (a -> a) ->{IO} ()
 ```
@@ -185,7 +185,7 @@ spawnN n fa =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       spawnN : Nat -> '{IO} a ->{IO} [a]
 ```
@@ -233,7 +233,7 @@ fullTest = do
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       fullTest : '{IO} [Result]
 ```

--- a/unison-src/transcripts-using-base/replacements.output.md
+++ b/unison-src/transcripts-using-base/replacements.output.md
@@ -24,7 +24,7 @@ mapTests = do [!testIt]
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       mapTests : '{IO} [Result]
       testIt   : '{IO} Result

--- a/unison-src/transcripts-using-base/serial-test-00.output.md
+++ b/unison-src/transcripts-using-base/serial-test-00.output.md
@@ -73,7 +73,7 @@ mkTestCase = do
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural type Tree a
       evaluate   : (Tree Nat -> Nat)

--- a/unison-src/transcripts-using-base/serial-test-01.output.md
+++ b/unison-src/transcripts-using-base/serial-test-01.output.md
@@ -21,7 +21,7 @@ mkTestCase = do
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       combines   : ([Float], [Int], [Char]) -> Text
       l1         : [Float]

--- a/unison-src/transcripts-using-base/serial-test-02.output.md
+++ b/unison-src/transcripts-using-base/serial-test-02.output.md
@@ -35,7 +35,7 @@ mkTestCase = do
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural ability Exit a
       l1         : [Nat]

--- a/unison-src/transcripts-using-base/serial-test-03.output.md
+++ b/unison-src/transcripts-using-base/serial-test-03.output.md
@@ -49,7 +49,7 @@ mkTestCase = do
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural ability DC r
       structural type Delayed r

--- a/unison-src/transcripts-using-base/serial-test-04.output.md
+++ b/unison-src/transcripts-using-base/serial-test-04.output.md
@@ -19,7 +19,7 @@ mkTestCase = do
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       mkTestCase : '{IO, Exception} ()
       mutual0    : Nat -> Text

--- a/unison-src/transcripts-using-base/stm.output.md
+++ b/unison-src/transcripts-using-base/stm.output.md
@@ -34,7 +34,7 @@ body k out v =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       body  : Nat -> TVar (Optional Nat) -> TVar Nat ->{IO} ()
       count : Nat -> ()
@@ -92,7 +92,7 @@ tests = '(map spawn nats)
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       display : Nat -> Nat -> Nat -> Text
       nats    : [Nat]

--- a/unison-src/transcripts-using-base/thread.output.md
+++ b/unison-src/transcripts-using-base/thread.output.md
@@ -22,7 +22,7 @@ testBasicFork = 'let
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       otherThread   : '{IO} ()
       testBasicFork : '{IO} [Result]
@@ -66,7 +66,7 @@ testBasicMultiThreadMVar = 'let
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       testBasicMultiThreadMVar : '{IO} [Result]
       thread1                  : Nat -> MVar Nat -> '{IO} ()
@@ -135,7 +135,7 @@ testTwoThreads = 'let
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       receivingThread : MVar Nat -> MVar Text -> '{IO} ()
       sendingThread   : Nat -> MVar Nat -> '{IO} ()

--- a/unison-src/transcripts-using-base/tls.output.md
+++ b/unison-src/transcripts-using-base/tls.output.md
@@ -37,7 +37,7 @@ what_should_work _ = this_should_work ++ this_should_not_work
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       this_should_not_work : [Result]
       this_should_work     : [Result]
@@ -224,7 +224,7 @@ testCNReject _ =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       serverThread          : MVar Nat -> Text -> '{IO} ()
       testCAReject          : '{IO} [Result]

--- a/unison-src/transcripts-using-base/utf8.output.md
+++ b/unison-src/transcripts-using-base/utf8.output.md
@@ -54,7 +54,7 @@ greek = "ΑΒΓΔΕ"
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       greek : Text
 
@@ -87,7 +87,7 @@ test> greekTest = checkRoundTrip greek
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       checkRoundTrip : Text -> [Result]
       greek          : Text
@@ -120,7 +120,7 @@ greek_bytes = Bytes.fromList [206, 145, 206, 146, 206, 147, 206, 148, 206]
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       greek_bytes : Bytes
 

--- a/unison-src/transcripts/hello.output.md
+++ b/unison-src/transcripts/hello.output.md
@@ -35,7 +35,7 @@ x = 42
   I found and typechecked these definitions in myfile.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       x : Nat
 ```

--- a/unison-src/transcripts/idempotent/add-run.md
+++ b/unison-src/transcripts/idempotent/add-run.md
@@ -82,7 +82,7 @@ main _ = y
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       main : '{IO, Exception} (Nat -> Nat -> Nat)
       y    : Nat -> Nat -> Nat
@@ -115,7 +115,7 @@ inc x = x + 1
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       inc : Nat -> Nat
 ```
@@ -165,7 +165,7 @@ main = 'y
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       main : 'Nat
       x    : Nat

--- a/unison-src/transcripts/idempotent/addupdatemessages.md
+++ b/unison-src/transcripts/idempotent/addupdatemessages.md
@@ -20,7 +20,7 @@ structural type Y = Two Nat Nat
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural type X
       structural type Y
@@ -53,7 +53,7 @@ structural type Z = One Nat
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural type Z
         (also named X)

--- a/unison-src/transcripts/idempotent/affine-handlers.md
+++ b/unison-src/transcripts/idempotent/affine-handlers.md
@@ -129,7 +129,7 @@ count'test = do
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ability Count
       ability Env e
@@ -204,7 +204,7 @@ fail'count'test = do
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ability CountOrFail
       fail'count'loop : Nat ->{CountOrFail} ()
@@ -268,7 +268,7 @@ local'count'test = do
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       local'count'test : '{IO, Exception} [Result]
       local'counter    : Nat -> '{Count} r -> r
@@ -346,7 +346,7 @@ elaborate'test = do
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ability Rec
       count'extra    : Nat -> '{Count} r -> r

--- a/unison-src/transcripts/idempotent/anf-tests.md
+++ b/unison-src/transcripts/idempotent/anf-tests.md
@@ -35,7 +35,7 @@ foo _ =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       foo : ∀ _. _ -> Nat
 

--- a/unison-src/transcripts/idempotent/api-find.md
+++ b/unison-src/transcripts/idempotent/api-find.md
@@ -13,7 +13,7 @@ joey.yaml.zz = 45
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       joey.httpServer.z   : ##Nat
       joey.yaml.zz        : ##Nat

--- a/unison-src/transcripts/idempotent/api-namespace-details.md
+++ b/unison-src/transcripts/idempotent/api-namespace-details.md
@@ -19,7 +19,7 @@ Here's a *README*!
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       nested.names.readme : Doc2
       nested.names.x      : Nat

--- a/unison-src/transcripts/idempotent/api-namespace-list.md
+++ b/unison-src/transcripts/idempotent/api-namespace-list.md
@@ -17,7 +17,7 @@ nested.names.readme = {{ I'm a readme! }}
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       nested.names.readme : Doc2
       nested.names.x      : Nat

--- a/unison-src/transcripts/idempotent/blocks.md
+++ b/unison-src/transcripts/idempotent/blocks.md
@@ -25,7 +25,7 @@ ex thing =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ex : thing -> Nat
 
@@ -56,7 +56,7 @@ ex thing =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ex : thing -> Nat
 
@@ -89,7 +89,7 @@ ex thing =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ex : (Nat ->{g} Nat) ->{g} Nat
 
@@ -119,7 +119,7 @@ ex thing =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ex : (Nat ->{g} Nat) ->{g} Nat
 
@@ -156,7 +156,7 @@ ex n =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ex    : n -> r
       sumTo : Nat -> Nat
@@ -181,7 +181,7 @@ ex n =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ex : n -> Nat
 ```
@@ -234,7 +234,7 @@ ex n =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ex : n -> r
 ```
@@ -283,7 +283,7 @@ ex n =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural ability SpaceAttack
       ex : n ->{SpaceAttack} Nat
@@ -310,7 +310,7 @@ ex n =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural ability SpaceAttack
       ex : n ->{SpaceAttack} r
@@ -335,7 +335,7 @@ ex n =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural ability SpaceAttack
       ex : n ->{SpaceAttack} r

--- a/unison-src/transcripts/idempotent/boolean-op-pretty-print-2819.md
+++ b/unison-src/transcripts/idempotent/boolean-op-pretty-print-2819.md
@@ -17,7 +17,7 @@ hangExample =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       hangExample : Boolean
 ```

--- a/unison-src/transcripts/idempotent/branch-relative-path.md
+++ b/unison-src/transcripts/idempotent/branch-relative-path.md
@@ -9,7 +9,7 @@ foo.bar = 1
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       foo     : ##Nat
       foo.bar : ##Nat
@@ -35,7 +35,7 @@ donk.bonk = 1
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bonk      : ##Nat
         (also named foo)

--- a/unison-src/transcripts/idempotent/bug-fix-4354.md
+++ b/unison-src/transcripts/idempotent/bug-fix-4354.md
@@ -18,7 +18,7 @@ bonk x =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bonk : a -> a
 ```

--- a/unison-src/transcripts/idempotent/bug-strange-closure.md
+++ b/unison-src/transcripts/idempotent/bug-strange-closure.md
@@ -423,7 +423,7 @@ rendered = Pretty.get (docFormatConsole doc.guide)
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       rendered : Annotated () (Either SpecialForm ConsoleText)
 ```
@@ -855,7 +855,7 @@ rendered = Pretty.get (docFormatConsole doc.guide)
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       rendered : Annotated () (Either SpecialForm ConsoleText)
 

--- a/unison-src/transcripts/idempotent/builtins.md
+++ b/unison-src/transcripts/idempotent/builtins.md
@@ -404,7 +404,7 @@ test> Any.test2 = checks [(not (Any "hi" == Any 42))]
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       Any.test1 : [Result]
       Any.test2 : [Result]
@@ -458,7 +458,7 @@ openFile]
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       Sandbox.test1          : [Result]
       Sandbox.test2          : [Result]
@@ -513,7 +513,7 @@ openFilesIO = do
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       openFilesIO : '{IO} [Result]
 ```
@@ -552,7 +552,7 @@ test> Universal.murmurHash.tests = checks [Universal.murmurHash [1,2,3] == Unive
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       Universal.murmurHash.tests : [Result]
 

--- a/unison-src/transcripts/idempotent/check763.md
+++ b/unison-src/transcripts/idempotent/check763.md
@@ -15,7 +15,7 @@ scratch/main> builtins.merge
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       +-+ : Nat -> Nat -> Nat
 ```

--- a/unison-src/transcripts/idempotent/check873.md
+++ b/unison-src/transcripts/idempotent/check873.md
@@ -14,7 +14,7 @@ scratch/main> builtins.merge
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       - : Nat -> Nat -> Int
 ```
@@ -38,7 +38,7 @@ baz x = x - 1
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       baz : Nat -> Int
 ```

--- a/unison-src/transcripts/idempotent/constructor-applied-to-unit.md
+++ b/unison-src/transcripts/idempotent/constructor-applied-to-unit.md
@@ -17,7 +17,7 @@ structural type Zoink a b c = Zoink a b c
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural type Zoink a b c
 

--- a/unison-src/transcripts/idempotent/contrabilities.md
+++ b/unison-src/transcripts/idempotent/contrabilities.md
@@ -13,7 +13,7 @@ f x = 42
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       f : '{g} a -> Nat
 ```

--- a/unison-src/transcripts/idempotent/cycle-update-1.md
+++ b/unison-src/transcripts/idempotent/cycle-update-1.md
@@ -18,7 +18,7 @@ pong _ = !ping + 2
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ping : 'Nat
       pong : 'Nat

--- a/unison-src/transcripts/idempotent/cycle-update-2.md
+++ b/unison-src/transcripts/idempotent/cycle-update-2.md
@@ -18,7 +18,7 @@ pong _ = !ping + 2
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ping : 'Nat
       pong : 'Nat

--- a/unison-src/transcripts/idempotent/cycle-update-3.md
+++ b/unison-src/transcripts/idempotent/cycle-update-3.md
@@ -18,7 +18,7 @@ pong _ = !ping + 2
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ping : 'Nat
       pong : 'Nat

--- a/unison-src/transcripts/idempotent/cycle-update-4.md
+++ b/unison-src/transcripts/idempotent/cycle-update-4.md
@@ -18,7 +18,7 @@ pong _ = !ping + 2
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ping : 'Nat
       pong : 'Nat
@@ -47,7 +47,7 @@ clang _ = !pong + 3
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       clang : 'Nat
     

--- a/unison-src/transcripts/idempotent/debug-name-diffs.md
+++ b/unison-src/transcripts/idempotent/debug-name-diffs.md
@@ -15,7 +15,7 @@ structural type a.b.Baz = Boo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural type a.b.Baz
       structural type a.x.Foo

--- a/unison-src/transcripts/idempotent/definition-diff-api.md
+++ b/unison-src/transcripts/idempotent/definition-diff-api.md
@@ -44,7 +44,7 @@ unitCase = id (x -> 1)
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ability Stream a
       type Type

--- a/unison-src/transcripts/idempotent/delete-namespace-dependents-check.md
+++ b/unison-src/transcripts/idempotent/delete-namespace-dependents-check.md
@@ -20,7 +20,7 @@ dependent = dependency + 99
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       dependent      : Nat
       sub.dependency : Nat

--- a/unison-src/transcripts/idempotent/destructuring-binds.md
+++ b/unison-src/transcripts/idempotent/destructuring-binds.md
@@ -24,7 +24,7 @@ ex1 tup =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ex0 : Nat -> Nat
       ex1 : (a, b, (Nat, Nat)) -> Nat
@@ -66,7 +66,7 @@ ex2 tup = match tup with
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ex2 : (a, b, (Nat, Nat)) -> Nat
         (also named ex1)
@@ -117,7 +117,7 @@ ex5a _ = match (99 + 1, "hi") with
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ex5  : 'Text
       ex5a : 'Text

--- a/unison-src/transcripts/idempotent/diff-namespace.md
+++ b/unison-src/transcripts/idempotent/diff-namespace.md
@@ -470,7 +470,7 @@ x = 1
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       x : Nat
 ```
@@ -494,7 +494,7 @@ y = 2
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       y : ##Nat
 ```

--- a/unison-src/transcripts/idempotent/doc-formatting.md
+++ b/unison-src/transcripts/idempotent/doc-formatting.md
@@ -19,7 +19,7 @@ foo n =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       foo : Nat -> Nat
 ```
@@ -50,7 +50,7 @@ escaping = [: Docs look [: like \@this \:] :]
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       escaping : Doc
 ```
@@ -84,7 +84,7 @@ commented = [:
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       commented : Doc
 ```
@@ -121,7 +121,7 @@ doc1 = [:   hi   :]
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       doc1 : Doc
 ```
@@ -155,7 +155,7 @@ doc2 = [: hello
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       doc2 : Doc
 ```
@@ -196,7 +196,7 @@ Note that because of the special treatment of the first line mentioned above, wh
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       doc3 : Doc
 ```
@@ -245,7 +245,7 @@ doc4 = [: Here's another example of some paragraphs.
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       doc4 : Doc
 ```
@@ -282,7 +282,7 @@ doc5 = [:   - foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       doc5 : Doc
 ```
@@ -316,7 +316,7 @@ doc6 = [:
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       doc6 : Doc
 ```
@@ -351,7 +351,7 @@ expr = foo 1
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       empty : Doc
       expr  : Nat
@@ -414,7 +414,7 @@ para line lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       test1 : Doc
 ```
@@ -498,7 +498,7 @@ reg1363 = [: `@List.take foo` bar
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       reg1363 : Doc
 ```
@@ -530,7 +530,7 @@ test2 = [:
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       test2 : Doc
 ```

--- a/unison-src/transcripts/idempotent/doc1.md
+++ b/unison-src/transcripts/idempotent/doc1.md
@@ -36,7 +36,7 @@ Can link to definitions like @List.drop or @List
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       doc1 : Doc
 ```
@@ -66,7 +66,7 @@ List.take.ex2 = take 2 [1,2,3,4,5]
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       List.take.ex1 : [Nat]
       List.take.ex2 : [Nat]
@@ -106,7 +106,7 @@ List.take.doc = [:
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       List.take.doc : Doc
 ```

--- a/unison-src/transcripts/idempotent/doc2markdown.md
+++ b/unison-src/transcripts/idempotent/doc2markdown.md
@@ -187,7 +187,7 @@ structural type MyStructuralType = MyStructuralType
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural type MyStructuralType
         (also named builtin.Unit)

--- a/unison-src/transcripts/idempotent/duplicate-names.md
+++ b/unison-src/transcripts/idempotent/duplicate-names.md
@@ -109,7 +109,7 @@ X = ()
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural type X
         (also named builtin.Unit)

--- a/unison-src/transcripts/idempotent/ed25519.md
+++ b/unison-src/transcripts/idempotent/ed25519.md
@@ -30,7 +30,7 @@ sigOkay = match signature with
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       down      : Bytes
       message   : Bytes

--- a/unison-src/transcripts/idempotent/edit-command.md
+++ b/unison-src/transcripts/idempotent/edit-command.md
@@ -16,7 +16,7 @@ mytest = [Ok "ok"]
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar    : Nat
       foo    : Nat
@@ -103,7 +103,7 @@ baz = 19
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar : Nat
       baz : Nat

--- a/unison-src/transcripts/idempotent/edit-dependents-command.md
+++ b/unison-src/transcripts/idempotent/edit-dependents-command.md
@@ -21,7 +21,7 @@ baz x = x
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Bar
       type Foo

--- a/unison-src/transcripts/idempotent/edit-namespace.md
+++ b/unison-src/transcripts/idempotent/edit-namespace.md
@@ -27,7 +27,7 @@ unique type Foo = { bar : Nat, baz : Nat }
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Foo
       Foo.bar               : Foo -> Nat

--- a/unison-src/transcripts/idempotent/fix-5267.md
+++ b/unison-src/transcripts/idempotent/fix-5267.md
@@ -16,7 +16,7 @@ bar = direct.foo + direct.foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar                         : Nat
       lib.direct.foo              : Nat
@@ -57,7 +57,7 @@ type Bar = MkBar direct.Foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Bar
       type lib.direct.Foo

--- a/unison-src/transcripts/idempotent/fix-5312.md
+++ b/unison-src/transcripts/idempotent/fix-5312.md
@@ -22,7 +22,7 @@ c = b.y + 1
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       a.y : Nat
       b.y : Nat

--- a/unison-src/transcripts/idempotent/fix-5323.md
+++ b/unison-src/transcripts/idempotent/fix-5323.md
@@ -23,7 +23,7 @@ c = b.y + 1
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       a.y       : Nat
       b.y       : Nat

--- a/unison-src/transcripts/idempotent/fix-5326.md
+++ b/unison-src/transcripts/idempotent/fix-5326.md
@@ -14,7 +14,7 @@ x = 1
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       x : Nat
 ```
@@ -157,7 +157,7 @@ y = 5
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       y : Nat
 ```

--- a/unison-src/transcripts/idempotent/fix-5340.md
+++ b/unison-src/transcripts/idempotent/fix-5340.md
@@ -16,7 +16,7 @@ lib.dep.lib.dep.foo = 18
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type lib.dep.lib.dep.Foo
       type my.Foo
@@ -49,7 +49,7 @@ type Bar = MkBar Foo
 
     ⊡ Previously added definitions will be ignored: my.Foo
     
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Bar
 ```
@@ -67,7 +67,7 @@ bar = foo Nat.+ foo
 
     ⊡ Previously added definitions will be ignored: my.foo
     
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar : Nat
 ```

--- a/unison-src/transcripts/idempotent/fix-5354.md
+++ b/unison-src/transcripts/idempotent/fix-5354.md
@@ -16,7 +16,7 @@ foo = 42
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       foo : Nat
 

--- a/unison-src/transcripts/idempotent/fix-5357.md
+++ b/unison-src/transcripts/idempotent/fix-5357.md
@@ -14,7 +14,7 @@ foo =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       foo         : ()
       util.ignore : a -> ()
@@ -40,7 +40,7 @@ lib.base.ignore _ = ()
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       lib.base.ignore : a -> ()
         (also named util.ignore)

--- a/unison-src/transcripts/idempotent/fix-5369.md
+++ b/unison-src/transcripts/idempotent/fix-5369.md
@@ -18,7 +18,7 @@ two.foo = "blah"
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       one.foo : Nat
       two.foo : Text
@@ -47,7 +47,7 @@ bar = foo + foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar : Nat
     

--- a/unison-src/transcripts/idempotent/fix-5374.md
+++ b/unison-src/transcripts/idempotent/fix-5374.md
@@ -15,7 +15,7 @@ thing = indirect.foo + indirect.foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       lib.direct.foo              : Nat
       lib.direct.lib.indirect.foo : Nat

--- a/unison-src/transcripts/idempotent/fix-5380.md
+++ b/unison-src/transcripts/idempotent/fix-5380.md
@@ -21,7 +21,7 @@ bar =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar : Nat
       foo : Nat

--- a/unison-src/transcripts/idempotent/fix-5402.md
+++ b/unison-src/transcripts/idempotent/fix-5402.md
@@ -12,7 +12,7 @@ x = 10
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       foo.x : ##Nat
 ```
@@ -29,7 +29,7 @@ x = 10
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       foo.x : ##Nat
 ```

--- a/unison-src/transcripts/idempotent/fix-5427.md
+++ b/unison-src/transcripts/idempotent/fix-5427.md
@@ -24,7 +24,7 @@ bar =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar : Nat
       foo : Nat
@@ -79,7 +79,7 @@ baz = foo + foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar : Nat
       baz : Nat

--- a/unison-src/transcripts/idempotent/fix-5433.md
+++ b/unison-src/transcripts/idempotent/fix-5433.md
@@ -15,7 +15,7 @@ ability foo.Bar where
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ability foo.Bar
 ```
@@ -45,7 +45,7 @@ hello = cases
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       hello : Request {Bar} a -> ()
     

--- a/unison-src/transcripts/idempotent/fix-5446.md
+++ b/unison-src/transcripts/idempotent/fix-5446.md
@@ -15,7 +15,7 @@ lib.two.bar = foo Nat.+ foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       lib.one.foo : Nat
       lib.two.bar : Nat

--- a/unison-src/transcripts/idempotent/fix-5464.md
+++ b/unison-src/transcripts/idempotent/fix-5464.md
@@ -23,7 +23,7 @@ qux = foo + foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar.baz : Nat
       foo     : Nat

--- a/unison-src/transcripts/idempotent/fix-5489.md
+++ b/unison-src/transcripts/idempotent/fix-5489.md
@@ -9,7 +9,7 @@ type Foo = Foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type foo.Foo
 ```

--- a/unison-src/transcripts/idempotent/fix-5525.md
+++ b/unison-src/transcripts/idempotent/fix-5525.md
@@ -22,7 +22,7 @@ foo =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       foo : Nat
 ```
@@ -75,7 +75,7 @@ bar = 17
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar : Nat
       foo : Nat

--- a/unison-src/transcripts/idempotent/fix-5575.md
+++ b/unison-src/transcripts/idempotent/fix-5575.md
@@ -49,7 +49,7 @@ foo =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       foo : Nat
 ```

--- a/unison-src/transcripts/idempotent/fix-5604.md
+++ b/unison-src/transcripts/idempotent/fix-5604.md
@@ -28,7 +28,7 @@ foo = 17
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       foo : MyNat
 ```
@@ -94,7 +94,7 @@ bar = foo + foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar : MyNat
 ```

--- a/unison-src/transcripts/idempotent/fix-5612.md
+++ b/unison-src/transcripts/idempotent/fix-5612.md
@@ -24,7 +24,7 @@ zzz = yyy ++ "zzz"
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       conflicted : Nat
       xxx        : Text
@@ -200,7 +200,7 @@ yyy = xxx ++ "yyy"
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       conflicted : Nat
       xxx        : Text
@@ -268,7 +268,7 @@ zzz = yyy ++ "zzz2"
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       zzz : Text
     

--- a/unison-src/transcripts/idempotent/fix-annotated-lambdas.md
+++ b/unison-src/transcripts/idempotent/fix-annotated-lambdas.md
@@ -19,7 +19,7 @@ bar k = k (x -> x)
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar : (∀ r. (a -> r) ->{g} r) ->{g} a
       foo : a -> a

--- a/unison-src/transcripts/idempotent/fix-big-list-crash.md
+++ b/unison-src/transcripts/idempotent/fix-big-list-crash.md
@@ -18,7 +18,7 @@ x = [(R,1005),(U,563),(R,417),(U,509),(L,237),(U,555),(R,397),(U,414),(L,490),(U
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Direction
       x : [(Direction, Nat)]

--- a/unison-src/transcripts/idempotent/fix-ls.md
+++ b/unison-src/transcripts/idempotent/fix-ls.md
@@ -16,7 +16,7 @@ foo.bar.subtract x y = x Int.- y
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       foo.bar.add      : Int -> Int -> Int
       foo.bar.subtract : Int -> Int -> Int

--- a/unison-src/transcripts/idempotent/fix-pattern-capture.md
+++ b/unison-src/transcripts/idempotent/fix-pattern-capture.md
@@ -33,7 +33,7 @@ xyzzy box decoy =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Decoy a
       type NatBox

--- a/unison-src/transcripts/idempotent/fix1063.md
+++ b/unison-src/transcripts/idempotent/fix1063.md
@@ -18,7 +18,7 @@ noop = not `.` not
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       `.`  : (i1 ->{g1} o) -> (i ->{g} i1) -> i ->{g1, g} o
       noop : Boolean -> Boolean

--- a/unison-src/transcripts/idempotent/fix1327.md
+++ b/unison-src/transcripts/idempotent/fix1327.md
@@ -10,7 +10,7 @@ bar = 5
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar : ##Nat
       foo : ##Nat

--- a/unison-src/transcripts/idempotent/fix1390.md
+++ b/unison-src/transcripts/idempotent/fix1390.md
@@ -19,7 +19,7 @@ List.map f =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       List.map : (i ->{g} o) -> [i] ->{g} [o]
 ```
@@ -58,7 +58,7 @@ List.map2 f =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       List.map2 : (g ->{h} g2) -> [g] ->{h} [g2]
 ```

--- a/unison-src/transcripts/idempotent/fix1421.md
+++ b/unison-src/transcripts/idempotent/fix1421.md
@@ -19,7 +19,7 @@ unique type B = B Nat Nat
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type A
       type B

--- a/unison-src/transcripts/idempotent/fix1532.md
+++ b/unison-src/transcripts/idempotent/fix1532.md
@@ -18,7 +18,7 @@ bar.z = x + y
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar.z : Nat
       foo.x : Nat

--- a/unison-src/transcripts/idempotent/fix1709.md
+++ b/unison-src/transcripts/idempotent/fix1709.md
@@ -12,7 +12,7 @@ id2 x =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       id  : x -> x
       id2 : x -> x

--- a/unison-src/transcripts/idempotent/fix1731.md
+++ b/unison-src/transcripts/idempotent/fix1731.md
@@ -26,7 +26,7 @@ repro = cases
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       repro : Text -> ()
 ```

--- a/unison-src/transcripts/idempotent/fix1844.md
+++ b/unison-src/transcripts/idempotent/fix1844.md
@@ -15,7 +15,7 @@ snoc k aN = match k with
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural type One a
       type Woot a b c

--- a/unison-src/transcripts/idempotent/fix1926.md
+++ b/unison-src/transcripts/idempotent/fix1926.md
@@ -16,7 +16,7 @@ sq = 2934892384
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       sq : Nat
 
@@ -40,7 +40,7 @@ sq = 2934892384
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       sq : Nat
 

--- a/unison-src/transcripts/idempotent/fix2026.md
+++ b/unison-src/transcripts/idempotent/fix2026.md
@@ -45,7 +45,7 @@ Exception.unsafeRun! e _ =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural ability Exception
         (also named builtin.Exception)

--- a/unison-src/transcripts/idempotent/fix2027.md
+++ b/unison-src/transcripts/idempotent/fix2027.md
@@ -54,7 +54,7 @@ myServer = unsafeRun! '(hello "127.0.0.1" "0")
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural type Either a b
         (also named builtin.Either)

--- a/unison-src/transcripts/idempotent/fix2049.md
+++ b/unison-src/transcripts/idempotent/fix2049.md
@@ -58,7 +58,7 @@ Fold.Stream.fold =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Fold g a b
       type Fold' g a b x
@@ -114,7 +114,7 @@ tests _ =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       catcher : '{IO} () ->{IO} Result
       tests   : ∀ _. _ ->{IO} [Result]

--- a/unison-src/transcripts/idempotent/fix2156.md
+++ b/unison-src/transcripts/idempotent/fix2156.md
@@ -18,7 +18,7 @@ sqr n = n * n
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       sqr : Nat -> Nat
 

--- a/unison-src/transcripts/idempotent/fix2167.md
+++ b/unison-src/transcripts/idempotent/fix2167.md
@@ -25,7 +25,7 @@ R.near1 region loc = match R.near 42 with
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural ability R t
       R.near  : Nat ->{R t} [Nat]

--- a/unison-src/transcripts/idempotent/fix2187.md
+++ b/unison-src/transcripts/idempotent/fix2187.md
@@ -24,7 +24,7 @@ lexicalScopeEx =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       lexicalScopeEx : [Text]
 ```

--- a/unison-src/transcripts/idempotent/fix2231.md
+++ b/unison-src/transcripts/idempotent/fix2231.md
@@ -30,7 +30,7 @@ txt = foldl (Text.++) "" ["a", "b", "c"]
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       <<    : (b ->{e} c) -> (a ->{e} b) -> a ->{e} c
       f     : Float -> Float

--- a/unison-src/transcripts/idempotent/fix2244.md
+++ b/unison-src/transcripts/idempotent/fix2244.md
@@ -23,7 +23,7 @@ let
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       x : Doc2
 ```

--- a/unison-src/transcripts/idempotent/fix2254.md
+++ b/unison-src/transcripts/idempotent/fix2254.md
@@ -136,7 +136,7 @@ combine r = uno r + dos r
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural type Rec
       Rec.dos        : Rec -> Nat
@@ -174,7 +174,7 @@ structural type Rec = { uno : Nat, dos : Nat, tres : Text }
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       Rec.tres        : Rec -> Text
       Rec.tres.modify : (Text ->{g} Text) -> Rec ->{g} Rec

--- a/unison-src/transcripts/idempotent/fix2268.md
+++ b/unison-src/transcripts/idempotent/fix2268.md
@@ -25,7 +25,7 @@ test _ =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ability A
       ability B

--- a/unison-src/transcripts/idempotent/fix2334.md
+++ b/unison-src/transcripts/idempotent/fix2334.md
@@ -24,7 +24,7 @@ f = cases
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       f : Nat -> Nat -> Nat
 

--- a/unison-src/transcripts/idempotent/fix2344.md
+++ b/unison-src/transcripts/idempotent/fix2344.md
@@ -26,7 +26,7 @@ sneezy dee _ =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ability Nate
       sneezy : (Nat ->{d} a) -> '{d, Nate} a

--- a/unison-src/transcripts/idempotent/fix2350.md
+++ b/unison-src/transcripts/idempotent/fix2350.md
@@ -34,7 +34,7 @@ save a = !(save.impl a)
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ability Storage d g
       save : a ->{g, Storage d g} d a

--- a/unison-src/transcripts/idempotent/fix2353.md
+++ b/unison-src/transcripts/idempotent/fix2353.md
@@ -21,7 +21,7 @@ pure.run a0 a =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ability Async t g
       ability Exception

--- a/unison-src/transcripts/idempotent/fix2378.md
+++ b/unison-src/transcripts/idempotent/fix2378.md
@@ -48,7 +48,7 @@ x _ = Ex.catch '(C.pure.run '(A.pure.run ex))
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ability A t g
       ability C c

--- a/unison-src/transcripts/idempotent/fix2423.md
+++ b/unison-src/transcripts/idempotent/fix2423.md
@@ -36,7 +36,7 @@ Split.zipSame sa sb _ =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural ability Split
       Split.append  : '{g, Split} a

--- a/unison-src/transcripts/idempotent/fix2474.md
+++ b/unison-src/transcripts/idempotent/fix2474.md
@@ -43,7 +43,7 @@ Stream.uncons s =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural ability Stream a
       Stream.uncons : '{g, Stream a} r

--- a/unison-src/transcripts/idempotent/fix2663.md
+++ b/unison-src/transcripts/idempotent/fix2663.md
@@ -30,7 +30,7 @@ bad x = match Some (Some x) with
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural type Trip
       bad : Nat -> (Nat, Nat)

--- a/unison-src/transcripts/idempotent/fix2693.md
+++ b/unison-src/transcripts/idempotent/fix2693.md
@@ -18,7 +18,7 @@ range = loop []
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       loop  : [Nat] -> Nat -> [Nat]
       range : Nat -> [Nat]

--- a/unison-src/transcripts/idempotent/fix2712.md
+++ b/unison-src/transcripts/idempotent/fix2712.md
@@ -15,7 +15,7 @@ mapWithKey f m = Tip
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Map k v
       mapWithKey : (k ->{e} a ->{e} b) -> Map k a ->{e} Map k b
@@ -49,7 +49,7 @@ naiomi =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       naiomi : Map Nat ()
 ```

--- a/unison-src/transcripts/idempotent/fix2795.md
+++ b/unison-src/transcripts/idempotent/fix2795.md
@@ -25,7 +25,7 @@ t1 = "hi"
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       t1   : Text
       test : Doc2

--- a/unison-src/transcripts/idempotent/fix2822.md
+++ b/unison-src/transcripts/idempotent/fix2822.md
@@ -18,7 +18,7 @@ b = _a.blah + 1
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       _a.blah : Nat
       b       : Nat
@@ -38,7 +38,7 @@ x = _b + 1
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       _b : Nat
       x  : Nat
@@ -59,7 +59,7 @@ c = A
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type _a.Blah
       c : Blah
@@ -79,7 +79,7 @@ doStuff = _value.modify
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Hello
       Hello._value        : Hello -> Nat
@@ -127,7 +127,7 @@ dontMap f = cases
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       dontMap : (Nat ->{g} Boolean) -> Optional a ->{g} Boolean
 ```

--- a/unison-src/transcripts/idempotent/fix2826.md
+++ b/unison-src/transcripts/idempotent/fix2826.md
@@ -20,7 +20,7 @@ doc = {{
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       doc : Doc2
 ```

--- a/unison-src/transcripts/idempotent/fix2970.md
+++ b/unison-src/transcripts/idempotent/fix2970.md
@@ -17,7 +17,7 @@ foo.+.doc = 10
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       foo.+.doc : Nat
 ```

--- a/unison-src/transcripts/idempotent/fix3171.md
+++ b/unison-src/transcripts/idempotent/fix3171.md
@@ -19,7 +19,7 @@ f x y z _ = x + y * z
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       f : Nat -> Nat -> Nat -> 'Nat
 

--- a/unison-src/transcripts/idempotent/fix3196.md
+++ b/unison-src/transcripts/idempotent/fix3196.md
@@ -39,7 +39,7 @@ w2 = cases W -> W
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural type C
       structural type W es

--- a/unison-src/transcripts/idempotent/fix3215.md
+++ b/unison-src/transcripts/idempotent/fix3215.md
@@ -26,7 +26,7 @@ f = cases
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural ability T
       f : Request {g, T} x -> Nat

--- a/unison-src/transcripts/idempotent/fix3244.md
+++ b/unison-src/transcripts/idempotent/fix3244.md
@@ -26,7 +26,7 @@ foo t =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       foo : (Nat, Nat) -> Nat
 

--- a/unison-src/transcripts/idempotent/fix3634.md
+++ b/unison-src/transcripts/idempotent/fix3634.md
@@ -20,7 +20,7 @@ d = {{
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural type M a
         (also named builtin.Optional)

--- a/unison-src/transcripts/idempotent/fix3678.md
+++ b/unison-src/transcripts/idempotent/fix3678.md
@@ -18,7 +18,7 @@ arr = Scope.run do
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       arr : ImmutableArray Text
 

--- a/unison-src/transcripts/idempotent/fix3752.md
+++ b/unison-src/transcripts/idempotent/fix3752.md
@@ -26,7 +26,7 @@ bar = do
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar : 'Text
       foo : 'Text

--- a/unison-src/transcripts/idempotent/fix3773.md
+++ b/unison-src/transcripts/idempotent/fix3773.md
@@ -17,7 +17,7 @@ foo =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       foo : Nat
 

--- a/unison-src/transcripts/idempotent/fix4172.md
+++ b/unison-src/transcripts/idempotent/fix4172.md
@@ -21,7 +21,7 @@ allowDebug = debug [1,2,3]
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       allowDebug : Text
       bool       : Boolean

--- a/unison-src/transcripts/idempotent/fix4280.md
+++ b/unison-src/transcripts/idempotent/fix4280.md
@@ -17,7 +17,7 @@ bonk =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bonk         : Nat
       foo.bar._baz : Nat

--- a/unison-src/transcripts/idempotent/fix4415.md
+++ b/unison-src/transcripts/idempotent/fix4415.md
@@ -9,7 +9,7 @@ unique type sub.Foo =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Foo
       type sub.Foo

--- a/unison-src/transcripts/idempotent/fix4482.md
+++ b/unison-src/transcripts/idempotent/fix4482.md
@@ -16,7 +16,7 @@ mybar = bar + bar
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       lib.foo0.baz           : Nat
       lib.foo0.lib.bonk1.bar : Nat

--- a/unison-src/transcripts/idempotent/fix4498.md
+++ b/unison-src/transcripts/idempotent/fix4498.md
@@ -15,7 +15,7 @@ myterm = foo + 2
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       lib.dep0.bonk.foo     : Nat
       lib.dep0.lib.dep1.foo : Nat

--- a/unison-src/transcripts/idempotent/fix4515.md
+++ b/unison-src/transcripts/idempotent/fix4515.md
@@ -18,7 +18,7 @@ useBar = cases
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Bar
       type Baz

--- a/unison-src/transcripts/idempotent/fix4528.md
+++ b/unison-src/transcripts/idempotent/fix4528.md
@@ -15,7 +15,7 @@ main _ = MkFoo 5
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural type Foo
       main : 'Foo

--- a/unison-src/transcripts/idempotent/fix4556.md
+++ b/unison-src/transcripts/idempotent/fix4556.md
@@ -15,7 +15,7 @@ hey = foo.hello
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar.hello : Nat
       foo.hello : Nat

--- a/unison-src/transcripts/idempotent/fix4592.md
+++ b/unison-src/transcripts/idempotent/fix4592.md
@@ -13,7 +13,7 @@ doc = {{ {{ bug "bug"
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       doc : Doc2
 ```

--- a/unison-src/transcripts/idempotent/fix4618.md
+++ b/unison-src/transcripts/idempotent/fix4618.md
@@ -13,7 +13,7 @@ unique type Bugs.Zonk = Bugs
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Bugs.Zonk
       foo : Nat
@@ -39,7 +39,7 @@ unique type Bugs =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Bugs
     

--- a/unison-src/transcripts/idempotent/fix4711.md
+++ b/unison-src/transcripts/idempotent/fix4711.md
@@ -16,7 +16,7 @@ thisDoesNotWork = ['(+1)]
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       thisDoesNotWork : ['{g} Int]
       thisWorks       : 'Int

--- a/unison-src/transcripts/idempotent/fix4722.md
+++ b/unison-src/transcripts/idempotent/fix4722.md
@@ -44,7 +44,7 @@ foo = cases
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Bar a
       type Foo b a

--- a/unison-src/transcripts/idempotent/fix4731.md
+++ b/unison-src/transcripts/idempotent/fix4731.md
@@ -8,7 +8,7 @@ structural type Void =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural type Void
 ```
@@ -35,7 +35,7 @@ Void.absurdly v = match !v with
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       Void.absurdly : '{e} Void ->{e} a
 ```
@@ -51,7 +51,7 @@ Void.absurdly v = match v with
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       Void.absurdly : Void -> a
 ```
@@ -69,7 +69,7 @@ Void.absurdly = cases
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       Void.absurdly : Void -> a
 ```

--- a/unison-src/transcripts/idempotent/fix4898.md
+++ b/unison-src/transcripts/idempotent/fix4898.md
@@ -18,7 +18,7 @@ redouble x = double x + double x
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       double   : Int -> Int
       redouble : Int -> Int

--- a/unison-src/transcripts/idempotent/fix5055.md
+++ b/unison-src/transcripts/idempotent/fix5055.md
@@ -16,7 +16,7 @@ foo.subtract x y = x Int.- y
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       foo.add      : Int -> Int -> Int
       foo.subtract : Int -> Int -> Int

--- a/unison-src/transcripts/idempotent/fix5076.md
+++ b/unison-src/transcripts/idempotent/fix5076.md
@@ -17,7 +17,7 @@ x = {{
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       x : Doc2
 ```

--- a/unison-src/transcripts/idempotent/fix5080.md
+++ b/unison-src/transcripts/idempotent/fix5080.md
@@ -13,7 +13,7 @@ test> fix5080.tests.failure = [Fail "fail"]
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       fix5080.tests.failure : [Result]
       fix5080.tests.success : [Result]

--- a/unison-src/transcripts/idempotent/fix5168.md
+++ b/unison-src/transcripts/idempotent/fix5168.md
@@ -10,7 +10,7 @@ b = 2
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       b : ##Nat
 ```

--- a/unison-src/transcripts/idempotent/fix5419.md
+++ b/unison-src/transcripts/idempotent/fix5419.md
@@ -22,7 +22,7 @@ foo w = match (5, w) with
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       foo : w
             -> ( Optional (Either Text Text),
@@ -59,7 +59,7 @@ bar x =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar : x
             -> ( Optional (Either Text Text),

--- a/unison-src/transcripts/idempotent/fix5506.md
+++ b/unison-src/transcripts/idempotent/fix5506.md
@@ -21,7 +21,7 @@ printLine t =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       printLine : Text ->{IO, Exception} ()
       putText   : Handle -> Text ->{IO, Exception} ()
@@ -48,7 +48,7 @@ hmmm = {{ I'll try {printLine}. That's a good trick. }}
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       hmmm : Doc2
 ```

--- a/unison-src/transcripts/idempotent/fix5538.md
+++ b/unison-src/transcripts/idempotent/fix5538.md
@@ -23,7 +23,7 @@ test> foo.test =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       foo.test : [Result]
       toText'  : a -> Text
@@ -71,7 +71,7 @@ bar.test =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar.test : [Result]
 ```

--- a/unison-src/transcripts/idempotent/fix5566.md
+++ b/unison-src/transcripts/idempotent/fix5566.md
@@ -14,7 +14,7 @@ type T2 = T2C
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type T1
       type T2
@@ -53,7 +53,7 @@ bomb = do
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type U
       ability V

--- a/unison-src/transcripts/idempotent/fix614.md
+++ b/unison-src/transcripts/idempotent/fix614.md
@@ -21,7 +21,7 @@ ex1 = do
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural ability Stream a
       ex1 : '{Stream Nat} Nat
@@ -66,7 +66,7 @@ ex3 = do
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ex3 : '()
 ```
@@ -87,7 +87,7 @@ ex4 =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ex4  : ()
       void : x -> ()

--- a/unison-src/transcripts/idempotent/fix689.md
+++ b/unison-src/transcripts/idempotent/fix689.md
@@ -17,7 +17,7 @@ tomorrow = '(SystemTime.systemTime + 24 * 60 * 60)
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural ability SystemTime
       tomorrow : '{SystemTime} Nat

--- a/unison-src/transcripts/idempotent/fix693.md
+++ b/unison-src/transcripts/idempotent/fix693.md
@@ -16,7 +16,7 @@ structural ability Abort where
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural ability Abort
       structural ability X t
@@ -123,7 +123,7 @@ h3 = cases
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       h3 : Request {X b, Abort} b -> Optional b
 ```

--- a/unison-src/transcripts/idempotent/fix845.md
+++ b/unison-src/transcripts/idempotent/fix845.md
@@ -18,7 +18,7 @@ Text.zonk txt = txt ++ "!! "
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       List.zonk : [a] -> [a]
       Text.zonk : Text -> Text
@@ -67,7 +67,7 @@ ex = baz ++ ", world!"
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ex          : Text
       foo.bar.baz : Nat
@@ -95,7 +95,7 @@ ex = zonk "hi"
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ex : Text
 
@@ -125,7 +125,7 @@ ex = zonk "hi" -- should resolve to Text.zonk, from the codebase
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ex         : Text
       woot.zonk  : Text

--- a/unison-src/transcripts/idempotent/fix849.md
+++ b/unison-src/transcripts/idempotent/fix849.md
@@ -16,7 +16,7 @@ x = 42
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       x : Nat
 

--- a/unison-src/transcripts/idempotent/fix942.md
+++ b/unison-src/transcripts/idempotent/fix942.md
@@ -16,7 +16,7 @@ z = y + 2
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       x : Nat
       y : Nat
@@ -90,7 +90,7 @@ test> t1 = if z == 3 then [Fail "nooo!!!"] else [Ok "great"]
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       t1 : [Result]
 

--- a/unison-src/transcripts/idempotent/fix987.md
+++ b/unison-src/transcripts/idempotent/fix987.md
@@ -20,7 +20,7 @@ spaceAttack1 x =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural ability DeathStar
       spaceAttack1 : x ->{DeathStar} Text
@@ -52,7 +52,7 @@ spaceAttack2 x =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       spaceAttack2 : x ->{DeathStar} Text
 ```

--- a/unison-src/transcripts/idempotent/higher-rank.md
+++ b/unison-src/transcripts/idempotent/higher-rank.md
@@ -23,7 +23,7 @@ f id = (id 1, id "hi")
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       f : (∀ a. a ->{g} a) ->{g} (Nat, Text)
 
@@ -50,7 +50,7 @@ f id _ =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       f : (∀ a g. '{g} a ->{h} '{g} a) -> '{h} ()
 ```
@@ -76,7 +76,7 @@ Functor.blah = cases Functor f ->
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Functor f
       Functor.blah : Functor f -> ()
@@ -118,7 +118,7 @@ Loc.transform2 nt = cases Loc f ->
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Loc
       ability Remote t

--- a/unison-src/transcripts/idempotent/io.md
+++ b/unison-src/transcripts/idempotent/io.md
@@ -65,7 +65,7 @@ testCreateRename _ =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       testCreateRename : '{IO} [Result]
 ```
@@ -148,7 +148,7 @@ testOpenClose _ =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       testOpenClose : '{IO} [Result]
 ```
@@ -239,7 +239,7 @@ testGetSomeBytes _ =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       testGetSomeBytes : '{IO} [Result]
 ```
@@ -355,7 +355,7 @@ testAppend _ =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       testAppend  : '{IO} [Result]
       testSeek    : '{IO} [Result]
@@ -425,7 +425,7 @@ testSystemTime _ =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       testSystemTime : '{IO} [Result]
 ```

--- a/unison-src/transcripts/idempotent/kind-inference.md
+++ b/unison-src/transcripts/idempotent/kind-inference.md
@@ -53,7 +53,7 @@ unique type Pong = Pong (Ping Optional)
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Ping a
       type Pong
@@ -91,7 +91,7 @@ unique ability Pong a where
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Ping a
       ability Pong a
@@ -129,7 +129,7 @@ unique type S = S (T Nat)
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type S
       type T a
@@ -151,7 +151,7 @@ unique type S = S (T Optional)
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type S
       type T a

--- a/unison-src/transcripts/idempotent/lambdacase.md
+++ b/unison-src/transcripts/idempotent/lambdacase.md
@@ -18,7 +18,7 @@ isEmpty x = match x with
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       isEmpty : [t] -> Boolean
 ```
@@ -41,7 +41,7 @@ isEmpty2 = cases
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       isEmpty2 : [t] -> Boolean
         (also named isEmpty)
@@ -101,7 +101,7 @@ merge2 = cases
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       merge2 : [a] -> [a] -> [a]
         (also named merge)
@@ -148,7 +148,7 @@ blorf = cases
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural type B
       blah  : B -> B -> Text
@@ -187,7 +187,7 @@ merge3 = cases
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       merge3 : [a] -> [a] -> [a]
 ```
@@ -228,7 +228,7 @@ merge4 a b = match (a,b) with
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       merge4 : [a] -> [a] -> [a]
         (also named merge3)

--- a/unison-src/transcripts/idempotent/merge.md
+++ b/unison-src/transcripts/idempotent/merge.md
@@ -1894,7 +1894,7 @@ foo = "alice and bobs foo"
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       foo : Text
 ```
@@ -2453,7 +2453,7 @@ structural type Foo = Bar Nat | Baz Nat Nat
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural type Foo
 ```
@@ -2501,7 +2501,7 @@ alice = 100
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       alice : Nat
 ```
@@ -2545,7 +2545,7 @@ bob = 101
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bob : Nat
 ```
@@ -2604,7 +2604,7 @@ bar = 17
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar : Nat
       foo : Nat
@@ -2672,7 +2672,7 @@ bob = 101
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bob : Nat
 ```
@@ -2726,7 +2726,7 @@ type Foo = Bar | Baz
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Foo
 ```
@@ -2757,7 +2757,7 @@ boop = "boop"
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       boop : Text
 ```
@@ -2851,7 +2851,7 @@ baz = "lca"
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar : Nat
       baz : Text
@@ -3015,7 +3015,7 @@ a = 1
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       a : ##Nat
 ```
@@ -3039,7 +3039,7 @@ b = 2
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       b : ##Nat
 ```
@@ -3083,7 +3083,7 @@ a = 1
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       a : ##Nat
 ```
@@ -3202,7 +3202,7 @@ bar =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar    : Nat
       foo    : Nat
@@ -3330,7 +3330,7 @@ type Bar = MkBar Foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Bar
       type Foo
@@ -3430,7 +3430,7 @@ type Bar = MkBar Foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Bar
       type Foo
@@ -3480,7 +3480,7 @@ type Foo = Bar
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Foo
 ```
@@ -3520,7 +3520,7 @@ type Foo = Bar
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Foo
 ```
@@ -3546,7 +3546,7 @@ type Foo = Bar
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Foo
 ```
@@ -3619,7 +3619,7 @@ type Foo = Bar
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Foo
 ```
@@ -3707,7 +3707,7 @@ type Foo = Bar
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Foo
 ```
@@ -3795,7 +3795,7 @@ type Foo = Bar
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Foo
 ```
@@ -3851,7 +3851,7 @@ hello = 17
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       hello : Nat
 ```
@@ -3883,7 +3883,7 @@ foo = 100
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       foo : Nat
     
@@ -3920,7 +3920,7 @@ bar = 100
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar : Nat
     

--- a/unison-src/transcripts/idempotent/move-all.md
+++ b/unison-src/transcripts/idempotent/move-all.md
@@ -21,7 +21,7 @@ unique type Foo.T = T
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Foo
       type Foo.T
@@ -117,7 +117,7 @@ bonk = 5
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bonk : Nat
 ```
@@ -156,7 +156,7 @@ bonk.zonk = 5
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bonk.zonk : Nat
         (also named zonk)

--- a/unison-src/transcripts/idempotent/move-namespace.md
+++ b/unison-src/transcripts/idempotent/move-namespace.md
@@ -124,7 +124,7 @@ unique type a.T = T
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type a.T
       a.termInA : Nat
@@ -216,7 +216,7 @@ b.termInB = 10
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       a.termInA : Nat
       b.termInB : Nat
@@ -317,7 +317,7 @@ b.termInB = 10
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       a.termInA : Nat
       b.termInB : Nat

--- a/unison-src/transcripts/idempotent/name-resolution-fuzzy.md
+++ b/unison-src/transcripts/idempotent/name-resolution-fuzzy.md
@@ -21,7 +21,7 @@ myFunction = truncate
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       myFunction : Float -> Int
 ```

--- a/unison-src/transcripts/idempotent/name-resolution.md
+++ b/unison-src/transcripts/idempotent/name-resolution.md
@@ -19,7 +19,7 @@ type Namespace.Foo = Bar
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Namespace.Foo
 ```
@@ -66,7 +66,7 @@ type UsesFoo = UsesFoo Namespace.Foo File.Foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type File.Foo
       type UsesFoo
@@ -97,7 +97,7 @@ type Foo = Bar
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Foo
 ```
@@ -122,7 +122,7 @@ type UsesFoo = UsesFoo Foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type File.Foo
       type UsesFoo
@@ -166,7 +166,7 @@ type Namespace.Foo = Bar
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Namespace.Foo
 ```
@@ -191,7 +191,7 @@ type UsesFoo = UsesFoo Foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Foo
       type UsesFoo
@@ -236,7 +236,7 @@ ns.foo = 42
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ns.foo : Nat
 ```
@@ -264,7 +264,7 @@ bar = foo ++ "bar"
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar      : Text
       file.foo : Text
@@ -296,7 +296,7 @@ ns.foo = 42
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ns.foo : Nat
 ```
@@ -324,7 +324,7 @@ bar = foo + 42
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar      : Nat
       file.foo : Text
@@ -356,7 +356,7 @@ ns.foo = 42
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ns.foo : Nat
 ```
@@ -408,7 +408,7 @@ bar = file.foo + ns.foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar      : Nat
       file.foo : Nat

--- a/unison-src/transcripts/idempotent/name-selection.md
+++ b/unison-src/transcripts/idempotent/name-selection.md
@@ -120,7 +120,7 @@ a = 10
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       a                  : Nat
       deeply.nested.num  : Nat
@@ -161,7 +161,7 @@ other.num = 20
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       other.num : Nat
 ```

--- a/unison-src/transcripts/idempotent/name-test-sandbox-violators.md
+++ b/unison-src/transcripts/idempotent/name-test-sandbox-violators.md
@@ -17,7 +17,7 @@ test> foo.test =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       foo.test : [Result]
 
@@ -68,7 +68,7 @@ bar.test =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar.test : [Result]
 ```

--- a/unison-src/transcripts/idempotent/names.md
+++ b/unison-src/transcripts/idempotent/names.md
@@ -42,7 +42,7 @@ xyz.baz = 100.1
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type a.baz
       type z.baz

--- a/unison-src/transcripts/idempotent/namespace-directive.md
+++ b/unison-src/transcripts/idempotent/namespace-directive.md
@@ -24,7 +24,7 @@ baz = 17
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       foo.baz : Nat
 ```
@@ -50,7 +50,7 @@ longer.evil.factorial n = n
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       foo.factorial             : Int -> Int
       foo.longer.evil.factorial : Int -> Int
@@ -94,7 +94,7 @@ type longer.foo.Baz = { qux : Nat }
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type longer.foo.Baz
       type longer.foo.Foo
@@ -138,7 +138,7 @@ hasTypeLink =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type foo.Baz
       type foo.Foo

--- a/unison-src/transcripts/idempotent/numbered-args.md
+++ b/unison-src/transcripts/idempotent/numbered-args.md
@@ -21,7 +21,7 @@ corge = "corge"
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar   : Text
       baz   : Text

--- a/unison-src/transcripts/idempotent/old-fold-right.md
+++ b/unison-src/transcripts/idempotent/old-fold-right.md
@@ -21,7 +21,7 @@ pecan = 'let
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       oldRight : (b ->{e} a ->{e} b) -> [a] ->{e} [b]
       pecan    : '[Text]

--- a/unison-src/transcripts/idempotent/pattern-match-coverage.md
+++ b/unison-src/transcripts/idempotent/pattern-match-coverage.md
@@ -114,7 +114,7 @@ test = cases
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type V
       test : Optional (Optional V) -> ()
@@ -217,7 +217,7 @@ test = cases
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       test : Optional Nat -> Nat
 ```
@@ -336,7 +336,7 @@ test = cases
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       test : Nat -> ()
 ```
@@ -356,7 +356,7 @@ test = cases
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       test : Boolean -> ()
 ```
@@ -416,7 +416,7 @@ test = cases
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       test : [()] -> ()
 ```
@@ -535,7 +535,7 @@ test = cases
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type V
       test : [V] -> ()
@@ -565,7 +565,7 @@ test = cases
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       test : [Boolean] -> ()
 ```
@@ -630,7 +630,7 @@ unit2t = cases
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type T
       unit2t : 'T
@@ -665,7 +665,7 @@ witht = match unit2t () with
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       witht : ()
 ```
@@ -683,7 +683,7 @@ evil = bug ""
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type V
       evil : 'V
@@ -722,7 +722,7 @@ unique type SomeType = A
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type SomeType
 ```
@@ -749,7 +749,7 @@ get x = match x with
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type R
       get : R -> SomeType
@@ -765,7 +765,7 @@ unique type R = { someType : SomeType }
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type R
       R.someType        : R -> SomeType
@@ -794,7 +794,7 @@ result f = handle !f with cases
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural ability Abort
       result : '{e, Abort} a ->{e} a
@@ -819,7 +819,7 @@ result f = handle !f with cases
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural ability Abort
       result : '{e, Abort} T ->{e} ()
@@ -848,7 +848,7 @@ result f =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural ability Abort
       result : '{e, Abort} V ->{e} V
@@ -876,7 +876,7 @@ handleMulti c =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural ability Abort
       structural ability Stream a
@@ -1033,7 +1033,7 @@ result f = handle !f with cases
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural ability Abort
       result : '{e, Abort} a ->{e, Abort} a
@@ -1059,7 +1059,7 @@ result f =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural ability Abort a
       result : '{e, Abort V} a ->{e, Abort V} a
@@ -1152,7 +1152,7 @@ result f =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ability Give a
       result : '{e, Give V} r ->{e} r
@@ -1178,7 +1178,7 @@ result f =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ability Give a
       result : '{e, Give V} r ->{e} r
@@ -1261,7 +1261,7 @@ result f =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ability GiveA a
       ability GiveB a

--- a/unison-src/transcripts/idempotent/pattern-pretty-print-2345.md
+++ b/unison-src/transcripts/idempotent/pattern-pretty-print-2345.md
@@ -69,7 +69,7 @@ doc = cases
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural ability Ab
       agitated  : Nat -> ()

--- a/unison-src/transcripts/idempotent/patternMatchTls.md
+++ b/unison-src/transcripts/idempotent/patternMatchTls.md
@@ -30,7 +30,7 @@ assertRight = cases
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       assertRight : Either a b -> b
       frank       : '{IO} ()

--- a/unison-src/transcripts/idempotent/patterns.md
+++ b/unison-src/transcripts/idempotent/patterns.md
@@ -17,7 +17,7 @@ p1 = join [literal "blue", literal "frog"]
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       p1 : Pattern Text
 

--- a/unison-src/transcripts/idempotent/propagate.md
+++ b/unison-src/transcripts/idempotent/propagate.md
@@ -19,7 +19,7 @@ fooToInt _ = +42
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Foo
       fooToInt : Foo -> Int
@@ -114,7 +114,7 @@ preserve.otherTerm y = someTerm y
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       preserve.otherTerm : Optional baz -> Optional baz
       preserve.someTerm  : Optional foo -> Optional foo

--- a/unison-src/transcripts/idempotent/quad-handlers.md
+++ b/unison-src/transcripts/idempotent/quad-handlers.md
@@ -71,7 +71,7 @@ forget2 k = handle provide 3 k with cases
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       ability Ask a
       ability Tell a

--- a/unison-src/transcripts/idempotent/records.md
+++ b/unison-src/transcripts/idempotent/records.md
@@ -184,7 +184,7 @@ unique type Record5 =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       Record5.a        : Record5 -> Text
       Record5.a.modify : (Text ->{g} Text)

--- a/unison-src/transcripts/idempotent/reflog.md
+++ b/unison-src/transcripts/idempotent/reflog.md
@@ -14,7 +14,7 @@ x = 1
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       x : Nat
 ```
@@ -38,7 +38,7 @@ y = 2
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       y : Nat
 ```

--- a/unison-src/transcripts/idempotent/release-draft-command.md
+++ b/unison-src/transcripts/idempotent/release-draft-command.md
@@ -16,7 +16,7 @@ someterm = 18
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       someterm : Nat
 ```

--- a/unison-src/transcripts/idempotent/reset.md
+++ b/unison-src/transcripts/idempotent/reset.md
@@ -12,7 +12,7 @@ def = "first value"
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       def : Text
 ```

--- a/unison-src/transcripts/idempotent/resolution-failures.md
+++ b/unison-src/transcripts/idempotent/resolution-failures.md
@@ -26,7 +26,7 @@ two.ambiguousTerm = "term two"
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type one.AmbiguousType
       type two.AmbiguousType

--- a/unison-src/transcripts/idempotent/rsa.md
+++ b/unison-src/transcripts/idempotent/rsa.md
@@ -41,7 +41,7 @@ sigKo = match signature with
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       down               : Bytes
       incorrectPublicKey : Bytes

--- a/unison-src/transcripts/idempotent/runtime-tests.md
+++ b/unison-src/transcripts/idempotent/runtime-tests.md
@@ -75,7 +75,7 @@ casting = (Nat.toInt 100,
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       casting                        : ( Int,
                                          Nat,

--- a/unison-src/transcripts/idempotent/scope-ref.md
+++ b/unison-src/transcripts/idempotent/scope-ref.md
@@ -23,7 +23,7 @@ test = Scope.run 'let
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       test : (Nat, Nat, Nat)
 

--- a/unison-src/transcripts/idempotent/suffixes.md
+++ b/unison-src/transcripts/idempotent/suffixes.md
@@ -76,7 +76,7 @@ lib.distributed.lib.baz.qux = "indirect dependency"
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       cool.abra.cadabra            : Text
       lib.distributed.abra.cadabra : Text

--- a/unison-src/transcripts/idempotent/sum-type-update-conflicts.md
+++ b/unison-src/transcripts/idempotent/sum-type-update-conflicts.md
@@ -18,7 +18,7 @@ structural type X = x
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural type X
         (also named lib.builtins.Unit)
@@ -51,7 +51,7 @@ dependsOnX = Text.size X.x
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       X.x        : Text
       dependsOnX : Nat

--- a/unison-src/transcripts/idempotent/switch-command.md
+++ b/unison-src/transcripts/idempotent/switch-command.md
@@ -18,7 +18,7 @@ someterm = 18
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       someterm : Nat
 ```

--- a/unison-src/transcripts/idempotent/tab-completion.md
+++ b/unison-src/transcripts/idempotent/tab-completion.md
@@ -40,7 +40,7 @@ unique type subnamespace.AType = A | B
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type subnamespace.AType
       othernamespace.someName    : ##Nat
@@ -165,7 +165,7 @@ add b = b
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Foo
       add : a -> a
@@ -220,7 +220,7 @@ mybranchsubnamespace.term = 1
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       mybranchsubnamespace.term : ##Nat
 ```

--- a/unison-src/transcripts/idempotent/tdnr.md
+++ b/unison-src/transcripts/idempotent/tdnr.md
@@ -16,7 +16,7 @@ thing = foo Nat.+ foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bad.foo  : Text
       good.foo : Nat
@@ -43,7 +43,7 @@ bad.foo = "bar"
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bad.foo : Text
 ```
@@ -68,7 +68,7 @@ thing = foo Nat.+ foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       good.foo : Nat
       thing    : Nat
@@ -94,7 +94,7 @@ bad.foo = "bar"
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bad.foo : Text
 ```
@@ -120,7 +120,7 @@ thing = foo Nat.+ foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       good.foo : Nat
       thing    : Nat
@@ -151,7 +151,7 @@ good.foo = 17
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       good.foo : Nat
 ```
@@ -176,7 +176,7 @@ thing = foo Nat.+ foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bad.foo : Text
       thing   : Nat
@@ -203,7 +203,7 @@ bad.foo = "bar"
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bad.foo  : Text
       good.foo : Nat
@@ -228,7 +228,7 @@ thing = foo Nat.+ foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       thing : Nat
 ```
@@ -254,7 +254,7 @@ bad.foo = "bar"
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bad.foo  : Text
       good.foo : Nat
@@ -280,7 +280,7 @@ thing = foo Nat.+ foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       thing : Nat
     
@@ -310,7 +310,7 @@ good.foo = 17
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       good.foo : Nat
 ```
@@ -336,7 +336,7 @@ thing = foo Nat.+ foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bad.foo : Text
       thing   : Nat
@@ -368,7 +368,7 @@ bad.foo = "bar"
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bad.foo  : Text
       good.foo : Nat
@@ -394,7 +394,7 @@ thing = foo Nat.+ foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       thing : Nat
     
@@ -425,7 +425,7 @@ bad.foo = "bar"
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bad.foo  : Text
       good.foo : Nat
@@ -452,7 +452,7 @@ thing = foo Nat.+ foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       thing : Nat
     
@@ -485,7 +485,7 @@ lib.bad.foo = "bar"
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       lib.bad.foo : Text
 ```
@@ -510,7 +510,7 @@ thing = foo Nat.+ foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       good.foo : Nat
       thing    : Nat
@@ -537,7 +537,7 @@ lib.bad.foo = "bar"
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       good.foo    : Nat
       lib.bad.foo : Text
@@ -562,7 +562,7 @@ thing = foo Nat.+ foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       thing : Nat
 ```
@@ -588,7 +588,7 @@ lib.bad.foo = "bar"
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       good.foo    : Nat
       lib.bad.foo : Text
@@ -614,7 +614,7 @@ thing = foo Nat.+ foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       thing : Nat
     
@@ -644,7 +644,7 @@ lib.dep.lib.dep.foo = 217
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       lib.dep.lib.dep.foo : Nat
 ```
@@ -669,7 +669,7 @@ thing = foo Nat.+ foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       good.foo : Nat
       thing    : Nat
@@ -696,7 +696,7 @@ lib.dep.lib.dep.foo = 217
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       good.foo            : Nat
       lib.dep.lib.dep.foo : Nat
@@ -721,7 +721,7 @@ thing = foo Nat.+ foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       thing : Nat
 ```
@@ -747,7 +747,7 @@ lib.dep.lib.dep.foo = 217
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       good.foo            : Nat
       lib.dep.lib.dep.foo : Nat
@@ -773,7 +773,7 @@ thing = foo Nat.+ foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       thing : Nat
     
@@ -803,7 +803,7 @@ lib.good.foo = 17
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       lib.good.foo : Nat
 ```
@@ -828,7 +828,7 @@ thing = foo Nat.+ foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bad.foo : Text
       thing   : Nat
@@ -855,7 +855,7 @@ bad.foo = "bar"
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bad.foo      : Text
       lib.good.foo : Nat
@@ -880,7 +880,7 @@ thing = foo Nat.+ foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       thing : Nat
 ```
@@ -906,7 +906,7 @@ bad.foo = "bar"
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bad.foo      : Text
       lib.good.foo : Nat
@@ -932,7 +932,7 @@ thing = foo Nat.+ foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       thing : Nat
     
@@ -963,7 +963,7 @@ lib.bad.foo = "bar"
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       lib.bad.foo  : Text
       lib.good.foo : Nat
@@ -988,7 +988,7 @@ thing = foo Nat.+ foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       thing : Nat
 ```
@@ -1014,7 +1014,7 @@ lib.dep.lib.dep.foo = 217
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       lib.dep.lib.dep.foo : Nat
       lib.good.foo        : Nat
@@ -1039,7 +1039,7 @@ thing = foo Nat.+ foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       thing : Nat
 ```
@@ -1065,7 +1065,7 @@ lib.dep.lib.bad.foo = "bar"
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       lib.dep.lib.bad.foo  : Text
       lib.dep.lib.good.foo : Nat
@@ -1090,7 +1090,7 @@ thing = foo Nat.+ foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       thing : Nat
 ```

--- a/unison-src/transcripts/idempotent/test-command.md
+++ b/unison-src/transcripts/idempotent/test-command.md
@@ -20,7 +20,7 @@ foo.test2 = [Ok "test2"]
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       foo.test2 : [Result]
       test1     : [Result]
@@ -77,7 +77,7 @@ lib.dep.testInLib = [Ok "testInLib"]
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       lib.dep.testInLib : [Result]
 ```

--- a/unison-src/transcripts/idempotent/text-literals.md
+++ b/unison-src/transcripts/idempotent/text-literals.md
@@ -41,7 +41,7 @@ lit2 = """"
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       lit1 : Text
       lit2 : Text

--- a/unison-src/transcripts/idempotent/textfind.md
+++ b/unison-src/transcripts/idempotent/textfind.md
@@ -57,7 +57,7 @@ lib.bar = 3
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar     : Nat
       baz     : [Text]

--- a/unison-src/transcripts/idempotent/todo-bug-builtins.md
+++ b/unison-src/transcripts/idempotent/todo-bug-builtins.md
@@ -72,7 +72,7 @@ complicatedMathStuff x = todo "Come back and to something with x here"
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       complicatedMathStuff : x -> r
 ```
@@ -93,7 +93,7 @@ test = match true with
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       test : Text
 ```

--- a/unison-src/transcripts/idempotent/todo.md
+++ b/unison-src/transcripts/idempotent/todo.md
@@ -30,7 +30,7 @@ bar = foo + foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar : Nat
       foo : Nat
@@ -75,7 +75,7 @@ baz = foo.bar + foo.bar
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       baz     : Nat
       foo.bar : Nat
@@ -131,7 +131,7 @@ bar = 17
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar : Nat
       foo : Nat
@@ -184,7 +184,7 @@ lib.foo = 16
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       lib.foo : Nat
 ```
@@ -226,7 +226,7 @@ type Foo = One
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Foo
 ```
@@ -275,7 +275,7 @@ type Foo = Bar
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Foo
 ```
@@ -326,7 +326,7 @@ structural type Foo.inner.Bar a = Uno a | Dos a a
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural type Foo a
       structural type Foo.inner.Bar a
@@ -371,7 +371,7 @@ type Foo = Bar
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Foo
 ```

--- a/unison-src/transcripts/idempotent/top-level-exceptions.md
+++ b/unison-src/transcripts/idempotent/top-level-exceptions.md
@@ -33,7 +33,7 @@ mytest _ = [Ok "Great"]
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       main   : '{IO, Exception} ()
       mytest : '{IO, Exception} [Result]
@@ -80,7 +80,7 @@ unique type RuntimeError =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type RuntimeError
       error : Text -> a ->{Exception} x

--- a/unison-src/transcripts/idempotent/transcript-parser-commands.md
+++ b/unison-src/transcripts/idempotent/transcript-parser-commands.md
@@ -16,7 +16,7 @@ x = 1
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       x : Nat
 ```

--- a/unison-src/transcripts/idempotent/type-deps.md
+++ b/unison-src/transcripts/idempotent/type-deps.md
@@ -29,7 +29,7 @@ structural type Y = Y Nat
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural type Z
     

--- a/unison-src/transcripts/idempotent/type-modifier-are-optional.md
+++ b/unison-src/transcripts/idempotent/type-modifier-are-optional.md
@@ -22,7 +22,7 @@ structural ability MyAbilityS where const : a
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Abc
       type Def

--- a/unison-src/transcripts/idempotent/unique-type-churn.md
+++ b/unison-src/transcripts/idempotent/unique-type-churn.md
@@ -14,7 +14,7 @@ unique type C = C B
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type A
       type B

--- a/unison-src/transcripts/idempotent/unitnamespace.md
+++ b/unison-src/transcripts/idempotent/unitnamespace.md
@@ -8,7 +8,7 @@
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       `()`.foo : ##Text
 ```

--- a/unison-src/transcripts/idempotent/universal-cmp.md
+++ b/unison-src/transcripts/idempotent/universal-cmp.md
@@ -20,7 +20,7 @@ threadEyeDeez _ =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type A
       threadEyeDeez : ∀ _. _ ->{IO} (Boolean, Boolean)

--- a/unison-src/transcripts/idempotent/unsafe-coerce.md
+++ b/unison-src/transcripts/idempotent/unsafe-coerce.md
@@ -21,7 +21,7 @@ main _ =
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       f    : 'Nat
       fc   : '{IO, Exception} Nat

--- a/unison-src/transcripts/idempotent/update-ignores-lib-namespace.md
+++ b/unison-src/transcripts/idempotent/update-ignores-lib-namespace.md
@@ -17,7 +17,7 @@ lib.foo = 100
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       foo     : Nat
       lib.foo : Nat

--- a/unison-src/transcripts/idempotent/update-on-conflict.md
+++ b/unison-src/transcripts/idempotent/update-on-conflict.md
@@ -17,7 +17,7 @@ temp = 2
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       temp : Nat
       x    : Nat

--- a/unison-src/transcripts/idempotent/update-suffixifies-properly.md
+++ b/unison-src/transcripts/idempotent/update-suffixifies-properly.md
@@ -17,7 +17,7 @@ bar = a.x.x.x.x + c.y.y.y.y
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       a.x.x.x.x : Nat
       b.x.x.x.x : Nat

--- a/unison-src/transcripts/idempotent/update-term-aliases-in-different-ways.md
+++ b/unison-src/transcripts/idempotent/update-term-aliases-in-different-ways.md
@@ -18,7 +18,7 @@ bar = 5
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar : Nat
       foo : Nat

--- a/unison-src/transcripts/idempotent/update-term-to-different-type.md
+++ b/unison-src/transcripts/idempotent/update-term-to-different-type.md
@@ -15,7 +15,7 @@ foo = 5
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       foo : Nat
 ```

--- a/unison-src/transcripts/idempotent/update-term-with-alias.md
+++ b/unison-src/transcripts/idempotent/update-term-with-alias.md
@@ -18,7 +18,7 @@ bar = 5
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar : Nat
       foo : Nat

--- a/unison-src/transcripts/idempotent/update-term-with-dependent-to-different-type.md
+++ b/unison-src/transcripts/idempotent/update-term-with-dependent-to-different-type.md
@@ -18,7 +18,7 @@ bar = foo + 10
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar : Nat
       foo : Nat

--- a/unison-src/transcripts/idempotent/update-term-with-dependent.md
+++ b/unison-src/transcripts/idempotent/update-term-with-dependent.md
@@ -18,7 +18,7 @@ bar = foo + 10
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar : Nat
       foo : Nat

--- a/unison-src/transcripts/idempotent/update-term.md
+++ b/unison-src/transcripts/idempotent/update-term.md
@@ -15,7 +15,7 @@ foo = 5
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       foo : Nat
 ```

--- a/unison-src/transcripts/idempotent/update-test-to-non-test.md
+++ b/unison-src/transcripts/idempotent/update-test-to-non-test.md
@@ -14,7 +14,7 @@ test> foo = []
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       foo : [Result]
 

--- a/unison-src/transcripts/idempotent/update-type-add-constructor.md
+++ b/unison-src/transcripts/idempotent/update-type-add-constructor.md
@@ -13,7 +13,7 @@ unique type Foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Foo
 ```

--- a/unison-src/transcripts/idempotent/update-type-add-field.md
+++ b/unison-src/transcripts/idempotent/update-type-add-field.md
@@ -12,7 +12,7 @@ unique type Foo = Bar Nat
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Foo
 ```

--- a/unison-src/transcripts/idempotent/update-type-add-new-record.md
+++ b/unison-src/transcripts/idempotent/update-type-add-new-record.md
@@ -12,7 +12,7 @@ unique type Foo = { bar : Nat }
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Foo
       Foo.bar        : Foo -> Nat

--- a/unison-src/transcripts/idempotent/update-type-add-record-field.md
+++ b/unison-src/transcripts/idempotent/update-type-add-record-field.md
@@ -12,7 +12,7 @@ unique type Foo = { bar : Nat }
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Foo
       Foo.bar        : Foo -> Nat
@@ -39,7 +39,7 @@ unique type Foo = { bar : Nat, baz : Int }
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       Foo.baz        : Foo -> Int
       Foo.baz.modify : (Int ->{g} Int) -> Foo ->{g} Foo

--- a/unison-src/transcripts/idempotent/update-type-constructor-alias.md
+++ b/unison-src/transcripts/idempotent/update-type-constructor-alias.md
@@ -12,7 +12,7 @@ unique type Foo = Bar Nat
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Foo
 ```

--- a/unison-src/transcripts/idempotent/update-type-delete-constructor-with-dependent.md
+++ b/unison-src/transcripts/idempotent/update-type-delete-constructor-with-dependent.md
@@ -19,7 +19,7 @@ foo = cases
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Foo
       foo : Foo -> Nat

--- a/unison-src/transcripts/idempotent/update-type-delete-constructor.md
+++ b/unison-src/transcripts/idempotent/update-type-delete-constructor.md
@@ -14,7 +14,7 @@ unique type Foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Foo
 ```

--- a/unison-src/transcripts/idempotent/update-type-delete-record-field.md
+++ b/unison-src/transcripts/idempotent/update-type-delete-record-field.md
@@ -12,7 +12,7 @@ unique type Foo = { bar : Nat, baz : Int }
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Foo
       Foo.bar        : Foo -> Nat

--- a/unison-src/transcripts/idempotent/update-type-missing-constructor.md
+++ b/unison-src/transcripts/idempotent/update-type-missing-constructor.md
@@ -12,7 +12,7 @@ unique type Foo = Bar Nat
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Foo
 ```

--- a/unison-src/transcripts/idempotent/update-type-nested-decl-aliases.md
+++ b/unison-src/transcripts/idempotent/update-type-nested-decl-aliases.md
@@ -15,7 +15,7 @@ structural type A = B.TheOtherAlias Foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       structural type A
       structural type A.B

--- a/unison-src/transcripts/idempotent/update-type-no-op-record.md
+++ b/unison-src/transcripts/idempotent/update-type-no-op-record.md
@@ -12,7 +12,7 @@ unique type Foo = { bar : Nat }
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Foo
       Foo.bar        : Foo -> Nat

--- a/unison-src/transcripts/idempotent/update-type-stray-constructor-alias.md
+++ b/unison-src/transcripts/idempotent/update-type-stray-constructor-alias.md
@@ -12,7 +12,7 @@ unique type Foo = Bar Nat
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Foo
 ```

--- a/unison-src/transcripts/idempotent/update-type-stray-constructor.md
+++ b/unison-src/transcripts/idempotent/update-type-stray-constructor.md
@@ -12,7 +12,7 @@ unique type Foo = Bar Nat
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Foo
 ```

--- a/unison-src/transcripts/idempotent/update-type-turn-constructor-into-smart-constructor.md
+++ b/unison-src/transcripts/idempotent/update-type-turn-constructor-into-smart-constructor.md
@@ -15,7 +15,7 @@ makeFoo n = Bar (n+10)
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Foo
       makeFoo : Nat -> Foo
@@ -45,7 +45,7 @@ Foo.Bar n = internal.Bar n
 
     ⊡ Previously added definitions will be ignored: Foo
     
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       Foo.Bar : Nat -> Foo
 ```

--- a/unison-src/transcripts/idempotent/update-type-turn-non-record-into-record.md
+++ b/unison-src/transcripts/idempotent/update-type-turn-non-record-into-record.md
@@ -12,7 +12,7 @@ unique type Foo = Nat
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Foo
 ```
@@ -36,7 +36,7 @@ unique type Foo = { bar : Nat }
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       Foo.bar        : Foo -> Nat
       Foo.bar.modify : (Nat ->{g} Nat) -> Foo ->{g} Foo

--- a/unison-src/transcripts/idempotent/update-type-with-dependent-term.md
+++ b/unison-src/transcripts/idempotent/update-type-with-dependent-term.md
@@ -15,7 +15,7 @@ incrFoo = cases Bar n -> Bar (n+1)
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Foo
       incrFoo : Foo -> Foo

--- a/unison-src/transcripts/idempotent/update-type-with-dependent-type-to-different-kind.md
+++ b/unison-src/transcripts/idempotent/update-type-with-dependent-type-to-different-kind.md
@@ -13,7 +13,7 @@ unique type Baz = Qux Foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Baz
       type Foo

--- a/unison-src/transcripts/idempotent/update-type-with-dependent-type.md
+++ b/unison-src/transcripts/idempotent/update-type-with-dependent-type.md
@@ -13,7 +13,7 @@ unique type Baz = Qux Foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       type Baz
       type Foo

--- a/unison-src/transcripts/idempotent/upgrade.md
+++ b/unison-src/transcripts/idempotent/upgrade.md
@@ -16,7 +16,7 @@ thingy = lib.old.foo + 10
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       lib.new.foo : Nat
       lib.old.foo : Nat
@@ -94,7 +94,7 @@ thingy = lib.old.foo + 10
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       lib.new.foo : Int
       lib.old.foo : Nat
@@ -203,7 +203,7 @@ thingy = lib.old.foo + 10
 
     ⊡ Previously added definitions will be ignored: lib.new.foo
     
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       lib.old.foo : Nat
     
@@ -320,7 +320,7 @@ mything = lib.old.foo + 100
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       bar         : Nat
       lib.new.foo : Nat
@@ -379,7 +379,7 @@ bar = a.x.x.x.x + c.y.y.y.y
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       a.x.x.x.x   : Nat
       b.x.x.x.x   : Nat
@@ -462,7 +462,7 @@ mything = lib.old.foo + lib.old.foo
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       lib.new.foo   : Nat
       lib.new.other : Nat
@@ -515,7 +515,7 @@ lib.dep__2.foo = 2
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       lib.dep.foo    : Nat
       lib.dep__2.foo : Nat
@@ -562,7 +562,7 @@ lib.dep__2.foo = 3
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       lib.dep.foo    : Nat
       lib.dep__2.foo : Nat

--- a/unison-src/transcripts/idempotent/watch-expressions.md
+++ b/unison-src/transcripts/idempotent/watch-expressions.md
@@ -14,7 +14,7 @@ test> pass = [Ok "Passed"]
   I found and typechecked these definitions in scratch.u. If you
   do an `update`, here's how your codebase would change:
 
-    ⍟ These new definitions are ok to `update`:
+    ⍟ New definitions:
     
       pass : [Result]
 


### PR DESCRIPTION
Rather than the confusingly-worded "These new definitions are ok to `update`"