### PR TITLE
Add check-and-set when running branch updates

### DIFF
--- a/unison-cli/src/Unison/Cli/Monad.hs
+++ b/unison-cli/src/Unison/Cli/Monad.hs
@@ -189,7 +189,7 @@ data Env = Env
 --
 -- There's an additional pseudo @"currentPath"@ field lens, for convenience.
 data LoopState = LoopState
-  { -- the current position in the codebase, with the head being the most recent lcoation.
+  { -- the current position in the codebase, with the head being the most recent location.
     projectPathStack :: List.NonEmpty PP.ProjectPathIds,
     -- TBD
     -- , _activeEdits :: Set Branch.EditGuid

--- a/unison-cli/src/Unison/Cli/MonadUtils.hs
+++ b/unison-cli/src/Unison/Cli/MonadUtils.hs
@@ -423,16 +423,26 @@ updateProjectBranchRoot :: ProjectBranch -> Text -> (Branch IO -> Cli (Branch IO
 updateProjectBranchRoot projectBranch reason f = do
   env <- ask
   Cli.time "updateProjectBranchRoot" do
-    old <- getProjectBranchRoot projectBranch
-    (new, result) <- f old
-    when (old /= new) do
+    beforeUpdates <- getProjectBranchRoot projectBranch
+    (new, result) <- f beforeUpdates
+    when (beforeUpdates /= new) do
       liftIO $ Codebase.putBranch env.codebase new
-      Cli.runTransaction do
-        -- TODO: If we transactionally check that the project branch hasn't changed while we were computing the new
-        -- branch, and if it has, abort the transaction and return an error, then we can
-        -- remove the single UCM per codebase restriction.
-        causalHashId <- Q.expectCausalHashIdByCausalHash (Branch.headHash new)
-        Q.setProjectBranchHead reason projectBranch.projectId projectBranch.branchId causalHashId
+      Cli.runTransactionWithRollback \rollback -> do
+        causalHashId <- Q.expectProjectBranchHead projectBranch.projectId projectBranch.branchId
+        currentHeadHash <- Q.expectCausalHash causalHashId
+        -- Inside the transaction we ensure that the branch from before the updates matches the current head of the
+        -- project branch, like a check-and-set operation.
+        -- If it doesn't, then some other process has updated the branch between when we read it and computed the
+        -- updates. We should abort and ask the user to try again.
+        if
+          | (currentHeadHash == Branch.headHash new) -> do
+              -- Someone else updated the branch, but they set it to what we wanted to anyways.
+              pure ()
+          | (currentHeadHash /= Branch.headHash beforeUpdates) -> do
+              rollback Output.BranchUpdate'BranchChanged
+          | otherwise -> do
+              causalHashId <- Q.expectCausalHashIdByCausalHash (Branch.headHash new)
+              Q.setProjectBranchHead reason projectBranch.projectId projectBranch.branchId causalHashId
       -- The input to this function isn't necessarily the *current* project branch, which is what LSP cares about. But
       -- it might be! There's no harm in unconditionally notifying the LSP that the current project branch may have
       -- changed, but it is slightly more efficient for us to just do the == comparison here (since otherwise the LSP

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -452,6 +452,7 @@ data Output
   | OpenCodebaseError CodebasePath OpenCodebaseError
   | UCMServerNotRunning
   | BranchSquashSuccess ({- source -} ProjectAndBranch Project ProjectBranch) ({- dest branch -} ProjectAndBranch Project ProjectBranch)
+  | BranchUpdate'BranchChanged
 
 data MoreEntriesThanShown = MoreEntriesThanShown | AllEntriesShown
   deriving (Eq, Show)
@@ -694,6 +695,7 @@ isFailure o = case o of
   OpenCodebaseError {} -> True
   UCMServerNotRunning -> True
   BranchSquashSuccess {} -> False
+  BranchUpdate'BranchChanged {} -> True
 
 isNumberedFailure :: NumberedOutput -> Bool
 isNumberedFailure = \case

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -871,6 +871,7 @@ notifyUser dir = \case
       --       defs in the codebase.  In some cases it's fine for bindings to
       --       shadow codebase names, but you don't want it to capture them in
       --       the decompiled output.
+
         let prettyBindings =
               P.bracket . P.lines $
                 P.wrap "The watch expression(s) reference these definitions:"

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -871,7 +871,6 @@ notifyUser dir = \case
       --       defs in the codebase.  In some cases it's fine for bindings to
       --       shadow codebase names, but you don't want it to capture them in
       --       the decompiled output.
-
         let prettyBindings =
               P.bracket . P.lines $
                 P.wrap "The watch expression(s) reference these definitions:"
@@ -2346,6 +2345,9 @@ notifyUser dir = \case
       P.lines
         [ P.wrap $ "I squashed " <> sourceName <> " into " <> destName
         ]
+  BranchUpdate'BranchChanged -> do
+    pure $
+      P.wrap "Another process updated the codebase while your command was running, so I didn't apply the update. Please run the command again."
 
 prettyShareError :: ShareError -> Pretty
 prettyShareError =


### PR DESCRIPTION
## Overview

The new MCP work I'm doing allows the MCP to `lib.install` and `update`, and the nature of the MCP server setup is that these will take place in separate instances of UCM, which ignore the codebase lock. I don't believe we have any commands that could possibly cause any corruption due to this, but it's certainly possible that one command could clobber work done by another, e.g. if you have a long pull running while MCP is making updates, then it's likely the pull would clobber your updates.

This change _only_  provides protection during a branch update within the scope of `updateProjectBranchRoot`, which unfortunately things like sync don't typically use for their entire transaction (though we could!); but it's one step in the right direction.

Also worth noting that new commands tend not to use this utility, since loading the branch to memory is slower than working with V2 branches and causal hashes directly.

## Implementation notes

We run the branch updates in IO like before, but then do a quick check-and-set to see if the branch the updates were run on match the branch in the transaction where we update.

## Interesting/controversial decisions

Is this strong enough of a guarantee to allow agents/servers to run updates? 
I think so, but others may disagree.

## Test coverage

Existing transcripts should be sufficient

## Loose ends

Should we move long-running updates like merges, `update` and pull/clone/lib.install to run in a project root branch update? 