### PR TITLE
nix flake: add aarch64-linux as supported platform

### DIFF
--- a/.github/workflows/nix-dev-cache.yaml
+++ b/.github/workflows/nix-dev-cache.yaml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os:
           - ubuntu-24.04
-          - ubuntu-24.04-arm
+          # - ubuntu-24.04-arm https://github.com/unisonweb/unison/issues/5789
           - macos-13
           - macos-14
     steps:

--- a/.github/workflows/nix-dev-cache.yaml
+++ b/.github/workflows/nix-dev-cache.yaml
@@ -22,6 +22,7 @@ jobs:
       matrix:
         os:
           - ubuntu-24.04
+          - ubuntu-24.04-arm
           - macos-13
           - macos-14
     steps:

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,7 @@
       "x86_64-linux"
       "x86_64-darwin"
       "aarch64-darwin"
+      "aarch64-linux"
     ]
     (system: let
       versions = import ./nix/versions.nix {inherit (nixpkgs-haskellNix) lib;};


### PR DESCRIPTION
As of a little while ago, ARM linux builds of ucm are available. This updates the flake to support building them as well, which will enable https://github.com/ceedubs/unison-nix/pull/140 .
