### PR TITLE
Use `threadCPUTime` in affine handler benchmark transcript

### DIFF
--- a/unison-src/transcripts/idempotent/affine-handlers.md
+++ b/unison-src/transcripts/idempotent/affine-handlers.md
@@ -37,7 +37,7 @@ repeated = cases
     handle looped k n with repeated
 
 now : '{IO, Exception} TimeSpec
-now _ = match monotonic () with
+now _ = match threadCPUTime () with
   Left e -> raise e
   Right t -> t
 


### PR DESCRIPTION
Hopefully this will be less sensitive to CI blips