### PR TITLE
Adds Http Stream Server for MCP

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -6,10 +6,34 @@ for projects and definitions, and more!
 
 ## Setup
 
+### Connecting to a running UCM executable (recommended)
+
 To configure the MCP for use with Claude, edit your Claude Desktop config JSON file, which is found:
 
 * On Mac: `~/Library/Application Support/Claude/claude_desktop_config.json`
 * On Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+
+Add the server config as a key in the `mcpServers` mapping there.
+
+The following defaults should work if you haven't tweaked things, but ensure you use the correct port and token if you've changed them:
+
+```
+{
+  "mcpServers": {
+    "unison": {
+      "type": "streamable-http",
+      "url": "http://localhost:5858/codebase/mcp",
+      "note": "Replace 5858 and 'codebase' with your UCM_PORT and UCM_TOKEN respectively if you've changed the defaults."
+    }
+  }
+}
+```
+
+After saving the file, restart the Claude Desktop app. You should now see a new "unison" option in the MCP server list.
+
+### MCP as an independent process
+
+Alternatively you can connect to the MCP using the UCM executable directly via stdin/stdout.
 
 Add the following as a key in the `mcpServers` mapping there. Replace `<path-to-ucm>` with the path to your `ucm` executable.
 E.g. on Mac this is likely `/opt/homebrew/bin/ucm`.
@@ -37,7 +61,8 @@ E.g. my complete file on Mac looks like this:
 }
 ```
 
-After saving the file, restart the Claude Desktop app. You should now see a new "unison" option in the MCP server list.
+Note that this causes the MCP server to run as an entirely separate process.
+If you're also running a UCM instance you may notice that it gets out of sync with changes made by AI agents via MCP.
 
 ## Usage
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -6,37 +6,19 @@ for projects and definitions, and more!
 
 ## Setup
 
-### Connecting to a running UCM executable (recommended)
+### MCP as an independent process (Recommended)
 
-To configure the MCP for use with Claude, edit your Claude Desktop config JSON file, which is found:
+This approach allows agents to connect to UCM's MCP server directly via stdin/stdout.
+
+Note that this causes an additional UCM to run as an entirely independent process for each agent you're using.
+
+To configure the MCP for use with Claude (and any tools which read Claude's json config), edit your Claude Desktop config JSON file, which is found:
 
 * On Mac: `~/Library/Application Support/Claude/claude_desktop_config.json`
 * On Windows: `%APPDATA%\Claude\claude_desktop_config.json`
 
-Add the server config as a key in the `mcpServers` mapping there.
-
-The following defaults should work if you haven't tweaked things, but ensure you use the correct port and token if you've changed them:
-
-```
-{
-  "mcpServers": {
-    "unison": {
-      "type": "streamable-http",
-      "url": "http://localhost:5858/codebase/mcp",
-      "note": "Replace 5858 and 'codebase' with your UCM_PORT and UCM_TOKEN respectively if you've changed the defaults."
-    }
-  }
-}
-```
-
-After saving the file, restart the Claude Desktop app. You should now see a new "unison" option in the MCP server list.
-
-### MCP as an independent process
-
-Alternatively you can connect to the MCP using the UCM executable directly via stdin/stdout.
-
-Add the following as a key in the `mcpServers` mapping there. Replace `<path-to-ucm>` with the path to your `ucm` executable.
-E.g. on Mac this is likely `/opt/homebrew/bin/ucm`.
+Configure a `unison` key in your `mcpServers` object as below. Replace `<path-to-ucm>` with the path to your `ucm` executable.
+E.g. on Mac this is likely `/opt/homebrew/bin/ucm`, you can run `which ucm` to find your UCM executable path.
 
 ``` json
 {
@@ -61,8 +43,31 @@ E.g. my complete file on Mac looks like this:
 }
 ```
 
-Note that this causes the MCP server to run as an entirely separate process.
-If you're also running a UCM instance you may notice that it gets out of sync with changes made by AI agents via MCP.
+After saving the file, restart the Claude Desktop app. You should then see a new "unison" option in the MCP server list.
+
+
+### Connecting to a running UCM executable (not recommended)
+
+If instead you wish to connect an agent to a running UCM executable you can use an HTTP MCP connection.
+This is less consistent than the stdio approach, since some agents have rather poor handling of error states if you close your running UCM, or start
+up an agent without UCM already running.
+
+The following defaults should work if you haven't tweaked things, but ensure you use the correct port and token if you've changed them:
+
+```
+{
+  "mcpServers": {
+    "unison": {
+      "type": "streamable-http",
+      "url": "http://localhost:5858/codebase/mcp",
+      "note": "Replace 5858 and 'codebase' with your UCM_PORT and UCM_TOKEN respectively if you've changed the defaults."
+    }
+  }
+}
+```
+
+After saving the file, restart the Claude Desktop app. You should now see a new "unison" option in the MCP server list.
+
 
 ## Usage
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -60,7 +60,7 @@ extra-deps:
   - github: unisonweb/haskeline
     commit: 9275eea7982dabbf47be2ba078ced669ae7ef3d5
   - github: ChrisPenner/hs-mcp
-    commit: 14fe82d086a04e82b1c05d7f5a4bbd30eec22042
+    commit: 1469ba7ef807d567ff05ba21d7cc8cd817649018
 
   # not in stackage
   - fuzzyfind-3.0.2@sha256:0fcd64eb1016fe0d0232abc26b2b80b32d676707ff41d155a28df8a9572603d4,1921

--- a/stack.yaml
+++ b/stack.yaml
@@ -60,7 +60,7 @@ extra-deps:
   - github: unisonweb/haskeline
     commit: 9275eea7982dabbf47be2ba078ced669ae7ef3d5
   - github: ChrisPenner/hs-mcp
-    commit: 2fc6096e45bd5568c532efeca08f26e625c713ef
+    commit: d8564c70ca09e333b7ce1717d1ac97a62d62966c
 
   # not in stackage
   - fuzzyfind-3.0.2@sha256:0fcd64eb1016fe0d0232abc26b2b80b32d676707ff41d155a28df8a9572603d4,1921

--- a/stack.yaml
+++ b/stack.yaml
@@ -60,7 +60,7 @@ extra-deps:
   - github: unisonweb/haskeline
     commit: 9275eea7982dabbf47be2ba078ced669ae7ef3d5
   - github: ChrisPenner/hs-mcp
-    commit: 1469ba7ef807d567ff05ba21d7cc8cd817649018
+    commit: 2fc6096e45bd5568c532efeca08f26e625c713ef
 
   # not in stackage
   - fuzzyfind-3.0.2@sha256:0fcd64eb1016fe0d0232abc26b2b80b32d676707ff41d155a28df8a9572603d4,1921

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -18,14 +18,14 @@ packages:
 - completed:
     name: hs-mcp
     pantry-tree:
-      sha256: 586b6acbfe807b45a80614e561d0a0cf4f2cfaaea3494a7e99b66bfc53a2f01e
-      size: 1207
-    sha256: 8badd3492463f6ad5b7998bd0803f81d82f3f5c571caa500b259c4eb33155f82
-    size: 20763
-    url: https://github.com/ChrisPenner/hs-mcp/archive/2fc6096e45bd5568c532efeca08f26e625c713ef.tar.gz
-    version: 0.1.0.0
+      sha256: 36c0d2cf95f95c734831ede52177393988bbba73fab91d03debecc5a0f1ad5a3
+      size: 1338
+    sha256: 4e4b0eb4ad152392db30fc5f45b422b46d7b1941b5c1893190af07faab2da1e3
+    size: 19647
+    url: https://github.com/ChrisPenner/hs-mcp/archive/d8564c70ca09e333b7ce1717d1ac97a62d62966c.tar.gz
+    version: 0.1.1.0
   original:
-    url: https://github.com/ChrisPenner/hs-mcp/archive/2fc6096e45bd5568c532efeca08f26e625c713ef.tar.gz
+    url: https://github.com/ChrisPenner/hs-mcp/archive/d8564c70ca09e333b7ce1717d1ac97a62d62966c.tar.gz
 - completed:
     hackage: fuzzyfind-3.0.2@sha256:0fcd64eb1016fe0d0232abc26b2b80b32d676707ff41d155a28df8a9572603d4,1921
     pantry-tree:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -18,14 +18,14 @@ packages:
 - completed:
     name: hs-mcp
     pantry-tree:
-      sha256: d1e8c5b2d6b45d89f7f50ec87caee24e9971d1d4c0f0620fe4155915815d9bb3
+      sha256: 586b6acbfe807b45a80614e561d0a0cf4f2cfaaea3494a7e99b66bfc53a2f01e
       size: 1207
-    sha256: 9b281f6d3481aae22ff76376844259432ef6f807655cb113d6437579f182ed16
-    size: 20762
-    url: https://github.com/ChrisPenner/hs-mcp/archive/1469ba7ef807d567ff05ba21d7cc8cd817649018.tar.gz
+    sha256: 8badd3492463f6ad5b7998bd0803f81d82f3f5c571caa500b259c4eb33155f82
+    size: 20763
+    url: https://github.com/ChrisPenner/hs-mcp/archive/2fc6096e45bd5568c532efeca08f26e625c713ef.tar.gz
     version: 0.1.0.0
   original:
-    url: https://github.com/ChrisPenner/hs-mcp/archive/1469ba7ef807d567ff05ba21d7cc8cd817649018.tar.gz
+    url: https://github.com/ChrisPenner/hs-mcp/archive/2fc6096e45bd5568c532efeca08f26e625c713ef.tar.gz
 - completed:
     hackage: fuzzyfind-3.0.2@sha256:0fcd64eb1016fe0d0232abc26b2b80b32d676707ff41d155a28df8a9572603d4,1921
     pantry-tree:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -18,14 +18,14 @@ packages:
 - completed:
     name: hs-mcp
     pantry-tree:
-      sha256: 5e0faf4005ccdce8bb93f0295e6017ed54419e7ee5584e83aae2bc62d805e169
+      sha256: d1e8c5b2d6b45d89f7f50ec87caee24e9971d1d4c0f0620fe4155915815d9bb3
       size: 1207
-    sha256: d922d8682940c8d191209a518c9fd2293b13eca93bc6d9975b134825dac836c8
-    size: 20595
-    url: https://github.com/ChrisPenner/hs-mcp/archive/14fe82d086a04e82b1c05d7f5a4bbd30eec22042.tar.gz
+    sha256: 9b281f6d3481aae22ff76376844259432ef6f807655cb113d6437579f182ed16
+    size: 20762
+    url: https://github.com/ChrisPenner/hs-mcp/archive/1469ba7ef807d567ff05ba21d7cc8cd817649018.tar.gz
     version: 0.1.0.0
   original:
-    url: https://github.com/ChrisPenner/hs-mcp/archive/14fe82d086a04e82b1c05d7f5a4bbd30eec22042.tar.gz
+    url: https://github.com/ChrisPenner/hs-mcp/archive/1469ba7ef807d567ff05ba21d7cc8cd817649018.tar.gz
 - completed:
     hackage: fuzzyfind-3.0.2@sha256:0fcd64eb1016fe0d0232abc26b2b80b32d676707ff41d155a28df8a9572603d4,1921
     pantry-tree:

--- a/unison-cli/src/Unison/Codebase/Transcript.hs
+++ b/unison-cli/src/Unison/Codebase/Transcript.hs
@@ -49,7 +49,10 @@ data UcmContext
   deriving (Eq, Show)
 
 data APIRequest
-  = GetRequest Text
+  = -- URL
+    GetRequest Text
+  | -- | URL, Body
+    PostRequest Text Text
   | APIComment Text
   | APIResponseLine Text
   deriving (Eq, Show)

--- a/unison-cli/src/Unison/Codebase/Transcript.hs
+++ b/unison-cli/src/Unison/Codebase/Transcript.hs
@@ -54,7 +54,7 @@ data APIRequest
   | -- | URL, Body
     PostRequest Text Text
   | APIComment Text
-  | APIResponseLine Text
+  | APIResponse Text
   deriving (Eq, Show)
 
 pattern CMarkCodeBlock :: (Maybe CMark.PosInfo) -> Text -> Text -> CMark.Node

--- a/unison-cli/src/Unison/Codebase/Transcript/Parser.hs
+++ b/unison-cli/src/Unison/Codebase/Transcript/Parser.hs
@@ -97,11 +97,12 @@ restOfLine = P.takeWhileP Nothing (/= '\n') <* P.single '\n'
 
 apiRequest :: P APIRequest
 apiRequest =
-  (getRequest
-    <|> postRequest
-    <|> apiComment
-    <|> apiResponse
-  ) <* spaces
+  ( getRequest
+      <|> postRequest
+      <|> apiComment
+      <|> apiResponse
+  )
+    <* spaces
   where
     getRequest = do
       _ <- word "GET"

--- a/unison-cli/src/Unison/Codebase/Transcript/Parser.hs
+++ b/unison-cli/src/Unison/Codebase/Transcript/Parser.hs
@@ -34,9 +34,9 @@ formatAPIRequest :: APIRequest -> Text
 formatAPIRequest = \case
   GetRequest txt -> "GET " <> txt <> "\n"
   PostRequest url body ->
-    "POST " <> url <> "\n" <> Text.unlines (fmap padIfNonEmpty $ Text.lines body) <> "\n"
+    "POST " <> url <> "\n" <> Text.unlines ("BODY:" : fmap padIfNonEmpty (Text.lines body)) <> "\n"
   APIComment txt -> "--" <> txt <> "\n"
-  APIResponseLine txt -> Text.unlines . fmap padIfNonEmpty $ Text.lines txt
+  APIResponse txt -> Text.unlines ("RESPONSE:" : fmap padIfNonEmpty (Text.lines txt)) <> "\n"
 
 formatUcmLine :: UcmLine -> Text
 formatUcmLine = \case
@@ -97,17 +97,32 @@ restOfLine = P.takeWhileP Nothing (/= '\n') <* P.single '\n'
 
 apiRequest :: P APIRequest
 apiRequest =
-  GetRequest <$> (word "GET" *> spaces *> restOfLine)
+  (getRequest
     <|> postRequest
-    <|> APIComment <$> (P.chunk "--" *> restOfLine)
-    <|> APIResponseLine <$> (P.chunk "  " *> restOfLine <|> "" <$ P.single '\n' <|> "" <$ P.chunk " \n")
+    <|> apiComment
+    <|> apiResponse
+  ) <* spaces
   where
+    getRequest = do
+      _ <- word "GET"
+      spaces
+      url <- restOfLine
+      pure $ GetRequest url
     postRequest = do
       _ <- word "POST"
       spaces
       url <- restOfLine
+      _ <- word "BODY:" *> P.many (P.single ' ') *> P.single '\n'
       body <- Text.unlines <$> some (P.chunk "  " *> restOfLine)
       pure $ PostRequest url body
+    apiComment = do
+      _ <- P.chunk "--"
+      comment <- restOfLine
+      pure $ APIComment comment
+    apiResponse = do
+      _ <- word "RESPONSE:" <* P.many (P.single ' ') *> P.single '\n'
+      response <- Text.unlines <$> some (P.chunk "  " *> restOfLine)
+      pure $ APIResponse response
 
 formatInfoString :: (a -> Maybe Text) -> Text -> InfoTags a -> Text
 formatInfoString formatA language infoTags =

--- a/unison-cli/src/Unison/Codebase/Transcript/Parser.hs
+++ b/unison-cli/src/Unison/Codebase/Transcript/Parser.hs
@@ -33,6 +33,8 @@ padIfNonEmpty line = if Text.null line then line else "  " <> line
 formatAPIRequest :: APIRequest -> Text
 formatAPIRequest = \case
   GetRequest txt -> "GET " <> txt <> "\n"
+  PostRequest url body ->
+    "POST " <> url <> "\n" <> Text.unlines (fmap padIfNonEmpty $ Text.lines body) <> "\n"
   APIComment txt -> "--" <> txt <> "\n"
   APIResponseLine txt -> Text.unlines . fmap padIfNonEmpty $ Text.lines txt
 
@@ -96,8 +98,16 @@ restOfLine = P.takeWhileP Nothing (/= '\n') <* P.single '\n'
 apiRequest :: P APIRequest
 apiRequest =
   GetRequest <$> (word "GET" *> spaces *> restOfLine)
+    <|> postRequest
     <|> APIComment <$> (P.chunk "--" *> restOfLine)
     <|> APIResponseLine <$> (P.chunk "  " *> restOfLine <|> "" <$ P.single '\n' <|> "" <$ P.chunk " \n")
+  where
+    postRequest = do
+      _ <- word "POST"
+      spaces
+      url <- restOfLine
+      body <- Text.unlines <$> some (P.chunk "  " *> restOfLine)
+      pure $ PostRequest url body
 
 formatInfoString :: (a -> Maybe Text) -> Text -> InfoTags a -> Text
 formatInfoString formatA language infoTags =

--- a/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
+++ b/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
@@ -13,12 +13,14 @@ import Control.Lens (use, (?~))
 import Crypto.Random qualified as Random
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Encode.Pretty qualified as Aeson
+import Data.ByteString.Char8 qualified as BSC
 import Data.ByteString.Lazy.Char8 qualified as BL
 import Data.IORef
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map qualified as Map
 import Data.Sequence qualified as Seq
 import Data.Text qualified as Text
+import Data.Text.Encoding qualified as Text
 import Data.These (These (..))
 import Data.UUID.V4 qualified as UUID
 import Network.HTTP.Client qualified as HTTP
@@ -53,6 +55,9 @@ import Unison.CommandLine.InputPattern (aliases, patternName)
 import Unison.CommandLine.InputPatterns qualified as IP
 import Unison.CommandLine.OutputMessages (notifyNumbered, notifyUser)
 import Unison.CommandLine.Welcome (asciiartUnison)
+import Unison.Debug qualified as Debug
+import Unison.MCP qualified as MCP
+import Unison.MCP.Server qualified as MCP
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
 import Unison.PrettyTerminal
@@ -102,15 +107,18 @@ withRunner isTest verbosity ucmVersion action = do
   -- This also prevents automated transcript tests from mistakenly opening fzf and waiting for user input.
   when isTest $ do
     liftIO $ setEnv Fuzzy.fzfPathEnvVar "NONE"
-  withRuntimes \runtime sbRuntime ->
-    action \transcriptName transcriptSrc (codebaseDir, codebase) ->
+  withRuntimes \runtime sbRuntime nRuntime ->
+    action \transcriptName transcriptSrc (codebaseDir, codebase) -> do
+      -- This is just used in output messages
+      let workDir = "<workdir>"
+      mcpServerConfig <- MCP.initServer codebase runtime sbRuntime workDir ucmVersion
       Server.startServer
         isTest
         Backend.BackendEnv {Backend.useNamesIndex = False}
         Server.defaultCodebaseServerOpts
         runtime
         codebase
-        (error "IMPLEMENT MCP SERVER in transcripts")
+        (MCP.mcpServer mcpServerConfig)
         \case
           Nothing -> pure $ Left PortBindingFailure
           Just baseUrl ->
@@ -233,6 +241,14 @@ run isTest verbosity dir codebase runtime sbRuntime ucmVersion baseURL stanzas =
                 ]
           (_, _) -> pure ()
 
+      doHttpRequest :: HTTP.Request -> IO Text
+      doHttpRequest req = do
+        resp <- HTTP.responseBody <$> HTTP.httpLbs req httpManager
+        case Aeson.eitherDecode @Aeson.Value resp of
+          Left err -> dieWithMsg $ "Error decoding response from " <> BSC.unpack (HTTP.method req) <> ": " <> err
+          Right v -> do
+            let prettyBytes = Aeson.encodePretty' (Aeson.defConfig {Aeson.confCompare = compare}) v
+            pure $ Text.pack . BL.unpack $ prettyBytes
       apiRequest :: APIRequest -> IO [APIRequest]
       apiRequest req = do
         hide <- hideOutput False
@@ -240,32 +256,30 @@ run isTest verbosity dir codebase runtime sbRuntime ucmVersion baseURL stanzas =
           -- We just discard this, because the runner will produce new output lines.
           APIResponseLine {} -> pure []
           APIComment {} -> pure $ pure req
-          GetRequest path ->
-            either
-              (([] <$) . maybeDieWithMsg . Pretty.string . show)
-              ( either
-                  ( ([] <$)
-                      . maybeDieWithMsg
-                      . (("Error decoding response from " <> Pretty.text path <> ": ") <>)
-                      . Pretty.string
-                  )
-                  ( \(v :: Aeson.Value) ->
-                      pure $
-                        if hide
-                          then [req]
-                          else
-                            [ req,
-                              APIResponseLine . Text.pack . BL.unpack $
-                                Aeson.encodePretty' (Aeson.defConfig {Aeson.confCompare = compare}) v
-                            ]
-                  )
-                  . Aeson.eitherDecode
-                  . HTTP.responseBody
-                  <=< flip HTTP.httpLbs httpManager
-              )
-              . HTTP.parseRequest
-              . Text.unpack
-              $ baseURL <> path
+          GetRequest path -> do
+            httpReq <- case HTTP.parseRequest (Text.unpack $ baseURL <> path) of
+              Left err -> dieWithMsg (show err)
+              Right r -> pure r
+            respTxt <- doHttpRequest httpReq
+            if hide
+              then pure [req]
+              else pure [req, APIResponseLine respTxt]
+          PostRequest path body -> do
+            httpReq <- case HTTP.parseRequest (Text.unpack $ baseURL <> path) of
+              Left err -> dieWithMsg (show err)
+              Right r ->
+                pure $
+                  r
+                    { HTTP.method = "POST",
+                      HTTP.requestBody = HTTP.RequestBodyBS (Text.encodeUtf8 body),
+                      HTTP.requestHeaders = [("Content-Type", "application/json"), ("Accept", "application/json")]
+                    }
+            Debug.debugM Debug.Temp "POST REQUEST" httpReq
+            respTxt <- doHttpRequest httpReq
+            Debug.debugM Debug.Temp "RESPONSE" respTxt
+            if hide
+              then pure [req]
+              else pure [req, APIResponseLine respTxt]
 
       endUcmBlock = do
         liftIO $ do

--- a/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
+++ b/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
@@ -110,6 +110,7 @@ withRunner isTest verbosity ucmVersion action = do
         Server.defaultCodebaseServerOpts
         runtime
         codebase
+        (error "IMPLEMENT MCP SERVER in transcripts")
         \case
           Nothing -> pure $ Left PortBindingFailure
           Just baseUrl ->

--- a/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
+++ b/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
@@ -107,7 +107,7 @@ withRunner isTest verbosity ucmVersion action = do
   -- This also prevents automated transcript tests from mistakenly opening fzf and waiting for user input.
   when isTest $ do
     liftIO $ setEnv Fuzzy.fzfPathEnvVar "NONE"
-  withRuntimes \runtime sbRuntime nRuntime ->
+  withRuntimes \runtime sbRuntime ->
     action \transcriptName transcriptSrc (codebaseDir, codebase) -> do
       -- This is just used in output messages
       let workDir = "<workdir>"

--- a/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
+++ b/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
@@ -254,7 +254,7 @@ run isTest verbosity dir codebase runtime sbRuntime ucmVersion baseURL stanzas =
         hide <- hideOutput False
         case req of
           -- We just discard this, because the runner will produce new output lines.
-          APIResponseLine {} -> pure []
+          APIResponse {} -> pure []
           APIComment {} -> pure $ pure req
           GetRequest path -> do
             httpReq <- case HTTP.parseRequest (Text.unpack $ baseURL <> path) of
@@ -263,7 +263,7 @@ run isTest verbosity dir codebase runtime sbRuntime ucmVersion baseURL stanzas =
             respTxt <- doHttpRequest httpReq
             if hide
               then pure [req]
-              else pure [req, APIResponseLine respTxt]
+              else pure [req, APIResponse respTxt]
           PostRequest path body -> do
             httpReq <- case HTTP.parseRequest (Text.unpack $ baseURL <> path) of
               Left err -> dieWithMsg (show err)
@@ -279,7 +279,7 @@ run isTest verbosity dir codebase runtime sbRuntime ucmVersion baseURL stanzas =
             Debug.debugM Debug.Temp "RESPONSE" respTxt
             if hide
               then pure [req]
-              else pure [req, APIResponseLine respTxt]
+              else pure [req, APIResponse respTxt]
 
       endUcmBlock = do
         liftIO $ do

--- a/unison-cli/src/Unison/MCP.hs
+++ b/unison-cli/src/Unison/MCP.hs
@@ -48,6 +48,7 @@ initServer codebase runtime sbRuntime workDir ucmVersion = do
 
   runMCP env $ MCPWrapper.mkServer serverInfo serverDescription staticResources tools prompts
 
+-- | Run the MCP server until we hit EOF.
 runOnStdIO :: Codebase IO Symbol Ann -> Runtime Symbol -> Runtime Symbol -> FilePath -> Text -> IO ()
 runOnStdIO codebase runtime sbRuntime workDir ucmVersion = do
   server <- initServer codebase runtime sbRuntime workDir ucmVersion

--- a/unison-cli/src/Unison/MCP.hs
+++ b/unison-cli/src/Unison/MCP.hs
@@ -48,7 +48,7 @@ initServer codebase runtime sbRuntime workDir ucmVersion = do
 
   runMCP env $ MCPWrapper.mkServer serverInfo serverDescription staticResources tools prompts
 
-runOnStdIO :: Codebase IO Symbol Ann ->  Runtime Symbol -> Runtime Symbol -> FilePath -> Text -> IO ()
+runOnStdIO :: Codebase IO Symbol Ann -> Runtime Symbol -> Runtime Symbol -> FilePath -> Text -> IO ()
 runOnStdIO codebase runtime sbRuntime workDir ucmVersion = do
   server <- initServer codebase runtime sbRuntime workDir ucmVersion
   -- Start the server with StdIO transport

--- a/unison-cli/src/Unison/MCP.hs
+++ b/unison-cli/src/Unison/MCP.hs
@@ -1,6 +1,8 @@
-module Unison.MCP (runOnStdIO) where
+module Unison.MCP (runOnStdIO, initServer) where
 
+import Network.MCP.Server qualified as MCP
 import Network.MCP.Server.StdIO qualified as MCP
+import Network.MCP.Types
 import Text.RawString.QQ (r)
 import Unison.Auth.CredentialManager qualified as AuthN
 import Unison.Auth.HTTPClient qualified as AuthN
@@ -11,7 +13,6 @@ import Unison.MCP.Prompts (prompts)
 import Unison.MCP.StaticResources (staticResources)
 import Unison.MCP.Tools (tools)
 import Unison.MCP.Types
-import Unison.MCP.Wrapper
 import Unison.MCP.Wrapper qualified as MCPWrapper
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
@@ -27,8 +28,8 @@ serverDescription =
         Before doing any work in unison please read the file://unison-guide resource for information on how to write unison.
     |]
 
-runOnStdIO :: Codebase IO Symbol Ann -> Runtime Symbol -> Runtime Symbol -> FilePath -> Text -> IO ()
-runOnStdIO codebase runtime sbRuntime workDir ucmVersion = do
+initServer :: Codebase IO Symbol Ann -> Runtime Symbol -> Runtime Symbol -> FilePath -> Text -> IO MCP.Server
+initServer codebase runtime sbRuntime workDir ucmVersion = do
   credMan <- AuthN.newCredentialManager
   let tokenProvider :: AuthN.TokenProvider
       tokenProvider = AuthN.newTokenProvider credMan
@@ -45,7 +46,10 @@ runOnStdIO codebase runtime sbRuntime workDir ucmVersion = do
   -- Create server
   let serverInfo = Implementation "unison-mcp" "0.0.1"
 
-  server <- runMCP env $ MCPWrapper.mkServer serverInfo serverDescription staticResources tools prompts
+  runMCP env $ MCPWrapper.mkServer serverInfo serverDescription staticResources tools prompts
 
+runOnStdIO :: Codebase IO Symbol Ann ->  Runtime Symbol -> Runtime Symbol -> FilePath -> Text -> IO ()
+runOnStdIO codebase runtime sbRuntime workDir ucmVersion = do
+  server <- initServer codebase runtime sbRuntime workDir ucmVersion
   -- Start the server with StdIO transport
   MCP.runServerWithSTDIO server

--- a/unison-cli/src/Unison/MCP/Server.hs
+++ b/unison-cli/src/Unison/MCP/Server.hs
@@ -1,0 +1,9 @@
+module Unison.MCP.Server (mcpServer) where
+
+import Network.MCP.Server qualified as MCP
+import Network.MCP.Transport.Types qualified as MCP
+import UnliftIO (MonadIO (..))
+
+mcpServer :: (MonadIO m) => MCP.Server -> (MCP.Message -> m (Maybe MCP.Message))
+mcpServer server msg = do
+  liftIO $ MCP.handleMessage server msg

--- a/unison-cli/src/Unison/MCP/Tools.hs
+++ b/unison-cli/src/Unison/MCP/Tools.hs
@@ -53,7 +53,9 @@ tools =
     listProjectBranchesTool,
     getCurrentProjectContextTool,
     searchDefinitionsTool,
-    searchByTypeTool
+    searchByTypeTool,
+    dependenciesTool,
+    dependentsTool
   ]
 
 currentProjectContext :: (MonadIO m, MonadReader Env m) => m ProjectContext
@@ -388,6 +390,46 @@ searchByTypeTool =
       toolHandler = \(SearchByTypeToolArguments {projectContext, query}) -> handleToolError $ do
         definitions <- handleInputMCP projectContext [Right $ Input.FindI False (FindLocal Path.Root') [":", Text.unpack query]]
         let outputJSON = Text.decodeUtf8 . BL.toStrict $ Aeson.encode definitions
+        pure $ textToolResult outputJSON
+    }
+
+dependenciesTool :: Tool MCP
+dependenciesTool =
+  Tool
+    { toolName = toToolName DependenciesTool,
+      toolDescription = "List the dependencies of a definition.",
+      toolAnnotations =
+        ToolAnnotations
+          { title = Just "List all definitions a given term or type depends on.",
+            readOnlyHint = Just True,
+            destructiveHint = Just False,
+            idempotentHint = Just True,
+            openWorldHint = Just False
+          },
+      toolArgType = Proxy,
+      toolHandler = \(ProjectDefinitionNameArgument {projectContext, definitionName}) -> handleToolError $ do
+        output <- handleInputMCP projectContext [Right $ Input.ListDependenciesI (HQ.NameOnly definitionName)]
+        let outputJSON = Text.decodeUtf8 . BL.toStrict $ Aeson.encode output
+        pure $ textToolResult outputJSON
+    }
+
+dependentsTool :: Tool MCP
+dependentsTool =
+  Tool
+    { toolName = toToolName DependentsTool,
+      toolDescription = "List the dependents of a definition.",
+      toolAnnotations =
+        ToolAnnotations
+          { title = Just "List all definitions that depend on a given term or type.",
+            readOnlyHint = Just True,
+            destructiveHint = Just False,
+            idempotentHint = Just True,
+            openWorldHint = Just False
+          },
+      toolArgType = Proxy,
+      toolHandler = \(ProjectDefinitionNameArgument {projectContext, definitionName}) -> handleToolError $ do
+        output <- handleInputMCP projectContext [Right $ Input.ListDependentsI (HQ.NameOnly definitionName)]
+        let outputJSON = Text.decodeUtf8 . BL.toStrict $ Aeson.encode output
         pure $ textToolResult outputJSON
     }
 

--- a/unison-cli/src/Unison/MCP/Tools.hs
+++ b/unison-cli/src/Unison/MCP/Tools.hs
@@ -28,6 +28,7 @@ import Unison.MCP.Types
 import Unison.MCP.Wrapper
 import Unison.MCP.Wrapper qualified as MCPWrapper
 import Unison.NameSegment qualified as NameSegment
+import Unison.Prelude (readUtf8)
 import Unison.Project (ProjectBranchNameOrLatestRelease (..))
 import Unison.Syntax.NameSegment qualified as NameSegment
 import Unison.Util.Relation qualified as R
@@ -127,15 +128,28 @@ typecheckCodeTool =
           If you would like to test the behaviour of any pure functions, you may prefix a code snippet with an angle bracket.
 
           e.g.
+
           ```
           > 1 + 2
           ```
 
           Or
+
           ```
           > let
               isGreaterThan3 x = x > 3
               isGreaterThan3 4
+          ```
+
+          If you wish to write unit tests, you may do so like this:
+
+          ```
+          test> Nat.tests.additionIsCommutative = test.verify do
+            Each.repeat 100
+            n = Random.natIn 0 1000
+            m = Random.natIn 0 1000
+            ensureEqual (n + m) (m + n)
+          ```
         |],
       toolAnnotations =
         ToolAnnotations
@@ -147,7 +161,10 @@ typecheckCodeTool =
           },
       toolArgType = Proxy,
       toolHandler = \(TypecheckCodeToolArguments {code, projectContext}) -> handleToolError do
-        output <- handleInputMCP projectContext [Left $ UnisonFileChanged "scratch.u" code]
+        source <- case code of
+          Left filePath -> liftIO $ readUtf8 filePath
+          Right codeSnippet -> pure codeSnippet
+        output <- handleInputMCP projectContext [Left $ UnisonFileChanged "scratch.u" source]
         let outputJSON = Text.decodeUtf8 . BL.toStrict $ Aeson.encode output
         pure $ textToolResult outputJSON
     }

--- a/unison-cli/src/Unison/MCP/Types.hs
+++ b/unison-cli/src/Unison/MCP/Types.hs
@@ -327,7 +327,7 @@ instance FromJSON ShareProjectReadmeToolArguments where
 
 data TypecheckCodeToolArguments = TypecheckCodeToolArguments
   { projectContext :: ProjectContext,
-    code :: Text
+    code :: Either FilePath Text
   }
   deriving (Eq, Show)
 
@@ -337,21 +337,54 @@ instance HasInputSchema TypecheckCodeToolArguments where
       [ "type" .= ("object" :: Text),
         "properties"
           .= object
-            [ "code"
+            [ "projectContext" .= toInputSchema (Proxy :: Proxy ProjectContext),
+              "code"
                 .= object
-                  [ "type" .= ("string" :: Text),
-                    "description" .= ("The code to typecheck, as a string. All the code you've written which is not yet part of the project must be provided at once." :: Text)
-                  ],
-              "projectContext" .= toInputSchema (Proxy :: Proxy ProjectContext)
+                  [ "description" .= ("The source code to typecheck. If a string, it is the source code itself. If a file path, it is the path to a file containing the source code." :: Text),
+                    "oneOf"
+                      .= [ object
+                             [ "description" .= ("The file path to the source code." :: Text),
+                               "type" .= ("object" :: Text),
+                               "properties"
+                                 .= object
+                                   [ "filePath"
+                                       .= object
+                                         [ "type" .= ("string" :: Text),
+                                           "description" .= ("An absolute file path to the source code." :: Text)
+                                         ]
+                                   ],
+                               "required" .= ["filePath" :: Text],
+                               "additionalProperties" .= False
+                             ],
+                           object
+                             [ "description" .= ("The source code to typecheck." :: Text),
+                               "type" .= ("object" :: Text),
+                               "properties"
+                                 .= object
+                                   [ "text"
+                                       .= object
+                                         [ "type" .= ("string" :: Text),
+                                           "description" .= ("The source code to typecheck." :: Text)
+                                         ]
+                                   ],
+                               "required" .= ["text" :: Text],
+                               "additionalProperties" .= False
+                             ]
+                         ]
+                  ]
             ],
-        "required" .= ["code", "projectContext" :: Text]
+        "required" .= ["projectContext", "code" :: Text]
       ]
 
 instance FromJSON TypecheckCodeToolArguments where
   parseJSON = withObject "TypecheckCodeToolArguments" $ \o -> do
     projectContext <- o .: "projectContext"
-    code <- o .: "code"
-    pure $ TypecheckCodeToolArguments {projectContext, code}
+    source <- o .: "code"
+    source .:? "filePath" >>= \case
+      Just filePath -> pure $ TypecheckCodeToolArguments {projectContext, code = Left filePath}
+      Nothing -> do
+        text <- source .: "text"
+        pure $ TypecheckCodeToolArguments {projectContext, code = Right text}
 
 data DocsToolArguments = DocsToolArguments
   { projectContext :: ProjectContext,

--- a/unison-cli/src/Unison/MCP/Types.hs
+++ b/unison-cli/src/Unison/MCP/Types.hs
@@ -18,6 +18,7 @@ module Unison.MCP.Types
     ProjectContext (..),
     ProjectContextArgument (..),
     ProjectNameArgument (..),
+    ProjectDefinitionNameArgument (..),
     toToolName,
     fromToolName,
   )
@@ -74,6 +75,8 @@ data ToolKind
   | ListLocalProjectsTool
   | ListProjectBranchesTool
   | GetCurrentProjectContextTool
+  | DependenciesTool
+  | DependentsTool
   deriving (Eq, Ord, Show, Bounded, Enum)
 
 kindNameMapping :: Map ToolKind Text
@@ -93,8 +96,41 @@ kindNameMapping =
       (SearchByTypeTool, "search-by-type"),
       (ListLocalProjectsTool, "list-local-projects"),
       (ListProjectBranchesTool, "list-project-branches"),
-      (GetCurrentProjectContextTool, "get-current-project-context")
+      (GetCurrentProjectContextTool, "get-current-project-context"),
+      (DependenciesTool, "list-definition-dependencies"),
+      (DependentsTool, "list-definition-dependents")
     ]
+
+data ProjectDefinitionNameArgument = ProjectDefinitionNameArgument
+  { definitionName :: Name,
+    projectContext :: ProjectContext
+  }
+  deriving (Eq, Show)
+
+instance HasInputSchema ProjectDefinitionNameArgument where
+  toInputSchema _ =
+    object
+      [ "type" .= ("object" :: Text),
+        "properties"
+          .= object
+            [ "definitionName"
+                .= object
+                  [ "type" .= ("string" :: Text),
+                    "description" .= ("The name of the definition to work with, e.g. `mynamespace.foo` or `lib.unison_base_1_0_0.data.List`." :: Text)
+                  ],
+              "projectContext" .= toInputSchema (Proxy :: Proxy ProjectContext)
+            ],
+        "required" .= ["definitionName", "projectContext" :: Text]
+      ]
+
+instance FromJSON ProjectDefinitionNameArgument where
+  parseJSON = withObject "ProjectDefinitionNameArgument" $ \o -> do
+    definitionNameText <- o .: "definitionName"
+    definitionName <- case Name.parseTextEither definitionNameText of
+      Left err -> fail $ "Invalid definition name: " ++ show err
+      Right definitionName -> pure definitionName
+    projectContext <- o .: "projectContext"
+    pure $ ProjectDefinitionNameArgument {definitionName, projectContext}
 
 newtype ProjectContextArgument = ProjectContextArgument ProjectContext
   deriving newtype (Eq, Show)

--- a/unison-cli/src/Unison/MCP/Types.hs
+++ b/unison-cli/src/Unison/MCP/Types.hs
@@ -97,7 +97,18 @@ kindNameMapping =
     ]
 
 newtype ProjectContextArgument = ProjectContextArgument ProjectContext
-  deriving newtype (Eq, Show, HasInputSchema)
+  deriving newtype (Eq, Show)
+
+instance HasInputSchema ProjectContextArgument where
+  toInputSchema _ =
+    object
+      [ "type" .= ("object" :: Text),
+        "properties"
+          .= object
+            [ "projectContext" .= toInputSchema (Proxy :: Proxy ProjectContext)
+            ],
+        "required" .= ["projectContext" :: Text]
+      ]
 
 instance FromJSON ProjectContextArgument where
   parseJSON = withObject "ProjectContextArgument" $ \o -> do

--- a/unison-cli/src/Unison/MCP/Wrapper.hs
+++ b/unison-cli/src/Unison/MCP/Wrapper.hs
@@ -50,8 +50,7 @@ instance HasInputSchema () where
         ("required", Aeson.Array mempty)
       ]
 
-data Tool m
-  = forall arg.
+data Tool m = forall arg.
   (FromJSON arg, HasInputSchema arg) =>
   Tool
   { toolName :: Text,

--- a/unison-cli/src/Unison/MCP/Wrapper.hs
+++ b/unison-cli/src/Unison/MCP/Wrapper.hs
@@ -35,6 +35,7 @@ import Network.MCP.Server
 import Network.MCP.Types (CallToolResult (CallToolResult))
 import Network.MCP.Types qualified as MCP
 import Unison.Prelude
+import UnliftIO qualified
 
 type StaticResources = Map Text (MCP.Resource, MCP.ResourceContent)
 
@@ -49,7 +50,8 @@ instance HasInputSchema () where
         ("required", Aeson.Array mempty)
       ]
 
-data Tool m = forall arg.
+data Tool m
+  = forall arg.
   (FromJSON arg, HasInputSchema arg) =>
   Tool
   { toolName :: Text,
@@ -116,7 +118,10 @@ doTools server tools = do
     case Map.lookup callToolName toolMap of
       Just Tool {toolHandler} -> do
         case Aeson.fromJSON callToolArguments of
-          Aeson.Success arg -> toolHandler arg
+          Aeson.Success arg ->
+            UnliftIO.timeout (60 * 1_000_000) (toolHandler arg) >>= \case
+              Nothing -> pure $ errorToolResult $ "Tool '" <> callToolName <> "' timed out after 1 minute."
+              Just result -> pure result
           Aeson.Error err -> pure $ errorToolResult $ "Failed to parse arguments for tool '" <> callToolName <> "': " <> Text.pack err
       Nothing -> pure $ errorToolResult $ "Tool '" <> callToolName <> "' not found."
 

--- a/unison-cli/src/Unison/Main.hs
+++ b/unison-cli/src/Unison/Main.hs
@@ -83,6 +83,7 @@ import Unison.Core.Project (ProjectAndBranch (..), ProjectName (..))
 import Unison.LSP qualified as LSP
 import Unison.LSP.Util.Signal qualified as Signal
 import Unison.MCP qualified as MCP
+import Unison.MCP.Server qualified as MCP
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
 import Unison.PrettyTerminal qualified as PT
@@ -320,7 +321,8 @@ main version = do
               -- https://gitlab.haskell.org/ghc/ghc/-/merge_requests/1224
               void . Ki.fork scope $ LSP.spawnLsp lspFormattingConfig theCodebase runtime changeSignal
               let isTest = False
-              Server.startServer isTest (Backend.BackendEnv {Backend.useNamesIndex = False}) codebaseServerOpts sbRuntime theCodebase $ \mayBaseUrl -> do
+              server <- MCP.initServer theCodebase runtime sbRuntime currentDir (Version.gitDescribeWithDate version)
+              Server.startServer isTest (Backend.BackendEnv {Backend.useNamesIndex = False}) codebaseServerOpts sbRuntime theCodebase (MCP.mcpServer server) $ \mayBaseUrl -> do
                 case exitOption of
                   DoNotExit -> do
                     case isHeadless of

--- a/unison-cli/src/Unison/Main.hs
+++ b/unison-cli/src/Unison/Main.hs
@@ -321,8 +321,8 @@ main version = do
               -- https://gitlab.haskell.org/ghc/ghc/-/merge_requests/1224
               void . Ki.fork scope $ LSP.spawnLsp lspFormattingConfig theCodebase runtime changeSignal
               let isTest = False
-              server <- MCP.initServer theCodebase runtime sbRuntime currentDir (Version.gitDescribeWithDate version)
-              Server.startServer isTest (Backend.BackendEnv {Backend.useNamesIndex = False}) codebaseServerOpts sbRuntime theCodebase (MCP.mcpServer server) $ \mayBaseUrl -> do
+              mcpServerConfig <- MCP.initServer theCodebase runtime sbRuntime currentDir (Version.gitDescribeWithDate version)
+              Server.startServer isTest (Backend.BackendEnv {Backend.useNamesIndex = False}) codebaseServerOpts sbRuntime theCodebase (MCP.mcpServer mcpServerConfig) $ \mayBaseUrl -> do
                 case exitOption of
                   DoNotExit -> do
                     case isHeadless of

--- a/unison-cli/transcripts/Transcripts.hs
+++ b/unison-cli/transcripts/Transcripts.hs
@@ -7,6 +7,7 @@
 module Main (main) where
 
 import Data.List
+import Unison.Util.Timing
 import Data.Text qualified as Text
 import Data.Text.IO qualified as Text
 import EasyTest
@@ -55,7 +56,7 @@ testBuilder ::
   [FilePath] ->
   FilePath ->
   Test ()
-testBuilder expectFailure replaceOriginal recordFailure inputDir outputDir prelude transcript =
+testBuilder expectFailure replaceOriginal recordFailure inputDir outputDir prelude transcript = time transcript $ do
   scope transcript do
     outputs <-
       io $ withTemporaryUcmCodebase SC.init Verbosity.Silent "transcript" SC.DoLock \(codebasePath, codebase) ->

--- a/unison-cli/transcripts/Transcripts.hs
+++ b/unison-cli/transcripts/Transcripts.hs
@@ -7,7 +7,6 @@
 module Main (main) where
 
 import Data.List
-import Unison.Util.Timing
 import Data.Text qualified as Text
 import Data.Text.IO qualified as Text
 import EasyTest
@@ -29,6 +28,7 @@ import Unison.Codebase.Transcript.Parser as Transcript
 import Unison.Codebase.Transcript.Runner as Transcript
 import Unison.Codebase.Verbosity qualified as Verbosity
 import Unison.Prelude
+import Unison.Util.Timing
 import UnliftIO.STM qualified as STM
 
 data TestConfig = TestConfig

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -155,6 +155,7 @@ library
       Unison.MCP
       Unison.MCP.Cli
       Unison.MCP.Prompts
+      Unison.MCP.Server
       Unison.MCP.Share.API
       Unison.MCP.StaticResources
       Unison.MCP.Tools

--- a/unison-share-api/package.yaml
+++ b/unison-share-api/package.yaml
@@ -23,6 +23,7 @@ library:
     - extra
     - filepath
     - fuzzyfind
+    - hs-mcp
     - http-media
     - http-types
     - lens

--- a/unison-share-api/src/Unison/Server/CodebaseServer.hs
+++ b/unison-share-api/src/Unison/Server/CodebaseServer.hs
@@ -25,6 +25,7 @@ import GHC.Generics ()
 import Network.HTTP.Media ((//), (/:))
 import Network.HTTP.Types (HeaderName)
 import Network.HTTP.Types.Status (ok200)
+import Network.MCP.Transport.Types qualified as MCP
 import Network.URI.Encode as UriEncode
 import Network.URI.Encode qualified as URI
 import Network.Wai (Middleware, responseLBS)
@@ -140,6 +141,12 @@ instance MimeRender HTML RawHtml where
 
 type OpenApiJSON = "openapi.json" :> Get '[JSON] OpenApi
 
+type MCPServer = MCP.Message -> Handler (Maybe MCP.Message)
+
+type MCPAPI =
+  Servant.ReqBody '[JSON] MCP.Message
+    :> Servant.Post '[JSON] (Maybe MCP.Message)
+
 type UnisonAndDocsAPI = UnisonLocalAPI :<|> OpenApiJSON :<|> Raw
 
 type UnisonLocalAPI =
@@ -204,7 +211,7 @@ instance ToParam (Servant.QueryParam' mods "newType" a) where
 
 type WebUI = CaptureAll "route" Text :> Get '[HTML] RawHtml
 
-type ServerAPI = ("ui" :> WebUI) :<|> ("api" :> UnisonAndDocsAPI)
+type ServerAPI = ("ui" :> WebUI) :<|> ("api" :> UnisonAndDocsAPI) :<|> ("mcp" :> MCPAPI)
 
 type StaticAPI = "static" :> Raw
 
@@ -395,9 +402,10 @@ app ::
   FilePath ->
   Strict.ByteString ->
   Maybe String ->
+  MCPServer ->
   Application
-app env rt codebase uiPath expectedToken allowCorsHost =
-  corsPolicy allowCorsHost $ serve appAPI $ server env rt codebase uiPath expectedToken
+app env rt codebase uiPath expectedToken allowCorsHost mcpServer =
+  corsPolicy allowCorsHost $ serve appAPI $ server env rt codebase uiPath expectedToken mcpServer
 
 data Waiter a = Waiter
   { notify :: a -> IO (),
@@ -454,9 +462,10 @@ startServer ::
   CodebaseServerOpts ->
   Rt.Runtime Symbol ->
   Codebase IO Symbol Ann ->
+  MCPServer ->
   (Maybe BaseUrl -> IO a) ->
   IO a
-startServer isTest env opts rt codebase onStart = do
+startServer isTest env opts rt codebase mcpServer onStart = do
   -- the `canonicalizePath` resolves symlinks
   exePath <- canonicalizePath =<< getExecutablePath
   envUI <- canonicalizePath $ fromMaybe (FilePath.takeDirectory exePath </> "ui") (codebaseUIPath opts)
@@ -468,7 +477,7 @@ startServer isTest env opts rt codebase onStart = do
         defaultSettings
           & setPort (fromMaybe 5858 $ port opts)
           & (setHost . fromString) (fromMaybe "127.0.0.1" $ host opts)
-  let app' = app env rt codebase envUI token (allowCorsHost opts)
+  let app' = app env rt codebase envUI token (allowCorsHost opts) mcpServer
   case port opts of
     Nothing -> withPort settings baseUrl app' 5858
     Just p -> withPort settings baseUrl app' p
@@ -564,8 +573,9 @@ server ::
   Codebase IO Symbol Ann ->
   FilePath ->
   Strict.ByteString ->
+  MCPServer ->
   Server AppAPI
-server backendEnv rt codebase uiPath expectedToken =
+server backendEnv rt codebase uiPath expectedToken mcpServer =
   serveDirectoryWebApp (uiPath </> "static")
     :<|> hoistWithAuth serverAPI expectedToken serveServer
   where
@@ -573,6 +583,7 @@ server backendEnv rt codebase uiPath expectedToken =
     serveServer =
       serveUI uiPath
         :<|> serveUnisonAndDocs backendEnv rt codebase
+        :<|> mcpServer
 
 serveUnisonAndDocs :: BackendEnv -> Rt.Runtime Symbol -> Codebase IO Symbol Ann -> Server UnisonAndDocsAPI
 serveUnisonAndDocs env rt codebase = serveUnisonLocal env codebase rt :<|> serveOpenAPI :<|> Tagged serveDocs

--- a/unison-share-api/unison-share-api.cabal
+++ b/unison-share-api/unison-share-api.cabal
@@ -103,6 +103,7 @@ library
     , extra
     , filepath
     , fuzzyfind
+    , hs-mcp
     , http-media
     , http-types
     , lens

--- a/unison-src/transcripts/errors/invalid-api-requests.output.md
+++ b/unison-src/transcripts/errors/invalid-api-requests.output.md
@@ -1,6 +1,6 @@
 :2:1:
   |
 2 | DELETE /something/important
-  | ^^^
-unexpected "DEL"
-expecting "  ", " <newline>", "--", "GET", end of input, or newline
+  | ^^^^^^^^^
+unexpected "DELETE /s"
+expecting "--", "GET", "POST", "RESPONSE:", or end of input

--- a/unison-src/transcripts/idempotent/api-doc-rendering.md
+++ b/unison-src/transcripts/idempotent/api-doc-rendering.md
@@ -156,6 +156,7 @@ term = 42
 
 ``` api
 GET /api/projects/scratch/branches/main/getDefinition?names=term
+RESPONSE:
   {
       "missingDefinitions": [],
       "termDefinitions": {
@@ -948,4 +949,5 @@ GET /api/projects/scratch/branches/main/getDefinition?names=term
       },
       "typeDefinitions": {}
   }
+
 ```

--- a/unison-src/transcripts/idempotent/api-find.md
+++ b/unison-src/transcripts/idempotent/api-find.md
@@ -30,6 +30,7 @@ joey.yaml.zz = 45
 ``` api
 -- Namespace segment prefix search
 GET /api/projects/scratch/branches/main/find?query=http
+RESPONSE:
   [
       [
           {
@@ -114,8 +115,10 @@ GET /api/projects/scratch/branches/main/find?query=http
           }
       ]
   ]
+
 -- Namespace segment suffix search
 GET /api/projects/scratch/branches/main/find?query=Server
+RESPONSE:
   [
       [
           {
@@ -159,8 +162,10 @@ GET /api/projects/scratch/branches/main/find?query=Server
           }
       ]
   ]
+
 -- Substring search
 GET /api/projects/scratch/branches/main/find?query=lesys
+RESPONSE:
   [
       [
           {
@@ -204,8 +209,10 @@ GET /api/projects/scratch/branches/main/find?query=lesys
           }
       ]
   ]
+
 -- Cross-segment search
 GET /api/projects/scratch/branches/main/find?query=joey.http
+RESPONSE:
   [
       [
           {
@@ -245,4 +252,5 @@ GET /api/projects/scratch/branches/main/find?query=joey.http
           }
       ]
   ]
+
 ```

--- a/unison-src/transcripts/idempotent/api-getDefinition.md
+++ b/unison-src/transcripts/idempotent/api-getDefinition.md
@@ -16,6 +16,7 @@ nested.names.x = 42
 ``` api
 -- Should NOT find names by suffix
 GET /api/projects/scratch/branches/main/getDefinition?names=x
+RESPONSE:
   {
       "missingDefinitions": [
           "x"
@@ -23,8 +24,10 @@ GET /api/projects/scratch/branches/main/getDefinition?names=x
       "termDefinitions": {},
       "typeDefinitions": {}
   }
+
 -- Term names should strip relativeTo prefix.
 GET /api/projects/scratch/branches/main/getDefinition?names=names.x&relativeTo=nested
+RESPONSE:
   {
       "missingDefinitions": [],
       "termDefinitions": {
@@ -118,8 +121,10 @@ GET /api/projects/scratch/branches/main/getDefinition?names=names.x&relativeTo=n
       },
       "typeDefinitions": {}
   }
+
 -- Should find definitions by hash, names should be relative
 GET /api/projects/scratch/branches/main/getDefinition?names=%23qkhkl0n238&relativeTo=nested
+RESPONSE:
   {
       "missingDefinitions": [],
       "termDefinitions": {
@@ -213,6 +218,7 @@ GET /api/projects/scratch/branches/main/getDefinition?names=%23qkhkl0n238&relati
       },
       "typeDefinitions": {}
   }
+
 ```
 
 ``` unison :hide
@@ -232,6 +238,7 @@ Only docs for the term we request should be returned, even if there are other te
 
 ``` api
 GET /api/projects/scratch/branches/main/getDefinition?names=thing&relativeTo=doctest
+RESPONSE:
   {
       "missingDefinitions": [],
       "termDefinitions": {
@@ -346,12 +353,14 @@ GET /api/projects/scratch/branches/main/getDefinition?names=thing&relativeTo=doc
       },
       "typeDefinitions": {}
   }
+
 ```
 
 If we request a doc, the api should return the source, but also the rendered doc should appear in the 'termDocs' list.
 
 ``` api
 GET /api/projects/scratch/branches/main/getDefinition?names=thing.doc&relativeTo=doctest
+RESPONSE:
   {
       "missingDefinitions": [],
       "termDefinitions": {
@@ -523,4 +532,5 @@ GET /api/projects/scratch/branches/main/getDefinition?names=thing.doc&relativeTo
       },
       "typeDefinitions": {}
   }
+
 ```

--- a/unison-src/transcripts/idempotent/api-list-projects-branches.md
+++ b/unison-src/transcripts/idempotent/api-list-projects-branches.md
@@ -22,6 +22,7 @@ project-apple/a-branch-banana> branch a-branch-apple
 ``` api
 -- Should list all projects
 GET /api/projects
+RESPONSE:
   [
       {
           "activeBranchRef": "a-branch-apple",
@@ -40,16 +41,20 @@ GET /api/projects
           "projectName": "scratch"
       }
   ]
+
 -- Can query for some infix of the project name
 GET /api/projects?query=bana
+RESPONSE:
   [
       {
           "activeBranchRef": "main",
           "projectName": "project-banana"
       }
   ]
+
 -- Should list all branches
 GET /api/projects/project-apple/branches
+RESPONSE:
   [
       {
           "branchName": "a-branch-apple"
@@ -64,11 +69,14 @@ GET /api/projects/project-apple/branches
           "branchName": "main"
       }
   ]
+
 -- Can query for some  infix of the project name
 GET /api/projects/project-apple/branches?query=bana
+RESPONSE:
   [
       {
           "branchName": "a-branch-banana"
       }
   ]
+
 ```

--- a/unison-src/transcripts/idempotent/api-namespace-details.md
+++ b/unison-src/transcripts/idempotent/api-namespace-details.md
@@ -35,6 +35,7 @@ Here's a *README*!
 ``` api
 -- Should find names by suffix
 GET /api/projects/scratch/branches/main/namespaces/nested.names
+RESPONSE:
   {
       "fqn": "nested.names",
       "hash": "#6tnmlu9knsce0u2991u6fvcmf4v44fdf0aiqtmnq7mjj0gi5sephg3lf12iv3odr5rc7vlgq75ciborrd3625c701bdmdomia2gcm3o",
@@ -76,4 +77,5 @@ GET /api/projects/scratch/branches/main/namespaces/nested.names
           "tag": "Paragraph"
       }
   }
+
 ```

--- a/unison-src/transcripts/idempotent/api-namespace-list.md
+++ b/unison-src/transcripts/idempotent/api-namespace-list.md
@@ -32,6 +32,7 @@ nested.names.readme = {{ I'm a readme! }}
 
 ``` api
 GET /api/projects/scratch/branches/main/list?namespace=nested.names
+RESPONSE:
   {
       "namespaceListingChildren": [
           {
@@ -80,7 +81,9 @@ GET /api/projects/scratch/branches/main/list?namespace=nested.names
       "namespaceListingFQN": "nested.names",
       "namespaceListingHash": "#oms19b4f9s3c8tb5skeb8jii95ij35n3hdg038pu6rv5b0fikqe4gd7lnu6a1i6aq5tdh2opdo4s0sfrupvk6vfkr9lf0n752gbl8o0"
   }
+
 GET /api/projects/scratch/branches/main/list?namespace=names&relativeTo=nested
+RESPONSE:
   {
       "namespaceListingChildren": [
           {
@@ -129,4 +132,5 @@ GET /api/projects/scratch/branches/main/list?namespace=names&relativeTo=nested
       "namespaceListingFQN": "nested.names",
       "namespaceListingHash": "#oms19b4f9s3c8tb5skeb8jii95ij35n3hdg038pu6rv5b0fikqe4gd7lnu6a1i6aq5tdh2opdo4s0sfrupvk6vfkr9lf0n752gbl8o0"
   }
+
 ```

--- a/unison-src/transcripts/idempotent/api-summaries.md
+++ b/unison-src/transcripts/idempotent/api-summaries.md
@@ -36,6 +36,7 @@ structural ability Stream s where
 ``` api
 -- term
 GET /api/projects/scratch/branches/main/definitions/terms/by-hash/@qkhkl0n238s1eqibd1ecb8605sqj1m4hpoaag177cu572otqlaf1u28c8suuuqgljdtthsjtr07rv04np05o6oa27ml9105k7uas0t8/summary?name=nat
+RESPONSE:
   {
       "displayName": "nat",
       "hash": "#qkhkl0n238s1eqibd1ecb8605sqj1m4hpoaag177cu572otqlaf1u28c8suuuqgljdtthsjtr07rv04np05o6oa27ml9105k7uas0t8",
@@ -53,8 +54,10 @@ GET /api/projects/scratch/branches/main/definitions/terms/by-hash/@qkhkl0n238s1e
       },
       "tag": "Plain"
   }
+
 -- term without name uses hash
 GET /api/projects/scratch/branches/main/definitions/terms/by-hash/@qkhkl0n238s1eqibd1ecb8605sqj1m4hpoaag177cu572otqlaf1u28c8suuuqgljdtthsjtr07rv04np05o6oa27ml9105k7uas0t8/summary
+RESPONSE:
   {
       "displayName": "#qkhkl0n238s1eqibd1ecb8605sqj1m4hpoaag177cu572otqlaf1u28c8suuuqgljdtthsjtr07rv04np05o6oa27ml9105k7uas0t8",
       "hash": "#qkhkl0n238s1eqibd1ecb8605sqj1m4hpoaag177cu572otqlaf1u28c8suuuqgljdtthsjtr07rv04np05o6oa27ml9105k7uas0t8",
@@ -72,8 +75,10 @@ GET /api/projects/scratch/branches/main/definitions/terms/by-hash/@qkhkl0n238s1e
       },
       "tag": "Plain"
   }
+
 -- doc
 GET /api/projects/scratch/branches/main/definitions/terms/by-hash/@icfnhas71n8q5rm7rmpe51hh7bltsr7rb4lv7qadc4cbsifu1mhonlqj2d7836iar2ptc648q9p4u7hf40ijvld574421b6u8gpu0lo/summary?name=doc
+RESPONSE:
   {
       "displayName": "doc",
       "hash": "#icfnhas71n8q5rm7rmpe51hh7bltsr7rb4lv7qadc4cbsifu1mhonlqj2d7836iar2ptc648q9p4u7hf40ijvld574421b6u8gpu0lo",
@@ -91,8 +96,10 @@ GET /api/projects/scratch/branches/main/definitions/terms/by-hash/@icfnhas71n8q5
       },
       "tag": "Doc"
   }
+
 -- test
 GET /api/projects/scratch/branches/main/definitions/terms/by-hash/@u17p9803hdibisou6rlr1sjbccdossgh7vtkd03ovlvnsl2n91lq94sqhughc62tnrual2jlrfk922sebp4nm22o7m5u9j40emft8r8/summary?name=mytest
+RESPONSE:
   {
       "displayName": "mytest",
       "hash": "#u17p9803hdibisou6rlr1sjbccdossgh7vtkd03ovlvnsl2n91lq94sqhughc62tnrual2jlrfk922sebp4nm22o7m5u9j40emft8r8",
@@ -122,8 +129,10 @@ GET /api/projects/scratch/branches/main/definitions/terms/by-hash/@u17p9803hdibi
       },
       "tag": "Test"
   }
+
 -- function
 GET /api/projects/scratch/branches/main/definitions/terms/by-hash/@6ee6j48hk3eovokflkgbmpbfr3oqj4hedqn8ocg3i4i0ko8j7nls7njjirmnh4k2bg8h95seaot798uuloqk62u2ttiqoceulkbmq2o/summary?name=func
+RESPONSE:
   {
       "displayName": "func",
       "hash": "#6ee6j48hk3eovokflkgbmpbfr3oqj4hedqn8ocg3i4i0ko8j7nls7njjirmnh4k2bg8h95seaot798uuloqk62u2ttiqoceulkbmq2o",
@@ -162,8 +171,10 @@ GET /api/projects/scratch/branches/main/definitions/terms/by-hash/@6ee6j48hk3eov
       },
       "tag": "Plain"
   }
+
 -- constructor
 GET /api/projects/scratch/branches/main/definitions/terms/by-hash/@altimqs66j3dh94dpab5pg7j5adjrndq61n803j7fg0v0ohdiut6or66bu1fiongpd45s5euiuo8ru47b928aqv8osln1ikdeg05hq0@d0/summary?name=Thing.This
+RESPONSE:
   {
       "displayName": "Thing.This",
       "hash": "#altimqs66j3dh94dpab5pg7j5adjrndq61n803j7fg0v0ohdiut6or66bu1fiongpd45s5euiuo8ru47b928aqv8osln1ikdeg05hq0#0",
@@ -202,8 +213,10 @@ GET /api/projects/scratch/branches/main/definitions/terms/by-hash/@altimqs66j3dh
       },
       "tag": "DataConstructor"
   }
+
 -- Long type signature
 GET /api/projects/scratch/branches/main/definitions/terms/by-hash/@ieskgcjjvuegpecq9pbha59ttonke7pf31keeq0jlh31ijkfq00e06fdi36ae90u24pjva6ucqdbedropjgi3g3b75nu76ll5ls8ke8/summary?name=funcWithLongType
+RESPONSE:
   {
       "displayName": "funcWithLongType",
       "hash": "#ieskgcjjvuegpecq9pbha59ttonke7pf31keeq0jlh31ijkfq00e06fdi36ae90u24pjva6ucqdbedropjgi3g3b75nu76ll5ls8ke8",
@@ -389,8 +402,10 @@ GET /api/projects/scratch/branches/main/definitions/terms/by-hash/@ieskgcjjvuegp
       },
       "tag": "Plain"
   }
+
 -- Long type signature with render width
 GET /api/projects/scratch/branches/main/definitions/terms/by-hash/@ieskgcjjvuegpecq9pbha59ttonke7pf31keeq0jlh31ijkfq00e06fdi36ae90u24pjva6ucqdbedropjgi3g3b75nu76ll5ls8ke8/summary?renderWidth=20&name=funcWithLongType
+RESPONSE:
   {
       "displayName": "funcWithLongType",
       "hash": "#ieskgcjjvuegpecq9pbha59ttonke7pf31keeq0jlh31ijkfq00e06fdi36ae90u24pjva6ucqdbedropjgi3g3b75nu76ll5ls8ke8",
@@ -576,8 +591,10 @@ GET /api/projects/scratch/branches/main/definitions/terms/by-hash/@ieskgcjjvuegp
       },
       "tag": "Plain"
   }
+
 -- Builtin Term
 GET /api/projects/scratch/branches/main/definitions/terms/by-hash/@@IO.putBytes.impl.v3/summary?name=putBytesImpl
+RESPONSE:
   {
       "displayName": "putBytesImpl",
       "hash": "##IO.putBytes.impl.v3",
@@ -679,6 +696,7 @@ GET /api/projects/scratch/branches/main/definitions/terms/by-hash/@@IO.putBytes.
       },
       "tag": "Plain"
   }
+
 ```
 
 ## Type Summary APIs
@@ -686,6 +704,7 @@ GET /api/projects/scratch/branches/main/definitions/terms/by-hash/@@IO.putBytes.
 ``` api
 -- data
 GET /api/projects/scratch/branches/main/definitions/types/by-hash/@altimqs66j3dh94dpab5pg7j5adjrndq61n803j7fg0v0ohdiut6or66bu1fiongpd45s5euiuo8ru47b928aqv8osln1ikdeg05hq0/summary?name=Thing
+RESPONSE:
   {
       "displayName": "Thing",
       "hash": "#altimqs66j3dh94dpab5pg7j5adjrndq61n803j7fg0v0ohdiut6or66bu1fiongpd45s5euiuo8ru47b928aqv8osln1ikdeg05hq0",
@@ -723,8 +742,10 @@ GET /api/projects/scratch/branches/main/definitions/types/by-hash/@altimqs66j3dh
       },
       "tag": "Data"
   }
+
 -- data with type args
 GET /api/projects/scratch/branches/main/definitions/types/by-hash/@nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg/summary?name=Maybe
+RESPONSE:
   {
       "displayName": "Maybe",
       "hash": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg",
@@ -772,8 +793,10 @@ GET /api/projects/scratch/branches/main/definitions/types/by-hash/@nirp5os0q69o4
       },
       "tag": "Data"
   }
+
 -- ability
 GET /api/projects/scratch/branches/main/definitions/types/by-hash/@rfi1v9429f9qluv533l2iba77aadttilrpmnhljfapfnfa6sru2nr8ibpqvib9nc4s4nb9s1as45upsfqfqe6ivqi2p82b2vd866it8/summary?name=Stream
+RESPONSE:
   {
       "displayName": "Stream",
       "hash": "#rfi1v9429f9qluv533l2iba77aadttilrpmnhljfapfnfa6sru2nr8ibpqvib9nc4s4nb9s1as45upsfqfqe6ivqi2p82b2vd866it8",
@@ -821,8 +844,10 @@ GET /api/projects/scratch/branches/main/definitions/types/by-hash/@rfi1v9429f9ql
       },
       "tag": "Ability"
   }
+
 -- builtin type
 GET /api/projects/scratch/branches/main/definitions/types/by-hash/@@Nat/summary?name=Nat
+RESPONSE:
   {
       "displayName": "Nat",
       "hash": "##Nat",
@@ -837,4 +862,5 @@ GET /api/projects/scratch/branches/main/definitions/types/by-hash/@@Nat/summary?
       },
       "tag": "Data"
   }
+
 ```

--- a/unison-src/transcripts/idempotent/definition-diff-api.md
+++ b/unison-src/transcripts/idempotent/definition-diff-api.md
@@ -124,6 +124,7 @@ Diff terms
 
 ``` api
 GET /api/projects/scratch/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=term&newTerm=term
+RESPONSE:
   {
       "diff": {
           "contents": [
@@ -632,12 +633,14 @@ GET /api/projects/scratch/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=
       },
       "project": "scratch"
   }
+
 ```
 
 More complex diff
 
 ``` api
 GET /api/projects/scratch/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=take&newTerm=take
+RESPONSE:
   {
       "diff": {
           "contents": [
@@ -3344,12 +3347,14 @@ GET /api/projects/scratch/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=
       },
       "project": "scratch"
   }
+
 ```
 
 Regression test for weird behavior w/r to unit and parens.
 
 ``` api
 GET /api/projects/scratch/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=unitCase&newTerm=unitCase
+RESPONSE:
   {
       "diff": {
           "contents": [
@@ -3972,12 +3977,14 @@ GET /api/projects/scratch/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=
       },
       "project": "scratch"
   }
+
 ```
 
 Diff types
 
 ``` api
 GET /api/projects/scratch/diff/types?oldBranchRef=main&newBranchRef=new&oldType=Type&newType=Type
+RESPONSE:
   {
       "diff": {
           "contents": [
@@ -4220,4 +4227,5 @@ GET /api/projects/scratch/diff/types?oldBranchRef=main&newBranchRef=new&oldType=
       },
       "project": "scratch"
   }
+
 ```

--- a/unison-src/transcripts/idempotent/definition-diff-api.output.md
+++ b/unison-src/transcripts/idempotent/definition-diff-api.output.md
@@ -1,6 +1,0 @@
-:130:3:
-    |
-130 |   {
-    |   ^^
-unexpected "{<newline>      ""
-expecting "--", "GET", "POST", "RESPONSE:", end of input, or spaces

--- a/unison-src/transcripts/idempotent/definition-diff-api.output.md
+++ b/unison-src/transcripts/idempotent/definition-diff-api.output.md
@@ -1,0 +1,6 @@
+:130:3:
+    |
+130 |   {
+    |   ^^
+unexpected "{<newline>      ""
+expecting "--", "GET", "POST", "RESPONSE:", end of input, or spaces

--- a/unison-src/transcripts/idempotent/mcp.md
+++ b/unison-src/transcripts/idempotent/mcp.md
@@ -72,7 +72,7 @@ BODY:
         "projectContext": {
           "projectName": "scratch",
           "branchName": "main"
-        }, "code": "> x = 1 + 2"
+        }, "code": {"text": "> x = 1 + 2"}
       }
     }
   }
@@ -84,7 +84,7 @@ RESPONSE:
       "result": {
           "content": [
               {
-                  "text": "{\"outputMessages\":[\"Loading changes detected in scratch.u.\",\"â\\n\\nscratch.u changed.\\n\\nNow evaluating any watch expressions (lines starting with `>`)... Ctrl+C cancels.\",\"  1 | > x = 1 + 2\\n        â§©\\n        3\"],\"sourceCodeUpdates\":[]}",
+                  "text": "{\"outputMessages\":[\"Loading changes detected in scratch.u.\",\"No changes found.\",\"  1 | > x = 1 + 2\\n        â§©\\n        3\"],\"sourceCodeUpdates\":[]}",
                   "type": "text"
               }
           ],
@@ -195,7 +195,7 @@ RESPONSE:
       "result": {
           "content": [
               {
-                  "text": "{\"outputMessages\":[\"1. builtins/ (657 terms, 96 types)\"],\"sourceCodeUpdates\":[]}",
+                  "text": "{\"outputMessages\":[\"1. builtins/ (755 terms, 118 types)\"],\"sourceCodeUpdates\":[]}",
                   "type": "text"
               }
           ],

--- a/unison-src/transcripts/idempotent/mcp.md
+++ b/unison-src/transcripts/idempotent/mcp.md
@@ -1,0 +1,38 @@
+``` ucm
+scratch/main> builtins.merge
+
+  Done.
+```
+
+``` api
+-- Namespace segment prefix search
+POST /mcp
+BODY:
+  {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "list-project-branches",
+      "arguments": {
+        "projectName": "scratch"
+      }
+    }
+  }
+
+RESPONSE:
+  {
+      "id": 1,
+      "jsonrpc": "2.0",
+      "result": {
+          "content": [
+              {
+                  "text": "{\"outputMessages\":[\"     Branch   Remote branch\\n1.   main     \"],\"sourceCodeUpdates\":[]}",
+                  "type": "text"
+              }
+          ],
+          "isError": false
+      }
+  }
+
+```

--- a/unison-src/transcripts/idempotent/mcp.md
+++ b/unison-src/transcripts/idempotent/mcp.md
@@ -1,11 +1,31 @@
 ``` ucm
-scratch/main> builtins.merge
+scratch/main> builtins.mergeio lib.builtins
 
   Done.
 ```
 
+``` unison :hide
+README = {{
+  This is a scratch project for testing tools in MCP.
+}}
+
+myTerm = 99
+
+type MyType = MyConstructor
+```
+
+``` ucm
+scratch/main> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+```
+
+## list-project-branches
+
 ``` api
--- Namespace segment prefix search
 POST /mcp
 BODY:
   {
@@ -28,6 +48,331 @@ RESPONSE:
           "content": [
               {
                   "text": "{\"outputMessages\":[\"     Branch   Remote branch\\n1.   main     \"],\"sourceCodeUpdates\":[]}",
+                  "type": "text"
+              }
+          ],
+          "isError": false
+      }
+  }
+
+```
+
+## typecheck-code
+
+``` api
+POST /mcp
+BODY:
+  {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "typecheck-code",
+      "arguments": {
+        "projectContext": {
+          "projectName": "scratch",
+          "branchName": "main"
+        }, "code": "> x = 1 + 2"
+      }
+    }
+  }
+
+RESPONSE:
+  {
+      "id": 1,
+      "jsonrpc": "2.0",
+      "result": {
+          "content": [
+              {
+                  "text": "{\"outputMessages\":[\"Loading changes detected in scratch.u.\",\"â\\n\\nscratch.u changed.\\n\\nNow evaluating any watch expressions (lines starting with `>`)... Ctrl+C cancels.\",\"  1 | > x = 1 + 2\\n        â§©\\n        3\"],\"sourceCodeUpdates\":[]}",
+                  "type": "text"
+              }
+          ],
+          "isError": false
+      }
+  }
+
+```
+
+## docs
+
+``` api
+POST /mcp
+BODY:
+  {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "docs",
+      "arguments": {
+        "projectContext": {
+          "projectName": "scratch",
+          "branchName": "main"
+        }, "name": "README"
+      }
+    }
+  }
+
+RESPONSE:
+  {
+      "id": 1,
+      "jsonrpc": "2.0",
+      "result": {
+          "content": [
+              {
+                  "text": "{\"outputMessages\":[\"This is a scratch project for testing tools in MCP.\\n\\n\\n\"],\"sourceCodeUpdates\":[]}",
+                  "type": "text"
+              }
+          ],
+          "isError": false
+      }
+  }
+
+```
+
+## list-project-definitions
+
+``` api
+POST /mcp
+BODY:
+  {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "list-project-definitions",
+      "arguments": {
+        "projectContext": {
+          "projectName": "scratch",
+          "branchName": "main"
+        }
+      }
+    }
+  }
+
+RESPONSE:
+  {
+      "id": 1,
+      "jsonrpc": "2.0",
+      "result": {
+          "content": [
+              {
+                  "text": "{\"content\":[{\"text\":\"{\\\"outputMessages\\\":[\\\"1. myTerm : Nat\\\\n2. type MyType\\\\n3. MyType.MyConstructor : MyType\\\\n4. README : Doc2\\\\n\\\"],\\\"sourceCodeUpdates\\\":[]}\",\"type\":\"text\"}],\"isError\":false}",
+                  "type": "text"
+              }
+          ],
+          "isError": false
+      }
+  }
+
+```
+
+## list-project-libraries
+
+``` api
+POST /mcp
+BODY:
+  {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "list-project-libraries",
+      "arguments": {
+        "projectContext": {
+          "projectName": "scratch",
+          "branchName": "main"
+        }
+      }
+    }
+  }
+
+RESPONSE:
+  {
+      "id": 1,
+      "jsonrpc": "2.0",
+      "result": {
+          "content": [
+              {
+                  "text": "{\"outputMessages\":[\"1. builtins/ (657 terms, 96 types)\"],\"sourceCodeUpdates\":[]}",
+                  "type": "text"
+              }
+          ],
+          "isError": false
+      }
+  }
+
+```
+
+## list-project-branches
+
+``` api
+POST /mcp
+BODY:
+  {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "list-project-branches",
+      "arguments": {
+        "projectName": "scratch"
+      }
+    }
+  }
+
+RESPONSE:
+  {
+      "id": 1,
+      "jsonrpc": "2.0",
+      "result": {
+          "content": [
+              {
+                  "text": "{\"outputMessages\":[\"     Branch   Remote branch\\n1.   main     \"],\"sourceCodeUpdates\":[]}",
+                  "type": "text"
+              }
+          ],
+          "isError": false
+      }
+  }
+
+```
+
+## view-definitions
+
+``` api
+POST /mcp
+BODY:
+  {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "view-definitions",
+      "arguments": {
+        "projectContext": {
+          "projectName": "scratch",
+          "branchName": "main"
+        }, "names": ["myTerm", "MyType"]
+      }
+    }
+  }
+
+RESPONSE:
+  {
+      "id": 1,
+      "jsonrpc": "2.0",
+      "result": {
+          "content": [
+              {
+                  "text": "{\"outputMessages\":[\"type MyType = MyConstructor\\n\\nmyTerm : Nat\\nmyTerm = 99\"],\"sourceCodeUpdates\":[]}",
+                  "type": "text"
+              }
+          ],
+          "isError": false
+      }
+  }
+
+```
+
+## search-definitions-by-name
+
+``` api
+POST /mcp
+BODY:
+  {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "search-definitions-by-name",
+      "arguments": {
+        "projectContext": {
+          "projectName": "scratch",
+          "branchName": "main"
+        }, "query": "my"
+      }
+    }
+  }
+
+RESPONSE:
+  {
+      "id": 1,
+      "jsonrpc": "2.0",
+      "result": {
+          "content": [
+              {
+                  "text": "{\"outputMessages\":[\"1. myTerm : Nat\\n2. type MyType\\n3. MyType.MyConstructor : MyType\\n\"],\"sourceCodeUpdates\":[]}",
+                  "type": "text"
+              }
+          ],
+          "isError": false
+      }
+  }
+
+```
+
+## search-by-type
+
+``` api
+POST /mcp
+BODY:
+  {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "search-by-type",
+      "arguments": {
+        "projectContext": {
+          "projectName": "scratch",
+          "branchName": "main"
+        }, "query": "Nat"
+      }
+    }
+  }
+
+RESPONSE:
+  {
+      "id": 1,
+      "jsonrpc": "2.0",
+      "result": {
+          "content": [
+              {
+                  "text": "{\"outputMessages\":[\"1. myTerm : Nat\\n\"],\"sourceCodeUpdates\":[]}",
+                  "type": "text"
+              }
+          ],
+          "isError": false
+      }
+  }
+
+```
+
+## get-current-project-context
+
+``` api
+POST /mcp
+BODY:
+  {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "get-current-project-context",
+      "arguments": { }
+    }
+  }
+
+RESPONSE:
+  {
+      "id": 1,
+      "jsonrpc": "2.0",
+      "result": {
+          "content": [
+              {
+                  "text": "{\"branchName\":\"main\",\"projectName\":\"scratch\"}",
                   "type": "text"
               }
           ],

--- a/unison-src/transcripts/project-outputs/docs/mcp.output.md
+++ b/unison-src/transcripts/project-outputs/docs/mcp.output.md
@@ -67,7 +67,6 @@ The following defaults should work if you haven't tweaked things, but ensure you
 
 After saving the file, restart the Claude Desktop app. You should now see a new "unison" option in the MCP server list.
 
-
 ## Usage
 
 By default, Claude will now automatically use the Unison MCP server when it deems it appropriate, however

--- a/unison-src/transcripts/project-outputs/docs/mcp.output.md
+++ b/unison-src/transcripts/project-outputs/docs/mcp.output.md
@@ -6,14 +6,50 @@ for projects and definitions, and more\!
 
 ## Setup
 
-### Connecting to a running UCM executable (recommended)
+### MCP as an independent process (Recommended)
 
-To configure the MCP for use with Claude, edit your Claude Desktop config JSON file, which is found:
+This approach allows agents to connect to UCM's MCP server directly via stdin/stdout.
+
+Note that this causes an additional UCM to run as an entirely independent process for each agent you're using.
+
+To configure the MCP for use with Claude (and any tools which read Claude's json config), edit your Claude Desktop config JSON file, which is found:
 
   - On Mac: `~/Library/Application Support/Claude/claude_desktop_config.json`
   - On Windows: `%APPDATA%\Claude\claude_desktop_config.json`
 
-Add the server config as a key in the `mcpServers` mapping there.
+Configure a `unison` key in your `mcpServers` object as below. Replace `<path-to-ucm>` with the path to your `ucm` executable.
+E.g. on Mac this is likely `/opt/homebrew/bin/ucm`, you can run `which ucm` to find your UCM executable path.
+
+``` json
+{
+  "mcpServers": {
+    "unison": {
+      "command": "<path-to-ucm>",
+      "args": ["mcp"]
+    }
+}
+```
+
+E.g. my complete file on Mac looks like this:
+
+``` 
+{
+  "mcpServers": {
+    "unison": {
+      "command": "/opt/homebrew/bin/ucm",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+After saving the file, restart the Claude Desktop app. You should then see a new "unison" option in the MCP server list.
+
+### Connecting to a running UCM executable (not recommended)
+
+If instead you wish to connect an agent to a running UCM executable you can use an HTTP MCP connection.
+This is less consistent than the stdio approach, since some agents have rather poor handling of error states if you close your running UCM, or start
+up an agent without UCM already running.
 
 The following defaults should work if you haven't tweaked things, but ensure you use the correct port and token if you've changed them:
 
@@ -31,38 +67,6 @@ The following defaults should work if you haven't tweaked things, but ensure you
 
 After saving the file, restart the Claude Desktop app. You should now see a new "unison" option in the MCP server list.
 
-### MCP as an independent process
-
-Alternatively you can connect to the MCP using the UCM executable directly via stdin/stdout.
-
-Add the following as a key in the `mcpServers` mapping there. Replace `<path-to-ucm>` with the path to your `ucm` executable.
-E.g. on Mac this is likely `/opt/homebrew/bin/ucm`.
-
-``` json
-{
-  "mcpServers": {
-    "unison": {
-      "command": "<path-to-ucm>",
-      "args": ["mcp"]
-    }
-}
-```
-
-E.g. my complete file on Mac looks like this:
-
-```
-{
-  "mcpServers": {
-    "unison": {
-      "command": "/opt/homebrew/bin/ucm",
-      "args": ["mcp"]
-    }
-  }
-}
-```
-
-Note that this causes the MCP server to run as an entirely separate process.
-If you're also running a UCM instance you may notice that it gets out of sync with changes made by AI agents via MCP.
 
 ## Usage
 

--- a/unison-src/transcripts/project-outputs/docs/mcp.output.md
+++ b/unison-src/transcripts/project-outputs/docs/mcp.output.md
@@ -6,10 +6,34 @@ for projects and definitions, and more\!
 
 ## Setup
 
+### Connecting to a running UCM executable (recommended)
+
 To configure the MCP for use with Claude, edit your Claude Desktop config JSON file, which is found:
 
   - On Mac: `~/Library/Application Support/Claude/claude_desktop_config.json`
   - On Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+
+Add the server config as a key in the `mcpServers` mapping there.
+
+The following defaults should work if you haven't tweaked things, but ensure you use the correct port and token if you've changed them:
+
+``` 
+{
+  "mcpServers": {
+    "unison": {
+      "type": "streamable-http",
+      "url": "http://localhost:5858/codebase/mcp",
+      "note": "Replace 5858 and 'codebase' with your UCM_PORT and UCM_TOKEN respectively if you've changed the defaults."
+    }
+  }
+}
+```
+
+After saving the file, restart the Claude Desktop app. You should now see a new "unison" option in the MCP server list.
+
+### MCP as an independent process
+
+Alternatively you can connect to the MCP using the UCM executable directly via stdin/stdout.
 
 Add the following as a key in the `mcpServers` mapping there. Replace `<path-to-ucm>` with the path to your `ucm` executable.
 E.g. on Mac this is likely `/opt/homebrew/bin/ucm`.
@@ -26,7 +50,7 @@ E.g. on Mac this is likely `/opt/homebrew/bin/ucm`.
 
 E.g. my complete file on Mac looks like this:
 
-``` 
+```
 {
   "mcpServers": {
     "unison": {
@@ -37,7 +61,8 @@ E.g. my complete file on Mac looks like this:
 }
 ```
 
-After saving the file, restart the Claude Desktop app. You should now see a new "unison" option in the MCP server list.
+Note that this causes the MCP server to run as an entirely separate process.
+If you're also running a UCM instance you may notice that it gets out of sync with changes made by AI agents via MCP.
 
 ## Usage
 


### PR DESCRIPTION
## Overview

* Adds support for the mcp http protocol
     * Most agents prefer to use the stdio approach instead (Claude doesn't even support local http servers), and the stdio version is more robust since it doesn't require a UCM to be already running to connect to, but perhaps some agents prefer this method, but it's at least an option now; and it's handy to have for transcript tests.
* Adds transcript tests against the http mcp server
* Refactors the tool setup to something a bit more robust and consistent
* Adds some new tools
* Allows typechecking against a file.
* Upgrades the hs-mcp dependency to a rewrite which _should_ prevent orphaned mcp processes.

## Implementation notes

* Mounts the mcp http server interface at `/codebase/mcp` on the codeserver port.
* Adds `POST` requests to the transcript parser
* Delimits the `BODY:` and `RESPONSE:` in API transcripts accordingly (this improves clarity and also makes parsing easier)

## Test coverage

* Adds transcript tests for the MCP server
