### PR TITLE
Remove old `Doc` syntax

### DIFF
--- a/lib/unison-pretty-printer/src/Unison/Util/SyntaxText.hs
+++ b/lib/unison-pretty-printer/src/Unison/Util/SyntaxText.hs
@@ -47,9 +47,9 @@ data Element r
   | -- ! '
     Parenthesis
   | LinkKeyword -- `typeLink` and `termLink`
-  -- [: :] @[]
+  -- { } @
   | DocDelimiter
-  | -- the 'include' in @[include], etc
+  | -- the 'source' in @source{…}, etc
     DocKeyword
   deriving (Eq, Ord, Show, Functor)
 

--- a/parser-typechecker/src/Unison/Syntax/TermParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermParser.hs
@@ -25,10 +25,8 @@ import Data.List.Extra qualified as List.Extra
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Maybe qualified as Maybe
-import Data.Sequence qualified as Sequence
 import Data.Set qualified as Set
 import Data.Text qualified as Text
-import Data.Tuple.Extra qualified as TupleE
 import Text.Megaparsec qualified as P
 import U.Codebase.Reference (ReferenceType (..))
 import U.Core.ABT qualified as ABT
@@ -67,7 +65,6 @@ import Unison.Type (Type)
 import Unison.Type qualified as Type
 import Unison.Typechecker.Components qualified as Components
 import Unison.Util.Bytes qualified as Bytes
-import Unison.Util.List (intercalateMapWith, quenchRuns)
 import Unison.Util.Recursion
 import Unison.Var (Var)
 import Unison.Var qualified as Var
@@ -145,17 +142,6 @@ termLink' = do
     s
       | Set.size s == 1 -> pure $ const (Set.findMin s) <$> id
       | otherwise -> customFailure $ UnknownTerm id s
-
-link' :: (Monad m, Var v) => P v m (Either (L.Token TypeReference) (L.Token Referent))
-link' = do
-  id <- hqPrefixId
-  ns <- asks names
-  let s = Names.lookupHQTerm Names.IncludeSuffixes (L.payload id) ns
-  let s2 = Names.lookupHQType Names.IncludeSuffixes (L.payload id) ns
-  if
-    | Set.size s == 1 && Set.null s2 -> pure . Right $ Set.findMin s <$ id
-    | Set.size s2 == 1 && Set.null s -> pure . Left $ Set.findMin s2 <$ id
-    | True -> customFailure $ UnknownId id s s2
 
 link :: (Monad m, Var v) => TermP v m
 link = termLink <|> typeLink
@@ -667,7 +653,6 @@ termLeaf =
       delayQuote,
       (snd <$> delayBlock),
       bang,
-      docBlock,
       doc2Block <&> \(spanAnn, trm) -> trm {ABT.annotation = ABT.annotation trm <> spanAnn}
     ]
 
@@ -855,66 +840,6 @@ doc2Block = do
     docGroup d (Doc.Group (Doc.Join leaves)) =
       Term.app d (f d "Group") . Term.app d (f d "Join") . Term.list (ann leaves) $ toList leaves
 
-docBlock :: (Monad m, Var v) => TermP v m
-docBlock = do
-  openTok <- openBlockWith "[:"
-  segs <- many segment
-  closeTok <- closeBlock
-  let a = ann openTok <> ann closeTok
-  pure . docNormalize $ Term.app a (Term.constructor a (ConstructorReference DD.docRef DD.docJoinId)) (Term.list a segs)
-  where
-    segment = blob <|> linky
-    blob = do
-      s <- string
-      pure $
-        Term.app
-          (ann s)
-          (Term.constructor (ann s) (ConstructorReference DD.docRef DD.docBlobId))
-          (Term.text (ann s) (L.payload s))
-    linky = asum [include, signature, evaluate, source, link]
-    include = do
-      _ <- P.try (reserved "include")
-      hashQualifiedPrefixTerm
-    signature = do
-      _ <- P.try (reserved "signature")
-      tok <- termLink'
-      pure $
-        Term.app
-          (ann tok)
-          (Term.constructor (ann tok) (ConstructorReference DD.docRef DD.docSignatureId))
-          (Term.termLink (ann tok) (L.payload tok))
-    evaluate = do
-      _ <- P.try (reserved "evaluate")
-      tok <- termLink'
-      pure $
-        Term.app
-          (ann tok)
-          (Term.constructor (ann tok) (ConstructorReference DD.docRef DD.docEvaluateId))
-          (Term.termLink (ann tok) (L.payload tok))
-    source = do
-      _ <- P.try (reserved "source")
-      l <- link''
-      pure $
-        Term.app
-          (ann l)
-          (Term.constructor (ann l) (ConstructorReference DD.docRef DD.docSourceId))
-          l
-    link'' = either ty t <$> link'
-      where
-        t tok =
-          Term.app
-            (ann tok)
-            (Term.constructor (ann tok) (ConstructorReference DD.linkRef DD.linkTermId))
-            (Term.termLink (ann tok) (L.payload tok))
-        ty tok =
-          Term.app
-            (ann tok)
-            (Term.constructor (ann tok) (ConstructorReference DD.linkRef DD.linkTypeId))
-            (Term.typeLink (ann tok) (L.payload tok))
-    link = d <$> link''
-      where
-        d tm = Term.app (ann tm) (Term.constructor (ann tm) (ConstructorReference DD.docRef DD.docLinkId)) tm
-
 -- Used by unbreakParas within docNormalize.  Doc literals are a joined sequence
 -- segments.  This type describes a property of a segment.
 data UnbreakCase
@@ -926,298 +851,6 @@ data UnbreakCase
   | -- Ends with "\nsomething", i.e. introduces an unindented line.
     StartsUnindented
   deriving (Eq, Show)
-
--- Doc literal normalization
---
--- This normalization allows the pretty-printer and doc display code to do
--- indenting, and to do line-wrap of paragraphs, but without the inserted
--- newlines being then frozen into the text for ever more over subsequent
--- edit/update cycles.
---
--- The alternative would be to stop line-wrapping docs on view/display by adding
--- newlines in the pretty-printer, and instead leave wrapping to the
--- terminal/editor.  Might be worth considering if this code ends up being
--- too buggy and fragile to maintain.  Maybe display could add newlines,
--- and view could refrain from doing so.
---
--- Operates on the text of the Blobs within a doc (as parsed by docBlock):
--- - reduces the whitespace after all newlines so that at least one of the
---   non-initial lines has zero indent (important because the pretty-printer adds
---   indenting when displaying doc literals)
--- - removes trailing whitespace from each line
--- - removes newlines between any sequence of non-empty zero-indent lines
---   (i.e. undo line-breaking within paragraphs).
---
--- Should be understood in tandem with Util.Pretty.paragraphyText, which
--- outputs doc text for display/edit/view.
--- See also unison-src/transcripts/doc-formatting.md.
---
--- There is some heuristic/approximate logic in here - see the comment flagged
--- with ** below.
---
--- This function is a bit painful - it's trying to act on a sequence of lines,
--- but that sequence is split up between the various blobs in the doc, which
--- are separated by the elements tracking things like @[source] etc.  It
--- would be simplified if the doc representation was something like
--- [Either Char EnrichedElement].
---
--- This function has some tracing which you can enable by deleting some calls to
--- 'const id' below.
-docNormalize :: (Ord v, Show v) => Term v a -> Term v a
-docNormalize tm = case tm of
-  -- This pattern is just `DD.DocJoin seqs`, but exploded in order to grab
-  -- the annotations.  The aim is just to map `normalize` over it.
-  a@(Term.App' c@(Term.Constructor' (ConstructorReference DD.DocRef DD.DocJoinId)) s@(Term.List' seqs)) ->
-    join
-      (ABT.annotation a)
-      (ABT.annotation c)
-      (ABT.annotation s)
-      (normalize seqs)
-    where
-
-  _ -> error $ "unexpected doc structure: " ++ show tm
-  where
-    normalize =
-      Sequence.fromList
-        . (map TupleE.fst3)
-        . (tracing "after unbreakParas")
-        . unbreakParas
-        . (tracing "after full preprocess")
-        . preProcess
-        . (tracing "after unindent")
-        . unIndent
-        . (tracing "initial parse")
-        . miniPreProcess
-    preProcess xs =
-      zip3
-        seqs
-        (lineStarteds $ Sequence.fromList seqs)
-        (followingLines $ Sequence.fromList seqs)
-      where
-        seqs = map fst xs
-    miniPreProcess seqs = zip (toList seqs) (lineStarteds seqs)
-    unIndent ::
-      (Ord v) =>
-      [(Term v a, UnbreakCase)] ->
-      [(Term v a, UnbreakCase)]
-    unIndent tms = map go tms
-      where
-        go (b, previous) =
-          ((mapBlob $ (reduceIndent includeFirst minIndent)) b, previous)
-          where
-            -- Since previous was calculated before unindenting, it will often be wrongly
-            -- StartsIndented instead of StartsUnindented - but that's OK just for the test
-            -- below.  And we'll recalculate it later in preProcess.
-            includeFirst = previous == LineEnds
-        concatenatedBlobs :: Text
-        concatenatedBlobs = mconcat (toList (fmap (getBlob . fst) tms))
-        getBlob (DD.DocBlob txt) = txt
-        getBlob _ = "."
-        -- Note we exclude the first line when calculating the minimum indent - the lexer
-        -- already stripped leading spaces from it, and anyway it would have been sharing
-        -- its line with the [: and maybe other stuff.
-        nonInitialNonEmptyLines =
-          filter (not . Text.null) $
-            map Text.stripEnd $
-              drop 1 $
-                Text.lines
-                  concatenatedBlobs
-        minIndent =
-          minimumOrZero $
-            map
-              (Text.length . (Text.takeWhile Char.isSpace))
-              nonInitialNonEmptyLines
-        minimumOrZero xs = if length xs == 0 then 0 else minimum xs
-        reduceIndent :: Bool -> Int -> Text -> Text
-        reduceIndent includeFirst n t =
-          fixup $
-            Text.unlines $
-              mapExceptFirst reduceLineIndent onFirst $
-                Text.lines t
-          where
-            onFirst = if includeFirst then reduceLineIndent else id
-            reduceLineIndent l = result
-              where
-                currentIndent = Text.length $ (Text.takeWhile Char.isSpace) l
-                remainder = (Text.dropWhile Char.isSpace) l
-                newIndent = maximum [0, currentIndent - n]
-                result = Text.replicate newIndent " " `mappend` remainder
-            -- unlines . lines adds a trailing newline if one was not present: undo that.
-            fixup = if Text.takeEnd 1 t == "\n" then id else Text.dropEnd 1
-    -- Remove newlines between any sequence of non-empty zero-indent lines.
-    -- This is made more complicated by Doc elements (e.g. links) which break up a
-    -- blob but don't break a line of output text**.  We sometimes need to refer back to the
-    -- previous blob to see whether a newline is between two zero-indented lines.
-    -- For example...
-    -- "This link to @foo makes it harder to see\n
-    --  that the newline should be removed."
-    -- Whether an element does this (breaks a blob but not a line of output text) really
-    -- depends on some things we don't know here: does an @[include] target doc occupy
-    -- just one line or several; whether this doc is going to be viewed or displayed.
-    -- So we'll get it wrong sometimes.  The impact of this is that we may sometimes
-    -- misjudge whether a newline is separating two non-indented lines, and should therefore
-    -- be removed.
-    unbreakParas ::
-      (Show v, Ord v) =>
-      [(Term v a, UnbreakCase, Bool)] ->
-      [(Term v a, UnbreakCase, Bool)]
-    unbreakParas = map go
-      where
-        -- 'candidate' means 'candidate to be joined with an adjacent line as part of a
-        -- paragraph'.
-        go (b, previous, nextIsCandidate) =
-          (mapBlob go b, previous, nextIsCandidate)
-          where
-            go txt = if Text.null txt then txt else tr result'
-              where
-                tr =
-                  const id $
-                    trace $
-                      "\nprocessElement on blob "
-                        ++ (show txt)
-                        ++ ", result' = "
-                        ++ (show result')
-                        ++ ", lines: "
-                        ++ (show ls)
-                        ++ ", candidates = "
-                        ++ (show candidates)
-                        ++ ", previous = "
-                        ++ (show previous)
-                        ++ ", firstIsCandidate = "
-                        ++ (show firstIsCandidate)
-                        ++ "\n\n"
-                -- remove trailing whitespace
-                -- ls is non-empty thanks to the Text.null check above
-                -- Don't cut the last line's trailing whitespace - there's an assumption here
-                -- that it's followed by something which will put more text on the same line.
-                ls = mapExceptLast Text.stripEnd id $ Text.lines txt
-                -- Work out which lines are candidates to be joined as part of a paragraph, i.e.
-                -- are not indented.
-                candidate l = case Text.uncons l of
-                  Just (initial, _) -> not . Char.isSpace $ initial
-                  Nothing -> False -- empty line
-                  -- The segment of this blob that runs up to the first newline may not itself
-                  -- be the start of a line of the doc - for example if it's preceded by a link.
-                  -- So work out whether the line of which it is a part is a candidate.
-                firstIsCandidate = case previous of
-                  LineEnds -> candidate (head ls)
-                  StartsIndented -> False
-                  StartsUnindented -> True
-                candidates = firstIsCandidate : (tail (map candidate ls))
-                result = mconcat $ intercalateMapWith sep fst (zip ls candidates)
-                sep (_, candidate1) (_, candidate2) =
-                  if candidate1 && candidate2 then " " else "\n"
-                -- Text.lines forgets whether there was a trailing newline.
-                -- If there was one, then either add it back or convert it to a space.
-                result' =
-                  if (Text.takeEnd 1 txt) == "\n"
-                    then
-                      if (last candidates) && nextIsCandidate
-                        then result `Text.append` " "
-                        else result `Text.append` "\n"
-                    else result
-    -- A list whose entries match those of tms.  `Nothing` is used for elements
-    -- which just continue a line, and so need to be ignored when looking back
-    -- for how the last line started.  Otherwise describes whether the last
-    -- line of this entry is indented (or maybe terminated by a newline.)
-    -- A value of `Nothing` protects ensuing text from having its leading
-    -- whitespace removed by `unindent`.
-    -- Note that some elements render over multiple lines when displayed.
-    -- See test2 in transcript doc-formatting.md for an example of how
-    -- this looks when there is whitespace immediately following @[source]
-    -- or @[evaluate].
-    lastLines :: (Show v) => Sequence.Seq (Term v a) -> [Maybe UnbreakCase]
-    lastLines tms = (flip fmap) (toList tms) $ \case
-      DD.DocBlob txt -> unbreakCase txt
-      DD.DocLink _ -> Nothing
-      DD.DocSource _ -> Nothing
-      DD.DocSignature _ -> Nothing
-      DD.DocEvaluate _ -> Nothing
-      Term.Var' _ -> Nothing -- @[include]
-      e@_ -> error ("unexpected doc element: " ++ show e)
-    -- Work out whether the last line of this blob is indented (or maybe
-    -- terminated by a newline.)
-    unbreakCase :: Text -> Maybe UnbreakCase
-    unbreakCase txt =
-      let (startAndNewline, afterNewline) = Text.breakOnEnd "\n" txt
-       in if Text.null startAndNewline
-            then Nothing
-            else
-              if Text.null afterNewline
-                then Just LineEnds
-                else
-                  if Char.isSpace (Text.head afterNewline)
-                    then Just StartsIndented
-                    else Just StartsUnindented
-    -- A list whose entries match those of tms.  Describes how the current
-    -- line started (the line including the start of this entry) - or LineEnds
-    -- if this entry is starting a line itself.
-    -- Calculated as the UnbreakCase of the previous entry that included a newline.
-    -- Really there's a function of type (a -> Bool) -> a -> [a] -> [a] in here
-    -- fighting to break free - overwriting elements that are 'shadowed' by
-    -- a preceding element for which the predicate is true, with a copy of
-    -- that element.
-    lineStarteds :: (Show v) => Sequence.Seq (Term v a) -> [UnbreakCase]
-    lineStarteds tms = tr $ quenchRuns LineEnds StartsUnindented $ xs''
-      where
-        tr =
-          const id $
-            trace $
-              "lineStarteds: xs = "
-                ++ (show xs)
-                ++ ", xss = "
-                ++ (show xss)
-                ++ ", xs' = "
-                ++ (show xs')
-                ++ ", xs'' = "
-                ++ (show xs'')
-                ++ "\n\n"
-        -- Make sure there's a Just at the start of the list so we always find
-        -- one when searching back.
-        -- Example: xs = [J1,N2,J3]
-        xs :: [Maybe UnbreakCase]
-        xs = Just LineEnds : (lastLines tms)
-        -- Example: xss = [[J1],[J1,N2],[J1,N2,J3]]
-        xss :: [[Maybe UnbreakCase]]
-        xss = drop 1 $ List.inits xs
-        -- Example: after each step of the map...
-        --            [[J1],[N2,J1],[J3,N2,J1]]   -- after reverse
-        --            [Just J1, Just J1, Just J3] -- after find
-        --            ...
-        --   result = [1,1,3]
-        xs' =
-          map (Maybe.fromJust . Maybe.fromJust . (List.find isJust) . reverse) xss
-        xs'' = List.Extra.dropEnd 1 xs'
-    -- For each element, can it be a line-continuation of a preceding blob?
-    continuesLine :: Sequence.Seq (Term v a) -> [Bool]
-    continuesLine tms = (flip fmap) (toList tms) \case
-      DD.DocBlob _ -> False -- value doesn't matter - you don't get adjacent blobs
-      DD.DocLink _ -> True
-      DD.DocSource _ -> False
-      DD.DocSignature _ -> False
-      DD.DocEvaluate _ -> False
-      Term.Var' _ -> False -- @[include]
-      _ -> error ("unexpected doc element" ++ show tm)
-    -- A list whose entries match those of tms.  Can the subsequent entry by a
-    -- line continuation of this one?
-    followingLines tms = drop 1 ((continuesLine tms) ++ [False])
-    mapExceptFirst :: (a -> b) -> (a -> b) -> [a] -> [b]
-    mapExceptFirst fRest fFirst = \case
-      [] -> []
-      x : rest -> (fFirst x) : (map fRest rest)
-    mapExceptLast fRest fLast = reverse . (mapExceptFirst fRest fLast) . reverse
-    tracing :: (Show a) => [Char] -> a -> a
-    tracing when x =
-      (const id $ trace ("at " ++ when ++ ": " ++ (show x) ++ "\n")) x
-    blob aa ac at txt =
-      Term.app aa (Term.constructor ac (ConstructorReference DD.docRef DD.docBlobId)) (Term.text at txt)
-    join aa ac as segs =
-      Term.app aa (Term.constructor ac (ConstructorReference DD.docRef DD.docJoinId)) (Term.list' as segs)
-    mapBlob :: (Ord v) => (Text -> Text) -> Term v a -> Term v a
-    -- this pattern is just `DD.DocBlob txt` but exploded to capture the annotations as well
-    mapBlob f (aa@(Term.App' ac@(Term.Constructor' (ConstructorReference DD.DocRef DD.DocBlobId)) at@(Term.Text' txt))) =
-      blob (ABT.annotation aa) (ABT.annotation ac) (ABT.annotation at) (f txt)
-    mapBlob _ t = t
 
 delayQuote :: (Monad m, Var v) => TermP v m
 delayQuote = P.label "quote" do

--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -129,7 +129,7 @@ data InfixContext
   deriving (Eq, Show)
 
 data DocLiteralContext
-  = -- We won't try and render this ABT node or anything under it as a [: @Doc literal :]
+  = -- We won't try and render this ABT node or anything under it as a {{ {type Doc} literal }}
     NoDoc
   | -- We'll keep checking as we recurse down
     MaybeDoc
@@ -1115,36 +1115,35 @@ isDocLiteral term = case term of
 prettyDoc :: (Var v) => PrettyPrintEnv -> Imports -> Term3 v a -> Pretty SyntaxText
 prettyDoc n im term =
   mconcat
-    [ fmt S.DocDelimiter $ l "[: ",
+    [ fmt S.DocDelimiter $ l "{{ ",
       go term,
       spaceUnlessBroken,
-      fmt S.DocDelimiter $ l ":]"
+      fmt S.DocDelimiter $ l "}}"
     ]
   where
     go (DD.DocJoin segs) = foldMap go segs
     go (DD.DocBlob txt) = PP.paragraphyText (escaped txt)
     go (DD.DocLink (DD.LinkTerm (TermLink' r))) =
-      fmt S.DocDelimiter (l "@") <> (fmt $ S.TermReference r) (fmtTerm r)
+      curlyRef . fmt (S.TermReference r) $ fmtTerm r
     go (DD.DocLink (DD.LinkType (TypeLink' r))) =
-      fmt S.DocDelimiter (l "@") <> (fmt $ S.TypeReference r) (fmtType r)
+      curlyRef $ fmt S.DocKeyword (l "type ") <> fmt (S.TypeReference r) (fmtType r)
     go (DD.DocSource (DD.LinkTerm (TermLink' r))) =
-      atKeyword "source" <> fmtTerm r
+      atKeyword "source" $ fmtTerm r
     go (DD.DocSource (DD.LinkType (TypeLink' r))) =
-      atKeyword "source" <> fmtType r
+      atKeyword "source" $ fmtType r
     go (DD.DocSignature (TermLink' r)) =
-      atKeyword "signature" <> fmtTerm r
+      atKeyword "signature" $ fmtTerm r
     go (DD.DocEvaluate (TermLink' r)) =
-      atKeyword "evaluate" <> fmtTerm r
-    go (Ref' r) = atKeyword "include" <> fmtTerm (Referent.Ref r)
+      atKeyword "eval" $ fmtTerm r
+    go (Ref' r) = curlyRef . curlyRef . fmtTerm $ Referent.Ref r
     go _ = l $ "(invalid doc literal: " ++ show term ++ ")"
     fmtName s = styleHashQualified'' (fmt $ S.HashQualifier s) $ elideFQN im s
     fmtTerm r = fmtName $ PrettyPrintEnv.termName n r
     fmtType r = fmtName $ PrettyPrintEnv.typeName n r
-    atKeyword w =
-      fmt S.DocDelimiter (l "@[")
-        <> fmt S.DocKeyword (l w)
-        <> fmt S.DocDelimiter (l "] ")
-    escaped = Text.replace "@" "\\@" . Text.replace ":]" "\\:]"
+    atKeyword w content =
+      fmt S.DocDelimiter (l "@") <> fmt S.DocKeyword (l w) <> curlyRef content
+    curlyRef content = fmt S.DocDelimiter (l "{") <> content <> fmt S.DocDelimiter (l "}")
+    escaped = Text.replace "{{" "`{{`" . Text.replace "}}" "`}}`"
     spaceUnlessBroken = PP.orElse " " ""
 
 paren :: Bool -> Pretty SyntaxText -> Pretty SyntaxText

--- a/unison-share-api/src/Unison/Server/Syntax.hs
+++ b/unison-share-api/src/Unison/Server/Syntax.hs
@@ -147,7 +147,7 @@ data Element
   | -- ! '
     Parenthesis
   | LinkKeyword -- `typeLink` and `termLink`
-  -- [: :] @[]
+  -- { } @
   | DocDelimiter
   | -- the 'include' in @[include], etc
     DocKeyword

--- a/unison-src/transcripts/hello.md
+++ b/unison-src/transcripts/hello.md
@@ -1,7 +1,7 @@
 # Hello!
 
-``` ucm :hide
-scratch/main> builtins.merge
+```ucm :hide
+scratch/main> builtins.mergeio
 ```
 
 This markdown file is also a Unison transcript file. Transcript files are an easy way to create self-documenting Unison programs, libraries, and tutorials.
@@ -54,8 +54,8 @@ scratch/main> rename.term x answerToUltimateQuestionOfLife
 
 Doing `unison :hide-all` hides the block altogether, both input and output - this is useful for doing behind-the-scenes control of `ucm`'s state.
 
-``` unison :hide-all
-> [: you won't see me :]
+```unison :hide-all
+> {{ you won't see me }}
 ```
 
 ## Expecting failures

--- a/unison-src/transcripts/hello.output.md
+++ b/unison-src/transcripts/hello.output.md
@@ -1,7 +1,7 @@
 # Hello\!
 
 ``` ucm :hide
-scratch/main> builtins.merge
+scratch/main> builtins.mergeio
 ```
 
 This markdown file is also a Unison transcript file. Transcript files are an easy way to create self-documenting Unison programs, libraries, and tutorials.

--- a/unison-src/transcripts/idempotent/doc-formatting.md
+++ b/unison-src/transcripts/idempotent/doc-formatting.md
@@ -3,13 +3,13 @@ This transcript explains a few minor details about doc parsing and pretty-printi
 Docs can be used as inline code comments.
 
 ``` ucm :hide
-scratch/main> builtins.merge
+scratch/main> builtins.mergeio
 ```
 
 ``` unison
 foo : Nat -> Nat
 foo n =
-  _ = [: do the thing :]
+  _ = {{ do the thing }}
   n + 1
 ```
 
@@ -38,10 +38,10 @@ scratch/main> view foo
     n + 1
 ```
 
-Note that `@` and `:]` must be escaped within docs.
+Note that `{{` and `}}` must be escaped within docs.
 
 ``` unison
-escaping = [: Docs look [: like \@this \:] :]
+escaping = {{ Docs look `{{ like {this} }}` }}
 ```
 
 ``` ucm :added-by-ucm
@@ -52,7 +52,7 @@ escaping = [: Docs look [: like \@this \:] :]
 
     ⍟ New definitions:
     
-      escaping : Doc
+      escaping : Doc2
 ```
 
 ``` ucm :hide
@@ -62,20 +62,20 @@ scratch/main> add
 ``` ucm
 scratch/main> view escaping
 
-  escaping : Doc
-  escaping = {{ Docs look [: like @this :] }}
+  escaping : Doc2
+  escaping = {{ Docs look `{{ like {this} }}` }}
 ```
 
-(Alas you can't have `\@` or `\:]` in your doc, as there's currently no way to 'unescape' them.)
+(Alas you can't have `\}}` in your doc, as there's currently no way to 'unescape' it.)
 
 ``` unison
 -- Note that -- comments are preserved within doc literals.
-commented = [:
+commented = {{
   example:
 
     -- a comment
     f x = x + 1
-:]
+}}
 ```
 
 ``` ucm :added-by-ucm
@@ -86,7 +86,7 @@ commented = [:
 
     ⍟ New definitions:
     
-      commented : Doc
+      commented : Doc2
 ```
 
 ``` ucm :hide
@@ -96,12 +96,13 @@ scratch/main> add
 ``` ucm
 scratch/main> view commented
 
-  commented : Doc
+  commented : Doc2
   commented =
-    {{ example:
+    {{
+    example:
     
     -- a comment f x = x + 1
-     }}
+    }}
 ```
 
 ### Indenting, and paragraph reflow
@@ -112,7 +113,7 @@ Handling of indenting in docs between the parser and pretty-printer is a bit fid
 -- The leading and trailing spaces are stripped from the stored Doc by the
 -- lexer, and one leading and trailing space is inserted again on view/edit
 -- by the pretty-printer.
-doc1 = [:   hi   :]
+doc1 = {{   hi   }}
 ```
 
 ``` ucm :added-by-ucm
@@ -123,7 +124,7 @@ doc1 = [:   hi   :]
 
     ⍟ New definitions:
     
-      doc1 : Doc
+      doc1 : Doc2
 ```
 
 ``` ucm :hide
@@ -133,20 +134,21 @@ scratch/main> add
 ``` ucm
 scratch/main> view doc1
 
-  doc1 : Doc
+  doc1 : Doc2
   doc1 = {{ hi }}
 ```
 
 ``` unison
--- Lines (apart from the first line, i.e. the bit between the [: and the
+-- Lines (apart from the first line, i.e. the bit between the {{ and the
 -- first newline) are unindented until at least one of
 -- them hits the left margin (by a post-processing step in the parser).
 -- You may not notice this because the pretty-printer indents them again on
 -- view/edit.
-doc2 = [: hello
+doc2 = {{ hello
+
             - foo
             - bar
-          and the rest. :]
+          and the rest. }}
 ```
 
 ``` ucm :added-by-ucm
@@ -157,7 +159,7 @@ doc2 = [: hello
 
     ⍟ New definitions:
     
-      doc2 : Doc
+      doc2 : Doc2
 ```
 
 ``` ucm :hide
@@ -167,16 +169,20 @@ scratch/main> add
 ``` ucm
 scratch/main> view doc2
 
-  doc2 : Doc
+  doc2 : Doc2
   doc2 =
-    {{ hello
-      - foo
-      - bar
-    and the rest. }}
+    {{
+    hello
+    
+    * foo
+    * bar
+    
+    and the rest.
+    }}
 ```
 
 ``` unison
-doc3 = [: When Unison identifies a paragraph, it removes any newlines from it before storing it, and then reflows the paragraph text to fit the display window on display/view/edit.
+doc3 = {{ When Unison identifies a paragraph, it removes any newlines from it before storing it, and then reflows the paragraph text to fit the display window on display/view/edit.
 
 For these purposes, a paragraph is any sequence of non-empty lines that have zero indent (after the unindenting mentioned above.)
 
@@ -187,7 +193,7 @@ For these purposes, a paragraph is any sequence of non-empty lines that have zer
    is not treated | either.
 
 Note that because of the special treatment of the first line mentioned above, where its leading space is removed, it is always treated as a paragraph.
-   :]
+   }}
 ```
 
 ``` ucm :added-by-ucm
@@ -198,7 +204,7 @@ Note that because of the special treatment of the first line mentioned above, wh
 
     ⍟ New definitions:
     
-      doc3 : Doc
+      doc3 : Doc2
 ```
 
 ``` ucm :hide
@@ -208,35 +214,34 @@ scratch/main> add
 ``` ucm
 scratch/main> view doc3
 
-  doc3 : Doc
+  doc3 : Doc2
   doc3 =
-    {{ When Unison identifies a paragraph, it removes any 
-    newlines from it before storing it, and then reflows the 
-    paragraph text to fit the display window on 
-    display/view/edit.
+    {{
+    When Unison identifies a paragraph, it removes any newlines
+    from it before storing it, and then reflows the paragraph
+    text to fit the display window on display/view/edit.
     
     For these purposes, a paragraph is any sequence of non-empty
     lines that have zero indent (after the unindenting mentioned
     above.)
     
-     - So this is not a paragraph, even
-       though you might want it to be.
+    * So this is not a paragraph, even though you might want it
+      to be.
     
-       And this text  | as a paragraph
-       is not treated | either.
+    And this text | as a paragraph is not treated | either.
     
     Note that because of the special treatment of the first line
-    mentioned above, where its leading space is removed, it is 
+    mentioned above, where its leading space is removed, it is
     always treated as a paragraph.
     }}
 ```
 
 ``` unison
-doc4 = [: Here's another example of some paragraphs.
+doc4 = {{ Here's another example of some paragraphs.
 
           All these lines have zero indent.
 
-            - Apart from this one. :]
+            - Apart from this one. }}
 ```
 
 ``` ucm :added-by-ucm
@@ -247,7 +252,7 @@ doc4 = [: Here's another example of some paragraphs.
 
     ⍟ New definitions:
     
-      doc4 : Doc
+      doc4 : Doc2
 ```
 
 ``` ucm :hide
@@ -257,23 +262,25 @@ scratch/main> add
 ``` ucm
 scratch/main> view doc4
 
-  doc4 : Doc
+  doc4 : Doc2
   doc4 =
-    {{ Here's another example of some paragraphs.
+    {{
+    Here's another example of some paragraphs.
     
     All these lines have zero indent.
     
-      - Apart from this one. }}
+    * Apart from this one.
+    }}
 ```
 
 ``` unison
 -- The special treatment of the first line does mean that the following
 -- is pretty-printed not so prettily.  To fix that we'd need to get the
 -- lexer to help out with interpreting doc literal indentation (because
--- it knows what columns the `[:` was in.)
-doc5 = [:   - foo
+-- it knows what columns the `{{` was in.)
+doc5 = {{   - foo
             - bar
-          and the rest. :]
+          and the rest. }}
 ```
 
 ``` ucm :added-by-ucm
@@ -284,7 +291,7 @@ doc5 = [:   - foo
 
     ⍟ New definitions:
     
-      doc5 : Doc
+      doc5 : Doc2
 ```
 
 ``` ucm :hide
@@ -294,20 +301,23 @@ scratch/main> add
 ``` ucm
 scratch/main> view doc5
 
-  doc5 : Doc
+  doc5 : Doc2
   doc5 =
-    {{ - foo
-      - bar
-    and the rest. }}
+    {{
+    * foo
+    * bar
+    
+    and the rest.
+    }}
 ```
 
 ``` unison
 -- You can do the following to avoid that problem.
-doc6 = [:
+doc6 = {{
             - foo
             - bar
           and the rest.
-       :]
+       }}
 ```
 
 ``` ucm :added-by-ucm
@@ -318,7 +328,8 @@ doc6 = [:
 
     ⍟ New definitions:
     
-      doc6 : Doc
+      doc6 : Doc2
+        (also named doc5)
 ```
 
 ``` ucm :hide
@@ -328,19 +339,21 @@ scratch/main> add
 ``` ucm
 scratch/main> view doc6
 
-  doc6 : Doc
+  doc6 : Doc2
   doc6 =
-    {{ - foo
-      - bar
+    {{
+    * foo
+    * bar
+    
     and the rest.
-     }}
+    }}
 ```
 
 ### More testing
 
 ``` unison
 -- Check empty doc works.
-empty = [::]
+empty = {{}}
 
 expr = foo 1
 ```
@@ -353,7 +366,7 @@ expr = foo 1
 
     ⍟ New definitions:
     
-      empty : Doc
+      empty : Doc2
       expr  : Nat
 ```
 
@@ -364,48 +377,52 @@ scratch/main> add
 ``` ucm
 scratch/main> view empty
 
-  empty : Doc
+  empty : Doc2
   empty = {{  }}
 ```
 
 ``` unison
-test1 = [:
-The internal logic starts to get hairy when you use the \@ features, for example referencing a name like @List.take.  Internally, the text between each such usage is its own blob (blob ends here --> @List.take), so paragraph reflow has to be aware of multiple blobs to do paragraph reflow (or, more accurately, to do the normalization step where newlines with a paragraph are removed.)
+test1 = {{
+The internal logic starts to get hairy when you use the reference features, for example referencing a name like {List.take}.  Internally, the text between each such usage is its own blob (blob ends here --> {List.take}), so paragraph reflow has to be aware of multiple blobs to do paragraph reflow (or, more accurately, to do the normalization step where newlines with a paragraph are removed.)
 
-Para to reflow: lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor ending in ref @List.take
+Para to reflow: lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor ending in ref {List.take}
 
-@List.take starting para lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor.
+{List.take} starting para lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor.
 
-Middle of para: lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor @List.take lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor.
+Middle of para: lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor {List.take} lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor.
 
-  - non-para line (@List.take) with ref @List.take
+  - non-para line ({List.take}) with ref {List.take}
   Another non-para line
-  @List.take starting non-para line
 
-  - non-para line with ref @List.take
+  {List.take} starting non-para line
+
+  - non-para line with ref {List.take}
 before a para-line lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor.
 
   - non-para line followed by a para line starting with ref
-@List.take lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor.
+{List.take} lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor.
 
-a para-line ending with ref lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor @List.take
+a para-line ending with ref lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor {List.take}
+
   - non-para line
 
 para line lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor
-  @List.take followed by non-para line starting with ref.
 
-@[signature] List.take
+  {List.take} followed by non-para line starting with ref.
 
-@[source] foo
+@signature{List.take}
 
-@[evaluate] expr
+@source{foo}
 
-@[include] doc1
+@eval{expr}
+
+{{doc1}}
 
 -- note the leading space below
-  @[signature] List.take
 
-:]
+  @signature{List.take}
+
+}}
 ```
 
 ``` ucm :added-by-ucm
@@ -416,7 +433,7 @@ para line lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolo
 
     ⍟ New definitions:
     
-      test1 : Doc
+      test1 : Doc2
 ```
 
 ``` ucm :hide
@@ -426,70 +443,78 @@ scratch/main> add
 ``` ucm
 scratch/main> view test1
 
-  test1 : Doc
+  test1 : Doc2
   test1 =
-    {{ The internal logic starts to get hairy when you use the @
-    features, for example referencing a name like {List.take}.  
-    Internally, the text between each such usage is its own blob
-    (blob ends here --> {List.take}), so paragraph reflow has to
-    be aware of multiple blobs to do paragraph reflow (or, more 
-    accurately, to do the normalization step where newlines with
-    a paragraph are removed.)
+    use List take
+    {{
+    The internal logic starts to get hairy when you use the
+    reference features, for example referencing a name like
+    {take}. Internally, the text between each such usage is its
+    own blob (blob ends here --> {take}), so paragraph reflow
+    has to be aware of multiple blobs to do paragraph reflow
+    (or, more accurately, to do the normalization step where
+    newlines with a paragraph are removed.)
     
-    Para to reflow: lorem ipsum dolor lorem ipsum dolor lorem 
-    ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum 
-    dolor lorem ipsum dolor ending in ref {List.take}
+    Para to reflow: lorem ipsum dolor lorem ipsum dolor lorem
+    ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum
+    dolor lorem ipsum dolor ending in ref {take}
     
-    {List.take} starting para lorem ipsum dolor lorem ipsum 
-    dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor 
-    lorem ipsum dolor lorem ipsum dolor.
+    {take} starting para lorem ipsum dolor lorem ipsum dolor
+    lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem
+    ipsum dolor lorem ipsum dolor.
     
-    Middle of para: lorem ipsum dolor lorem ipsum dolor lorem 
-    ipsum dolor {List.take} lorem ipsum dolor lorem ipsum dolor 
-    lorem ipsum dolor lorem ipsum dolor.
+    Middle of para: lorem ipsum dolor lorem ipsum dolor lorem
+    ipsum dolor {take} lorem ipsum dolor lorem ipsum dolor lorem
+    ipsum dolor lorem ipsum dolor.
     
-      - non-para line ({List.take}) with ref {List.take}
-      Another non-para line
-      {List.take} starting non-para line
+    * non-para line ({List.take}) with ref {take}
     
-      - non-para line with ref {List.take}
+    Another non-para line
+    
+    {take} starting non-para line
+    
+    * non-para line with ref {take}
+    
     before a para-line lorem ipsum dolor lorem ipsum dolor lorem
-    ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum 
+    ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum
     dolor lorem ipsum dolor lorem ipsum dolor.
     
-      - non-para line followed by a para line starting with ref
-    {List.take} lorem ipsum dolor lorem ipsum dolor lorem ipsum 
-    dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor 
-    lorem ipsum dolor lorem ipsum dolor.
+    * non-para line followed by a para line starting with ref
     
-    a para-line ending with ref lorem ipsum dolor lorem ipsum 
-    dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor 
-    lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor {List.take}
-      - non-para line
+    {take} lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor
+    lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem
+    ipsum dolor lorem ipsum dolor.
     
-    para line lorem ipsum dolor lorem ipsum dolor lorem ipsum 
-    dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor 
+    a para-line ending with ref lorem ipsum dolor lorem ipsum
+    dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor
+    lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor {take}
+    
+    * non-para line
+    
+    para line lorem ipsum dolor lorem ipsum dolor lorem ipsum
+    dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor
     lorem ipsum dolor lorem ipsum dolor
-      {List.take} followed by non-para line starting with ref.
     
-    @signature{List.take}
+    {take} followed by non-para line starting with ref.
     
-    @source{foo}
+        @signature{take}
     
-    @eval{expr}
+        @source{foo}
     
-    {{doc1}}
+    @eval{ expr }
+    
+    {{ doc1 }}
     
     -- note the leading space below
-      @signature{List.take}
     
+        @signature{take}
     }}
 ```
 
 ``` unison
 -- Regression test for #1363 - preservation of spaces after @ directives in first line when unindenting
-reg1363 = [: `@List.take foo` bar
-  baz :]
+reg1363 = {{ `{List.take} foo` bar
+  baz }}
 ```
 
 ``` ucm :added-by-ucm
@@ -500,7 +525,7 @@ reg1363 = [: `@List.take foo` bar
 
     ⍟ New definitions:
     
-      reg1363 : Doc
+      reg1363 : Doc2
 ```
 
 ``` ucm :hide
@@ -510,18 +535,19 @@ scratch/main> add
 ``` ucm
 scratch/main> view reg1363
 
-  reg1363 : Doc
+  reg1363 : Doc2
   reg1363 = {{ `{List.take} foo` bar baz }}
 ```
 
 ``` unison
--- Demonstrate doc display when whitespace follows a @[source] or @[evaluate]
+-- Demonstrate doc display when whitespace follows a `@source` or @eval`
 -- whose output spans multiple lines.
 
-test2 = [:
+test2 = {{
   Take a look at this:
-  @[source] foo    ▶    bar
-:]
+
+  @source{foo}    ▶    bar
+}}
 ```
 
 ``` ucm :added-by-ucm
@@ -532,7 +558,7 @@ test2 = [:
 
     ⍟ New definitions:
     
-      test2 : Doc
+      test2 : Doc2
 ```
 
 ``` ucm :hide
@@ -544,11 +570,13 @@ View is fine.
 ``` ucm
 scratch/main> view test2
 
-  test2 : Doc
+  test2 : Doc2
   test2 =
-    {{ Take a look at this:
-    @source{foo}    ▶    bar
-     }}
+    {{
+    Take a look at this:
+    
+        @source{foo} ▶ bar
+    }}
 ```
 
 But note it's not obvious how display should best be handling this.  At the moment it just does the simplest thing:
@@ -557,9 +585,10 @@ But note it's not obvious how display should best be handling this.  At the mome
 scratch/main> display test2
 
   Take a look at this:
-  foo : Nat -> Nat
-  foo n =
-    use Nat +
-    _ = {{ do the thing }}
-    n + 1    ▶    bar
+
+      foo : Nat -> Nat
+      foo n =
+        use Nat +
+        _ = {{ do the thing }}
+        n + 1 ▶ bar
 ```

--- a/unison-src/transcripts/idempotent/doc-formatting.md
+++ b/unison-src/transcripts/idempotent/doc-formatting.md
@@ -34,7 +34,7 @@ scratch/main> view foo
   foo : Nat -> Nat
   foo n =
     use Nat +
-    _ = [: do the thing :]
+    _ = {{ do the thing }}
     n + 1
 ```
 
@@ -63,7 +63,7 @@ scratch/main> add
 scratch/main> view escaping
 
   escaping : Doc
-  escaping = [: Docs look [: like \@this \:] :]
+  escaping = {{ Docs look [: like @this :] }}
 ```
 
 (Alas you can't have `\@` or `\:]` in your doc, as there's currently no way to 'unescape' them.)
@@ -98,10 +98,10 @@ scratch/main> view commented
 
   commented : Doc
   commented =
-    [: example:
+    {{ example:
     
     -- a comment f x = x + 1
-     :]
+     }}
 ```
 
 ### Indenting, and paragraph reflow
@@ -134,7 +134,7 @@ scratch/main> add
 scratch/main> view doc1
 
   doc1 : Doc
-  doc1 = [: hi :]
+  doc1 = {{ hi }}
 ```
 
 ``` unison
@@ -169,10 +169,10 @@ scratch/main> view doc2
 
   doc2 : Doc
   doc2 =
-    [: hello
+    {{ hello
       - foo
       - bar
-    and the rest. :]
+    and the rest. }}
 ```
 
 ``` unison
@@ -210,7 +210,7 @@ scratch/main> view doc3
 
   doc3 : Doc
   doc3 =
-    [: When Unison identifies a paragraph, it removes any 
+    {{ When Unison identifies a paragraph, it removes any 
     newlines from it before storing it, and then reflows the 
     paragraph text to fit the display window on 
     display/view/edit.
@@ -228,7 +228,7 @@ scratch/main> view doc3
     Note that because of the special treatment of the first line
     mentioned above, where its leading space is removed, it is 
     always treated as a paragraph.
-    :]
+    }}
 ```
 
 ``` unison
@@ -259,11 +259,11 @@ scratch/main> view doc4
 
   doc4 : Doc
   doc4 =
-    [: Here's another example of some paragraphs.
+    {{ Here's another example of some paragraphs.
     
     All these lines have zero indent.
     
-      - Apart from this one. :]
+      - Apart from this one. }}
 ```
 
 ``` unison
@@ -296,9 +296,9 @@ scratch/main> view doc5
 
   doc5 : Doc
   doc5 =
-    [: - foo
+    {{ - foo
       - bar
-    and the rest. :]
+    and the rest. }}
 ```
 
 ``` unison
@@ -330,10 +330,10 @@ scratch/main> view doc6
 
   doc6 : Doc
   doc6 =
-    [: - foo
+    {{ - foo
       - bar
     and the rest.
-     :]
+     }}
 ```
 
 ### More testing
@@ -365,7 +365,7 @@ scratch/main> add
 scratch/main> view empty
 
   empty : Doc
-  empty = [:  :]
+  empty = {{  }}
 ```
 
 ``` unison
@@ -428,62 +428,62 @@ scratch/main> view test1
 
   test1 : Doc
   test1 =
-    [: The internal logic starts to get hairy when you use the 
-    \@ features, for example referencing a name like @List.take.
+    {{ The internal logic starts to get hairy when you use the @
+    features, for example referencing a name like {List.take}.  
     Internally, the text between each such usage is its own blob
-    (blob ends here --> @List.take), so paragraph reflow has to 
+    (blob ends here --> {List.take}), so paragraph reflow has to
     be aware of multiple blobs to do paragraph reflow (or, more 
     accurately, to do the normalization step where newlines with
     a paragraph are removed.)
     
     Para to reflow: lorem ipsum dolor lorem ipsum dolor lorem 
     ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum 
-    dolor lorem ipsum dolor ending in ref @List.take
+    dolor lorem ipsum dolor ending in ref {List.take}
     
-    @List.take starting para lorem ipsum dolor lorem ipsum dolor
-    lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem 
-    ipsum dolor lorem ipsum dolor.
-    
-    Middle of para: lorem ipsum dolor lorem ipsum dolor lorem 
-    ipsum dolor @List.take lorem ipsum dolor lorem ipsum dolor 
+    {List.take} starting para lorem ipsum dolor lorem ipsum 
+    dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor 
     lorem ipsum dolor lorem ipsum dolor.
     
-      - non-para line (@List.take) with ref @List.take
-      Another non-para line
-      @List.take starting non-para line
+    Middle of para: lorem ipsum dolor lorem ipsum dolor lorem 
+    ipsum dolor {List.take} lorem ipsum dolor lorem ipsum dolor 
+    lorem ipsum dolor lorem ipsum dolor.
     
-      - non-para line with ref @List.take
+      - non-para line ({List.take}) with ref {List.take}
+      Another non-para line
+      {List.take} starting non-para line
+    
+      - non-para line with ref {List.take}
     before a para-line lorem ipsum dolor lorem ipsum dolor lorem
     ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum 
     dolor lorem ipsum dolor lorem ipsum dolor.
     
       - non-para line followed by a para line starting with ref
-    @List.take lorem ipsum dolor lorem ipsum dolor lorem ipsum 
+    {List.take} lorem ipsum dolor lorem ipsum dolor lorem ipsum 
     dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor 
     lorem ipsum dolor lorem ipsum dolor.
     
     a para-line ending with ref lorem ipsum dolor lorem ipsum 
     dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor 
-    lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor @List.take
+    lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor {List.take}
       - non-para line
     
     para line lorem ipsum dolor lorem ipsum dolor lorem ipsum 
     dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor 
     lorem ipsum dolor lorem ipsum dolor
-      @List.take followed by non-para line starting with ref.
+      {List.take} followed by non-para line starting with ref.
     
-    @[signature] List.take
+    @signature{List.take}
     
-    @[source] foo
+    @source{foo}
     
-    @[evaluate] expr
+    @eval{expr}
     
-    @[include] doc1
+    {{doc1}}
     
     -- note the leading space below
-      @[signature] List.take
+      @signature{List.take}
     
-    :]
+    }}
 ```
 
 ``` unison
@@ -511,7 +511,7 @@ scratch/main> add
 scratch/main> view reg1363
 
   reg1363 : Doc
-  reg1363 = [: `@List.take foo` bar baz :]
+  reg1363 = {{ `{List.take} foo` bar baz }}
 ```
 
 ``` unison
@@ -546,9 +546,9 @@ scratch/main> view test2
 
   test2 : Doc
   test2 =
-    [: Take a look at this:
-    @[source] foo    ▶    bar
-     :]
+    {{ Take a look at this:
+    @source{foo}    ▶    bar
+     }}
 ```
 
 But note it's not obvious how display should best be handling this.  At the moment it just does the simplest thing:
@@ -560,6 +560,6 @@ scratch/main> display test2
   foo : Nat -> Nat
   foo n =
     use Nat +
-    _ = [: do the thing :]
+    _ = {{ do the thing }}
     n + 1    ▶    bar
 ```

--- a/unison-src/transcripts/idempotent/doc1.md
+++ b/unison-src/transcripts/idempotent/doc1.md
@@ -1,7 +1,7 @@
 # Documenting Unison code
 
 ``` ucm :hide
-scratch/main> builtins.merge lib.builtins
+scratch/main> builtins.mergeio lib.builtins
 ```
 
 Unison documentation is written in Unison. Documentation is a value of the following type:
@@ -13,21 +13,21 @@ scratch/main> view lib.builtins.Doc
     = Blob Text
     | Link Link
     | Source Link
-    | Signature Term
-    | Evaluate Term
+    | Signature Link.Term
+    | Evaluate Link.Term
     | Join [Doc]
 ```
 
 You can create these `Doc` values with ordinary code, or you can use the special syntax. A value of structural type `Doc` can be created via syntax like:
 
 ``` unison
-doc1 = [: This is some documentation.
+doc1 = {{ This is some documentation.
 
 It can span multiple lines.
 
-Can link to definitions like @List.drop or @List
+Can link to definitions like {List.drop} or {type List}
 
-:]
+}}
 ```
 
 ``` ucm :added-by-ucm
@@ -38,67 +38,38 @@ Can link to definitions like @List.drop or @List
 
     ⍟ New definitions:
     
-      doc1 : Doc
+      doc1 : Doc2
 ```
 
 Syntax:
 
-`[:` starts a documentation block; `:]` finishes it. Within the block:
+`{{` starts a documentation block; `}}` finishes it. Within the block:
 
-  - Links to definitions are done with `@List`. `\@` (and `\:]`) if you want to escape.
-  - `@[signature] List.take` expands to the type signature of `List.take`
-  - `@[source] List.map` expands to the full source of `List.map`
-  - `@[include] someOtherDoc`, inserts a value `someOtherDoc : Doc` here.
-  - `@[evaluate] someDefinition` expands to the result of evaluating `someDefinition`, which must be a pre-existing definition in the codebase (can't be an arbitrary expression).
+  - Links to definitions are done with `{List.take}` or `{type List}`.
+  - `@signature{List.take}` expands to the type signature of `List.take`
+  - `@source{List.map}` expands to the full source of `List.map`
+  - `{{someOtherDoc}}`, inserts a value `someOtherDoc : Doc2` here.
+  - `@eval{someDefinition}` expands to the result of evaluating `someDefinition`, which can be an arbitrary expression.
 
 ### An example
 
-We are going to document `List.take` using some verbiage and a few examples. First we have to add the examples to the codebase:
+We are going to document `List.take` using some verbiage and a few examples.
 
-``` unison
-List.take.ex1 = take 0 [1,2,3,4,5]
-List.take.ex2 = take 2 [1,2,3,4,5]
-```
-
-``` ucm :added-by-ucm
-  Loading changes detected in scratch.u.
-
-  I found and typechecked these definitions in scratch.u. If you
-  do an `update`, here's how your codebase would change:
-
-    ⍟ New definitions:
-    
-      List.take.ex1 : [Nat]
-      List.take.ex2 : [Nat]
-```
-
-``` ucm
-scratch/main> add
-
-  Okay, I'm searching the branch for code that needs to be
-  updated...
-
-  Done.
-```
-
-And now let's write our docs and reference these examples:
-
-``` unison
-List.take.doc = [:
-`@List.take n xs` returns the first `n` elements of `xs`. (No need to add line breaks manually. The display command will do wrapping of text for you.  Indent any lines where you don't want it to do this.)
+```` unison
+List.take.doc = {{
+`List.take n xs` returns the first `n` elements of `xs`. (No need to add line breaks manually. The display command will do wrapping of text for you.  Indent any lines where you don't want it to do this.)
 
 ## Examples:
 
-  @[source] List.take.ex1
-  🔽
-  @List.take.ex1 = @[evaluate] List.take.ex1
-
-
-  @[source] List.take.ex2
-  🔽
-  @List.take.ex2 = @[evaluate] List.take.ex2
-:]
 ```
+take 0 [1,2,3,4,5]
+```
+
+```
+take 2 [1,2,3,4,5]
+```
+}}
+````
 
 ``` ucm :added-by-ucm
   Loading changes detected in scratch.u.
@@ -108,7 +79,7 @@ List.take.doc = [:
 
     ⍟ New definitions:
     
-      List.take.doc : Doc
+      List.take.doc : Doc2
 ```
 
 Let's add it to the codebase.
@@ -127,23 +98,20 @@ We can view it with `docs`, which shows the `Doc` value that is associated with 
 ``` ucm
 scratch/main> docs List.take
 
-  `List.take n xs` returns the first `n` elements of `xs`. (No 
-  need to add line breaks manually. The display command will do 
-  wrapping of text for you.  Indent any lines where you don't 
+  `List.take n xs` returns the first `n` elements of `xs`. (No
+  need to add line breaks manually. The display command will do
+  wrapping of text for you. Indent any lines where you don't
   want it to do this.)
 
-  ## Examples:
+  # Examples:
 
-    List.take.ex1 : [Nat]
-  List.take.ex1 = List.take 0 [1, 2, 3, 4, 5]
-    🔽
-    ex1 = []
+        List.take 0 [1, 2, 3, 4, 5]
+        ⧨
+        []
 
-
-    List.take.ex2 : [Nat]
-  List.take.ex2 = List.take 2 [1, 2, 3, 4, 5]
-    🔽
-    ex2 = [1, 2]
+        List.take 2 [1, 2, 3, 4, 5]
+        ⧨
+        [1, 2]
 ```
 
 Note that if we view the source of the documentation, the various references are *not* expanded.

--- a/unison-src/transcripts/pretty-print-libraries.output.md
+++ b/unison-src/transcripts/pretty-print-libraries.output.md
@@ -48192,8 +48192,8 @@ Doc.Deprecated.example e =
 
 Doc.Deprecated.example.doc : Deprecated
 Doc.Deprecated.example.doc =
-  [: Given a `termRef` reference, constructs an example that shows the source 
-  of that term as well as the result of evaluating it.:]
+  {{ Given a `termRef` reference, constructs an example that shows the source 
+  of that term as well as the result of evaluating it.}}
 
 Doc.doc : Doc
 Doc.doc =

--- a/unison-syntax/src/Unison/Syntax/Lexer/Unison.hs
+++ b/unison-syntax/src/Unison/Syntax/Lexer/Unison.hs
@@ -454,41 +454,11 @@ lexemes eof =
     toks :: P [Token Lexeme]
     toks =
       doc2
-        <|> doc
         <|> token numeric
         <|> token character
         <|> reserved
         <|> token identifierLexemeP
         <|> (asum . map token) [semi, textual, hash]
-
-    doc :: P [Token Lexeme]
-    doc = open <+> (CP.space *> fmap fixup body) <+> (close <* space)
-      where
-        open = token'' (\t _ _ -> t) $ tok (Open <$> lit "[:")
-        close = tok (Close <$ lit ":]")
-        at = lit "@"
-        -- this removes some trailing whitespace from final textual segment
-        fixup [] = []
-        fixup (Token (Textual (reverse -> txt)) start stop : []) =
-          [Token (Textual txt') start stop]
-          where
-            txt' = reverse (dropWhile (\c -> isSpace c && not (c == '\n')) txt)
-        fixup (h : t) = h : fixup t
-
-        body :: P [Token Lexeme]
-        body = txt <+> (atk <|> pure [])
-          where
-            ch = (":]" <$ lit "\\:]") <|> ("@" <$ lit "\\@") <|> (pure <$> P.anySingle)
-            txt = tok (Textual . join <$> P.manyTill ch (P.lookAhead sep))
-            sep = void at <|> void close
-            ref = at *> (tok identifierLexemeP <|> docTyp)
-            atk = (ref <|> docTyp) <+> body
-            docTyp = do
-              _ <- lit "["
-              typ <- tok (P.manyTill P.anySingle (P.lookAhead (lit "]")))
-              _ <- lit "]" *> CP.space
-              t <- tok identifierLexemeP
-              pure $ (fmap Reserved <$> typ) <> t
 
     semi = char ';' $> Semi False
     textual = Textual <$> quoted
@@ -733,11 +703,6 @@ openKw s = separated wordySep $ do
   env <- S.get
   S.put (env {opening = Just s})
   pure [Open <$> token]
-
-tok :: P a -> P [Token a]
-tok p = do
-  token <- tokenP p
-  pure [token]
 
 -- An identifier is a non-empty dot-delimited list of segments, with an optional leading dot, where each segment is
 -- symboly (comprised of only symbols) or wordy (comprised of only alphanums).


### PR DESCRIPTION
## Overview

This removes the old `Doc` syntax.

The lexer and parser components have simply been removed, but values of this type may still live in codebases, so the pretty printer now prints `Doc` values using `Doc2` syntax, which will then be parsed as the new type.

The few remaining transcripts that used `Doc`, now use `Doc2`.

## Loose ends

Two of the updated transcripts, doc1.md and doc-formatting.md, could stand to be rewritten (or deleted), since they don’t simply contain it, but describe the syntax.