### PR TITLE
don't use `actions/cache` to share artifacts between jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
         with:
           path: ${{env.ucm_local_bin}}
-          key: ucm-${{ matrix.os }}-${{ hashFiles('**/ci.yaml', '**/stack.yaml', '**/package.yaml', '**/*.hs', '**/unison-cli-integration/integrationtests/IntegrationTests/*')}}
+          key: ucm-${{ matrix.os }}-${{ hashFiles('**/ci.yaml', '**/stack.yaml', '**/package.yaml', '**/*.hs', '**/unison-cli-integration/integration-tests/IntegrationTests/*')}}
           # added the integration test dependencies here as if they were source, for simplicity
 
       - name: restore stack caches

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
         with:
           path: ${{env.ucm_local_bin}}
-          key: ucm-${{ matrix.os }}-${{ hashFiles('**/stack.yaml', '**/package.yaml', '**/*.hs', '**/unison-cli-integration/integrationtests/IntegrationTests/*')}}
+          key: ucm-${{ matrix.os }}-${{ hashFiles('**/ci.yaml', '**/stack.yaml', '**/package.yaml', '**/*.hs', '**/unison-cli-integration/integrationtests/IntegrationTests/*')}}
           # added the integration test dependencies here as if they were source, for simplicity
 
       - name: restore stack caches
@@ -174,6 +174,13 @@ jobs:
           path: ${{ env.ucm }}
           if-no-files-found: error
 
+      - name: save built binaries
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+        with:
+          path: ${{ env.ucm_local_bin }}
+          name: local-bin-${{ matrix.os }}
+          if-no-files-found: error
+
       - name: save stack caches
         if: |
           !cancelled()
@@ -230,12 +237,15 @@ jobs:
           path: ${{env.transcript_test_results}}
           key: transcripts-results-${{ matrix.os }}-${{ hashFiles('**/stack.yaml', '**/package.yaml', '**/*.hs')}}-${{ hashFiles('**/unison-src/**/*.md', '**/unison-src/**/*.u') }}
       - name: restore binaries
-        uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
+        uses: actions/download-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         if: steps.cache-transcript-test-results.outputs.cache-hit != 'true'
         with:
           path: ${{env.ucm_local_bin}}
-          key: ucm-${{ matrix.os }}-${{ hashFiles('**/stack.yaml', '**/package.yaml', '**/*.hs')}}
-          fail-on-cache-miss: true
+          name: local-bin-${{matrix.os}}
+          if-no-files-found: error
+      - name: set built binaries permissions
+        if: steps.cache-transcript-test-results.outputs.cache-hit != 'true'
+        run: chmod +x ${{env.ucm_local_bin}}/*
       # One of the transcripts fails if the user's git name hasn't been set.
       ## (Which transcript? -AI)
       - name: set git user info
@@ -324,12 +334,15 @@ jobs:
           key: runtime-tests-codebase-${{env.runtime_tests_causalhash}}
           restore-keys: runtime-tests-codebase-
       - name: restore binaries
-        uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
-        if: steps.cache-interpreter-test-results.outputs.cache-hit != 'true'
+        uses: actions/download-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+        if: steps.cache-transcript-test-results.outputs.cache-hit != 'true'
         with:
           path: ${{env.ucm_local_bin}}
-          key: ucm-${{ matrix.os }}-${{ hashFiles('**/stack.yaml', '**/package.yaml', '**/*.hs')}}
-          fail-on-cache-miss: true
+          name: local-bin-${{ matrix.os }}
+          if-no-files-found: error
+      - name: set binaries permissions
+        if: steps.cache-transcript-test-results.outputs.cache-hit != 'true'
+        run: chmod +x ${{env.ucm_local_bin}}/*
       - name: interpreter tests
         # this one should be re-run if the ucm binaries have changed or unison-src/ has changed
         if: steps.cache-interpreter-test-results.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -237,7 +237,7 @@ jobs:
           path: ${{env.transcript_test_results}}
           key: transcripts-results-${{ matrix.os }}-${{ hashFiles('**/stack.yaml', '**/package.yaml', '**/*.hs')}}-${{ hashFiles('**/unison-src/**/*.md', '**/unison-src/**/*.u') }}
       - name: restore binaries
-        uses: actions/download-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
         if: steps.cache-transcript-test-results.outputs.cache-hit != 'true'
         with:
           path: ${{env.ucm_local_bin}}
@@ -334,7 +334,7 @@ jobs:
           key: runtime-tests-codebase-${{env.runtime_tests_causalhash}}
           restore-keys: runtime-tests-codebase-
       - name: restore binaries
-        uses: actions/download-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
         if: steps.cache-transcript-test-results.outputs.cache-hit != 'true'
         with:
           path: ${{env.ucm_local_bin}}


### PR DESCRIPTION
thanks @chrispenner for the suggestion
closes #5800
