### PR TITLE
Some fixes for the new serialization

### DIFF
--- a/unison-runtime/src/Unison/Runtime/ANF.hs
+++ b/unison-runtime/src/Unison/Runtime/ANF.hs
@@ -125,6 +125,7 @@ import Unison.Reference (Id, Reference, Reference' (Builtin, DerivedId), toShort
 import Unison.Referent (Referent, pattern Con, pattern Ref)
 import Unison.Runtime.Array qualified as PA
 import Unison.Runtime.Foreign.Function.Type (ForeignFunc (..))
+import Unison.Runtime.Referenced
 import Unison.Runtime.TypeTags (CTag (..), PackedTag (..), RTag (..), Tag (..), maskTags, packTags, unpackTags)
 import Unison.ShortHash (shortenTo)
 import Unison.Symbol (Symbol)
@@ -1608,28 +1609,6 @@ type ANFD v = Compose (ANFM v) (Directed ())
 
 data GroupRef = GR Reference Word64
   deriving (Show, Eq)
-
--- A value with optional optimization information for serialization.
--- The references are required for serialization V5, and are assumed
--- to be the only references used in the value _up to in-memory
--- uniqueness_.
---
--- This is parameterized so that it can be used with both Value and
--- Code.
---
--- Also note, the stored referenced might not be 'tight' in the sense
--- that they all actually occur in the value. Maintaining this
--- invariant together with actual canonicalization would be onerous
--- and isn't done at this time.
-data Referenced a
-  = -- types, terms
-    WithRefs [Reference] [Reference] a
-  | Plain a
-  deriving (Show, Eq)
-
-dereference :: Referenced a -> a
-dereference (WithRefs _ _ x) = x
-dereference (Plain x) = x
 
 -- | A list of either unboxed or boxed values.
 -- Each slot is one of unboxed or boxed but not both.

--- a/unison-runtime/src/Unison/Runtime/ANF/Serialize.hs
+++ b/unison-runtime/src/Unison/Runtime/ANF/Serialize.hs
@@ -7,6 +7,7 @@ module Unison.Runtime.ANF.Serialize where
 
 import Control.Monad
 import Control.Monad.Reader
+import Control.Monad.State.Strict (StateT (..))
 import Data.Bifunctor (bimap, first)
 import Data.Binary.Get (runGetOrFail)
 import Data.Binary.Get qualified as BGet
@@ -37,8 +38,10 @@ import Unison.Runtime.ANF.Optimize as ANF
 import Unison.Runtime.ANF.Serialize.CodeV4 qualified as CodeV4
 import Unison.Runtime.ANF.Serialize.Tags
 import Unison.Runtime.ANF.Serialize.ValueV5 qualified as ValueV5
+import Unison.Runtime.Canonicalizer qualified as C
 import Unison.Runtime.Exception
 import Unison.Runtime.Foreign.Function.Type (ForeignFunc)
+import Unison.Runtime.Referenced
 import Unison.Runtime.Serialize
 import Unison.Util.Text qualified as Util.Text
 import Unison.Var (Type (ANFBlank), Var (..))
@@ -970,20 +973,22 @@ serializeCode fops (dereference -> co) =
     putVersion = putWord32be codeVersion
 
 serializeCodeWithVersion ::
-  Word64 -> Bool -> Referenced Code -> Either String L.ByteString
-serializeCodeWithVersion v fops = \case
-  WithRefs tys tms co
-    | v == 4 ->
-        Right . runPutL $
-          putWord32be 4 *> CodeV4.putCodeWithHeader tys tms fops co
-  rco
-    | v == 3 ->
-        Right . runPutL $
-          putWord32be 3 *> putCode fops (dereference rco)
-    | v == 4 ->
-        Left "could not serialize plain code at v4"
-    | otherwise ->
-        Left $ "unsupported code serialization version: " ++ show v
+  Word64 -> Bool -> Referenced Code -> IO (Either String L.ByteString)
+serializeCodeWithVersion v fops rco
+  | v == 4 = enreference rco >>= \(tys, tms, co) ->
+      pure . Right . runPutL $
+        putWord32be 4 *> CodeV4.putCodeWithHeader tys tms fops co
+  | v == 3 =
+      pure . Right . runPutL $
+        putWord32be 3 *> putCode fops (dereference rco)
+  | otherwise =
+      pure . Left $ "unsupported code serialization version: " ++ show v
+  where
+    enreference (WithRefs tys tms co) = pure (tys, tms, co)
+    enreference (Plain co) =
+      runStateT
+        (canonicalizeRefs traverseCodeRefs co)
+        (C.empty, [], []) >>= \(co, (_, tys, tms)) -> pure (tys, tms, co)
 
 -- | Serializes a `SuperGroup` for rehashing.
 --
@@ -1041,14 +1046,27 @@ serializeValue (dereference -> v) =
   where
     putVersion = putWord32be valueVersion
 
-serializeValueWithVersion :: Word64 -> Referenced Value -> L.ByteString
-serializeValueWithVersion v = \case
-  WithRefs tys tms x
-    | v == 5 ->
-        runPutL $ putWord32be 5 *> ValueV5.putValueWithHeader tys tms x
-  rval
-    | n <- fromIntegral v ->
-        runPutL $ putWord32be n *> putValue (Transfer n) (dereference rval)
+serializeValueWithVersion ::
+  Word64 -> Referenced Value -> IO L.ByteString
+serializeValueWithVersion v rval
+  | v == 5 = case rval of
+      WithRefs tys tms x -> v5ser tys tms x
+      Plain x -> do
+        (x, (_, tys, tms)) <-
+          runStateT
+            (canonicalizeRefs traverseValueRefs x)
+            (C.empty, [], [])
+        v5ser tys tms x
+  | v < 5, n <- fromIntegral v =
+      pure . runPutL $
+        putWord32be n *>
+        putValue (Transfer n) (dereference rval)
+  | otherwise =
+      die $ "Value.serialize.versioned: unrecognized version: " ++ show v
+  where
+    v5ser tys tms x =
+      pure . runPutL $
+        putWord32be 5 *> ValueV5.putValueWithHeader tys tms x
 
 -- This serializer is used exclusively for hashing unison values.
 -- For this reason, it doesn't prefix the string with the current

--- a/unison-runtime/src/Unison/Runtime/ANF/Serialize.hs
+++ b/unison-runtime/src/Unison/Runtime/ANF/Serialize.hs
@@ -964,9 +964,8 @@ deserializeCode bs = runGetS go bs
 -- Boolean argument determines whether ForeignFunc occurrences are
 -- allowed to be serialized. For interchange, this should be False.
 serializeCode :: Bool -> Referenced Code -> ByteString
-serializeCode fops (WithRefs tys tms co) =
-  runPutS (putWord32be 4 *> CodeV4.putCodeWithHeader tys tms fops co)
-serializeCode fops (Plain co) = runPutS (putVersion *> putCode fops co)
+serializeCode fops (dereference -> co) =
+  runPutS (putVersion *> putCode fops co)
   where
     putVersion = putWord32be codeVersion
 

--- a/unison-runtime/src/Unison/Runtime/ANF/Serialize.hs
+++ b/unison-runtime/src/Unison/Runtime/ANF/Serialize.hs
@@ -975,9 +975,10 @@ serializeCode fops (dereference -> co) =
 serializeCodeWithVersion ::
   Word64 -> Bool -> Referenced Code -> IO (Either String L.ByteString)
 serializeCodeWithVersion v fops rco
-  | v == 4 = enreference rco >>= \(tys, tms, co) ->
-      pure . Right . runPutL $
-        putWord32be 4 *> CodeV4.putCodeWithHeader tys tms fops co
+  | v == 4 =
+      enreference rco >>= \(tys, tms, co) ->
+        pure . Right . runPutL $
+          putWord32be 4 *> CodeV4.putCodeWithHeader tys tms fops co
   | v == 3 =
       pure . Right . runPutL $
         putWord32be 3 *> putCode fops (dereference rco)
@@ -988,7 +989,8 @@ serializeCodeWithVersion v fops rco
     enreference (Plain co) =
       runStateT
         (canonicalizeRefs traverseCodeRefs co)
-        (C.empty, [], []) >>= \(co, (_, tys, tms)) -> pure (tys, tms, co)
+        (C.empty, [], [])
+        >>= \(co, (_, tys, tms)) -> pure (tys, tms, co)
 
 -- | Serializes a `SuperGroup` for rehashing.
 --
@@ -1057,10 +1059,11 @@ serializeValueWithVersion v rval
             (canonicalizeRefs traverseValueRefs x)
             (C.empty, [], [])
         v5ser tys tms x
-  | v < 5, n <- fromIntegral v =
+  | v < 5,
+    n <- fromIntegral v =
       pure . runPutL $
-        putWord32be n *>
-        putValue (Transfer n) (dereference rval)
+        putWord32be n
+          *> putValue (Transfer n) (dereference rval)
   | otherwise =
       die $ "Value.serialize.versioned: unrecognized version: " ++ show v
   where

--- a/unison-runtime/src/Unison/Runtime/Foreign/Function.hs
+++ b/unison-runtime/src/Unison/Runtime/Foreign/Function.hs
@@ -510,7 +510,7 @@ foreignCallHelper = \case
       pure . Bytes.fromArray $ ANF.serializeCode False co
   Code_serialize_versioned -> mkForeign $
     \(ver :: Word64, co :: ANF.Referenced ANF.Code) ->
-      case ANF.serializeCodeWithVersion ver False co of
+      ANF.serializeCodeWithVersion ver False co >>= \case
         Left err -> die err
         Right bs -> pure $ Bytes.fromLazyByteString bs
   Code_deserialize ->
@@ -527,7 +527,7 @@ foreignCallHelper = \case
       pure . Bytes.fromArray . ANF.serializeValue
   Value_serialize_versioned ->
     mkForeign $
-      pure . Bytes.fromLazyByteString . uncurry ANF.serializeValueWithVersion
+      fmap Bytes.fromLazyByteString . uncurry ANF.serializeValueWithVersion
   Value_deserialize ->
     mkForeign $
       pure . ANF.deserializeValue . Bytes.toLazyByteString

--- a/unison-runtime/src/Unison/Runtime/Machine.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine.hs
@@ -87,6 +87,7 @@ import Unison.Runtime.Foreign.Function
 import Unison.Runtime.MCode
 import Unison.Runtime.Machine.Primops
 import Unison.Runtime.Machine.Types
+import Unison.Runtime.Referenced
 import Unison.Runtime.Stack
 import Unison.Runtime.TypeTags qualified as TT
 import Unison.Symbol (Symbol)
@@ -1415,25 +1416,16 @@ type Reflect = StateT ReflectionState IO
 emptyRS :: ReflectionState
 emptyRS = RS HM.empty HM.empty C.empty [] []
 
-type RTrav a =
-  forall f.
-  (Applicative f) =>
-  (Bool -> Reference -> f Reference) ->
-  (a -> f a)
+mediate ::
+  StateT (C.Canonicalizer Reference, [Reference], [Reference]) IO a ->
+  Reflect a
+mediate act = StateT \(RS sty stm canon tys tms) -> do
+   (v, (canon, tys, tms)) <- runStateT act (canon, tys, tms)
+   pure $ (v, RS sty stm canon tys tms)
+{-# INLINE mediate #-}
 
 canonicalizeReference :: Bool -> Reference -> Reflect Reference
-canonicalizeReference isTy r = StateT \st@(RS _ _ canon tys tms) ->
-  C.categorize canon r >>= \case
-    C.Canonical -> pure (r, st)
-    C.Equivalent s canon -> (s,) <$> evaluate (st {_canon = canon})
-    C.Novel canon ->
-      (r,)
-        <$> evaluate
-          st
-            { _canon = canon,
-              _tys = if isTy then r : tys else tys,
-              _tms = if isTy then tms else r : tms
-            }
+canonicalizeReference isTy = mediate . canonicalizeRefs (\f -> f isTy)
 
 canonicalizeReferent :: Referent -> Reflect Referent
 canonicalizeReferent (Ref r) = Ref <$> canonicalizeReference False r
@@ -1441,59 +1433,7 @@ canonicalizeReferent (Con (ConstructorReference r i) j) =
   flip Con j . flip ConstructorReference i <$> canonicalizeReference True r
 
 canonicalizeReferenced :: RTrav a -> ANF.Referenced a -> Reflect a
-canonicalizeReferenced trav = \case
-  -- no stored refs, have to traverse
-  ANF.Plain v -> trav h v
-  ANF.WithRefs tys tms v -> do
-    typs <- mapMaybe id <$> traverse (g True) tys
-    tmps <- mapMaybe id <$> traverse (g False) tms
-
-    ctys <- lift $ C.fromList typs
-    ctms <- lift $ C.fromList tmps
-
-    let f False r = C.findWithDefault r r ctms
-        f True r = C.findWithDefault r r ctys
-
-    if null typs && null tmps
-      then -- all references are already canonical
-        pure v
-      else lift $ trav f v
-  where
-    -- traversal function for plain values
-    g isTy r = StateT \st@(RS _ _ canon tys tms) ->
-      C.categorize canon r >>= \case
-        C.Canonical -> pure (Nothing, st)
-        C.Novel canon ->
-          (Nothing,)
-            <$> evaluate
-              st
-                { _canon = canon,
-                  _tys = if isTy then r : tys else tys,
-                  _tms = if isTy then tms else r : tms
-                }
-        C.Equivalent s canon ->
-          (Just (r, s),) <$> evaluate (st {_canon = canon})
-
-    -- traversal function for remapping WithRefs values
-    h isTy r = StateT \st@(RS _ _ canon tys tms) ->
-      C.categorize canon r >>= \case
-        C.Canonical -> pure (r, st)
-        C.Novel canon ->
-          (r,)
-            <$> evaluate
-              if isTy
-                then
-                  st
-                    { _canon = canon,
-                      _tys = r : tys
-                    }
-                else
-                  st
-                    { _canon = canon,
-                      _tms = r : tms
-                    }
-        C.Equivalent r canon ->
-          (r,) <$> evaluate (st {_canon = canon})
+canonicalizeReferenced trav x = mediate $ recanonicalizeRefs trav x
 {-# INLINE canonicalizeReferenced #-}
 
 reflectValue :: CCache -> Val -> IO (ANF.Referenced ANF.Value)

--- a/unison-runtime/src/Unison/Runtime/Machine.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine.hs
@@ -1420,8 +1420,8 @@ mediate ::
   StateT (C.Canonicalizer Reference, [Reference], [Reference]) IO a ->
   Reflect a
 mediate act = StateT \(RS sty stm canon tys tms) -> do
-   (v, (canon, tys, tms)) <- runStateT act (canon, tys, tms)
-   pure $ (v, RS sty stm canon tys tms)
+  (v, (canon, tys, tms)) <- runStateT act (canon, tys, tms)
+  pure $ (v, RS sty stm canon tys tms)
 {-# INLINE mediate #-}
 
 canonicalizeReference :: Bool -> Reference -> Reflect Reference

--- a/unison-runtime/src/Unison/Runtime/Referenced.hs
+++ b/unison-runtime/src/Unison/Runtime/Referenced.hs
@@ -1,12 +1,12 @@
-
 module Unison.Runtime.Referenced
-  ( Referenced (..)
-  , dereference
-  , RTrav
-  , Canonize
-  , canonicalizeRefs
-  , recanonicalizeRefs
-  ) where
+  ( Referenced (..),
+    dereference,
+    RTrav,
+    Canonize,
+    canonicalizeRefs,
+    recanonicalizeRefs,
+  )
+where
 
 import Control.Monad.State.Strict
 import Data.Maybe (mapMaybe)
@@ -56,8 +56,8 @@ canonicalizeRefs trav = trav h
       categorize canon r >>= \case
         Canonical -> pure (r, st)
         Novel canon
-          | isTy -> pure (r, (canon, r:tys, tms))
-          | otherwise -> pure (r, (canon, tys, r:tms))
+          | isTy -> pure (r, (canon, r : tys, tms))
+          | otherwise -> pure (r, (canon, tys, r : tms))
         Equivalent s canon -> pure (s, (canon, tys, tms))
 {-# INLINE canonicalizeRefs #-}
 
@@ -83,7 +83,7 @@ recanonicalizeRefs trav = \case
     ctms <- lift $ fromList tmps
 
     let f False r = findWithDefault r r ctms
-        f True  r = findWithDefault r r ctys
+        f True r = findWithDefault r r ctys
 
     if null typs && null tmps
       then pure v -- already canonical
@@ -93,10 +93,12 @@ recanonicalizeRefs trav = \case
       categorize canon r >>= \case
         Canonical -> pure (Nothing, st)
         Novel canon ->
-          pure ( Nothing,
-                 ( canon,
-                   if isTy then r : tys else tys,
-                   if isTy then tms else r : tms
-                 ))
-        Equivalent s canon -> pure (Just (r,s), (canon, tys, tms))
+          pure
+            ( Nothing,
+              ( canon,
+                if isTy then r : tys else tys,
+                if isTy then tms else r : tms
+              )
+            )
+        Equivalent s canon -> pure (Just (r, s), (canon, tys, tms))
 {-# INLINE recanonicalizeRefs #-}

--- a/unison-runtime/src/Unison/Runtime/Referenced.hs
+++ b/unison-runtime/src/Unison/Runtime/Referenced.hs
@@ -1,0 +1,102 @@
+
+module Unison.Runtime.Referenced
+  ( Referenced (..)
+  , dereference
+  , RTrav
+  , Canonize
+  , canonicalizeRefs
+  , recanonicalizeRefs
+  ) where
+
+import Control.Monad.State.Strict
+import Data.Maybe (mapMaybe)
+import Unison.Reference
+import Unison.Runtime.Canonicalizer
+
+-- A value with optional optimization information for serialization.
+-- The references are required for serialization V5, and are assumed
+-- to be the only references used in the value _up to in-memory
+-- uniqueness_.
+--
+-- This is parameterized so that it can be used with both Value and
+-- Code.
+--
+-- Also note, the stored referenced might not be 'tight' in the sense
+-- that they all actually occur in the value. Maintaining this
+-- invariant together with actual canonicalization would be onerous
+-- and isn't done at this time.
+data Referenced a
+  = -- types, terms
+    WithRefs [Reference] [Reference] a
+  | Plain a
+  deriving (Show, Eq)
+
+dereference :: Referenced a -> a
+dereference (WithRefs _ _ x) = x
+dereference (Plain x) = x
+
+type RTrav a =
+  forall f.
+  (Applicative f) =>
+  (Bool -> Reference -> f Reference) ->
+  (a -> f a)
+
+type Canonize =
+  StateT (Canonicalizer Reference, [Reference], [Reference]) IO
+
+-- Given a reference traversal, canonicalizes the references in a
+-- value. The operation is presented as a state transformation, so
+-- that it can hook into a larger canonicalization procedure. The
+-- lists of canonical references of each sort are yielded as part of
+-- the state.
+canonicalizeRefs :: RTrav a -> a -> Canonize a
+canonicalizeRefs trav = trav h
+  where
+    h isTy r = StateT \st@(canon, tys, tms) ->
+      categorize canon r >>= \case
+        Canonical -> pure (r, st)
+        Novel canon
+          | isTy -> pure (r, (canon, r:tys, tms))
+          | otherwise -> pure (r, (canon, tys, r:tms))
+        Equivalent s canon -> pure (s, (canon, tys, tms))
+{-# INLINE canonicalizeRefs #-}
+
+-- Given a `Referenced` value, this recanonicalizes the references in
+-- the wrapped value. The intention is for this to be hooked into a
+-- larger canonicalization procedure, so that already canonicalized
+-- values can be more efficiently brought in line with other values
+-- that are already canonicalized.
+--
+-- If the `Referenced` value is `Plain`, then all we can do is
+-- traverse it, canonicalizing the references. However, if it is
+-- tagged with canonical refs, we can see if they all match existing
+-- canonical refs. If so, we don't need to traverse the value. Even if
+-- not, we can traverse with marginally more efficient lookups.
+recanonicalizeRefs :: RTrav a -> Referenced a -> Canonize a
+recanonicalizeRefs trav = \case
+  Plain v -> canonicalizeRefs trav v
+  WithRefs tys tms v -> do
+    typs <- mapMaybe id <$> traverse (g True) tys
+    tmps <- mapMaybe id <$> traverse (g False) tms
+
+    ctys <- lift $ fromList typs
+    ctms <- lift $ fromList tmps
+
+    let f False r = findWithDefault r r ctms
+        f True  r = findWithDefault r r ctys
+
+    if null typs && null tmps
+      then pure v -- already canonical
+      else lift $ trav f v
+  where
+    g isTy r = StateT \st@(canon, tys, tms) ->
+      categorize canon r >>= \case
+        Canonical -> pure (Nothing, st)
+        Novel canon ->
+          pure ( Nothing,
+                 ( canon,
+                   if isTy then r : tys else tys,
+                   if isTy then tms else r : tms
+                 ))
+        Equivalent s canon -> pure (Just (r,s), (canon, tys, tms))
+{-# INLINE recanonicalizeRefs #-}

--- a/unison-runtime/unison-runtime.cabal
+++ b/unison-runtime/unison-runtime.cabal
@@ -66,6 +66,7 @@ library
       Unison.Runtime.MCode
       Unison.Runtime.MCode.Serialize
       Unison.Runtime.Pattern
+      Unison.Runtime.Referenced
       Unison.Runtime.Serialize
       Unison.Runtime.SparseVector
       Unison.Runtime.Stack

--- a/unison-src/transcripts-using-base/all-base-hashes.output.md
+++ b/unison-src/transcripts-using-base/all-base-hashes.output.md
@@ -2977,11 +2977,15 @@ scratch/main> find.verbose
        runTest : '{IO, TempDirs, Exception, Stream Result} a
        ->{IO} [Result]
        
-  851. -- #ub9vp3rs8gh7kj9ksq0dbpoj22r61iq179co8tpgsj9m52n36qha52rm5hlht4hesgqfb8917cp1tk8jhgcft6sufgis6bgemmd57ag
-       saveSelfContained : a -> Text ->{IO, Exception} ()
+  851. -- #emt8oa7ee2hha5993870s292rk3muaf44m46ribq3959ps80u3msge1e9dp9p4vprqqnha588s8khqplpcatlqv5gmhuj11ek0abpfo
+       saveSelfContained : Optional Nat
+       -> a
+       -> Text
+       ->{IO, Exception} ()
        
-  852. -- #6jriif58nb7gbb576kcabft4k4qaa74prd4dpsomokbqceust7p0gu0jlpar4o70qt987lkki2sj1pknkr0ggoif8fcvu2jg2uenqe8
-       saveTestCase : Text
+  852. -- #48nls8b5okebjcn689uk8bbo7nenitarsrpvmln9fh0s6mvpnt6slumbg46ofm061urucqeuq70lmkm1chu1b1tdbviid1fl4mriqb8
+       saveTestCase : Optional Nat
+       -> Text
        -> Text
        -> (a -> Text)
        -> a

--- a/unison-src/transcripts-using-base/codeops.md
+++ b/unison-src/transcripts-using-base/codeops.md
@@ -7,20 +7,29 @@ function. Also ask for its dependencies for display later.
 save : a -> Bytes
 save x = Value.serialize (Value.value x)
 
+save.versioned : Nat -> a -> Bytes
+save.versioned v x = Value.serialize.versioned v (Value.value x)
+
 Code.save : Code -> Bytes
 Code.save = Code.serialize
+
+Code.save.versioned : Nat -> Code -> Bytes
+Code.save.versioned = Code.serialize.versioned
 
 Code.get : Link.Term -> Code
 Code.get tl = match Code.lookup tl with
   Some co -> co
   None -> throw "could not look up code"
 
-load : Bytes ->{io2.IO, Throw Text} a
-load b = match Value.deserialize b with
+Value.deser : Bytes ->{io2.IO, Throw Text} Value
+Value.deser b = match Value.deserialize b with
   Left _ -> throw "could not deserialize value"
-  Right v -> match Value.load v with
-    Left _ -> throw "could not load value"
-    Right x -> x
+  Right v -> v
+
+load : Bytes ->{io2.IO, Throw Text} a
+load b = match Value.load (deser b) with
+  Left _ -> throw "could not load value"
+  Right x -> x
 
 Code.load : Bytes ->{io2.IO, Throw Text} Code
 Code.load b = match Code.deserialize b with
@@ -29,6 +38,23 @@ Code.load b = match Code.deserialize b with
 
 roundtrip : a ->{io2.IO, Throw Text} a
 roundtrip x = load (save x)
+
+roundtrip.versioned : Nat -> a ->{io2.IO, Throw Text} a
+roundtrip.versioned v x = load (save.versioned v x)
+
+Code.crossVersion : Nat -> Nat -> Text -> Link.Term ->{io2.IO} Result
+Code.crossVersion v0 v1 txt ln =
+  handle
+    Code.serialize.versioned v1
+      (Code.load (Code.serialize.versioned v0 (Code.get ln)))
+  with handleTest txt
+
+-- tests that you can load a v0 saved value and save it as v1
+Value.crossVersion : Nat -> Nat -> Text -> a ->{io2.IO} Result
+Value.crossVersion v0 v1 txt a =
+  handle
+    Value.serialize.versioned v1 (Value.deser (save.versioned v0 a))
+  with handleTest txt
 
 handleTest : Text -> Request {Throw Text} a -> Result
 handleTest t = let
@@ -104,6 +130,10 @@ identicality : Text -> a ->{io2.IO} Result
 identicality t x
   = handle identical "" x (roundtrip x) with handleTest t
 
+identicality.versioned : Nat -> Text -> a ->{io2.IO} Result
+identicality.versioned v t x
+  = handle identical "" x (roundtrip.versioned v x) with handleTest t
+
 idempotence : Text -> Link.Term ->{io2.IO} Result
 idempotence t tl =
   handle let
@@ -111,6 +141,16 @@ idempotence t tl =
     b1 = Code.save co1
     co2 = Code.load b1
     b2 = Code.save co2
+    identical "" b1 b2
+  with handleTest t
+
+idempotence.versioned : Nat -> Text -> Link.Term ->{io2.IO} Result
+idempotence.versioned v t tl =
+  handle let
+    co1 = Code.get tl
+    b1 = Code.save.versioned v co1
+    co2 = Code.load b1
+    b2 = Code.save.versioned v co2
     identical "" b1 b2
   with handleTest t
 
@@ -204,12 +244,38 @@ tests =
    , identicality "ident effect" (_ -> zap)
    , identicality "ident zero" zero
    , identicality "ident h" h
-   , identicality "ident text" "hello"
+   , identicality "ident text v5" "hello"
    , identicality "ident int" +5
    , identicality "ident float" 0.5
    , identicality "ident termlink" fDeps
    , identicality "ident bool" false
    , identicality "ident bytes" [fSer, Bytes.empty]
+
+   , identicality.versioned 5 "ident compound v5"
+       (x -> handle f x with zapper (zero 5))
+   , identicality.versioned 5 "ident fib10 v5" fib10
+   , identicality.versioned 5 "ident effect v5" (_ -> zap)
+   , identicality.versioned 5 "ident zero v5" zero
+   , identicality.versioned 5 "ident h v5" h
+   , identicality.versioned 5 "ident text v5" "hello"
+   , identicality.versioned 5 "ident int v5" +5
+   , identicality.versioned 5 "ident float v5" 0.5
+   , identicality.versioned 5 "ident termlink v5" fDeps
+   , identicality.versioned 5 "ident bool v5" false
+   , identicality.versioned 5 "ident bytes v5" [fSer, Bytes.empty]
+
+   , Value.crossVersion 4 5 "cross version compound"
+       (x -> handle f x with zapper (zero 5))
+   , Value.crossVersion 4 5 "cross version fib10" fib10
+   , Value.crossVersion 4 5 "cross version effect" (_ -> zap)
+   , Value.crossVersion 4 5 "cross version zero" zero
+   , Value.crossVersion 4 5 "cross version h" h
+   , Value.crossVersion 4 5 "cross version text" "hello"
+   , Value.crossVersion 4 5 "cross version int" +5
+   , Value.crossVersion 4 5 "cross version float" 0.5
+   , Value.crossVersion 4 5 "cross version termlink" fDeps
+   , Value.crossVersion 4 5 "cross version bool" false
+   , Value.crossVersion 4 5 "cross version bytes" [fSer, Bytes.empty]
    ]
 
 badLoad : '{IO} [Result]
@@ -252,6 +318,27 @@ codeTests =
    , idempotence "idem big" (termLink bigFun)
    , idempotence "idem extensionality" (termLink extensionality)
    , idempotence "idem identicality" (termLink identicality)
+
+   , idempotence.versioned 4 "idem f v4" (termLink f)
+   , idempotence.versioned 4 "idem h v4" (termLink h)
+   , idempotence.versioned 4 "idem rotate v4" (termLink rotate)
+   , idempotence.versioned 4 "idem zapper v4" (termLink zapper)
+   , idempotence.versioned 4 "idem showThree v4" (termLink showThree)
+   , idempotence.versioned 4 "idem concatMap v4" (termLink concatMap)
+   , idempotence.versioned 4 "idem big v4" (termLink bigFun)
+   , idempotence.versioned 4 "idem extensionality v4" (termLink extensionality)
+   , idempotence.versioned 4 "idem identicality v4" (termLink identicality)
+
+   , Code.crossVersion 3 4 "cross version idem f" (termLink f)
+   , Code.crossVersion 3 4 "cross version idem h" (termLink h)
+   , Code.crossVersion 3 4 "cross version idem rotate" (termLink rotate)
+   , Code.crossVersion 3 4 "cross version idem zapper" (termLink zapper)
+   , Code.crossVersion 3 4 "cross version idem showThree" (termLink showThree)
+   , Code.crossVersion 3 4 "cross version idem concatMap" (termLink concatMap)
+   , Code.crossVersion 3 4 "cross version idem big" (termLink bigFun)
+   , Code.crossVersion 3 4 "cross version idem extensionality" (termLink extensionality)
+   , Code.crossVersion 3 4 "cross version idem identicality" (termLink identicality)
+
    , verified "f" (termLink f)
    , verified "h" (termLink h)
    , verified "rotate" (termLink rotate)
@@ -264,9 +351,11 @@ codeTests =
    , verified "mutual0" (termLink mutual0)
    , verified "mutual1" (termLink mutual0)
    , verified "mutual2" (termLink mutual0)
+
    , missed "mutual0" (termLink mutual0)
    , missed "mutual1" (termLink mutual1)
    , missed "mutual2" (termLink mutual2)
+
    , swapped "zapper" (termLink zapper)
    , swapped "extensionality" (termLink extensionality)
    , swapped "identicality" (termLink identicality)

--- a/unison-src/transcripts-using-base/codeops.output.md
+++ b/unison-src/transcripts-using-base/codeops.output.md
@@ -7,20 +7,29 @@ function. Also ask for its dependencies for display later.
 save : a -> Bytes
 save x = Value.serialize (Value.value x)
 
+save.versioned : Nat -> a -> Bytes
+save.versioned v x = Value.serialize.versioned v (Value.value x)
+
 Code.save : Code -> Bytes
 Code.save = Code.serialize
+
+Code.save.versioned : Nat -> Code -> Bytes
+Code.save.versioned = Code.serialize.versioned
 
 Code.get : Link.Term -> Code
 Code.get tl = match Code.lookup tl with
   Some co -> co
   None -> throw "could not look up code"
 
-load : Bytes ->{io2.IO, Throw Text} a
-load b = match Value.deserialize b with
+Value.deser : Bytes ->{io2.IO, Throw Text} Value
+Value.deser b = match Value.deserialize b with
   Left _ -> throw "could not deserialize value"
-  Right v -> match Value.load v with
-    Left _ -> throw "could not load value"
-    Right x -> x
+  Right v -> v
+
+load : Bytes ->{io2.IO, Throw Text} a
+load b = match Value.load (deser b) with
+  Left _ -> throw "could not load value"
+  Right x -> x
 
 Code.load : Bytes ->{io2.IO, Throw Text} Code
 Code.load b = match Code.deserialize b with
@@ -29,6 +38,23 @@ Code.load b = match Code.deserialize b with
 
 roundtrip : a ->{io2.IO, Throw Text} a
 roundtrip x = load (save x)
+
+roundtrip.versioned : Nat -> a ->{io2.IO, Throw Text} a
+roundtrip.versioned v x = load (save.versioned v x)
+
+Code.crossVersion : Nat -> Nat -> Text -> Link.Term ->{io2.IO} Result
+Code.crossVersion v0 v1 txt ln =
+  handle
+    Code.serialize.versioned v1
+      (Code.load (Code.serialize.versioned v0 (Code.get ln)))
+  with handleTest txt
+
+-- tests that you can load a v0 saved value and save it as v1
+Value.crossVersion : Nat -> Nat -> Text -> a ->{io2.IO} Result
+Value.crossVersion v0 v1 txt a =
+  handle
+    Value.serialize.versioned v1 (Value.deser (save.versioned v0 a))
+  with handleTest txt
 
 handleTest : Text -> Request {Throw Text} a -> Result
 handleTest t = let
@@ -104,6 +130,10 @@ identicality : Text -> a ->{io2.IO} Result
 identicality t x
   = handle identical "" x (roundtrip x) with handleTest t
 
+identicality.versioned : Nat -> Text -> a ->{io2.IO} Result
+identicality.versioned v t x
+  = handle identical "" x (roundtrip.versioned v x) with handleTest t
+
 idempotence : Text -> Link.Term ->{io2.IO} Result
 idempotence t tl =
   handle let
@@ -111,6 +141,16 @@ idempotence t tl =
     b1 = Code.save co1
     co2 = Code.load b1
     b2 = Code.save co2
+    identical "" b1 b2
+  with handleTest t
+
+idempotence.versioned : Nat -> Text -> Link.Term ->{io2.IO} Result
+idempotence.versioned v t tl =
+  handle let
+    co1 = Code.get tl
+    b1 = Code.save.versioned v co1
+    co2 = Code.load b1
+    b2 = Code.save.versioned v co2
     identical "" b1 b2
   with handleTest t
 
@@ -160,40 +200,67 @@ swapped name link =
     ⍟ New definitions:
     
       structural type Three a b c
-      Code.get       : Link.Term ->{IO, Throw Text} Code
-      Code.load      : Bytes ->{IO, Throw Text} Code
-      Code.save      : Code -> Bytes
-      concatMap      : (a ->{g} [b]) -> [a] ->{g} [b]
-      expectFailure  : Text -> Request {Throw Text} a -> Result
-      extensionality : Text
-                       -> (Three Nat Nat Nat -> Nat -> b)
-                       ->{IO} Result
-      extensionals   : (a -> b -> Text)
-                       -> (a -> b -> c)
-                       -> (a -> b -> c)
-                       -> [(a, b)]
-                       ->{Throw Text} ()
-      fib10          : [Nat]
-      handleTest     : Text -> Request {Throw Text} a -> Result
-      idempotence    : Text -> Link.Term ->{IO} Result
-      identical      : Text -> a -> a ->{Throw Text} ()
-      identicality   : Text -> a ->{IO} Result
-      load           : Bytes ->{IO, Throw Text} a
-      missed         : Text -> Link.Term ->{IO} Result
-      mutual0        : Nat -> Nat
-      mutual1        : Nat -> Nat
-      mutual2        : Nat -> Nat
-      prod           : [a] -> [b] -> [(a, b)]
-      rejected       : Text -> [(Link.Term, Code)] ->{IO} Result
-      roundtrip      : a ->{IO, Throw Text} a
-      save           : a -> Bytes
-      showThree      : Three Nat Nat Nat -> Text
-      swapped        : Text -> Link.Term ->{IO} Result
-      threes         : [Three Nat Nat Nat]
-      verified       : Text -> Link.Term ->{IO} Result
-      verify         : Text
-                       -> [(Link.Term, Code)]
-                       ->{Throw Text} ()
+      Code.crossVersion      : Nat
+                               -> Nat
+                               -> Text
+                               -> Link.Term
+                               ->{IO} Result
+      Code.get               : Link.Term ->{IO, Throw Text} Code
+      Code.load              : Bytes ->{IO, Throw Text} Code
+      Code.save              : Code -> Bytes
+      Code.save.versioned    : Nat -> Code -> Bytes
+      Value.crossVersion     : Nat
+                               -> Nat
+                               -> Text
+                               -> a
+                               ->{IO} Result
+      Value.deser            : Bytes ->{IO, Throw Text} Value
+      concatMap              : (a ->{g} [b]) -> [a] ->{g} [b]
+      expectFailure          : Text
+                               -> Request {Throw Text} a
+                               -> Result
+      extensionality         : Text
+                               -> (Three Nat Nat Nat
+                               -> Nat
+                               -> b)
+                               ->{IO} Result
+      extensionals           : (a -> b -> Text)
+                               -> (a -> b -> c)
+                               -> (a -> b -> c)
+                               -> [(a, b)]
+                               ->{Throw Text} ()
+      fib10                  : [Nat]
+      handleTest             : Text
+                               -> Request {Throw Text} a
+                               -> Result
+      idempotence            : Text -> Link.Term ->{IO} Result
+      idempotence.versioned  : Nat
+                               -> Text
+                               -> Link.Term
+                               ->{IO} Result
+      identical              : Text -> a -> a ->{Throw Text} ()
+      identicality           : Text -> a ->{IO} Result
+      identicality.versioned : Nat -> Text -> a ->{IO} Result
+      load                   : Bytes ->{IO, Throw Text} a
+      missed                 : Text -> Link.Term ->{IO} Result
+      mutual0                : Nat -> Nat
+      mutual1                : Nat -> Nat
+      mutual2                : Nat -> Nat
+      prod                   : [a] -> [b] -> [(a, b)]
+      rejected               : Text
+                               -> [(Link.Term, Code)]
+                               ->{IO} Result
+      roundtrip              : a ->{IO, Throw Text} a
+      roundtrip.versioned    : Nat -> a ->{IO, Throw Text} a
+      save                   : a -> Bytes
+      save.versioned         : Nat -> a -> Bytes
+      showThree              : Three Nat Nat Nat -> Text
+      swapped                : Text -> Link.Term ->{IO} Result
+      threes                 : [Three Nat Nat Nat]
+      verified               : Text -> Link.Term ->{IO} Result
+      verify                 : Text
+                               -> [(Link.Term, Code)]
+                               ->{Throw Text} ()
 ```
 
 ``` ucm
@@ -254,12 +321,38 @@ tests =
    , identicality "ident effect" (_ -> zap)
    , identicality "ident zero" zero
    , identicality "ident h" h
-   , identicality "ident text" "hello"
+   , identicality "ident text v5" "hello"
    , identicality "ident int" +5
    , identicality "ident float" 0.5
    , identicality "ident termlink" fDeps
    , identicality "ident bool" false
    , identicality "ident bytes" [fSer, Bytes.empty]
+
+   , identicality.versioned 5 "ident compound v5"
+       (x -> handle f x with zapper (zero 5))
+   , identicality.versioned 5 "ident fib10 v5" fib10
+   , identicality.versioned 5 "ident effect v5" (_ -> zap)
+   , identicality.versioned 5 "ident zero v5" zero
+   , identicality.versioned 5 "ident h v5" h
+   , identicality.versioned 5 "ident text v5" "hello"
+   , identicality.versioned 5 "ident int v5" +5
+   , identicality.versioned 5 "ident float v5" 0.5
+   , identicality.versioned 5 "ident termlink v5" fDeps
+   , identicality.versioned 5 "ident bool v5" false
+   , identicality.versioned 5 "ident bytes v5" [fSer, Bytes.empty]
+
+   , Value.crossVersion 4 5 "cross version compound"
+       (x -> handle f x with zapper (zero 5))
+   , Value.crossVersion 4 5 "cross version fib10" fib10
+   , Value.crossVersion 4 5 "cross version effect" (_ -> zap)
+   , Value.crossVersion 4 5 "cross version zero" zero
+   , Value.crossVersion 4 5 "cross version h" h
+   , Value.crossVersion 4 5 "cross version text" "hello"
+   , Value.crossVersion 4 5 "cross version int" +5
+   , Value.crossVersion 4 5 "cross version float" 0.5
+   , Value.crossVersion 4 5 "cross version termlink" fDeps
+   , Value.crossVersion 4 5 "cross version bool" false
+   , Value.crossVersion 4 5 "cross version bytes" [fSer, Bytes.empty]
    ]
 
 badLoad : '{IO} [Result]
@@ -324,14 +417,36 @@ scratch/main> io.test tests
                ◉ (ident effect) passed
                ◉ (ident zero) passed
                ◉ (ident h) passed
-               ◉ (ident text) passed
+               ◉ (ident text v5) passed
                ◉ (ident int) passed
                ◉ (ident float) passed
                ◉ (ident termlink) passed
                ◉ (ident bool) passed
                ◉ (ident bytes) passed
+               ◉ (ident compound v5) passed
+               ◉ (ident fib10 v5) passed
+               ◉ (ident effect v5) passed
+               ◉ (ident zero v5) passed
+               ◉ (ident h v5) passed
+               ◉ (ident text v5) passed
+               ◉ (ident int v5) passed
+               ◉ (ident float v5) passed
+               ◉ (ident termlink v5) passed
+               ◉ (ident bool v5) passed
+               ◉ (ident bytes v5) passed
+               ◉ (cross version compound) passed
+               ◉ (cross version fib10) passed
+               ◉ (cross version effect) passed
+               ◉ (cross version zero) passed
+               ◉ (cross version h) passed
+               ◉ (cross version text) passed
+               ◉ (cross version int) passed
+               ◉ (cross version float) passed
+               ◉ (cross version termlink) passed
+               ◉ (cross version bool) passed
+               ◉ (cross version bytes) passed
 
-  ✅ 13 test(s) passing
+  ✅ 35 test(s) passing
 
   Tip: Use view 1 to view the source of a test.
 
@@ -358,6 +473,27 @@ codeTests =
    , idempotence "idem big" (termLink bigFun)
    , idempotence "idem extensionality" (termLink extensionality)
    , idempotence "idem identicality" (termLink identicality)
+
+   , idempotence.versioned 4 "idem f v4" (termLink f)
+   , idempotence.versioned 4 "idem h v4" (termLink h)
+   , idempotence.versioned 4 "idem rotate v4" (termLink rotate)
+   , idempotence.versioned 4 "idem zapper v4" (termLink zapper)
+   , idempotence.versioned 4 "idem showThree v4" (termLink showThree)
+   , idempotence.versioned 4 "idem concatMap v4" (termLink concatMap)
+   , idempotence.versioned 4 "idem big v4" (termLink bigFun)
+   , idempotence.versioned 4 "idem extensionality v4" (termLink extensionality)
+   , idempotence.versioned 4 "idem identicality v4" (termLink identicality)
+
+   , Code.crossVersion 3 4 "cross version idem f" (termLink f)
+   , Code.crossVersion 3 4 "cross version idem h" (termLink h)
+   , Code.crossVersion 3 4 "cross version idem rotate" (termLink rotate)
+   , Code.crossVersion 3 4 "cross version idem zapper" (termLink zapper)
+   , Code.crossVersion 3 4 "cross version idem showThree" (termLink showThree)
+   , Code.crossVersion 3 4 "cross version idem concatMap" (termLink concatMap)
+   , Code.crossVersion 3 4 "cross version idem big" (termLink bigFun)
+   , Code.crossVersion 3 4 "cross version idem extensionality" (termLink extensionality)
+   , Code.crossVersion 3 4 "cross version idem identicality" (termLink identicality)
+
    , verified "f" (termLink f)
    , verified "h" (termLink h)
    , verified "rotate" (termLink rotate)
@@ -370,9 +506,11 @@ codeTests =
    , verified "mutual0" (termLink mutual0)
    , verified "mutual1" (termLink mutual0)
    , verified "mutual2" (termLink mutual0)
+
    , missed "mutual0" (termLink mutual0)
    , missed "mutual1" (termLink mutual1)
    , missed "mutual2" (termLink mutual2)
+
    , swapped "zapper" (termLink zapper)
    , swapped "extensionality" (termLink extensionality)
    , swapped "identicality" (termLink identicality)
@@ -414,6 +552,24 @@ scratch/main> io.test codeTests
                    ◉ (idem big) passed
                    ◉ (idem extensionality) passed
                    ◉ (idem identicality) passed
+                   ◉ (idem f v4) passed
+                   ◉ (idem h v4) passed
+                   ◉ (idem rotate v4) passed
+                   ◉ (idem zapper v4) passed
+                   ◉ (idem showThree v4) passed
+                   ◉ (idem concatMap v4) passed
+                   ◉ (idem big v4) passed
+                   ◉ (idem extensionality v4) passed
+                   ◉ (idem identicality v4) passed
+                   ◉ (cross version idem f) passed
+                   ◉ (cross version idem h) passed
+                   ◉ (cross version idem rotate) passed
+                   ◉ (cross version idem zapper) passed
+                   ◉ (cross version idem showThree) passed
+                   ◉ (cross version idem concatMap) passed
+                   ◉ (cross version idem big) passed
+                   ◉ (cross version idem extensionality) passed
+                   ◉ (cross version idem identicality) passed
                    ◉ (verified f) passed
                    ◉ (verified h) passed
                    ◉ (verified rotate) passed
@@ -436,7 +592,7 @@ scratch/main> io.test codeTests
                    ◉ (rejected swapped mututal1) passed
                    ◉ (rejected swapped mututal2) passed
 
-  ✅ 30 test(s) passing
+  ✅ 48 test(s) passing
 
   Tip: Use view 1 to view the source of a test.
 ```


### PR DESCRIPTION
This fixes some issues with the last serialization PR.

- `Code.serialize` was choosing between v3 and v4 depending on what sort of values it was given. I did this while developing things, but forgot to roll it back. Now it just uses v3, and you need to use the new builtin to get v4. This caused the issue with the scheme stuff (I think).
- By contrast, the `serialize.versioned` builtins were doing erroneous stuff for the new version if they were given unexpected values. There are basically two sorts of `Code`/`Value`. One with definitely canonicalized references, and a `Plain` one without. If you gave them `Plain` values, they would either throw an exception with the newest version, or use an older format.

I've fixed the latter issue by running canonicalization over the `Plain` values. To do that, I did some refactoring of the wrapper and some associated functions.

I also added tests that check that deserializing old formats and re-serializing in the new format work, which was the scenario that would lead to the weird behavior above.

There's also a transcript change that has to do with changes in `base.u`. I'm not sure how that got through last time.