### PR TITLE
make update v2 the default

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Load.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Load.hs
@@ -75,7 +75,7 @@ import Unison.WatchKind qualified as WK
 
 useUpdateV2 :: Bool
 useUpdateV2 =
-  isJust (unsafePerformIO (lookupEnv "UNISON_USE_UPDATE_V2"))
+  not . isJust . unsafePerformIO $ lookupEnv "UNISON_USE_UPDATE_V1"
 {-# NOINLINE useUpdateV2 #-}
 
 handleLoad :: Maybe FilePath -> Cli ()

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
@@ -84,7 +84,7 @@ import Witch (unsafeFrom)
 
 useUpdateV2 :: Bool
 useUpdateV2 =
-  isJust (unsafePerformIO (lookupEnv "UNISON_USE_UPDATE_V2"))
+  not . isJust . unsafePerformIO $ lookupEnv "UNISON_USE_UPDATE_V1"
 {-# NOINLINE useUpdateV2 #-}
 
 handleUpdate2 :: Cli ()

--- a/unison-src/transcripts-using-base/all-base-hashes.output.md
+++ b/unison-src/transcripts-using-base/all-base-hashes.output.md
@@ -3454,13 +3454,13 @@ scratch/main> find.verbose
        runTest : '{IO, TempDirs, Exception, Stream Result} a
        ->{IO} [Result]
        
-  851. -- #emt8oa7ee2hha5993870s292rk3muaf44m46ribq3959ps80u3msge1e9dp9p4vprqqnha588s8khqplpcatlqv5gmhuj11ek0abpfo
+  968. -- #emt8oa7ee2hha5993870s292rk3muaf44m46ribq3959ps80u3msge1e9dp9p4vprqqnha588s8khqplpcatlqv5gmhuj11ek0abpfo
        saveSelfContained : Optional Nat
        -> a
        -> Text
        ->{IO, Exception} ()
        
-  852. -- #48nls8b5okebjcn689uk8bbo7nenitarsrpvmln9fh0s6mvpnt6slumbg46ofm061urucqeuq70lmkm1chu1b1tdbviid1fl4mriqb8
+  969. -- #48nls8b5okebjcn689uk8bbo7nenitarsrpvmln9fh0s6mvpnt6slumbg46ofm061urucqeuq70lmkm1chu1b1tdbviid1fl4mriqb8
        saveTestCase : Optional Nat
        -> Text
        -> Text

--- a/unison-src/transcripts/idempotent/cycle-update-3.md
+++ b/unison-src/transcripts/idempotent/cycle-update-3.md
@@ -58,9 +58,12 @@ scratch/main> update
 
   That's done. Now I'm making sure everything typechecks...
 
-  Typechecking failed. I've updated your scratch file with the
-  definitions that need fixing. Once the file is compiling, try
-  `update` again.
+  Some definitions don't typecheck with your changes. I've
+  update the file scratch.u with the definitions that need
+  fixing. Once the file is compiling, try `update` again.
+
+  I've also switched you to a new branch update-main for this
+  work. On `update`, it will be merged back into main.
 ```
 
 ``` unison :added-by-ucm scratch.u

--- a/unison-src/transcripts/idempotent/update-suffixifies-properly.md
+++ b/unison-src/transcripts/idempotent/update-suffixifies-properly.md
@@ -60,9 +60,12 @@ myproject/main> update
 
   That's done. Now I'm making sure everything typechecks...
 
-  Typechecking failed. I've updated your scratch file with the
-  definitions that need fixing. Once the file is compiling, try
-  `update` again.
+  Some definitions don't typecheck with your changes. I've
+  update the file scratch.u with the definitions that need
+  fixing. Once the file is compiling, try `update` again.
+
+  I've also switched you to a new branch update-main for this
+  work. On `update`, it will be merged back into main.
 ```
 
 ``` unison :added-by-ucm scratch.u

--- a/unison-src/transcripts/idempotent/update-term-with-dependent-to-different-type.md
+++ b/unison-src/transcripts/idempotent/update-term-with-dependent-to-different-type.md
@@ -58,9 +58,12 @@ scratch/main> update
 
   That's done. Now I'm making sure everything typechecks...
 
-  Typechecking failed. I've updated your scratch file with the
-  definitions that need fixing. Once the file is compiling, try
-  `update` again.
+  Some definitions don't typecheck with your changes. I've
+  update the file scratch.u with the definitions that need
+  fixing. Once the file is compiling, try `update` again.
+
+  I've also switched you to a new branch update-main for this
+  work. On `update`, it will be merged back into main.
 ```
 
 ``` unison :added-by-ucm scratch.u

--- a/unison-src/transcripts/idempotent/update-test-watch-roundtrip.md
+++ b/unison-src/transcripts/idempotent/update-test-watch-roundtrip.md
@@ -47,9 +47,12 @@ scratch/main> update
 
   That's done. Now I'm making sure everything typechecks...
 
-  Typechecking failed. I've updated your scratch file with the
-  definitions that need fixing. Once the file is compiling, try
-  `update` again.
+  Some definitions don't typecheck with your changes. I've
+  update the file scratch.u with the definitions that need
+  fixing. Once the file is compiling, try `update` again.
+
+  I've also switched you to a new branch update-main for this
+  work. On `update`, it will be merged back into main.
 ```
 
 ``` unison :added-by-ucm scratch.u

--- a/unison-src/transcripts/idempotent/update-type-delete-constructor-with-dependent.md
+++ b/unison-src/transcripts/idempotent/update-type-delete-constructor-with-dependent.md
@@ -59,9 +59,12 @@ scratch/main> update
 
   That's done. Now I'm making sure everything typechecks...
 
-  Typechecking failed. I've updated your scratch file with the
-  definitions that need fixing. Once the file is compiling, try
-  `update` again.
+  Some definitions don't typecheck with your changes. I've
+  update the file scratch.u with the definitions that need
+  fixing. Once the file is compiling, try `update` again.
+
+  I've also switched you to a new branch update-main for this
+  work. On `update`, it will be merged back into main.
 ```
 
 ``` unison :added-by-ucm scratch.u

--- a/unison-src/transcripts/idempotent/update-type-delete-record-field.md
+++ b/unison-src/transcripts/idempotent/update-type-delete-record-field.md
@@ -30,6 +30,17 @@ scratch/main> add
   updated...
 
   Done.
+
+scratch/main> find
+
+  1. type Foo
+  2. Foo.bar : Foo -> Nat
+  3. Foo.bar.modify : (Nat ->{g} Nat) -> Foo ->{g} Foo
+  4. Foo.bar.set : Nat -> Foo -> Foo
+  5. Foo.baz : Foo -> Int
+  6. Foo.baz.modify : (Int ->{g} Int) -> Foo ->{g} Foo
+  7. Foo.baz.set : Int -> Foo -> Foo
+  8. Foo.Foo : Nat -> Int -> Foo
 ```
 
 ``` unison
@@ -61,40 +72,12 @@ scratch/main> update
 
   That's done. Now I'm making sure everything typechecks...
 
-  Typechecking failed. I've updated your scratch file with the
-  definitions that need fixing. Once the file is compiling, try
-  `update` again.
+  Some definitions don't typecheck with your changes. I've
+  update the file scratch.u with the definitions that need
+  fixing. Once the file is compiling, try `update` again.
 
-scratch/main> view Foo
-
-  type Foo = { bar : Nat, baz : Int }
-
-scratch/main> find.verbose
-
-  1. -- #m0tpa159pbsdld5ea0marnq9614dnmjjc72n1evi4bsk45a1hl84qprt6vdvejuuiuc3f5o23olc1t19tk1dt8mjobmr0chqc3svij8
-     type Foo
-     
-  2. -- #16o21u2lli7rd8f3h4epnblpfk3h68gag99d5gicihcpk15dkv4m9601picg37ncsbg2e8j63tu7ebs40jrcoifs7f6nqrus3qnfgv0
-     Foo.bar : Foo -> Nat
-     
-  3. -- #64v4pv4rvmnts82gbsb1u2dvgdu4eqq8leq37anqjrkq8s9c7ogrjahdotc36nrodva6ok1rs4ah5k09i7sb0clvcap2773k1t7thb8
-     Foo.bar.modify : (Nat ->{g} Nat) -> Foo ->{g} Foo
-     
-  4. -- #bkfjhnu5jqv2m49hosd8g6m4e5u9ju4b1du90cji8s8hnaendvnep2a5cd085ejtu27c4lm3u7slamk52p86rubp211jc5c0qcut2l0
-     Foo.bar.set : Nat -> Foo -> Foo
-     
-  5. -- #u394ule3vr1ab8q5nit6miktgpki9gj4nft5jfjsho6cflg94kf953mdhjj8s18e9j1525iv8l5ebjhebnuc01q51fl8ni5n9j0gs28
-     Foo.baz : Foo -> Int
-     
-  6. -- #cbbi7mqcaqdlcl41uajb608b8fi5dfvc654rmd47mk9okpn1t3jltrf8psnn3g2tnr1ftctj753fjhco3ku1oapc664upo1h6eodfrg
-     Foo.baz.modify : (Int ->{g} Int) -> Foo ->{g} Foo
-     
-  7. -- #hhi45ik1245qq3g93586f998di8j5afvjamqr2m08auqq8ogqt4d01rejrse4qsl27381vnqnt8uffhgvnc0nk22o5uabimjhji4868
-     Foo.baz.set : Int -> Foo -> Foo
-     
-  8. -- #m0tpa159pbsdld5ea0marnq9614dnmjjc72n1evi4bsk45a1hl84qprt6vdvejuuiuc3f5o23olc1t19tk1dt8mjobmr0chqc3svij8#0
-     Foo.Foo : Nat -> Int -> Foo
-     
+  I've also switched you to a new branch update-main for this
+  work. On `update`, it will be merged back into main.
 ```
 
 ``` unison :added-by-ucm scratch.u
@@ -112,4 +95,55 @@ Foo.baz.modify f = cases Foo bar baz -> Foo bar (f baz)
 Foo.baz.set : Int -> Foo -> Foo
 Foo.baz.set baz1 = cases Foo bar _ -> Foo bar baz1
 
+```
+
+The definitions related to the update are only present in the scratch file now,
+and not in the temporary branch:
+
+``` unison
+scratch/update-main> ls
+
+  1. lib/ (580 terms, 100 types)
+```
+
+so we can remove the unwanted definitions from the scratch file and `update` again to delete them:
+
+``` unison
+type Foo = { bar : Nat }
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  ~ type Foo
+
+  ~ Foo.bar        : Foo -> Nat
+  ~ Foo.bar.modify : (Nat ->{g} Nat) -> Foo ->{g} Foo
+  ~ Foo.bar.set    : Nat -> Foo -> Foo
+  - Foo.baz        : Foo -> Int
+  - Foo.baz.modify : (Int ->{g} Int) -> Foo ->{g} Foo
+  - Foo.baz.set    : Int -> Foo -> Foo
+
+  + (added), ~ (modified), - (deleted)
+
+  Run `update` to apply these changes to your codebase.
+```
+
+``` ucm
+scratch/update-main> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  I fast-forward merged scratch/update-main into scratch/main.
+
+  Done.
+
+scratch/main> find
+
+  1. type Foo
+  2. Foo.bar : Foo -> Nat
+  3. Foo.bar.modify : (Nat ->{g} Nat) -> Foo ->{g} Foo
+  4. Foo.bar.set : Nat -> Foo -> Foo
+  5. Foo.Foo : Nat -> Foo
 ```

--- a/unison-src/transcripts/idempotent/update-type-with-dependent-term.md
+++ b/unison-src/transcripts/idempotent/update-type-with-dependent-term.md
@@ -54,9 +54,12 @@ scratch/main> update
 
   That's done. Now I'm making sure everything typechecks...
 
-  Typechecking failed. I've updated your scratch file with the
-  definitions that need fixing. Once the file is compiling, try
-  `update` again.
+  Some definitions don't typecheck with your changes. I've
+  update the file scratch.u with the definitions that need
+  fixing. Once the file is compiling, try `update` again.
+
+  I've also switched you to a new branch update-main for this
+  work. On `update`, it will be merged back into main.
 ```
 
 ``` unison :added-by-ucm scratch.u

--- a/unison-src/transcripts/idempotent/update-type-with-dependent-type-to-different-kind.md
+++ b/unison-src/transcripts/idempotent/update-type-with-dependent-type-to-different-kind.md
@@ -52,9 +52,12 @@ scratch/main> update
 
   That's done. Now I'm making sure everything typechecks...
 
-  Typechecking failed. I've updated your scratch file with the
-  definitions that need fixing. Once the file is compiling, try
-  `update` again.
+  Some definitions don't typecheck with your changes. I've
+  update the file scratch.u with the definitions that need
+  fixing. Once the file is compiling, try `update` again.
+
+  I've also switched you to a new branch update-main for this
+  work. On `update`, it will be merged back into main.
 ```
 
 ``` unison :added-by-ucm scratch.u


### PR DESCRIPTION
* manually tested that setting `UNISON_USE_UPDATE_V1` does trigger the old behavior
* updated `update-type-delete-record-field.md` to show new process to delete a record field, which previously we couldn't show completely
