### PR TITLE
Refactor some intermediate and serialization code

### DIFF
--- a/unison-runtime/src/Unison/Runtime/ANF.hs
+++ b/unison-runtime/src/Unison/Runtime/ANF.hs
@@ -909,10 +909,11 @@ alignBranch f (MatchText bl dl) (MatchText br dr)
           <*> ds
 alignBranch f (MatchRequest bl pl) (MatchRequest br pr)
   | Just bs <- alignAscList h bl br =
-    Just $ MatchRequest <$> bs <*> f pl pr
+      Just $ MatchRequest <$> bs <*> f pl pr
   where
     h csl csr
-      | keysSet csl == keysSet csr, all q (keys csl) =
+      | keysSet csl == keysSet csr,
+        all q (keys csl) =
           Just $ interverse (alignCCs f) csl csr
       | otherwise = Nothing
       where
@@ -955,9 +956,9 @@ alignAscList f ls0 rs0
       Left n -> (n, sortBy (comparing fst) rs0)
       Right n -> (n, rs0)
 
-    prep !n ((k0,_) : xs@((k1, _) : _))
-      | k0 <= k1 = prep (n+1) xs
-    prep n [_] = Right (n+1)
+    prep !n ((k0, _) : xs@((k1, _) : _))
+      | k0 <= k1 = prep (n + 1) xs
+    prep n [_] = Right (n + 1)
     prep n [] = Right n
     prep n xs = Left (n + length xs)
 

--- a/unison-runtime/src/Unison/Runtime/ANF.hs
+++ b/unison-runtime/src/Unison/Runtime/ANF.hs
@@ -64,8 +64,6 @@ module Unison.Runtime.ANF
     Code (..),
     ValList,
     Value (..),
-    Referenced (..),
-    dereference,
     Cont (..),
     BLit (..),
     packTags,
@@ -109,6 +107,7 @@ import Data.Bitraversable (Bitraversable (..))
 import Data.Functor.Compose (Compose (..))
 import Data.List hiding (and, or)
 import Data.Map qualified as Map
+import Data.Ord (comparing)
 import Data.Set qualified as Set
 import Data.Text qualified as Data.Text
 import GHC.Stack (CallStack, callStack)
@@ -125,7 +124,6 @@ import Unison.Reference (Id, Reference, Reference' (Builtin, DerivedId), toShort
 import Unison.Referent (Referent, pattern Con, pattern Ref)
 import Unison.Runtime.Array qualified as PA
 import Unison.Runtime.Foreign.Function.Type (ForeignFunc (..))
-import Unison.Runtime.Referenced
 import Unison.Runtime.TypeTags (CTag (..), PackedTag (..), RTag (..), Tag (..), maskTags, packTags, unpackTags)
 import Unison.ShortHash (shortenTo)
 import Unison.Symbol (Symbol)
@@ -910,18 +908,15 @@ alignBranch f (MatchText bl dl) (MatchText br dr)
           <$> traverse id (Map.intersectionWith f bl br)
           <*> ds
 alignBranch f (MatchRequest bl pl) (MatchRequest br pr)
-  | Map.keysSet bl == Map.keysSet br,
-    all p (Map.keysSet bl) =
-      Just $
-        MatchRequest
-          <$> traverse id (Map.intersectionWith (interverse (alignCCs f)) bl br)
-          <*> f pl pr
+  | Just bs <- alignAscList h bl br =
+    Just $ MatchRequest <$> bs <*> f pl pr
   where
-    p r = keysSet hsl == keysSet hsr && all q (keys hsl)
+    h csl csr
+      | keysSet csl == keysSet csr, all q (keys csl) =
+          Just $ interverse (alignCCs f) csl csr
+      | otherwise = Nothing
       where
-        hsl = bl Map.! r
-        hsr = br Map.! r
-        q t = fst (hsl ! t) == fst (hsr ! t)
+        q t = fst (csl ! t) == fst (csr ! t)
 alignBranch f (MatchData rfl bl dl) (MatchData rfr br dr)
   | rfl == rfr,
     keysSet bl == keysSet br,
@@ -941,6 +936,35 @@ alignBranch f (MatchNumeric rl bl dl) (MatchNumeric rr br dr)
           <$> interverse f bl br
           <*> ds
 alignBranch _ _ _ = Nothing
+
+alignAscList ::
+  (Applicative f, Ord k) =>
+  (a -> b -> Maybe (f c)) ->
+  [(k, a)] ->
+  [(k, b)] ->
+  Maybe (f [(k, c)])
+alignAscList f ls0 rs0
+  | ll /= lr = Nothing
+  | otherwise = getCompose $ zipped ls rs
+  where
+    (ll, ls) = case prep 0 ls0 of
+      Left n -> (n, sortBy (comparing fst) ls0)
+      Right n -> (n, ls0)
+
+    (lr, rs) = case prep 0 rs0 of
+      Left n -> (n, sortBy (comparing fst) rs0)
+      Right n -> (n, rs0)
+
+    prep !n ((k0,_) : xs@((k1, _) : _))
+      | k0 <= k1 = prep (n+1) xs
+    prep n [_] = Right (n+1)
+    prep n [] = Right n
+    prep n xs = Left (n + length xs)
+
+    zipped [] [] = Compose . Just $ pure []
+    zipped ((lk, lv) : lkvs) ((rk, rv) : rkvs)
+      | lk == rk = (:) . (lk,) <$> Compose (f lv rv) <*> zipped lkvs rkvs
+    zipped _ _ = Compose Nothing
 
 alignCCs :: (Functor f) => (l -> r -> f s) -> (a, l) -> (a, r) -> f (a, s)
 alignCCs f (ccs, l) (_, r) = (,) ccs <$> f l r
@@ -1208,7 +1232,7 @@ data SeqEnd = SLeft | SRight
 data Branched e
   = MatchIntegral (EnumMap Word64 e) (Maybe e)
   | MatchText (Map.Map Util.Text.Text e) (Maybe e)
-  | MatchRequest (Map Reference (EnumMap CTag ([Mem], e))) e
+  | MatchRequest [(Reference, (EnumMap CTag ([Mem], e)))] e
   | MatchEmpty
   | MatchData Reference (EnumMap CTag ([Mem], e)) (Maybe e)
   | MatchSum (EnumMap Word64 ([Mem], e))
@@ -2125,7 +2149,7 @@ makeHandler v abr df = do
       Set.toList $ ABTN.freeVars hfb `Set.difference` gvs
   pure (hfvs, Lambda (BX <$ hfvs ++ [v]) $ ABTN.TAbss hfvs hfb)
   where
-    hfb = ABTN.TAbs v . TMatch v $ MatchRequest abr df
+    hfb = ABTN.TAbs v . TMatch v $ MatchRequest (Map.toList abr) df
 
 -- Note: this assumes that patterns have already been translated
 -- to a state in which every case matches a single layer of data,
@@ -2426,6 +2450,7 @@ anfFLinks f g (AHnd rs nh ah e) =
   (\rs -> AHnd rs nh ah) <$> traverse (f True) rs <*> g e
 anfFLinks f _ (AApp fu vs) = flip AApp vs <$> funcLinks f fu
 anfFLinks f _ (ALit l) = ALit <$> litLinks f l
+anfFLinks f _ (ABLit l) = ABLit <$> litLinks f l
 anfFLinks _ _ v = pure v
 
 litLinks ::
@@ -2446,9 +2471,9 @@ branchLinks ::
   Branched e ->
   f (Branched e)
 branchLinks f g (MatchRequest m e) =
-  MatchRequest . Map.fromList
-    <$> traverse (bitraverse f $ (traverse . traverse) g) (Map.toList m)
-    <*> g e
+  MatchRequest <$> traverse h m <*> g e
+  where
+    h (r, cs) = (,) <$> f r <*> (traverse . traverse) g cs
 branchLinks f g (MatchData r m e) =
   MatchData <$> f r <*> (traverse . traverse) g m <*> traverse g e
 branchLinks _ g (MatchText m e) =
@@ -2693,7 +2718,7 @@ prettyBranches ind bs = case bs of
             (mapToList $ snd <$> m)
       )
       (prettyCase ind (showString "REQ(0,0)") df id)
-      (Map.toList bs)
+      bs
   MatchSum bs ->
     foldr
       (uncurry $ prettyCase ind . shows)

--- a/unison-runtime/src/Unison/Runtime/ANF/Optimize.hs
+++ b/unison-runtime/src/Unison/Runtime/ANF/Optimize.hs
@@ -734,11 +734,11 @@ translateHandlerMatch opts self ah (Lambda ccs (ABTN.TAbss args body))
         . ABTN.TAbss args
         . TMatch u
         . flip MatchRequest df
-        <$> traverse3 (affineHandlerCase opts self bound vs ah) cs
+        <$> traverse4 (affineHandlerCase opts self bound vs ah) cs
   | otherwise = Nothing
   where
     ar = freshAff 2
-    traverse3 = traverse . traverse . traverse
+    traverse4 = traverse . traverse . traverse . traverse
 
 -- Recognizes the entry combinator of a compiled handler. If it is
 -- one, then the result is a modified version with an affine handler

--- a/unison-runtime/src/Unison/Runtime/ANF/Serialize.hs
+++ b/unison-runtime/src/Unison/Runtime/ANF/Serialize.hs
@@ -714,7 +714,7 @@ putBranches refrep fops ctx bs = case bs of
     putMaybe df $ putNormal refrep fops ctx
   MatchRequest m (TAbs v df) -> do
     putTag MReqT
-    putMap putReference (putEnumMap putCTag (putCase refrep fops ctx)) m
+    putMapping putReference (putEnumMap putCTag (putCase refrep fops ctx)) m
     putNormal refrep fops (v : ctx) df
   MatchData r m df -> do
     putTag MDataT
@@ -751,7 +751,7 @@ getBranches ctx frsh0 =
         <*> getMaybe (getNormal ctx frsh0)
     MReqT ->
       MatchRequest
-        <$> getMap getReference (getEnumMap getCTag (getCase ctx frsh0))
+        <$> getMapping getReference (getEnumMap getCTag (getCase ctx frsh0))
         <*> (TAbs v <$> getNormal (v : ctx) (frsh0 + 1))
       where
         v = getFresh frsh0

--- a/unison-runtime/src/Unison/Runtime/ANF/Serialize/CodeV4.hs
+++ b/unison-runtime/src/Unison/Runtime/ANF/Serialize/CodeV4.hs
@@ -20,6 +20,7 @@ import Unison.Runtime.ANF.Serialize.Tags
 import Unison.Runtime.Canonicalizer qualified as C
 import Unison.Runtime.Exception
 import Unison.Runtime.Foreign.Function.Type (ForeignFunc)
+import Unison.Runtime.Referenced
 import Unison.Runtime.Serialize hiding
   ( getReferent,
     putReferent,
@@ -554,7 +555,7 @@ putBranches pref@(tys, _) fops ctx bs = case bs of
     putMaybe df $ putNormal pref fops ctx
   MatchRequest m (TAbs v df) -> do
     putTag MReqT
-    putMap
+    putMapping
       (putReferenceByNumber tys)
       (putEnumMap putCTag (putCase pref fops ctx))
       m
@@ -594,7 +595,7 @@ getBranches gref@(tys, _) ctx frsh0 =
         <*> getMaybe (getNormal gref ctx frsh0)
     MReqT ->
       MatchRequest
-        <$> getMap
+        <$> getMapping
           (getReferenceByNumber tys)
           (getEnumMap getCTag (getCase gref ctx frsh0))
         <*> (TAbs v <$> getNormal gref (v : ctx) (frsh0 + 1))

--- a/unison-runtime/src/Unison/Runtime/ANF/Serialize/ValueV5.hs
+++ b/unison-runtime/src/Unison/Runtime/ANF/Serialize/ValueV5.hs
@@ -18,6 +18,7 @@ import Unison.Runtime.ANF as ANF hiding (Tag)
 import Unison.Runtime.ANF.Serialize.CodeV4
 import Unison.Runtime.ANF.Serialize.Tags
 import Unison.Runtime.Canonicalizer
+import Unison.Runtime.Referenced
 import Unison.Runtime.Serialize hiding
   ( getConstructorReference,
     getReference,

--- a/unison-runtime/src/Unison/Runtime/Builtin.hs
+++ b/unison-runtime/src/Unison/Runtime/Builtin.hs
@@ -488,7 +488,7 @@ raise =
   binop0 2 $ \[ah, r, f, n] ->
     TMatch r
       . flip MatchRequest (TAbs f $ TVar f)
-      . Map.singleton Ty.exceptionRef
+      . (:[]) . (Ty.exceptionRef,)
       $ mapSingleton
         0
         ( [BX],

--- a/unison-runtime/src/Unison/Runtime/Builtin.hs
+++ b/unison-runtime/src/Unison/Runtime/Builtin.hs
@@ -488,7 +488,8 @@ raise =
   binop0 2 $ \[ah, r, f, n] ->
     TMatch r
       . flip MatchRequest (TAbs f $ TVar f)
-      . (:[]) . (Ty.exceptionRef,)
+      . (: [])
+      . (Ty.exceptionRef,)
       $ mapSingleton
         0
         ( [BX],

--- a/unison-runtime/src/Unison/Runtime/Canonicalizer.hs
+++ b/unison-runtime/src/Unison/Runtime/Canonicalizer.hs
@@ -116,28 +116,44 @@ canonicalize cn !x =
   unsafePerformIO $ makeStableName x >>= canonicalize0 cn x
 {-# INLINEABLE canonicalize #-}
 
-newtype CanonMap k v = CanonM (HashMap (StableName k) v)
+data CanonMap k v =
+  CanonM { _fast :: HashMap (StableName k) v,
+           _slow :: M.Map k v
+         }
   deriving (Functor)
 
-lookup :: k -> CanonMap k v -> IO (Maybe v)
-lookup !k (CanonM m) = flip HM.lookup m <$> makeStableName k
+lookup0 :: (Ord k) => k -> CanonMap k v -> StableName k -> Maybe v
+lookup0 k (CanonM fast slow) name
+  | r@Just {} <- HM.lookup name fast = r
+  | otherwise = M.lookup k slow
+{-# INLINE lookup0 #-}
+
+lookup :: (Ord k) => k -> CanonMap k v -> IO (Maybe v)
+lookup !k m = lookup0 k m <$> makeStableName k
 {-# INLINE lookup #-}
 
-findWithDefault :: v -> k -> CanonMap k v -> IO v
-findWithDefault d !k (CanonM m) =
-  flip (HM.findWithDefault d) m <$> makeStableName k
+findWithDefault0 :: (Ord k) => v -> k -> CanonMap k v -> StableName k -> v
+findWithDefault0 df k (CanonM fast slow) name =
+  HM.findWithDefault (M.findWithDefault df k slow) name fast
+{-# INLINE findWithDefault0 #-}
+
+findWithDefault :: (Ord k) => v -> k -> CanonMap k v -> IO v
+findWithDefault df !k m =
+  findWithDefault0 df k m <$> makeStableName k
 {-# INLINE findWithDefault #-}
 
-unsafeLookup :: k -> CanonMap k v -> Maybe v
+unsafeLookup :: (Ord k) => k -> CanonMap k v -> Maybe v
 unsafeLookup k m = unsafePerformIO $ lookup k m
 {-# INLINE unsafeLookup #-}
 
-fromListByIndex :: [k] -> CanonMap k Int
-fromListByIndex l = unsafePerformIO do
-  l <- traverse (\k -> makeStableName =<< evaluate k) l
-  pure . CanonM $ HM.fromList (zip l [0 ..])
+fromListByIndex :: (Ord k) => [k] -> CanonMap k Int
+fromListByIndex ks = unsafePerformIO do
+  ns <- traverse (\k -> makeStableName =<< evaluate k) ks
+  pure $ CanonM (HM.fromList (zip ns [0 ..])) (M.fromList (zip ks [0 ..]))
 
-fromList :: [(k, v)] -> IO (CanonMap k v)
-fromList = fmap (CanonM . HM.fromList) . traverse f
+fromList :: (Ord k) => [(k, v)] -> IO (CanonMap k v)
+fromList kvs = do
+  nvs <- traverse f kvs
+  pure $ CanonM (HM.fromList nvs) (M.fromList kvs)
   where
     f (k, v) = (,v) <$> (makeStableName =<< evaluate k)

--- a/unison-runtime/src/Unison/Runtime/Canonicalizer.hs
+++ b/unison-runtime/src/Unison/Runtime/Canonicalizer.hs
@@ -116,10 +116,10 @@ canonicalize cn !x =
   unsafePerformIO $ makeStableName x >>= canonicalize0 cn x
 {-# INLINEABLE canonicalize #-}
 
-data CanonMap k v =
-  CanonM { _fast :: HashMap (StableName k) v,
-           _slow :: M.Map k v
-         }
+data CanonMap k v = CanonM
+  { _fast :: HashMap (StableName k) v,
+    _slow :: M.Map k v
+  }
   deriving (Functor)
 
 lookup0 :: (Ord k) => k -> CanonMap k v -> StableName k -> Maybe v

--- a/unison-runtime/src/Unison/Runtime/Foreign.hs
+++ b/unison-runtime/src/Unison/Runtime/Foreign.hs
@@ -35,9 +35,9 @@ import System.Mem.StableName
 import System.Process (ProcessHandle)
 import Unison.Reference (Reference)
 import Unison.Referent (Referent)
-import Unison.Runtime.Referenced (Referenced, dereference)
 import Unison.Runtime.ANF (Code, Value)
 import Unison.Runtime.Array
+import Unison.Runtime.Referenced (Referenced, dereference)
 import Unison.Type qualified as Ty
 import Unison.Util.Bytes (Bytes)
 import Unison.Util.Text (Text)

--- a/unison-runtime/src/Unison/Runtime/Foreign.hs
+++ b/unison-runtime/src/Unison/Runtime/Foreign.hs
@@ -35,7 +35,8 @@ import System.Mem.StableName
 import System.Process (ProcessHandle)
 import Unison.Reference (Reference)
 import Unison.Referent (Referent)
-import Unison.Runtime.ANF (Code, Referenced, Value, dereference)
+import Unison.Runtime.Referenced (Referenced, dereference)
+import Unison.Runtime.ANF (Code, Value)
 import Unison.Runtime.Array
 import Unison.Type qualified as Ty
 import Unison.Util.Bytes (Bytes)

--- a/unison-runtime/src/Unison/Runtime/Foreign/Function.hs
+++ b/unison-runtime/src/Unison/Runtime/Foreign/Function.hs
@@ -171,6 +171,7 @@ import Unison.Runtime.Foreign.Function.Type
     foreignFuncBuiltinName,
   )
 import Unison.Runtime.MCode
+import Unison.Runtime.Referenced (Referenced, dereference)
 import Unison.Runtime.Stack
 import Unison.Runtime.TypeTags qualified as TT
 import Unison.Symbol
@@ -504,21 +505,21 @@ foreignCallHelper = \case
   Tls_terminate_impl_v3 -> mkForeignTls $
     \(tls :: Tls) -> TLS.bye tls.context
   Code_validateLinks -> mkForeignExn $
-    \(lsgs0 :: [(Referent, ANF.Referenced ANF.Code)]) -> do
+    \(lsgs0 :: [(Referent, Referenced ANF.Code)]) -> do
       let f (msg, rs) =
             F.Failure Ty.miscFailureRef (Util.Text.fromText msg) rs
-      pure . first f . checkGroupHashes $ second ANF.dereference <$> lsgs0
+      pure . first f . checkGroupHashes $ second dereference <$> lsgs0
   Code_dependencies -> mkForeign $
-    \(ANF.dereference -> ANF.CodeRep sg _) ->
+    \(dereference -> ANF.CodeRep sg _) ->
       -- note: it's not correct to use the stored references of a
       -- `Referenced Code` because they may over-estimate the actual
       -- occurrences.
       pure $ Ref <$> ANF.groupTermLinks sg
   Code_serialize -> mkForeign $
-    \(co :: ANF.Referenced ANF.Code) ->
+    \(co :: Referenced ANF.Code) ->
       pure . Bytes.fromArray $ ANF.serializeCode False co
   Code_serialize_versioned -> mkForeign $
-    \(ver :: Word64, co :: ANF.Referenced ANF.Code) ->
+    \(ver :: Word64, co :: Referenced ANF.Code) ->
       ANF.serializeCodeWithVersion ver False co >>= \case
         Left err -> die err
         Right bs -> pure $ Bytes.fromLazyByteString bs
@@ -526,11 +527,11 @@ foreignCallHelper = \case
     mkForeign $
       pure . ANF.deserializeCode . Bytes.toArray
   Code_display -> mkForeign $
-    \(nm, (ANF.dereference -> ANF.CodeRep sg _)) ->
+    \(nm, (dereference -> ANF.CodeRep sg _)) ->
       pure $ ANF.prettyGroup @Symbol (Util.Text.unpack nm) sg ""
   Value_dependencies ->
     mkForeign $
-      pure . fmap (Wrap Ty.termLinkRef . Ref) . ANF.valueTermLinks . ANF.dereference
+      pure . fmap (Wrap Ty.termLinkRef . Ref) . ANF.valueTermLinks . dereference
   Value_serialize ->
     mkForeign $
       pure . Bytes.fromArray . ANF.serializeValue
@@ -567,7 +568,7 @@ foreignCallHelper = \case
             L.ByteString ->
             Hash.Digest a
           hashlazy _ l = Hash.hashlazy l
-       in pure . Bytes.fromArray . hashlazy alg . ANF.serializeValueForHash $ ANF.dereference x
+       in pure . Bytes.fromArray . hashlazy alg . ANF.serializeValueForHash $ dereference x
   Crypto_hmac -> mkForeign $
     \(HashAlgorithm _ alg, key, x) ->
       let hmac ::
@@ -577,7 +578,7 @@ foreignCallHelper = \case
               . HMAC.updates
                 (HMAC.initialize $ Bytes.toArray @BA.Bytes key)
               $ L.toChunks s
-       in pure . Bytes.fromArray . hmac alg . ANF.serializeValueForHash $ ANF.dereference x
+       in pure . Bytes.fromArray . hmac alg . ANF.serializeValueForHash $ dereference x
   Crypto_Ed25519_sign_impl ->
     mkForeign $
       pure . signEd25519Wrapper
@@ -592,7 +593,7 @@ foreignCallHelper = \case
       pure . verifyRsaWrapper
   Universal_murmurHash ->
     mkForeign $
-      pure . asWord64 . hash64 . ANF.serializeValueForHash . ANF.dereference
+      pure . asWord64 . hash64 . ANF.serializeValueForHash . dereference
   IO_randomBytes -> mkForeign $
     \n -> Bytes.fromArray <$> getRandomBytes @IO @ByteString n
   Bytes_zlib_compress -> mkForeign $ pure . Bytes.zlibCompress

--- a/unison-runtime/src/Unison/Runtime/MCode.hs
+++ b/unison-runtime/src/Unison/Runtime/MCode.hs
@@ -1050,7 +1050,7 @@ emitSection rns grpr grpn rec ctx (TMatch v bs)
         <$> emitDataMatching r rns grpr grpn rec ctx cs df
   | Just (i, BX) <- ctxResolve ctx v,
     MatchRequest hs0 df <- bs,
-    hs <- mapFromList $ first (dnum rns) <$> M.toList hs0 =
+    hs <- mapFromList $ first (dnum rns) <$> hs0 =
       uncurry (RMatch i)
         <$> emitRequestMatching rns grpr grpn rec ctx hs df
   | Just (i, UN) <- ctxResolve ctx v,

--- a/unison-runtime/src/Unison/Runtime/Machine.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine.hs
@@ -1213,7 +1213,7 @@ updateMap new0 r = do
 decodeCacheArgument :: USeq -> IO [(Reference, Code)]
 decodeCacheArgument s = traverse (f <=< decodeVal) $ toList s
   where
-    f (Ref r, rco) = pure (r, ANF.dereference rco)
+    f (Ref r, rco) = pure (r, dereference rco)
     f _ = die "decodeCacheArgument: Con reference"
 
 addRefs ::
@@ -1432,11 +1432,11 @@ canonicalizeReferent (Ref r) = Ref <$> canonicalizeReference False r
 canonicalizeReferent (Con (ConstructorReference r i) j) =
   flip Con j . flip ConstructorReference i <$> canonicalizeReference True r
 
-canonicalizeReferenced :: RTrav a -> ANF.Referenced a -> Reflect a
+canonicalizeReferenced :: RTrav a -> Referenced a -> Reflect a
 canonicalizeReferenced trav x = mediate $ recanonicalizeRefs trav x
 {-# INLINE canonicalizeReferenced #-}
 
-reflectValue :: CCache -> Val -> IO (ANF.Referenced ANF.Value)
+reflectValue :: CCache -> Val -> IO (Referenced ANF.Value)
 reflectValue env val = do
   tyr <- readTVarIO (tagRefs env)
   tmr <- readTVarIO (combRefs env)
@@ -1479,7 +1479,7 @@ reflectValue0 ::
   EnumMap Word64 Reference ->
   EnumMap Word64 Reference ->
   Val ->
-  IO (ANF.Referenced ANF.Value)
+  IO (Referenced ANF.Value)
 reflectValue0 rty rtm = goV0
   where
     refTy w =
@@ -1509,9 +1509,9 @@ reflectValue0 rty rtm = goV0
 
     reflExn msg = lift . throwIO $ ReflectExn msg
 
-    finish (val, RS _ _ _ tys tms) = ANF.WithRefs tys tms val
+    finish (val, RS _ _ _ tys tms) = WithRefs tys tms val
 
-    goV0 :: Val -> IO (ANF.Referenced ANF.Value)
+    goV0 :: Val -> IO (Referenced ANF.Value)
     goV0 v = finish <$> runStateT (goV v) emptyRS
 
     goV :: Val -> Reflect ANF.Value
@@ -1586,7 +1586,7 @@ data ReflectExn = ReflectExn String deriving (Show)
 instance Exception ReflectExn
 
 reifyValue ::
-  CCache -> ANF.Referenced ANF.Value -> IO (Either [Reference] Val)
+  CCache -> Referenced ANF.Value -> IO (Either [Reference] Val)
 reifyValue cc val = do
   erc <-
     atomically $ do
@@ -1602,15 +1602,15 @@ reifyValue cc val = do
     f False r = (mempty, S.singleton r)
     f True r = (S.singleton r, mempty)
     (tyLinks, tmLinks) = case val of
-      ANF.WithRefs tys tms _ -> (Set.fromList tys, Set.fromList tms)
-      ANF.Plain val -> valueLinks f val
+      WithRefs tys tms _ -> (Set.fromList tys, Set.fromList tms)
+      Plain val -> valueLinks f val
 
 reifyValue1 ::
   (EnumMap Word64 MCombs, M.Map Reference Word64, M.Map Reference Word64) ->
-  ANF.Referenced ANF.Value ->
+  Referenced ANF.Value ->
   IO Val
-reifyValue1 tup (ANF.Plain v) = reifyValue0 tup v
-reifyValue1 (combs, rty0, rtm0) (ANF.WithRefs tys tms v) = do
+reifyValue1 tup (Plain v) = reifyValue0 tup v
+reifyValue1 (combs, rty0, rtm0) (WithRefs tys tms v) = do
   rty <- C.fromList $ mapMaybe (\r -> (r,) <$> M.lookup r rty0) tys
   rtm <- C.fromList $ mapMaybe procTermRefs tms
   reifyValue0Canon combs tys tms rty rtm v
@@ -1700,8 +1700,8 @@ reifyValue0Canon combs tys tms rty rtm = goV
     goL (ANF.TmLink r) = pure $ encodeVal r
     goL (ANF.TyLink r) = pure $ encodeVal r
     goL (ANF.Bytes b) = pure $ encodeVal b
-    goL (ANF.Quote v) = pure $ encodeVal (ANF.WithRefs tys tms v)
-    goL (ANF.Code g) = pure $ encodeVal (ANF.WithRefs tys tms g)
+    goL (ANF.Quote v) = pure $ encodeVal (WithRefs tys tms v)
+    goL (ANF.Code g) = pure $ encodeVal (WithRefs tys tms g)
     goL (ANF.BArr a) = pure $ encodeVal a
     goL (ANF.Char c) = pure $ CharVal c
     goL (ANF.Pos w) =
@@ -1788,8 +1788,8 @@ reifyValue0 (combs, rty, rtm) = goV
     goL (ANF.TmLink r) = pure $ encodeVal r
     goL (ANF.TyLink r) = pure $ encodeVal r
     goL (ANF.Bytes b) = pure $ encodeVal b
-    goL (ANF.Quote v) = pure $ encodeVal (ANF.Plain v)
-    goL (ANF.Code g) = pure $ encodeVal (ANF.Plain g)
+    goL (ANF.Quote v) = pure $ encodeVal (Plain v)
+    goL (ANF.Code g) = pure $ encodeVal (Plain g)
     goL (ANF.BArr a) = pure $ encodeVal a
     goL (ANF.Char c) = pure $ CharVal c
     goL (ANF.Pos w) =

--- a/unison-runtime/src/Unison/Runtime/Machine/Primops.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine/Primops.hs
@@ -16,15 +16,14 @@ import Unison.Reference (Reference)
 import Unison.Referent (Referent, toShortHash, pattern Ref)
 import Unison.Runtime.ANF
   ( Code,
-    Referenced,
     Value,
     codeGroup,
-    dereference,
   )
 import Unison.Runtime.Foreign
 import Unison.Runtime.Foreign.Function
 import Unison.Runtime.MCode
 import Unison.Runtime.Machine.Types
+import Unison.Runtime.Referenced (Referenced, dereference)
 import Unison.Runtime.Stack
 import Unison.Runtime.TypeTags qualified as Ty
 import Unison.ShortHash qualified as SH

--- a/unison-runtime/src/Unison/Runtime/Machine/Types.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine/Types.hs
@@ -3,7 +3,6 @@ module Unison.Runtime.Machine.Types where
 import Control.Concurrent (ThreadId)
 import Control.Concurrent.STM as STM
 import Control.Exception hiding (Handler)
-import Control.Monad.State.Strict
 import Data.IORef (IORef)
 import Data.Map.Strict qualified as M
 import Data.Set qualified as S
@@ -17,19 +16,18 @@ import Unison.Runtime.ANF
   ( Cacheability (..),
     Code (..),
     CompileExn (..),
-    Referenced (..),
     SuperGroup (..),
     Value,
     foldGroupLinks,
-    traverseGroupLinks,
+    traverseCodeRefs,
     valueLinks,
   )
 import Unison.Runtime.ANF.Optimize (OptInfos)
 import Unison.Runtime.Builtin
-import Unison.Runtime.Canonicalizer as C
 import Unison.Runtime.Exception hiding (die)
 import Unison.Runtime.Foreign (Failure (..))
 import Unison.Runtime.MCode
+import Unison.Runtime.Referenced
 import Unison.Runtime.Stack
 import Unison.Symbol
 import Unison.Util.EnumContainers as EC
@@ -163,20 +161,7 @@ lookupCode _ _ = die "lookupCode: Expected Ref"
 -- Traverses a `Code`, calculating the used references within, and
 -- canonicalizing them in memory.
 canonicalizeCodeRefs :: Code -> IO (Referenced Code)
-canonicalizeCodeRefs (CodeRep sg ch) =
-  finalize <$> runStateT (traverseGroupLinks f sg) (C.empty, [], [])
-  where
-    finalize (sg, (_, tys, tms)) = WithRefs tys tms (CodeRep sg ch)
-    f isTy r = StateT \st@(canon, tys, tms) ->
-      categorize canon r >>= \case
-        Canonical -> pure (r, st)
-        Equivalent r canon -> pure (r, (canon, tys, tms))
-        Novel canon ->
-          pure . (r,) $
-            ( canon,
-              if isTy then r : tys else tys,
-              if isTy then tms else r : tms
-            )
+canonicalizeCodeRefs = toReferenced . canonicalizeRefs traverseCodeRefs
 
 resolveCode ::
   Reference ->

--- a/unison-runtime/src/Unison/Runtime/Referenced.hs
+++ b/unison-runtime/src/Unison/Runtime/Referenced.hs
@@ -5,6 +5,7 @@ module Unison.Runtime.Referenced
     Canonize,
     canonicalizeRefs,
     recanonicalizeRefs,
+    toReferenced
   )
 where
 
@@ -55,9 +56,8 @@ canonicalizeRefs trav = trav h
     h isTy r = StateT \st@(canon, tys, tms) ->
       categorize canon r >>= \case
         Canonical -> pure (r, st)
-        Novel canon
-          | isTy -> pure (r, (canon, r : tys, tms))
-          | otherwise -> pure (r, (canon, tys, r : tms))
+        Novel canon ->
+          pure (r, if isTy then (canon, r : tys, tms) else (canon, tys, r : tms))
         Equivalent s canon -> pure (s, (canon, tys, tms))
 {-# INLINE canonicalizeRefs #-}
 
@@ -82,8 +82,7 @@ recanonicalizeRefs trav = \case
     ctys <- lift $ fromList typs
     ctms <- lift $ fromList tmps
 
-    let f False r = findWithDefault r r ctms
-        f True r = findWithDefault r r ctys
+    let f isTy r = findWithDefault r r (if isTy then ctys else ctms)
 
     if null typs && null tmps
       then pure v -- already canonical
@@ -102,3 +101,9 @@ recanonicalizeRefs trav = \case
             )
         Equivalent s canon -> pure (Just (r, s), (canon, tys, tms))
 {-# INLINE recanonicalizeRefs #-}
+
+toReferenced :: Canonize a -> IO (Referenced a)
+toReferenced cn = finalize <$> runStateT cn (empty, [], [])
+  where
+    finalize (x, (_, tys, tms)) = WithRefs tys tms x
+{-# INLINE toReferenced #-}

--- a/unison-runtime/src/Unison/Runtime/Referenced.hs
+++ b/unison-runtime/src/Unison/Runtime/Referenced.hs
@@ -5,7 +5,7 @@ module Unison.Runtime.Referenced
     Canonize,
     canonicalizeRefs,
     recanonicalizeRefs,
-    toReferenced
+    toReferenced,
   )
 where
 

--- a/unison-runtime/tests/Unison/Test/Runtime/ANF.hs
+++ b/unison-runtime/tests/Unison/Test/Runtime/ANF.hs
@@ -169,12 +169,12 @@ denormalizeBranch tm = (0, denormalize tm)
 
 denormalizeHandler ::
   (Var v) =>
-  Map.Map Reference (EnumMap CTag ([Mem], ANormal v)) ->
+  [(Reference, (EnumMap CTag ([Mem], ANormal v)))] ->
   ANormal v ->
   [Term.MatchCase () (Term.Term0 v)]
 denormalizeHandler cs df = dcs
   where
-    dcs = Map.foldMapWithKey rf cs <> dfc
+    dcs = foldMap rf cs <> dfc
     dfc =
       [ Term.MatchCase
           (P.EffectPure () (P.Var ()))
@@ -183,7 +183,7 @@ denormalizeHandler cs df = dcs
       ]
       where
         (_, db) = denormalizeBranch @Int df
-    rf r rcs = foldMapWithKey (cf r) rcs
+    rf (r, rcs) = foldMapWithKey (cf r) rcs
     cf r t b =
       [ Term.MatchCase
           ( P.EffectBind

--- a/unison-src/transcripts-using-base/codeops.md
+++ b/unison-src/transcripts-using-base/codeops.md
@@ -199,6 +199,9 @@ scratch/main> add
 structural ability Zap where
   zap : Three Nat Nat Nat
 
+structural ability Zep where
+  harp : Nat
+
 h : Three Nat Nat Nat -> Nat -> Nat
 h y x = match y with
   zero y -> x + y
@@ -227,6 +230,12 @@ zapper : Three Nat Nat Nat -> Request {Zap} r -> r
 zapper t = cases
   { r } -> r
   { zap -> k } -> handle k t with zapper (rotate t)
+
+zaeper : Request {Zap,Zep} r -> Nat
+zaeper = cases
+ { r } -> 1
+ { zap -> _ } -> 2
+ { harp -> _ } -> 3
 
 bigFun : Nat -> Nat -> Nat -> Nat
 bigFun i j k = let
@@ -318,6 +327,10 @@ codeTests =
    , idempotence "idem big" (termLink bigFun)
    , idempotence "idem extensionality" (termLink extensionality)
    , idempotence "idem identicality" (termLink identicality)
+
+   -- actually tests that code serialization works on this previously
+   -- problem term
+   , idempotence "idem zaeper" (termLink zaeper)
 
    , idempotence.versioned 4 "idem f v4" (termLink f)
    , idempotence.versioned 4 "idem h v4" (termLink h)

--- a/unison-src/transcripts-using-base/codeops.output.md
+++ b/unison-src/transcripts-using-base/codeops.output.md
@@ -276,6 +276,9 @@ scratch/main> add
 structural ability Zap where
   zap : Three Nat Nat Nat
 
+structural ability Zep where
+  harp : Nat
+
 h : Three Nat Nat Nat -> Nat -> Nat
 h y x = match y with
   zero y -> x + y
@@ -304,6 +307,12 @@ zapper : Three Nat Nat Nat -> Request {Zap} r -> r
 zapper t = cases
   { r } -> r
   { zap -> k } -> handle k t with zapper (rotate t)
+
+zaeper : Request {Zap,Zep} r -> Nat
+zaeper = cases
+ { r } -> 1
+ { zap -> _ } -> 2
+ { harp -> _ } -> 3
 
 bigFun : Nat -> Nat -> Nat -> Nat
 bigFun i j k = let
@@ -382,6 +391,7 @@ badLoad _ =
     ⍟ New definitions:
     
       structural ability Zap
+      structural ability Zep
       badLoad : '{IO} [Result]
       bigFun  : Nat -> Nat -> Nat -> Nat
       f       : Nat ->{Zap} Nat
@@ -391,6 +401,7 @@ badLoad _ =
       h       : Three Nat Nat Nat -> Nat -> Nat
       rotate  : Three Nat Nat Nat -> Three Nat Nat Nat
       tests   : '{IO} [Result]
+      zaeper  : Request {Zap, Zep} r -> Nat
       zapper  : Three Nat Nat Nat -> Request {Zap} r -> r
 ```
 
@@ -474,6 +485,10 @@ codeTests =
    , idempotence "idem extensionality" (termLink extensionality)
    , idempotence "idem identicality" (termLink identicality)
 
+   -- actually tests that code serialization works on this previously
+   -- problem term
+   , idempotence "idem zaeper" (termLink zaeper)
+
    , idempotence.versioned 4 "idem f v4" (termLink f)
    , idempotence.versioned 4 "idem h v4" (termLink h)
    , idempotence.versioned 4 "idem rotate v4" (termLink rotate)
@@ -552,6 +567,7 @@ scratch/main> io.test codeTests
                    ◉ (idem big) passed
                    ◉ (idem extensionality) passed
                    ◉ (idem identicality) passed
+                   ◉ (idem zaeper) passed
                    ◉ (idem f v4) passed
                    ◉ (idem h v4) passed
                    ◉ (idem rotate v4) passed
@@ -592,7 +608,7 @@ scratch/main> io.test codeTests
                    ◉ (rejected swapped mututal1) passed
                    ◉ (rejected swapped mututal2) passed
 
-  ✅ 48 test(s) passing
+  ✅ 49 test(s) passing
 
   Tip: Use view 1 to view the source of a test.
 ```


### PR DESCRIPTION
This contains a few related changes.

The code for canonicalizing the references in Code values was basically a duplicate of the one from the Referenced module. It has been replaced with that version.

The ANF module was re-exporting Referenced stuff. That has been removed, and the downstream modules now import Referenced.

The intermediate representation of request matching has been switched to a list of pairs. The reason for this was that `Map.fromList` gets optimized in a way that rebuilds some `Reference` keys. This foils the in-memory canonicity of the references, and causes crashes during serialization. The association list doesn't have this problem.

This is more of a stop-gap fix for the problem while a more robust solution not relying on `StableName` can be written.

I'll add a test case for the known problem tomorrow.