### PR TITLE
Don't call codebase getTypeOfTerm with non-codebase refs

### DIFF
--- a/unison-runtime/src/Unison/Runtime/Interface.hs
+++ b/unison-runtime/src/Unison/Runtime/Interface.hs
@@ -370,6 +370,12 @@ backmapRef ctx r0 = r2
     r1 = Map.findWithDefault r0 r0 . backmap $ intermedRemap ctx
     r2 = Map.findWithDefault r1 r1 . backmap $ floatRemap ctx
 
+-- Runs references through the backmaps with defaults at all steps.
+maybeBackmapRef :: EvalCtx -> Reference -> Maybe CodebaseReference
+maybeBackmapRef ctx r0 = do
+  r1 <- Map.lookup r0 . backmap $ intermedRemap ctx
+  Map.lookup r1 . backmap $ floatRemap ctx
+
 performRehash ::
   Map.Map Reference (SuperGroup Symbol) ->
   EvalCtx ->
@@ -452,7 +458,7 @@ checkCacheability ::
   (IntermediateReference, SuperGroup Symbol) ->
   IO (IntermediateReference, Code)
 checkCacheability cl ctx (r, sg) =
-  getTermType codebaseRef >>= \case
+  getTermType mayCodebaseRef >>= \case
     -- A term's result is cacheable iff it has no arrows in its type,
     -- this is sufficient since top-level definitions can't have effects without a delay.
     Just typ
@@ -460,14 +466,16 @@ checkCacheability cl ctx (r, sg) =
           pure (r, CodeRep sg Cacheable)
     _ -> pure (r, CodeRep sg Uncacheable)
   where
-    codebaseRef = backmapRef ctx r
-    getTermType :: CodebaseReference -> IO (Maybe (Type Symbol))
+    mayCodebaseRef :: Maybe CodebaseReference
+    mayCodebaseRef = maybeBackmapRef ctx r
+    getTermType :: Maybe CodebaseReference -> IO (Maybe (Type Symbol))
     getTermType = \case
-      (RF.DerivedId i) ->
+      Just (RF.DerivedId i) ->
         getTypeOfTerm cl i >>= \case
           Just t -> pure $ Just t
           Nothing -> pure Nothing
-      RF.Builtin {} -> pure $ Nothing
+      Just (RF.Builtin {}) -> pure $ Nothing
+      Nothing -> pure Nothing
     hasArrows :: Type.TypeF v a Bool -> Bool
     hasArrows abt = case ABT.out' abt of
       (ABT.Tm f) -> case f of


### PR DESCRIPTION
## Overview

The current behaviour tries to map runtime references into codebase references when calling to get type info for them, but if the term is generated by the runtime, it will still call through with the intermediate/floating ref, which will always fail.

This isn't a big deal in UCM, but on Share each bogus ref triggers a DB call.

This changes it so we don't call through if there's no valid codebase ref for a runtime ref.

## Implementation notes

* Add new backref method which returns a Maybe instead.
* Just return Nothing for the type lookup if we can't get a codebase ref for a runtime ref.

## Interesting/controversial decisions

Nah 

## Test coverage

Existing tests show the runtime still behaves;
On Share I've tried out this build with debugging to ensure we're no longer calling through with bogus refs or cache misses :)

## Loose ends

This should do it for now; I didn't see any other spots this would be a concern.
