### PR TITLE
Add `transcripts.in-place`

### DIFF
--- a/unison-cli/src/ArgParse.hs
+++ b/unison-cli/src/ArgParse.hs
@@ -79,6 +79,13 @@ data RunSource
   | RunCompiled FilePath
   deriving (Show, Eq)
 
+data TranscriptCodebaseSetup
+  = -- Use the default codebase or one provided by the --codebase option.
+    InPlace
+  | -- Operate on a temp codebase, which is possibly forked from an existing codebase, and is possibly saved to a given location afterwards.
+    UseTempCodebase ShouldForkCodebase ShouldSaveCodebase
+  deriving stock (Show, Eq)
+
 data ShouldForkCodebase
   = UseFork
   | DontFork
@@ -115,7 +122,7 @@ data Command
   | -- @deprecated in trunk after M2g. Remove the Init command completely after M2h has been released
     Init
   | Run RunSource [String]
-  | Transcript ShouldForkCodebase ShouldSaveCodebase (Maybe RtsStatsPath) (NonEmpty FilePath)
+  | Transcript TranscriptCodebaseSetup (Maybe RtsStatsPath) (NonEmpty FilePath)
   deriving (Show, Eq)
 
 -- | Options shared by sufficiently many subcommands.
@@ -242,6 +249,18 @@ transcriptForkCommand =
           "Multiple transcript files may be provided; they are processed in sequence" <+> "starting from the same codebase."
         ]
 
+transcriptInPlaceCommand :: Mod CommandFields Command
+transcriptInPlaceCommand =
+  command "transcript.in-place" (info transcriptInPlaceParser (fullDesc <> progDesc transcriptHelp <> footerDoc transcriptFooter))
+  where
+    transcriptHelp = "Execute transcript markdown files on the specified (or default) codebase"
+    transcriptFooter =
+      Just . fold . List.intersperse P.line $
+        [ "For each <transcript>.md file provided this executes the transcript directly on the codebase and creates" <+> P.annotate bold "<transcript>.output.md" <+> "if successful.",
+          "After completion, any changes made to the codebase will persist.",
+          "Multiple transcript files may be provided; they are processed in sequence."
+        ]
+
 commandParser :: CodebaseServerOpts -> Parser Command
 commandParser envOpts =
   hsubparser commands <|> launchParser envOpts WithCLI
@@ -256,6 +275,7 @@ commandParser envOpts =
           runPipeCommand,
           transcriptCommand,
           transcriptForkCommand,
+          transcriptInPlaceCommand,
           launchHeadlessCommand envOpts
         ]
 
@@ -494,7 +514,7 @@ transcriptParser = do
     ( let saveCodebase = case shouldSaveCodebaseTo of
             DontSaveCodebase -> shouldSaveCodebase
             _ -> shouldSaveCodebaseTo
-       in Transcript DontFork saveCodebase mrtsStatsFp files
+       in Transcript (UseTempCodebase DontFork saveCodebase) mrtsStatsFp files
     )
 
 transcriptForkParser :: Parser Command
@@ -508,8 +528,14 @@ transcriptForkParser = do
     ( let saveCodebase = case shouldSaveCodebaseTo of
             DontSaveCodebase -> shouldSaveCodebase
             _ -> shouldSaveCodebaseTo
-       in Transcript UseFork saveCodebase mrtsStatsFp files
+       in Transcript (UseTempCodebase UseFork saveCodebase) mrtsStatsFp files
     )
+
+transcriptInPlaceParser :: Parser Command
+transcriptInPlaceParser = do
+  mrtsStatsFp <- rtsStatsOption
+  files <- liftA2 (NE.:|) (fileArgument "FILE") (many (fileArgument "FILES..."))
+  pure (Transcript InPlace mrtsStatsFp files)
 
 unisonHelp :: String -> String -> P.Doc
 unisonHelp (fromString -> executable) (fromString -> version) =

--- a/unison-cli/src/Unison/Main.hs
+++ b/unison-cli/src/Unison/Main.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ViewPatterns #-}
-{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 
 module Unison.Main
   ( main,
@@ -376,7 +375,7 @@ initHTTPClient version = do
 
 -- | Prep the codebase for transcripts, then pass the directory to the action.
 -- After the action the codebase will be deleted/copied/saved as indicated.
-withTranscriptDir :: Verbosity.Verbosity -> _ -> TranscriptCodebaseSetup -> Maybe CodebasePathOption -> (FilePath -> IO r) -> IO r
+withTranscriptDir :: Verbosity.Verbosity -> String -> TranscriptCodebaseSetup -> Maybe CodebasePathOption -> (FilePath -> IO r) -> IO r
 withTranscriptDir verbosity progName codebaseSetup mCodePathOption action = do
   UnliftIO.bracket setup cleanup (action . fst)
   where
@@ -384,8 +383,8 @@ withTranscriptDir verbosity progName codebaseSetup mCodePathOption action = do
     setup = do
       case codebaseSetup of
         InPlace -> do
-          -- TODO: Do we need this?
-          -- getCodebaseOrExit mCodePathOption (SC.MigrateAutomatically SC.Backup SC.Vacuum) $ const (pure ())
+          -- Create the codebase/migrate it according to codebase path option
+          getCodebaseOrExit mCodePathOption (SC.MigrateAfterPrompt SC.Backup SC.Vacuum) $ const (pure ())
           path <- Codebase.getCodebaseDir (fmap codebasePathOptionToPath mCodePathOption)
           unless (Verbosity.isSilent verbosity) . PT.putPrettyLn $
             P.lines

--- a/unison-cli/src/Unison/Main.hs
+++ b/unison-cli/src/Unison/Main.hs
@@ -26,6 +26,7 @@ import ArgParse
 import Compat (defaultInterruptHandler, withInterruptHandler)
 import Control.Concurrent (newEmptyMVar, runInUnboundThread, takeMVar)
 import Control.Exception (displayException, evaluate, fromException)
+import Data.Bitraversable (bitraverse)
 import Data.ByteString.Lazy qualified as BL
 import Data.Either.Validation (Validation (..))
 import Data.List.NonEmpty (NonEmpty)
@@ -94,6 +95,7 @@ import Unison.Version (Version)
 import Unison.Version qualified as Version
 import UnliftIO qualified as UnliftIO
 import UnliftIO.Directory (getHomeDirectory)
+import UnliftIO.Directory qualified as Directory
 
 type Runtimes = (RTI.Runtime Symbol, RTI.Runtime Symbol)
 
@@ -375,11 +377,11 @@ initHTTPClient version = do
 
 -- | Prep the codebase for transcripts, then pass the directory to the action.
 -- After the action the codebase will be deleted/copied/saved as indicated.
-withTranscriptDir :: Verbosity.Verbosity -> String -> TranscriptCodebaseSetup -> Maybe CodebasePathOption -> (FilePath -> IO r) -> IO r
+withTranscriptDir :: Verbosity.Verbosity -> String -> TranscriptCodebaseSetup -> Maybe CodebasePathOption -> (FilePath -> IO r) -> IO (Maybe r)
 withTranscriptDir verbosity progName codebaseSetup mCodePathOption action = do
-  UnliftIO.bracket setup cleanup (action . fst)
+  UnliftIO.bracket setup cleanup (\(mayDir, _cleanup) -> for mayDir action)
   where
-    setup :: IO (FilePath, IO ())
+    setup :: IO (Maybe FilePath, IO ())
     setup = do
       case codebaseSetup of
         InPlace -> do
@@ -403,7 +405,7 @@ withTranscriptDir verbosity progName codebaseSetup mCodePathOption action = do
                           P.indentN 2 (P.string path)
                         ]
                     )
-          pure (path, after)
+          pure (Just path, after)
         UseTempCodebase shouldFork shouldSaveCodebase -> do
           (tmp, cleanup) <- case shouldSaveCodebase of
             SaveCodebase (Just path) -> do
@@ -433,18 +435,32 @@ withTranscriptDir verbosity progName codebaseSetup mCodePathOption action = do
               -- A forked codebase does not need to Create a codebase, because it already exists
               getCodebaseOrExit mCodePathOption (SC.MigrateAutomatically SC.Backup SC.Vacuum) $ const (pure ())
               path <- Codebase.getCodebaseDir (fmap codebasePathOptionToPath mCodePathOption)
-              unless (Verbosity.isSilent verbosity) . PT.putPrettyLn $
-                P.lines
-                  [ P.wrap "Transcript will be run on a copy of the codebase at: ",
-                    "",
-                    P.indentN 2 (P.string path)
-                  ]
-              Path.copyDir (CodebaseInit.codebasePath cbInit path) (CodebaseInit.codebasePath cbInit tmp)
+              (absPath, absTmp) <- bitraverse Directory.canonicalizePath Directory.canonicalizePath (path, tmp)
+              if (absPath == absTmp)
+                then do
+                  unless (Verbosity.isSilent verbosity) . PT.putPrettyLn $
+                    P.hang "⚠️" $
+                      P.lines
+                        [ "I noticed that you're forking from and saving to the same path at: " <> P.string path,
+                          "",
+                          "I'll skip running the transcript for now in case this was a mistake.",
+                          "If this is what you meant to do, use `transcript.in-place` instead."
+                        ]
+                  pure (Nothing, pure ())
+                else do
+                  unless (Verbosity.isSilent verbosity) . PT.putPrettyLn $
+                    P.lines
+                      [ P.wrap "Transcript will be run on a copy of the codebase at: ",
+                        "",
+                        P.indentN 2 (P.string path)
+                      ]
+                  Path.copyDir (CodebaseInit.codebasePath cbInit path) (CodebaseInit.codebasePath cbInit tmp)
+                  pure (Just tmp, cleanup)
             DontFork -> do
               PT.putPrettyLn . P.wrap $ "Transcript will be run on a new, empty codebase."
               CodebaseInit.withNewUcmCodebaseOrExit cbInit verbosity "main.transcript" tmp SC.DoLock (const $ pure ())
-          pure (tmp, cleanup)
-    cleanup :: (FilePath, IO ()) -> IO ()
+              pure (Just tmp, cleanup)
+    cleanup :: (Maybe FilePath, IO ()) -> IO ()
     cleanup (_transcriptDir, cleanupAction) = do
       cleanupAction
 
@@ -533,8 +549,9 @@ runTranscripts version verbosity renderUsageInfo codebaseSetup mCodePathOption a
       Exit.exitWith (Exit.ExitFailure 1)
     Success markdownFiles -> pure markdownFiles
   progName <- getProgName
-  completed <- withTranscriptDir verbosity progName codebaseSetup mCodePathOption \transcriptDir -> do
-    runTranscripts' version progName transcriptDir markdownFiles
+  completed <-
+    fromMaybe False <$> withTranscriptDir verbosity progName codebaseSetup mCodePathOption \transcriptDir -> do
+      runTranscripts' version progName transcriptDir markdownFiles
   when (not completed) $ Exit.exitWith (Exit.ExitFailure 1)
 
 launch ::

--- a/unison-cli/src/Unison/Main.hs
+++ b/unison-cli/src/Unison/Main.hs
@@ -20,6 +20,7 @@ import ArgParse
     ShouldExit (DoNotExit, Exit),
     ShouldForkCodebase (..),
     ShouldSaveCodebase (..),
+    TranscriptCodebaseSetup (..),
     UsageRenderer,
     parseCLIArgs,
   )
@@ -274,8 +275,8 @@ main version = do
                           "to produce a new compiled program \
                           \that matches your version of Unison."
                       ]
-        Transcript shouldFork shouldSaveCodebase mrtsStatsFp transcriptFiles -> do
-          let action = runTranscripts version Verbosity.Verbose renderUsageInfo shouldFork shouldSaveCodebase mCodePathOption transcriptFiles
+        Transcript codebaseSetup mrtsStatsFp transcriptFiles -> do
+          let action = runTranscripts version Verbosity.Verbose renderUsageInfo codebaseSetup mCodePathOption transcriptFiles
           case mrtsStatsFp of
             Nothing -> action
             Just fp -> recordRtsStats fp action
@@ -373,28 +374,80 @@ initHTTPClient version = do
   manager <- HTTP.newTlsManagerWith managerSettings
   HTTP.setGlobalManager manager
 
-prepareTranscriptDir :: Verbosity.Verbosity -> ShouldForkCodebase -> Maybe CodebasePathOption -> ShouldSaveCodebase -> IO FilePath
-prepareTranscriptDir verbosity shouldFork mCodePathOption shouldSaveCodebase = do
-  tmp <- case shouldSaveCodebase of
-    SaveCodebase (Just path) -> pure path
-    _ -> Temp.getCanonicalTemporaryDirectory >>= (`Temp.createTempDirectory` "transcript")
-  let cbInit = SC.init
-  case shouldFork of
-    UseFork -> do
-      -- A forked codebase does not need to Create a codebase, because it already exists
-      getCodebaseOrExit mCodePathOption (SC.MigrateAutomatically SC.Backup SC.Vacuum) $ const (pure ())
-      path <- Codebase.getCodebaseDir (fmap codebasePathOptionToPath mCodePathOption)
-      unless (Verbosity.isSilent verbosity) . PT.putPrettyLn $
-        P.lines
-          [ P.wrap "Transcript will be run on a copy of the codebase at: ",
-            "",
-            P.indentN 2 (P.string path)
-          ]
-      Path.copyDir (CodebaseInit.codebasePath cbInit path) (CodebaseInit.codebasePath cbInit tmp)
-    DontFork -> do
-      PT.putPrettyLn . P.wrap $ "Transcript will be run on a new, empty codebase."
-      CodebaseInit.withNewUcmCodebaseOrExit cbInit verbosity "main.transcript" tmp SC.DoLock (const $ pure ())
-  pure tmp
+-- | Prep the codebase for transcripts, then pass the directory to the action.
+-- After the action the codebase will be deleted/copied/saved as indicated.
+withTranscriptDir :: Verbosity.Verbosity -> _ -> TranscriptCodebaseSetup -> Maybe CodebasePathOption -> (FilePath -> IO r) -> IO r
+withTranscriptDir verbosity progName codebaseSetup mCodePathOption action = do
+  UnliftIO.bracket setup cleanup (action . fst)
+  where
+    setup :: IO (FilePath, IO ())
+    setup = do
+      case codebaseSetup of
+        InPlace -> do
+          -- TODO: Do we need this?
+          -- getCodebaseOrExit mCodePathOption (SC.MigrateAutomatically SC.Backup SC.Vacuum) $ const (pure ())
+          path <- Codebase.getCodebaseDir (fmap codebasePathOptionToPath mCodePathOption)
+          unless (Verbosity.isSilent verbosity) . PT.putPrettyLn $
+            P.lines
+              [ P.wrap "Transcript will be run in-place on the codebase at: ",
+                "",
+                P.indentN 2 (P.string path)
+              ]
+          let after =
+                do
+                  PT.putPrettyLn
+                  $ P.callout
+                    "🌸"
+                    ( P.lines
+                        [ "I've finished running the transcript(s) on the provided codebase:",
+                          "",
+                          P.indentN 2 (P.string path)
+                        ]
+                    )
+          pure (path, after)
+        UseTempCodebase shouldFork shouldSaveCodebase -> do
+          (tmp, cleanup) <- case shouldSaveCodebase of
+            SaveCodebase (Just path) -> do
+              let after = do
+                    PT.putPrettyLn $
+                      P.callout
+                        "🌸"
+                        ( P.lines
+                            [ "I've finished running the transcript(s) in this codebase:",
+                              "",
+                              P.indentN 2 (P.string path),
+                              "",
+                              P.wrap $
+                                "You can run"
+                                  <> P.backticked (P.string progName <> " --codebase " <> P.string path)
+                                  <> "to do more work with it."
+                            ]
+                        )
+              pure (path, after)
+            _ -> do
+              path <- Temp.getCanonicalTemporaryDirectory >>= (`Temp.createTempDirectory` "transcript")
+              let cleanup = removeDirectoryRecursive path
+              pure (path, cleanup)
+          let cbInit = SC.init
+          case shouldFork of
+            UseFork -> do
+              -- A forked codebase does not need to Create a codebase, because it already exists
+              getCodebaseOrExit mCodePathOption (SC.MigrateAutomatically SC.Backup SC.Vacuum) $ const (pure ())
+              path <- Codebase.getCodebaseDir (fmap codebasePathOptionToPath mCodePathOption)
+              unless (Verbosity.isSilent verbosity) . PT.putPrettyLn $
+                P.lines
+                  [ P.wrap "Transcript will be run on a copy of the codebase at: ",
+                    "",
+                    P.indentN 2 (P.string path)
+                  ]
+              Path.copyDir (CodebaseInit.codebasePath cbInit path) (CodebaseInit.codebasePath cbInit tmp)
+            DontFork -> do
+              PT.putPrettyLn . P.wrap $ "Transcript will be run on a new, empty codebase."
+              CodebaseInit.withNewUcmCodebaseOrExit cbInit verbosity "main.transcript" tmp SC.DoLock (const $ pure ())
+          pure (tmp, cleanup)
+    cleanup :: (FilePath, IO ()) -> IO ()
+    cleanup (_transcriptDir, cleanupAction) = do
+      cleanupAction
 
 runTranscripts' ::
   Version ->
@@ -461,12 +514,11 @@ runTranscripts ::
   Version ->
   Verbosity.Verbosity ->
   UsageRenderer ->
-  ShouldForkCodebase ->
-  ShouldSaveCodebase ->
+  TranscriptCodebaseSetup ->
   Maybe CodebasePathOption ->
   NonEmpty String ->
   IO ()
-runTranscripts version verbosity renderUsageInfo shouldFork shouldSaveTempCodebase mCodePathOption args = do
+runTranscripts version verbosity renderUsageInfo codebaseSetup mCodePathOption args = do
   markdownFiles <- case traverse (first (pure @[]) . markdownFile) args of
     Failure invalidArgs -> do
       PT.putPrettyLn $
@@ -482,27 +534,8 @@ runTranscripts version verbosity renderUsageInfo shouldFork shouldSaveTempCodeba
       Exit.exitWith (Exit.ExitFailure 1)
     Success markdownFiles -> pure markdownFiles
   progName <- getProgName
-  transcriptDir <- prepareTranscriptDir verbosity shouldFork mCodePathOption shouldSaveTempCodebase
-  completed <-
+  completed <- withTranscriptDir verbosity progName codebaseSetup mCodePathOption \transcriptDir -> do
     runTranscripts' version progName transcriptDir markdownFiles
-  case shouldSaveTempCodebase of
-    DontSaveCodebase -> removeDirectoryRecursive transcriptDir
-    SaveCodebase _ ->
-      when completed $ do
-        PT.putPrettyLn $
-          P.callout
-            "🌸"
-            ( P.lines
-                [ "I've finished running the transcript(s) in this codebase:",
-                  "",
-                  P.indentN 2 (P.string transcriptDir),
-                  "",
-                  P.wrap $
-                    "You can run"
-                      <> P.backticked (P.string progName <> " --codebase " <> P.string transcriptDir)
-                      <> "to do more work with it."
-                ]
-            )
   when (not completed) $ Exit.exitWith (Exit.ExitFailure 1)
 
 launch ::


### PR DESCRIPTION
## Overview

A feature requested by Paul and Cody, also see here: https://discord.com/channels/862108724948500490/1200119435931942994/1400567949357617302

This allows you to simply specify `ucm transcript.in-place -c foo` and it will run the transcript on `foo` in-place.

This uses the default codebase if unspecified, and will create a new codebase, then modify it if passed with `-C` to a codebase which doesn't already exist.

If the old workaround of `transcript.fork -S codebase -C codebase` is provided, this will now issue a warning suggesting to use `transcript.in-place` explicitly instead.

## Implementation notes

* Adds a new subcommand
* Adds a new InPlace configuration for the transcript runner
* Refactors the transcript pre-post commands into a bracketed style to ensure resource cleanup
* Detects and warns if using fork with save-to on the same codebase.
* Did a small tweak to normalize output paths, so instead of:
```
💾  Wrote /Users/cpenner/dev/unison/./gi/basic-transcript.output.md
```

We now get:
```
💾  Wrote ./gi/basic-transcript.output.md
```

If the path is outside of the current dir It will remain an absolute path as you'd expect.

## Test coverage

I tested manually:

* Creating a new codebase using `transcript.in-place`
* Modifying an existing codebase using `transcript.in-place`
* Modifying my default codebase with `transcript.in-place`
* Saving a codebase in-place with `transcript.fork`, and getting a warning. (Also tried with mismatched but canonically equal paths, like relative vs absolute, etc.)
* Tested `transcript.fork` to ensure it still works
* Tested `transcript` to ensure it still works
