### PR TITLE
Insert yields into the interpreter to improve fairness

### DIFF
--- a/unison-runtime/src/Unison/Runtime/Machine.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine.hs
@@ -27,6 +27,7 @@ module Unison.Runtime.Machine
 where
 
 import Control.Concurrent (ThreadId)
+import Control.Concurrent qualified as CNC
 import Control.Concurrent.STM as STM
 import Control.Exception
 import Control.Lens
@@ -113,6 +114,9 @@ info ctx x = infos ctx (show x)
 infos :: String -> String -> IO ()
 infos ctx s = putStrLn $ ctx ++ ": " ++ s
 
+yieldSteps :: Int
+yieldSteps = 5000
+
 -- Entry point for evaluating a section
 eval0 :: CCache -> ActiveThreads -> MSection -> IO ()
 eval0 env !activeThreads !co = do
@@ -122,7 +126,7 @@ eval0 env !activeThreads !co = do
     rfTy <- readTVarIO (refTy env)
     rfTm <- readTVarIO (refTm env)
     topHEnv cmbs rfTy rfTm
-  eval env henv activeThreads stk (k KE) dummyRef co
+  eval yieldSteps env henv activeThreads stk (k KE) dummyRef co
 
 mCombVal :: CombIx -> MComb -> Val
 mCombVal cix (RComb (Comb comb)) =
@@ -180,7 +184,7 @@ apply0 !callback env !threadTracker !i = do
   let entryCix = (CIx r i 0)
   case unRComb $ rCombSection cmbs entryCix of
     Comb entryComb -> do
-      apply env henv threadTracker stk (kf k0) True ZArgs . BoxedVal $
+      apply yieldSteps env henv threadTracker stk (kf k0) True ZArgs . BoxedVal $
         PAp entryCix entryComb nullSeg
     -- if it's cached, we can just finish
     CachedVal _ val -> bump stk >>= \stk -> poke stk val
@@ -197,7 +201,7 @@ apply1 ::
   IO ()
 apply1 callback env threadTracker clo = do
   stk <- alloc
-  apply env mempty threadTracker stk k0 True ZArgs clo
+  apply yieldSteps env mempty threadTracker stk k0 True ZArgs clo
   where
     k0 = CB $ Hook (\stk -> callback $ packXStack stk)
 {-# INLINE apply1 #-}
@@ -490,6 +494,7 @@ encodeExn stk exc = do
 -- immediately evaluated when created to avoid thunks building up, so
 -- that it doesn't need to be a strict argument.
 eval ::
+  Int ->
   CCache ->
   HEnv ->
   ActiveThreads ->
@@ -499,48 +504,49 @@ eval ::
   MSection ->
   IO ()
 #ifdef STACK_CHECK
-eval _ _ !_ !stk !_ !_ section
+eval !_ _ _ !_ !stk !_ !_ section
   | debugger stk "eval" section = undefined
 #endif
-eval env henv !activeThreads !stk !k r (Match i (TestT df cs)) = do
+eval !yld env henv !activeThreads !stk !k r (Match i (TestT df cs)) = do
   t <- peekOffBi stk i
-  eval env henv activeThreads stk k r $ selectTextBranch t df cs
-eval env henv !activeThreads !stk !k r (Match i br) = do
+  eval yld env henv activeThreads stk k r $ selectTextBranch t df cs
+eval !yld env henv !activeThreads !stk !k r (Match i br) = do
   n <- peekOffN stk i
-  eval env henv activeThreads stk k r $ selectBranch n br
-eval env henv !activeThreads !stk !k r (DMatch mr i br) = do
+  eval yld env henv activeThreads stk k r $ selectBranch n br
+eval !yld env henv !activeThreads !stk !k r (DMatch mr i br) = do
   (nx, stk) <- dataBranch mr stk br =<< bpeekOff stk i
-  eval env henv activeThreads stk k r nx
-eval env henv !activeThreads !stk !k r (NMatch _mr i br) = do
+  eval yld env henv activeThreads stk k r nx
+eval !yld env henv !activeThreads !stk !k r (NMatch _mr i br) = do
   n <- peekOffN stk i
-  eval env henv activeThreads stk k r $ selectBranch n br
-eval env henv !activeThreads !stk !k r (RMatch i pu br) = do
+  eval yld env henv activeThreads stk k r $ selectBranch n br
+eval !yld env henv !activeThreads !stk !k r (RMatch i pu br) = do
   (t, stk) <- dumpDataValNoTag stk =<< peekOff stk i
   if t == TT.pureEffectTag
-    then eval env henv activeThreads stk k r pu
+    then eval yld env henv activeThreads stk k r pu
     else case ANF.unpackTags t of
       (ANF.rawTag -> e, ANF.rawTag -> t)
         | Just ebs <- EC.lookup e br ->
-            eval env henv activeThreads stk k r $ selectBranch t ebs
+            eval yld env henv activeThreads stk k r $ selectBranch t ebs
         | otherwise -> unhandledAbilityRequest
-eval env henv !activeThreads !stk !k _ (Yield args)
+eval !yld env henv !activeThreads !stk !k _ (Yield args)
   | asize stk > 0,
     VArg1 i <- args =
-      peekOff stk i >>= apply env henv activeThreads stk k False ZArgs
+      peekOff stk i >>= apply yld env henv activeThreads stk k False ZArgs
   | otherwise = do
       stk <- moveArgs stk args
       stk <- frameArgs stk
-      yield env henv activeThreads stk k
-eval env henv !activeThreads !stk !k _ (App ck r args) =
+      yield yld env henv activeThreads stk k
+eval !yld env henv !activeThreads !stk !k _ (App ck r args) =
   resolve env henv stk r
-    >>= apply env henv activeThreads stk k ck args
-eval env henv !activeThreads !stk !k _ (Call ck combIx rcomb args) =
-  enter env henv activeThreads stk k (combRef combIx) ck args rcomb
-eval env henv !activeThreads !stk !k _ (Jump i args) =
-  bpeekOff stk i >>= jump env henv activeThreads stk k args
-eval env henv !activeThreads !stk !k r (Let nw cix f sect) = do
+    >>= apply yld env henv activeThreads stk k ck args
+eval !yld env henv !activeThreads !stk !k _ (Call ck combIx rcomb args) =
+  enter yld env henv activeThreads stk k (combRef combIx) ck args rcomb
+eval !yld env henv !activeThreads !stk !k _ (Jump i args) =
+  bpeekOff stk i >>= jump yld env henv activeThreads stk k args
+eval !yld env henv !activeThreads !stk !k r (Let nw cix f sect) = do
   (stk, fsz, asz) <- saveFrame stk
   eval
+    yld
     env
     henv
     activeThreads
@@ -548,7 +554,7 @@ eval env henv !activeThreads !stk !k r (Let nw cix f sect) = do
     (Push fsz asz cix f sect k)
     r
     nw
-eval env henv !activeThreads !stk !k r (Ins i nx) = do
+eval !yld env henv !activeThreads !stk !k r (Ins i nx) = do
   exec env henv activeThreads stk k r i >>= \case
     (exception, henv, !stk, !k)
       -- In this case, the instruction indicated an exception to
@@ -561,10 +567,10 @@ eval env henv !activeThreads !stk !k r (Ins i nx) = do
           bpoke stk $ Data1 exceptionRef TT.exceptionRaiseTag fv
           (stk, fsz, asz) <- saveFrame stk
           let kk = Push fsz asz fakeCix 10 nx k
-          apply env henv activeThreads stk kk False (VArg1 0) eh
-      | otherwise -> eval env henv activeThreads stk k r nx
-eval _ _ !_ !_activeThreads !_ _ Exit = pure ()
-eval _ _ !_ !_activeThreads !_ _ (Die s) = die s
+          apply yld env henv activeThreads stk kk False (VArg1 0) eh
+      | otherwise -> eval yld env henv activeThreads stk k r nx
+eval !_ _ _ !_ !_activeThreads !_ _ Exit = pure ()
+eval !_ _ _ !_ !_activeThreads !_ _ (Die s) = die s
 {-# NOINLINE eval #-}
 
 -- Note: denv shadows aenv always
@@ -621,7 +627,8 @@ atomicEval env activeThreads write val =
 {-# INLINE atomicEval #-}
 
 -- fast path application
-enter ::
+enter' ::
+  Int ->
   CCache ->
   HEnv ->
   ActiveThreads ->
@@ -632,18 +639,38 @@ enter ::
   Args ->
   MComb ->
   IO ()
-enter env henv !activeThreads !stk !k !cref !sck !args = \case
+enter' !yld env henv !activeThreads !stk !k !cref !sck !args = \case
   (RComb (Lam a f entry)) -> do
     -- check for stack check _skip_
     stk <- if sck then pure stk else ensure stk f
     stk <- moveArgs stk args
     stk <- acceptArgs stk a
-    eval env henv activeThreads stk k cref entry
+    eval yld env henv activeThreads stk k cref entry
   (RComb (CachedVal _ val)) -> do
     stk <- discardFrame stk
     stk <- bump stk
     poke stk val
-    yield env henv activeThreads stk k
+    yield yld env henv activeThreads stk k
+{-# INLINE enter' #-}
+
+enter ::
+  Int ->
+  CCache ->
+  HEnv ->
+  ActiveThreads ->
+  Stack ->
+  K ->
+  Reference ->
+  Bool ->
+  Args ->
+  MComb ->
+  IO ()
+enter !yld env henv !activeThreads !stk !k !cref !sck !args comb
+  | yld <= 0 = do
+      CNC.yield
+      enter' yieldSteps env henv activeThreads stk k cref sck args comb
+  | otherwise =
+      enter' (yld - 1) env henv activeThreads stk k cref sck args comb
 {-# INLINE enter #-}
 
 -- fast path by-name delaying
@@ -678,7 +705,8 @@ extendPAp v _ =
 {-# INLINE extendPAp #-}
 
 -- slow path application
-apply ::
+apply' ::
+  Int ->
   CCache ->
   HEnv ->
   ActiveThreads ->
@@ -689,10 +717,10 @@ apply ::
   Val ->
   IO ()
 #ifdef STACK_CHECK
-apply _env _henv !_activeThreads !stk !_k !_ck !args !val
+apply' !yld _env _henv !_activeThreads !stk !_k !_ck !args !val
   | debugger stk "apply" (args, val) = undefined
 #endif
-apply env henv !activeThreads !stk !k !ck !args !val =
+apply' !yld env henv !activeThreads !stk !k !ck !args !val =
   case val of
     BoxedVal (PAp cix@(CIx combRef _ _) comb seg) ->
       case comb of
@@ -702,13 +730,13 @@ apply env henv !activeThreads !stk !k !ck !args !val =
               stk <- moveArgs stk args
               stk <- dumpSeg stk seg A
               stk <- acceptArgs stk a
-              eval env henv activeThreads stk k combRef entry
+              eval yld env henv activeThreads stk k combRef entry
           | otherwise -> do
               seg <- closeArgs C stk seg args
               stk <- discardFrame =<< frameArgs stk
               stk <- bump stk
               bpoke stk $ PAp cix comb seg
-              yield env henv activeThreads stk k
+              yield yld env henv activeThreads stk k
       where
         ac = asize stk + countArgs args + scount seg
     v -> zeroArgClosure v
@@ -720,11 +748,31 @@ apply env henv !activeThreads !stk !k !ck !args !val =
           stk <- discardFrame stk
           stk <- bump stk
           poke stk v
-          yield env henv activeThreads stk k
+          yield yld env henv activeThreads stk k
       | otherwise = die $ "applying non-function: " ++ show v
+{-# INLINE apply' #-}
+
+apply ::
+  Int ->
+  CCache ->
+  HEnv ->
+  ActiveThreads ->
+  Stack ->
+  K ->
+  Bool ->
+  Args ->
+  Val ->
+  IO ()
+apply !yld env henv !activeThreads !stk !k !ck !args !val
+  | yld <= 0 = do
+      CNC.yield
+      apply' yieldSteps env henv activeThreads stk k ck args val
+  | otherwise =
+      apply' (yld - 1) env henv activeThreads stk k ck args val
 {-# INLINE apply #-}
 
 jump ::
+  Int ->
   CCache ->
   HEnv ->
   ActiveThreads ->
@@ -733,14 +781,14 @@ jump ::
   Args ->
   Closure ->
   IO ()
-jump env henv !activeThreads !stk !k !args clo = case clo of
+jump !yld env henv !activeThreads !stk !k !args clo = case clo of
   Captured sk0 a seg -> do
     let (p, sk) = adjust sk0
     seg <- closeArgs K stk seg args
     stk <- discardFrame stk
     stk <- dumpSeg stk seg $ F (countArgs args) a
     stk <- adjustArgs stk p
-    repush env activeThreads stk henv sk k
+    repush yld env activeThreads stk henv sk k
   _ -> die "jump: non-cont"
   where
     -- Adjusts a repushed continuation to account for pending arguments. If
@@ -758,6 +806,7 @@ jump env henv !activeThreads !stk !k !args clo = case clo of
 {-# INLINE jump #-}
 
 repush ::
+  Int ->
   CCache ->
   ActiveThreads ->
   Stack ->
@@ -765,9 +814,9 @@ repush ::
   K ->
   K ->
   IO ()
-repush env !activeThreads !stk (HEnv aenv denv0) = go denv0
+repush !yld env !activeThreads !stk (HEnv aenv denv0) = go denv0
   where
-    go !denv KE !k = yield env (HEnv aenv denv) activeThreads stk k
+    go !denv KE !k = yield yld env (HEnv aenv denv) activeThreads stk k
     go !denv (Mark a ps cs sk) !k = go denv' sk $ Mark a ps cs' k
       where
         denv' = cs <> EC.withoutKeys denv ps
@@ -915,13 +964,14 @@ closeArgs mode !stk !seg args = augSeg mode stk seg as
           l = fsize stk - i
 
 yield ::
+  Int ->
   CCache ->
   HEnv ->
   ActiveThreads ->
   Stack ->
   K ->
   IO ()
-yield env henv0 !activeThreads !stk = leap
+yield !yld env henv0 !activeThreads !stk = leap
   where
     leap (Mark a ps cs k) | HEnv aenv0 denv0 <- henv0 = do
       denv <- evaluate $ cs <> EC.withoutKeys denv0 ps
@@ -931,7 +981,7 @@ yield env henv0 !activeThreads !stk = leap
       bpoke stk $ Data1 Rf.effectRef (PackedTag 0) v
       stk <- adjustArgs stk a
       henv <- evaluate $ HEnv aenv0 denv
-      apply env henv activeThreads stk k False (VArg1 0) h
+      apply yld env henv activeThreads stk k False (VArg1 0) h
     leap (AMark a aenv (ARef r) k) = do
       v <- peek stk
       h <- BoxedVal <$> readIORef r
@@ -939,14 +989,14 @@ yield env henv0 !activeThreads !stk = leap
       bpoke stk $ Data1 Rf.effectRef (PackedTag 0) v
       stk <- adjustArgs stk a
       henv <- evaluate $ HEnv aenv mempty
-      apply env henv activeThreads stk k False (VArg1 0) h
+      apply yld env henv activeThreads stk k False (VArg1 0) h
     leap (Push fsz asz (CIx ref _ _) f nx k) = do
       stk <- restoreFrame stk fsz asz
       stk <- ensure stk f
-      eval env henv0 activeThreads stk k ref nx
+      eval yld env henv0 activeThreads stk k ref nx
     leap (Local henv asz k) = do
       stk <- restoreFrame stk 0 asz
-      yield env henv activeThreads stk k
+      yield yld env henv activeThreads stk k
     leap (CB (Hook f)) = f (unpackXStack stk)
     leap KE = pure ()
 {-# INLINE yield #-}


### PR DESCRIPTION
This PR adds a counter to execution of the interpreter. Each time a function application occurs (either fast or slow path), the counter is decremented. When it reaches 0, the interpreter calls `Control.Concurrent.yield` before continuing. The counter starts at 5,000.

The goal is to avoid certain thread starvation scenarios. GHC's thread preemption is based on memory allocation. If a thread is executing code that does _not_ allocate any memory, the RTS has no way of preempting it. It's actually possible to write loops in unison that cause very little memory to be allocated, meaning that such threads could cause other threads to starve.

The counter itself seems to be free (actually, the altered code seems to be optimized better, making numeric code faster), so the only performance implications are the overhead of the yield, which is determined by the frequency. 5,000 is only a little slower on our benchmarks, but considerably improves latency on a thread starvation benchmark (from seconds to milliseconds).

Benchmarks comparisons vs. the 0.5.44 release. I know it looks like most things got worse, but the release build actually got better timings than my local build from before I made these changes, so maybe my local builds are just a little worse in general. The ones that actually seemed worse are the `fib`s and (for some reason) CAS on IORefs.

```
Mutate a Ref 1000 times
147.278µs --> 154.553µs

Mutate a local Remote.Ref 10k times
66.706991ms --> 70.887834ms

Do 10k arithmetic operations
100.687µs --> 101.182µs

List.map increment (range 0 1000)
199.117µs --> 211.367µs

List.map murmurHash (range 0 1000)
659.266µs --> 719.155µs

Multimap.fromList (range 0 1000)
92.674µs --> 93.718µs

Stream functions
8.625797ms --> 9.027248ms

Value.serializeUncompressed (10k element map)
24.309563ms --> 25.521379ms

Value.serializeCompressed (10k element map)
30.743942ms --> 32.187171ms

Value.deserializeCompressed (10k element map)
68.330335ms --> 69.632748ms

Json.toText (per document)
50.165µs --> 51.022µs

Json parsing (per document)
15.585µs --> 14.898µs

Json complex parsing (per document)
20.326µs --> 19.479µs

Json complex decoding (per document)
116.316µs --> 115.395µs

Decode Nat
194ns --> 199ns

Generate 100 random numbers
132.655µs --> 129.236µs

List.foldLeft
1.68029ms --> 1.739753ms

Count to 1 million
41.24927ms --> 47.40688ms

Count to N (per element)
96ns --> 104ns

Count to 1000
96.397µs --> 104.998µs

CAS an IO.ref 1000 times
169.548µs --> 178.61µs

List.range (per element)
60ns --> 56ns

List.range 0 1000
80.869µs --> 79.87µs

Set.fromList (range 0 1000)
40.203µs --> 39.208µs

Map.fromList (range 0 1000)
39.39µs --> 38.721µs

NatMap.fromList (range 0 1000)
3.425246ms --> 3.577727ms

Map.lookup (1k element map)
225ns --> 229ns

Map.insert (1k element map)
339ns --> 344ns

Shuffle a 1000 element array
2.085716ms --> 2.093931ms

Mutably mergesort a 1000 element array
2.778179ms --> 2.788406ms

List.at (1k element list)
192ns --> 201ns

Text.split /
3.566µs --> 3.622µs

Two match
6.362905ms --> 6.738259ms

Four match
6.410241ms --> 6.758093ms

Thirty match
5.887544ms --> 6.216448ms

fib1
188.355µs --> 192.991µs

fib2
472.384µs --> 489.29µs

fib3
475.395µs --> 494.204µs
```