### PR TITLE
Add Env var to skip migration prompt

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,6 +11,7 @@
     * [`UNISON_READONLY`](#unison_readonly)
     * [`UNISON_ENTITY_VALIDATION`](#unison_entity_validation)
     * [`UNISON_SYNC_VERSION`](#unison_sync_version)
+    * [`UNISON_MIGRATION`](#unison_migration)
     * [`UNISON_FZF_PATH`](#unison_fzf_path)
     * [Local Codebase Server](#local-codebase-server)
 * [Codebase Configuration](#codebase-configuration)
@@ -126,6 +127,16 @@ Allows regressing to sync version 1 when interacting with Share.
 ```sh
 $ UNISON_SYNC_VERSION="1" ucm
 ```
+
+### `UNISON_MIGRATION`
+
+Setting:
+
+```sh
+$ UNISON_MIGRATION="auto" ucm
+```
+
+will cause ucm to automatically migrate the codebase to the latest version, without prompting for confirmation.
 
 ### `UNISON_FZF_PATH`
 

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -12,6 +12,7 @@ module Unison.Codebase.SqliteCodebase
   )
 where
 
+import Data.Char qualified as Char
 import Data.Either.Extra ()
 import Data.Foldable qualified as Foldable
 import Data.Map qualified as Map
@@ -57,6 +58,7 @@ import UnliftIO (finally)
 import UnliftIO qualified as UnliftIO
 import UnliftIO.Concurrent qualified as UnliftIO
 import UnliftIO.Directory (createDirectoryIfMissing, doesFileExist)
+import UnliftIO.Environment (lookupEnv)
 import UnliftIO.STM
 
 debug :: Bool
@@ -179,7 +181,10 @@ sqliteCodebase debugName root localOrRemote lockOption migrationStrategy action 
         case migrationStrategy of
           DontMigrate -> pure $ Left (OpenCodebaseRequiresMigration fromSv toSv)
           MigrateAfterPrompt backupStrategy vacuumStrategy -> do
-            let shouldPrompt = True
+            shouldPrompt <-
+              lookupEnv "UNISON_MIGRATION" >>= \case
+                Just (fmap Char.toLower -> "auto") -> pure False
+                _ -> pure True
             Migrations.ensureCodebaseIsUpToDate localOrRemote root getDeclType termBuffer declBuffer shouldPrompt backupStrategy vacuumStrategy conn
           MigrateAutomatically backupStrategy vacuumStrategy -> do
             let shouldPrompt = False

--- a/unison-src/transcripts/project-outputs/docs/configuration.output.md
+++ b/unison-src/transcripts/project-outputs/docs/configuration.output.md
@@ -10,6 +10,7 @@
       - [`UNISON_READONLY`](#unison_readonly)
       - [`UNISON_ENTITY_VALIDATION`](#unison_entity_validation)
       - [`UNISON_SYNC_VERSION`](#unison_sync_version)
+      - [`UNISON_MIGRATION`](#unison_migration)
       - [`UNISON_FZF_PATH`](#unison_fzf_path)
       - [Local Codebase Server](#local-codebase-server)
   - [Codebase Configuration](#codebase-configuration)
@@ -125,6 +126,16 @@ Allows regressing to sync version 1 when interacting with Share.
 ``` sh
 $ UNISON_SYNC_VERSION="1" ucm
 ```
+
+### `UNISON_MIGRATION`
+
+Setting:
+
+``` sh
+$ UNISON_MIGRATION="auto" ucm
+```
+
+will cause ucm to automatically migrate the codebase to the latest version, without prompting for confirmation.
 
 ### `UNISON_FZF_PATH`
 


### PR DESCRIPTION
## Overview

Allows setting the env var `UNISON_MIGRATION=auto` to skip migration prompts.

Requested by @ceedubs  for CI jobs, where prompting doesn't make sense.

## Implementation notes

Adds an env var, checks it at migration time.

## Test coverage

I tested it on an old codebase I had sitting around and it worked fine :)