### PR TITLE
Add lib.install.local

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Path.hs
+++ b/parser-typechecker/src/Unison/Codebase/Path.hs
@@ -73,6 +73,9 @@ newtype Path = Path {toSeq :: Seq NameSegment}
   deriving stock (Eq, Ord, Show)
   deriving newtype (Semigroup, Monoid)
 
+instance From Path Text where
+  from = toText
+
 instance Recursive Path (XNor NameSegment) where
   cata φ = cata φ . toSeq
   embed = Path . embed . fmap toSeq
@@ -87,6 +90,9 @@ instance GHC.IsList Path where
 -- | An absolute from the current project root
 newtype Absolute = Absolute {unabsolute :: Path} deriving (Eq, Ord, Show)
 
+instance From Absolute Text where
+  from = toText
+
 instance Recursive Absolute (XNor NameSegment) where
   cata φ = cata φ . unabsolute
   embed = Absolute . embed . fmap unabsolute
@@ -100,6 +106,9 @@ newtype Relative = Relative {unrelative :: Path}
   deriving stock (Eq, Ord, Show)
   deriving newtype (Semigroup, Monoid)
 
+instance From Relative Text where
+  from = toText
+
 relPath_ :: Lens' Relative Path
 relPath_ = lens unrelative (\_ new -> Relative new)
 
@@ -108,6 +117,9 @@ data Path'
   = AbsolutePath' Absolute
   | RelativePath' Relative
   deriving (Eq, Ord, Show)
+
+instance From Path' Text where
+  from = toText
 
 isAbsolute :: Path' -> Bool
 isAbsolute (AbsolutePath' _) = True

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
@@ -61,6 +61,7 @@ import Unison.Names (Names (Names))
 import Unison.Names qualified as Names
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
+import Unison.Project (defaultBranchName)
 import Unison.Reference (Reference)
 import Unison.Reference qualified as Reference
 import Unison.Referent qualified as Referent
@@ -105,7 +106,7 @@ createSchema = do
   Q.setCurrentProjectPath projectId branchId []
   where
     scratchProjectName = UnsafeProjectName "scratch"
-    scratchBranchName = UnsafeProjectBranchName "main"
+    scratchBranchName = defaultBranchName
     currentSchemaVersion = Q.currentSchemaVersion
     insertSchemaVersionSql =
       [Sqlite.sql|

--- a/unison-cli/src/Unison/Cli/ProjectUtils.hs
+++ b/unison-cli/src/Unison/Cli/ProjectUtils.hs
@@ -72,7 +72,7 @@ import Unison.Codebase.ProjectPath qualified as PP
 import Unison.CommandLine.BranchRelativePath (BranchRelativePath (..))
 import Unison.Core.Project (ProjectBranchName (..))
 import Unison.Prelude
-import Unison.Project (ProjectAndBranch (..), ProjectName)
+import Unison.Project (ProjectAndBranch (..), ProjectName, defaultBranchName)
 import Unison.Sqlite (Transaction)
 import Unison.Sqlite qualified as Sqlite
 import Witch (unsafeFrom)
@@ -136,7 +136,7 @@ expectProjectBranchByName project branchName =
 --   * The branch named "main"
 hydrateNames :: These ProjectName ProjectBranchName -> Cli (ProjectAndBranch ProjectName ProjectBranchName)
 hydrateNames = \case
-  This projectName -> pure (ProjectAndBranch projectName (unsafeFrom @Text "main"))
+  This projectName -> pure (ProjectAndBranch projectName defaultBranchName)
   That branchName -> do
     pp <- Cli.getCurrentProjectPath
     pure (ProjectAndBranch (pp ^. #project . #name) branchName)
@@ -166,7 +166,7 @@ getProjectAndBranchByTheseNames ::
   These ProjectName ProjectBranchName ->
   Cli (Maybe (ProjectAndBranch Sqlite.Project Sqlite.ProjectBranch))
 getProjectAndBranchByTheseNames = \case
-  This projectName -> getProjectAndBranchByTheseNames (These projectName (unsafeFrom @Text "main"))
+  This projectName -> getProjectAndBranchByTheseNames (These projectName defaultBranchName)
   That branchName -> runMaybeT do
     (PP.ProjectPath proj _branch _path) <- lift Cli.getCurrentProjectPath
     branch <- MaybeT (Cli.runTransaction (Queries.loadProjectBranchByName (proj ^. #projectId) branchName))
@@ -186,7 +186,7 @@ expectProjectAndBranchByTheseNames ::
   These ProjectName ProjectBranchName ->
   Cli (ProjectAndBranch Sqlite.Project Sqlite.ProjectBranch)
 expectProjectAndBranchByTheseNames = \case
-  This projectName -> expectProjectAndBranchByTheseNames (These projectName (unsafeFrom @Text "main"))
+  This projectName -> expectProjectAndBranchByTheseNames (These projectName defaultBranchName)
   That branchName -> do
     PP.ProjectPath project _branch _restPath <- Cli.getCurrentProjectPath
     branch <-
@@ -210,7 +210,7 @@ expectProjectAndBranchByTheseNames = \case
 --      project, defaulting to 'main' if branch is unspecified.
 resolveProjectBranchInProject :: Project -> ProjectAndBranch (Maybe ProjectName) (Maybe ProjectBranchName) -> Cli (ProjectAndBranch Sqlite.Project Sqlite.ProjectBranch)
 resolveProjectBranchInProject defaultProj (ProjectAndBranch mayProjectName mayBranchName) = do
-  let branchName = fromMaybe (unsafeFrom @Text "main") mayBranchName
+  let branchName = fromMaybe defaultBranchName mayBranchName
   let projectName = fromMaybe (defaultProj ^. #name) mayProjectName
   projectAndBranch <- expectProjectAndBranchByTheseNames (These projectName branchName)
   pure projectAndBranch
@@ -317,7 +317,7 @@ expectRemoteProjectBranchByTheseNames includeSquashed = \case
   This remoteProjectName -> do
     remoteProject <- expectRemoteProjectByName remoteProjectName
     let remoteProjectId = remoteProject ^. #projectId
-    let remoteBranchName = unsafeFrom @Text "main"
+    let remoteBranchName = defaultBranchName
     expectRemoteProjectBranchByName includeSquashed (ProjectAndBranch (remoteProjectId, remoteProjectName) remoteBranchName)
   That branchName -> do
     PP.ProjectPath localProject localBranch _restPath <- Cli.getCurrentProjectPath

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -65,7 +65,7 @@ import Unison.Codebase.Editor.HandleInput.EditNamespace (handleEditNamespace)
 import Unison.Codebase.Editor.HandleInput.FindAndReplace (handleStructuredFindI, handleStructuredFindReplaceI, handleTextFindI)
 import Unison.Codebase.Editor.HandleInput.FormatFile qualified as Format
 import Unison.Codebase.Editor.HandleInput.Global qualified as Global
-import Unison.Codebase.Editor.HandleInput.InstallLib (handleInstallLib)
+import Unison.Codebase.Editor.HandleInput.InstallLib (handleInstallLib, handleInstallLocalLib)
 import Unison.Codebase.Editor.HandleInput.LSPDebug qualified as LSPDebug
 import Unison.Codebase.Editor.HandleInput.Load (EvalMode (Sandboxed), evalUnisonFile, handleLoad, loadUnisonFile)
 import Unison.Codebase.Editor.HandleInput.Ls (handleLs)
@@ -763,6 +763,7 @@ loop e = do
         UpgradeI old new -> handleUpgrade old new
         UpgradeCommitI -> handleCommitUpgrade
         LibInstallI remind libdep -> handleInstallLib remind libdep
+        LibInstallLocalI src destLibName -> handleInstallLocalLib src destLibName
         DebugSynhashTermI name -> handleDebugSynhashTerm name
         EditDependentsI name -> handleEditDependents name
 
@@ -891,6 +892,8 @@ inputDescription input =
     FindShallowI {} -> wat
     HistoryI {} -> wat
     LibInstallI {} -> wat
+    LibInstallLocalI src mayDest ->
+      pure $ "lib.install.local " <> into @Text src <> " " <> maybe "" NameSegment.toEscapedText mayDest
     ListDependenciesI {} -> wat
     ListDependentsI {} -> wat
     LoadI {} -> wat

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/DeleteBranch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/DeleteBranch.hs
@@ -23,9 +23,8 @@ import Unison.Codebase.ProjectPath (ProjectPathG (..))
 import Unison.Codebase.SqliteCodebase.Operations qualified as Ops
 import Unison.Core.Project (ProjectBranchName (..), ProjectName (..))
 import Unison.Prelude
-import Unison.Project (ProjectAndBranch (..))
+import Unison.Project (ProjectAndBranch (..), defaultBranchName)
 import Unison.Sqlite qualified as Sqlite
-import Witch (unsafeFrom)
 
 -- | Delete a project branch.
 --
@@ -66,7 +65,7 @@ handleDeleteBranch projectAndBranchNamesToDelete = do
 
     findMainBranchInProjectExcept :: ProjectId -> ProjectBranchId -> MaybeT Sqlite.Transaction (ProjectAndBranch ProjectId ProjectBranchId)
     findMainBranchInProjectExcept projectId exceptBranchId = do
-      branch <- MaybeT $ Queries.loadProjectBranchByName projectId (unsafeFrom @Text "main")
+      branch <- MaybeT $ Queries.loadProjectBranchByName projectId defaultBranchName
       guard (branch ^. #branchId /= exceptBranchId)
       pure (ProjectAndBranch projectId (branch ^. #branchId))
 

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/DeleteProject.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/DeleteProject.hs
@@ -17,9 +17,9 @@ import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Editor.Output qualified as Output
 import Unison.Codebase.ProjectPath (ProjectPathG (..))
 import Unison.Codebase.SqliteCodebase.Operations qualified as Ops
-import Unison.Core.Project (ProjectBranchName (..), ProjectName (..))
+import Unison.Core.Project (ProjectName (..))
 import Unison.Prelude
-import Unison.Project (ProjectAndBranch (..))
+import Unison.Project (ProjectAndBranch (..), defaultBranchName)
 import Unison.Sqlite qualified as Sqlite
 
 -- | Delete a project
@@ -48,9 +48,9 @@ handleDeleteProject projectName = do
     createDummyProjectExcept :: ProjectName -> Sqlite.Transaction (ProjectAndBranch ProjectId ProjectBranchId)
     createDummyProjectExcept (UnsafeProjectName "scratch") = do
       (_, emptyCausalHashId) <- Codebase.emptyCausalHash
-      Ops.insertProjectAndBranch (UnsafeProjectName "scratch2") (UnsafeProjectBranchName "main") emptyCausalHashId
+      Ops.insertProjectAndBranch (UnsafeProjectName "scratch2") defaultBranchName emptyCausalHashId
         <&> \(proj, branch) -> ProjectAndBranch proj.projectId branch.branchId
     createDummyProjectExcept _ = do
       (_, emptyCausalHashId) <- Codebase.emptyCausalHash
-      Ops.insertProjectAndBranch (UnsafeProjectName "scratch") (UnsafeProjectBranchName "main") emptyCausalHashId
+      Ops.insertProjectAndBranch (UnsafeProjectName "scratch") defaultBranchName emptyCausalHashId
         <&> \(proj, branch) -> ProjectAndBranch proj.projectId branch.branchId

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/InstallLib.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/InstallLib.hs
@@ -1,6 +1,7 @@
 -- | @lib.install@ input handler
 module Unison.Codebase.Editor.HandleInput.InstallLib
   ( handleInstallLib,
+    handleInstallLocalLib,
   )
 where
 
@@ -10,6 +11,10 @@ import Data.Map.Strict qualified as Map
 import Data.Maybe (fromJust)
 import Data.Set qualified as Set
 import Data.Text qualified as Text
+import Data.These (These (..))
+import U.Codebase.Causal qualified as UCausal
+import U.Codebase.Causal.Squash qualified as UCausal
+import U.Codebase.Sqlite.V2.HashHandle qualified as HH
 import Unison.Cli.DownloadUtils
 import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
@@ -35,7 +40,7 @@ import Unison.Project
     classifyProjectBranchName,
     projectNameToUserProjectSlugs,
   )
-import Unison.Syntax.NameSegment qualified as NameSegment (unsafeParseText)
+import Unison.Syntax.NameSegment qualified as NameSegment
 
 handleInstallLib :: Bool -> ProjectAndBranch ProjectName (Maybe ProjectBranchNameOrLatestRelease) -> Cli ()
 handleInstallLib remind (ProjectAndBranch libdepProjectName unresolvedLibdepBranchName) = do
@@ -130,3 +135,26 @@ makeDependencyName projectName branchName =
     semverSegments :: Semver -> [Text]
     semverSegments (Semver x y z) =
       [tShow x, tShow y, tShow z]
+
+---------------------------------
+
+handleInstallLocalLib :: (ProjectAndBranch ProjectName ProjectBranchName) -> Maybe NameSegment -> Cli ()
+handleInstallLocalLib srcPAB@(ProjectAndBranch projName branchName) mayDestLibName = do
+  sourcePAB <- ProjectUtils.expectProjectAndBranchByTheseNames (These projName branchName)
+  causalBranchToSquash <- Cli.runTransaction $ Codebase.expectProjectBranchRootCausal sourcePAB.branch
+  squashResult <- Cli.runTransaction $ UCausal.squashCausal HH.v2HashHandle causalBranchToSquash
+  destLibName <- case mayDestLibName of
+    Just destLibName -> do
+      pure destLibName
+    Nothing -> do
+      case NameSegment.parseText (into @Text projName) of
+        Left _err -> Cli.returnEarly $ Output.InvalidLibName (into @Text projName)
+        Right parsedName -> pure parsedName
+  let destPath = Path.fromList [NameSegment.libSegment, destLibName]
+  let description = "Installed local lib from " <> into @Text srcPAB <> " to " <> into @Text destPath
+  pb <- Cli.getCurrentProjectBranch
+  Cli.Env {codebase} <- ask
+  squashedBranchIO <- liftIO $ Codebase.expectBranchForHash codebase squashResult.causalHash
+  Cli.updateProjectBranchRoot_ pb description \b -> do
+    Branch.modifyAt destPath (const squashedBranchIO) b
+  Cli.respond $ Output.InstalledLibdep srcPAB destLibName

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/InstallLib.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/InstallLib.hs
@@ -70,27 +70,29 @@ handleInstallLib remind (ProjectAndBranch libdepProjectName unresolvedLibdepBran
 
   remoteBranchObject <- liftIO (Codebase.expectBranchForHash codebase causalHash)
   let reflogDescription = "lib.install " <> into @Text libdepProjectAndBranchNames
-  libdepNameSegment <- attachNewLib reflogDescription remoteBranchObject libdepProjectName libdepBranchName
+  libdepNameSegment <- attachNewLib reflogDescription remoteBranchObject libdepProjectName libdepBranchName Nothing
   Cli.respond (Output.InstalledLibdep libdepProjectAndBranchNames libdepNameSegment)
 
 -- | Attach a new library to the current project branch, under the `lib` namespace, using a fresh name derived from the
 -- project and branch names.
-attachNewLib :: Text -> Branch.Branch IO -> ProjectName -> ProjectBranchName -> Cli NameSegment
-attachNewLib reflogDescription libBranch libdepProjectName libdepBranchName = do
+attachNewLib :: Text -> Branch.Branch IO -> ProjectName -> ProjectBranchName -> Maybe NameSegment -> Cli NameSegment
+attachNewLib reflogDescription libBranch libdepProjectName libdepBranchName preferredName = do
   -- Find the best available dependency name, starting with the best one (e.g. "unison_base_1_0_0"), and tacking on a
   -- "__2", "__3", etc. suffix.
   --
   -- For example, if the best name is "foo", and libdeps "foo" and "foo__2" already exist, then we'll get "foo__3".
-  libdepNameSegment :: NameSegment <- do
-    currentBranchObject <- Cli.getCurrentProjectRoot0
-    pure $
-      fresh
-        (\i -> NameSegment.unsafeParseText . (<> "__" <> tShow i) . NameSegment.toUnescapedText)
-        ( case Map.lookup NameSegment.libSegment (currentBranchObject ^. Branch.children_) of
-            Nothing -> Set.empty
-            Just libdeps -> Map.keysSet (Branch.head libdeps ^. Branch.children_)
-        )
-        (makeDependencyName libdepProjectName libdepBranchName)
+  libdepNameSegment :: NameSegment <- case preferredName of
+    Just name -> pure name
+    Nothing -> do
+      currentBranchObject <- Cli.getCurrentProjectRoot0
+      pure $
+        fresh
+          (\i -> NameSegment.unsafeParseText . (<> "__" <> tShow i) . NameSegment.toUnescapedText)
+          ( case Map.lookup NameSegment.libSegment (currentBranchObject ^. Branch.children_) of
+              Nothing -> Set.empty
+              Just libdeps -> Map.keysSet (Branch.head libdeps ^. Branch.children_)
+          )
+          (makeDependencyName libdepProjectName libdepBranchName)
 
   let libdepPath :: Path.Absolute
       libdepPath = Path.Absolute $ Path.fromList [NameSegment.libSegment, libdepNameSegment]
@@ -148,16 +150,8 @@ handleInstallLocalLib srcPAB@(ProjectAndBranch projName branchName) mayDestLibNa
   sourcePAB <- ProjectUtils.expectProjectAndBranchByTheseNames (These projName branchName)
   causalBranchToSquash <- Cli.runTransaction $ Codebase.expectProjectBranchRootCausal sourcePAB.branch
   squashResult <- Cli.runTransaction $ UCausal.squashCausal HH.v2HashHandle causalBranchToSquash
-  destLibName <- case mayDestLibName of
-    Just destLibName -> do
-      pure destLibName
-    Nothing -> do
-      case NameSegment.parseText (into @Text projName) of
-        Left _err -> Cli.returnEarly $ Output.InvalidLibName (into @Text projName)
-        Right parsedName -> pure parsedName
-  let destPath = Path.fromList [NameSegment.libSegment, destLibName]
-  let description = "Installed local lib from " <> into @Text srcPAB <> " to " <> into @Text destPath
+  let reflogDescription = "lib.install " <> into @Text srcPAB <> maybe "" (\n -> " " <> NameSegment.toEscapedText n) mayDestLibName
   Cli.Env {codebase} <- ask
   squashedBranchIO <- liftIO $ Codebase.expectBranchForHash codebase squashResult.causalHash
-  libSegmentName <- attachNewLib description squashedBranchIO projName branchName
+  libSegmentName <- attachNewLib reflogDescription squashedBranchIO projName branchName mayDestLibName
   Cli.respond $ Output.InstalledLibdep srcPAB libSegmentName

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/InstallLib.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/InstallLib.hs
@@ -69,7 +69,14 @@ handleInstallLib remind (ProjectAndBranch libdepProjectName unresolvedLibdepBran
       & onLeftM (Cli.returnEarly . Output.ShareError)
 
   remoteBranchObject <- liftIO (Codebase.expectBranchForHash codebase causalHash)
+  let reflogDescription = "lib.install " <> into @Text libdepProjectAndBranchNames
+  libdepNameSegment <- attachNewLib reflogDescription remoteBranchObject libdepProjectName libdepBranchName
+  Cli.respond (Output.InstalledLibdep libdepProjectAndBranchNames libdepNameSegment)
 
+-- | Attach a new library to the current project branch, under the `lib` namespace, using a fresh name derived from the
+-- project and branch names.
+attachNewLib :: Text -> Branch.Branch IO -> ProjectName -> ProjectBranchName -> Cli NameSegment
+attachNewLib reflogDescription libBranch libdepProjectName libdepBranchName = do
   -- Find the best available dependency name, starting with the best one (e.g. "unison_base_1_0_0"), and tacking on a
   -- "__2", "__3", etc. suffix.
   --
@@ -88,12 +95,10 @@ handleInstallLib remind (ProjectAndBranch libdepProjectName unresolvedLibdepBran
   let libdepPath :: Path.Absolute
       libdepPath = Path.Absolute $ Path.fromList [NameSegment.libSegment, libdepNameSegment]
 
-  let reflogDescription = "lib.install " <> into @Text libdepProjectAndBranchNames
   pp <- Cli.getCurrentProjectPath
   let libDepPP = pp & PP.absPath_ .~ libdepPath
-  _didUpdate <- Cli.updateAt reflogDescription libDepPP (\_empty -> remoteBranchObject)
-
-  Cli.respond (Output.InstalledLibdep libdepProjectAndBranchNames libdepNameSegment)
+  _didUpdate <- Cli.updateAt reflogDescription libDepPP (\_empty -> libBranch)
+  pure libdepNameSegment
 
 fresh :: (Ord a) => (Int -> a -> a) -> Set a -> a -> a
 fresh bump taken x =
@@ -152,9 +157,7 @@ handleInstallLocalLib srcPAB@(ProjectAndBranch projName branchName) mayDestLibNa
         Right parsedName -> pure parsedName
   let destPath = Path.fromList [NameSegment.libSegment, destLibName]
   let description = "Installed local lib from " <> into @Text srcPAB <> " to " <> into @Text destPath
-  pb <- Cli.getCurrentProjectBranch
   Cli.Env {codebase} <- ask
   squashedBranchIO <- liftIO $ Codebase.expectBranchForHash codebase squashResult.causalHash
-  Cli.updateProjectBranchRoot_ pb description \b -> do
-    Branch.modifyAt destPath (const squashedBranchIO) b
-  Cli.respond $ Output.InstalledLibdep srcPAB destLibName
+  libSegmentName <- attachNewLib description squashedBranchIO projName branchName
+  Cli.respond $ Output.InstalledLibdep srcPAB libSegmentName

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectClone.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectClone.hs
@@ -21,9 +21,8 @@ import Unison.Cli.ProjectUtils qualified as ProjectUtils
 import Unison.Cli.Share.Projects qualified as Share
 import Unison.Codebase.Editor.Output qualified as Output
 import Unison.Prelude
-import Unison.Project (ProjectAndBranch (..), ProjectAndBranchNames (..), ProjectBranchName, ProjectName, projectNameUserSlug)
+import Unison.Project (ProjectAndBranch (..), ProjectAndBranchNames (..), ProjectBranchName, ProjectName, defaultBranchName, projectNameUserSlug)
 import Unison.Sqlite qualified as Sqlite
-import Witch (unsafeFrom)
 
 data LocalProjectKey
   = LocalProjectKey'Name ProjectName
@@ -97,7 +96,7 @@ resolveRemoteNames includeSquashed currentProjectAndBranch = \case
               (Just remoteProject, Nothing) -> do
                 let remoteProjectId = remoteProject.projectId
                 let remoteProjectName = remoteProject.projectName
-                let remoteBranchName = unsafeFrom @Text "main"
+                let remoteBranchName = defaultBranchName
                 remoteBranch <-
                   ProjectUtils.expectRemoteProjectBranchByName
                     includeSquashed
@@ -136,7 +135,7 @@ resolveRemoteNames includeSquashed currentProjectAndBranch = \case
 
     resolveP projectName = do
       assertProjectNameHasUserSlug projectName
-      branch <- expectB (RemoteProjectKey'Name projectName) (unsafeFrom @Text "main")
+      branch <- expectB (RemoteProjectKey'Name projectName) defaultBranchName
       pure ResolvedRemoteNames {branch, from = ResolvedRemoteNamesFrom'Project}
 
     resolvePB projectName branchName = do

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectCreate.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectCreate.hs
@@ -24,7 +24,7 @@ import Unison.Codebase.Editor.Output qualified as Output
 import Unison.Codebase.SqliteCodebase.Operations qualified as Ops
 import Unison.NameSegment qualified as NameSegment
 import Unison.Prelude
-import Unison.Project (ProjectAndBranch (..), ProjectName)
+import Unison.Project (ProjectAndBranch (..), ProjectName, defaultBranchName)
 import Unison.Share.API.Hash qualified as Share.API
 import Unison.Sync.Common qualified as Sync.Common
 import Witch (unsafeFrom)
@@ -57,7 +57,7 @@ import Witch (unsafeFrom)
 -- much time getting everything perfectly correct before we get there.
 projectCreate :: Bool -> Maybe ProjectName -> Cli (ProjectAndBranch ProjectId ProjectBranchId)
 projectCreate tryDownloadingBase maybeProjectName = do
-  let branchName = unsafeFrom @Text "main"
+  let branchName = defaultBranchName
   (_, emptyCausalHashId) <- Cli.runTransaction Codebase.emptyCausalHash
 
   (project, branch) <-

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectSwitch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectSwitch.hs
@@ -13,8 +13,7 @@ import Unison.Cli.MonadUtils qualified as Cli
 import Unison.Cli.ProjectUtils qualified as ProjectUtils
 import Unison.Codebase.Editor.Output qualified as Output
 import Unison.Prelude
-import Unison.Project (ProjectAndBranch (..), ProjectAndBranchNames (..), ProjectBranchName, ProjectName)
-import Witch (unsafeFrom)
+import Unison.Project (ProjectAndBranch (..), ProjectAndBranchNames (..), ProjectBranchName, ProjectName, defaultBranchName)
 
 -- | Switch to an existing project or project branch, with a flexible syntax that does not require prefixing branch
 -- names with forward slashes (though doing so makes the command unambiguous).
@@ -57,7 +56,7 @@ switchToProjectAndBranchByTheseNames projectAndBranchNames0 = do
             rollback (Output.LocalProjectDoesntExist projectName)
         Queries.loadMostRecentBranch (project ^. #projectId) >>= \case
           Nothing -> do
-            let branchName = unsafeFrom @Text "main"
+            let branchName = defaultBranchName
             branch <-
               Queries.loadProjectBranchByName project.projectId branchName & onNothingM do
                 rollback (Output.LocalProjectBranchDoesntExist (ProjectAndBranch projectName branchName))

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Pull.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Pull.hs
@@ -32,8 +32,7 @@ import Unison.Codebase.ProjectPath qualified as PP
 import Unison.CommandLine.InputPattern qualified as InputPattern
 import Unison.CommandLine.InputPatterns qualified as InputPatterns
 import Unison.Prelude
-import Unison.Project (ProjectAndBranch (..), ProjectBranchNameOrLatestRelease (..), ProjectName)
-import Witch (unsafeFrom)
+import Unison.Project (ProjectAndBranch (..), ProjectBranchNameOrLatestRelease (..), ProjectName, defaultBranchName)
 
 handlePull :: PullSourceTarget -> PullMode -> Cli ()
 handlePull unresolvedSourceAndTarget pullMode = do
@@ -179,7 +178,7 @@ resolveExplicitSource includeSquashed = \case
   ReadShare'ProjectBranch (This remoteProjectName) -> do
     remoteProject <- ProjectUtils.expectRemoteProjectByName remoteProjectName
     let remoteProjectId = remoteProject.projectId
-    let remoteBranchName = unsafeFrom @Text "main"
+    let remoteBranchName = defaultBranchName
     remoteProjectBranch <-
       ProjectUtils.expectRemoteProjectBranchByName
         includeSquashed

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Push.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Push.hs
@@ -41,6 +41,7 @@ import Unison.Project
     ProjectBranchNameKind (..),
     ProjectName,
     classifyProjectBranchName,
+    defaultBranchName,
     prependUserSlugToProjectName,
     projectNameUserSlug,
   )
@@ -52,7 +53,6 @@ import Unison.Share.Sync.Types qualified as Share
 import Unison.Share.Types (codeserverBaseURL)
 import Unison.Sqlite qualified as Sqlite
 import Unison.Sync.Types qualified as Share
-import Witch (unsafeFrom)
 
 -- | Handle a @push@ command.
 handlePushRemoteBranch :: PushRemoteBranchInput -> Cli ()
@@ -263,7 +263,7 @@ deriveRemoteBranchName userHandle localBranchName =
     ProjectBranchNameKind'DraftRelease _ -> localBranchName
     ProjectBranchNameKind'Release _ -> localBranchName
     ProjectBranchNameKind'NothingSpecial
-      | localBranchName == unsafeFrom @Text "main" -> localBranchName
+      | localBranchName == defaultBranchName -> localBranchName
       | otherwise ->
           (UnsafeProjectBranchName . Text.Builder.run . fold)
             [ Text.Builder.char '@',

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -234,6 +234,11 @@ data Input
   | LibInstallI
       !Bool -- Remind the user to use `lib.install` next time, not `pull`?
       !(ProjectAndBranch ProjectName (Maybe ProjectBranchNameOrLatestRelease))
+  | LibInstallLocalI
+      -- The source local project and branch.
+      !(ProjectAndBranch ProjectName ProjectBranchName)
+      -- The destination lib name
+      (Maybe NameSegment)
   | UpgradeCommitI
   | MergeCommitI
   | DebugSynhashTermI !Name

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -374,6 +374,7 @@ data Output
     RemoteProjectBranchIsUpToDate URI (ProjectAndBranch ProjectName ProjectBranchName)
   | InvalidProjectName Text
   | InvalidProjectBranchName Text
+  | InvalidLibName Text
   | InvalidStructuredFindReplace (HQ.HashQualified Name)
   | InvalidStructuredFind (HQ.HashQualified Name)
   | ProjectNameAlreadyExists ProjectName
@@ -635,6 +636,7 @@ isFailure o = case o of
   CreatedRemoteProjectBranch {} -> False
   InvalidProjectName {} -> True
   InvalidProjectBranchName {} -> True
+  InvalidLibName {} -> True
   InvalidStructuredFindReplace {} -> True
   InvalidStructuredFind {} -> True
   ProjectNameAlreadyExists {} -> True

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -374,7 +374,6 @@ data Output
     RemoteProjectBranchIsUpToDate URI (ProjectAndBranch ProjectName ProjectBranchName)
   | InvalidProjectName Text
   | InvalidProjectBranchName Text
-  | InvalidLibName Text
   | InvalidStructuredFindReplace (HQ.HashQualified Name)
   | InvalidStructuredFind (HQ.HashQualified Name)
   | ProjectNameAlreadyExists ProjectName
@@ -636,7 +635,6 @@ isFailure o = case o of
   CreatedRemoteProjectBranch {} -> False
   InvalidProjectName {} -> True
   InvalidProjectBranchName {} -> True
-  InvalidLibName {} -> True
   InvalidStructuredFindReplace {} -> True
   InvalidStructuredFind {} -> True
   ProjectNameAlreadyExists {} -> True

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -67,6 +67,7 @@ module Unison.CommandLine.InputPatterns
     ioTest,
     ioTestAll,
     libInstallInputPattern,
+    libInstallLocalInputPattern,
     load,
     makeStandalone,
     mergeBuiltins,
@@ -410,6 +411,17 @@ handleProjectMaybeBranchArg =
         pure . ProjectAndBranch proj . pure $ ProjectBranchNameOrLatestRelease'Name branch
       otherArgType -> Left $ wrongStructuredArgument "a project or branch" otherArgType
 
+handleProjectBranchArg ::
+  I.Argument -> Either (P.Pretty CT.ColorText) (ProjectAndBranch ProjectName ProjectBranchName)
+handleProjectBranchArg =
+  either
+    (\str -> first (const $ expectedButActually' "a project or branch" str) . tryInto $ Text.pack str)
+    \case
+      SA.Project proj -> pure $ ProjectAndBranch proj defaultBranchName
+      SA.ProjectBranch (ProjectAndBranch (Just proj) branch) ->
+        pure $ ProjectAndBranch proj branch
+      otherArgType -> Left $ wrongStructuredArgument "a project or branch" otherArgType
+
 handleHashQualifiedNameArg :: I.Argument -> Either (P.Pretty CT.ColorText) (HQ.HashQualified Name)
 handleHashQualifiedNameArg =
   either
@@ -649,6 +661,15 @@ handleRelativeNameSegmentArg arg = do
   if Name.isRelative name && null tail
     then pure segment
     else Left $ P.text "Wanted a single relative name segment, but it wasn’t."
+
+-- | Just a single simple name segment. Useful for lib names, etc.
+handleNameSegmentArg :: I.Argument -> Either (P.Pretty CT.ColorText) NameSegment
+handleNameSegmentArg arg = do
+  case arg of
+    Left txt -> mapLeft P.text $ NameSegment.parseText (Text.pack txt)
+    -- There are no valid structured args for a single name segment identifier, and there are no commands that
+    -- output them as numbered output.
+    Right _ -> Left "Expected a name segment"
 
 handleNameArg :: I.Argument -> Either (P.Pretty CT.ColorText) Name
 handleNameArg =
@@ -1619,6 +1640,45 @@ libInstallInputPattern =
         [arg] -> Input.LibInstallI False <$> handleProjectMaybeBranchArg arg
         args -> wrongArgsLength "exactly one argument" args
     }
+
+libInstallLocalInputPattern :: InputPattern
+libInstallLocalInputPattern =
+  InputPattern
+    { patternName = "lib.install.local",
+      aliases = ["install.lib.local"],
+      visibility = I.Visible,
+      params = Parameters [("local branch", projectBranchNameArg suggestionsConfig)] $ Optional [("destination lib name", noCompletionsArg)] Nothing,
+      help =
+        P.lines
+          [ P.wrap $
+              "The"
+                <> makeExample' libInstallLocalInputPattern
+                <> "command installs a local project branch into the `lib` namespace of the current branch.",
+            "",
+            P.wrapColumn2
+              [ ( makeExample libInstallLocalInputPattern ["myproject"],
+                  "installs the `main` branch of `myproject` in your codebase into the current branch's lib directory at `lib.myproject`"
+                ),
+                ( makeExample libInstallLocalInputPattern ["myproject/feature"],
+                  "installs the `feature` branch of `myproject` in your codebase into the current branch's lib directory at `lib.myproject`"
+                ),
+                ( makeExample libInstallLocalInputPattern ["myproject/development", "myproject_dev"],
+                  "installs the `development` branch of `myproject` in your codebase into the current branch's lib directory at `lib.myproject_dev`"
+                )
+              ]
+          ],
+      parse = \case
+        [src] -> Input.LibInstallLocalI <$> handleProjectBranchArg src <*> pure Nothing
+        [src, dest] -> Input.LibInstallLocalI <$> handleProjectBranchArg src <*> (Just <$> handleNameSegmentArg dest)
+        args -> wrongArgsLength "exactly one argument" args
+    }
+  where
+    suggestionsConfig =
+      ProjectBranchSuggestionsConfig
+        { showProjectCompletions = False,
+          projectInclusion = OnlyOutsideCurrentProject,
+          branchInclusion = AllBranches
+        }
 
 reset :: InputPattern
 reset =
@@ -3414,6 +3474,7 @@ validInputs =
       ioTest,
       ioTestAll,
       libInstallInputPattern,
+      libInstallLocalInputPattern,
       load,
       makeStandalone,
       mergeBuiltins,

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -137,6 +137,7 @@ where
 import Control.Lens.Cons qualified as Cons
 import Data.Bitraversable (bitraverse)
 import Data.Char (isSpace)
+import Data.Generics.Product (HasField (..))
 import Data.List (intercalate)
 import Data.List.Extra qualified as List
 import Data.List.NonEmpty qualified as NE
@@ -413,14 +414,21 @@ handleProjectMaybeBranchArg =
 
 handleProjectBranchArg ::
   I.Argument -> Either (P.Pretty CT.ColorText) (ProjectAndBranch ProjectName ProjectBranchName)
-handleProjectBranchArg =
-  either
-    (\str -> first (const $ expectedButActually' "a project or branch" str) . tryInto $ Text.pack str)
-    \case
+handleProjectBranchArg arg =
+  case arg of
+    Left str ->
+      parseProjBranchName str <|> parseJustProjName str
+        & maybeToEither (P.string $ "Invalid project/branch name: " <> str)
+    Right structured -> case structured of
       SA.Project proj -> pure $ ProjectAndBranch proj defaultBranchName
       SA.ProjectBranch (ProjectAndBranch (Just proj) branch) ->
         pure $ ProjectAndBranch proj branch
       otherArgType -> Left $ wrongStructuredArgument "a project or branch" otherArgType
+  where
+    parseProjBranchName str = eitherToMaybe (tryInto @(ProjectAndBranch ProjectName ProjectBranchName) $ Text.pack str)
+    parseJustProjName str = do
+      projMayBranch <- eitherToMaybe (tryInto @(ProjectAndBranch ProjectName (Maybe ProjectBranchName)) $ Text.pack str)
+      pure $ projMayBranch & field @"branch" %~ fromMaybe defaultBranchName
 
 handleHashQualifiedNameArg :: I.Argument -> Either (P.Pretty CT.ColorText) (HQ.HashQualified Name)
 handleHashQualifiedNameArg =

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -215,6 +215,7 @@ import Unison.Project
     ProjectName,
     Semver,
     branchWithOptionalProjectParser,
+    defaultBranchName,
   )
 import Unison.Referent qualified as Referent
 import Unison.Server.Backend (ShallowListEntry (..))
@@ -2144,7 +2145,7 @@ mergeCommitInputPattern =
       visibility = I.Visible,
       params = noParams,
       help =
-        let mainBranch = UnsafeProjectBranchName "main"
+        let mainBranch = defaultBranchName
             tempBranch = UnsafeProjectBranchName "merge-topic-into-main"
          in P.wrap
               ( makeExample' mergeCommitInputPattern
@@ -3289,7 +3290,7 @@ upgradeCommitInputPattern =
       visibility = I.Visible,
       params = noParams,
       help =
-        let mainBranch = UnsafeProjectBranchName "main"
+        let mainBranch = defaultBranchName
             tempBranch = UnsafeProjectBranchName "upgrade-foo-to-bar"
          in P.wrap
               ( makeExample' upgradeCommitInputPattern

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -2157,7 +2157,7 @@ notifyUser dir = \case
     pure . P.wrap $
       "I installed"
         <> prettyProjectAndBranchName libdep
-        <> "as"
+        <> "into"
         <> P.group (P.text $ into @Text $ Path.fromList [NameSegment.libSegment, segment])
   NoUpgradeInProgress ->
     pure . P.wrap $ "It doesn't look like there's an upgrade in progress."

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -111,7 +111,7 @@ import Unison.PrintError
     renderCompilerBug,
     renderTypeWarnings,
   )
-import Unison.Project (ProjectAndBranch (..))
+import Unison.Project (ProjectAndBranch (..), defaultBranchName)
 import Unison.Reference (Reference)
 import Unison.Reference qualified as Reference
 import Unison.Referent (Referent)
@@ -413,7 +413,7 @@ notifyNumbered = \case
           ),
       [ SA.ProjectBranch $ ProjectAndBranch Nothing branch,
         SA.ProjectBranch . ProjectAndBranch (pure project) $
-          UnsafeProjectBranchName "main"
+          defaultBranchName
       ]
     )
     where

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -872,7 +872,6 @@ notifyUser dir = \case
       --       defs in the codebase.  In some cases it's fine for bindings to
       --       shadow codebase names, but you don't want it to capture them in
       --       the decompiled output.
-
         let prettyBindings =
               P.bracket . P.lines $
                 P.wrap "The watch expression(s) reference these definitions:"
@@ -1714,6 +1713,7 @@ notifyUser dir = \case
           <> "is already up-to-date."
   InvalidProjectName name -> pure (P.wrap (P.text name <> "is not a valid project name."))
   InvalidProjectBranchName name -> pure (P.wrap (P.text name <> "is not a valid branch name."))
+  InvalidLibName name -> pure (P.wrap (P.text name <> "is not a valid lib name."))
   ProjectNameAlreadyExists name ->
     pure . P.wrap $
       "Project" <> prettyProjectName name <> "already exists."

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -2157,7 +2157,7 @@ notifyUser dir = \case
       "I installed"
         <> prettyProjectAndBranchName libdep
         <> "as"
-        <> P.group (P.text (NameSegment.toEscapedText segment) <> ".")
+        <> P.group (P.text $ into @Text $ Path.fromList [NameSegment.libSegment, segment])
   NoUpgradeInProgress ->
     pure . P.wrap $ "It doesn't look like there's an upgrade in progress."
   UseLibInstallNotPull libdep ->

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1714,7 +1714,6 @@ notifyUser dir = \case
           <> "is already up-to-date."
   InvalidProjectName name -> pure (P.wrap (P.text name <> "is not a valid project name."))
   InvalidProjectBranchName name -> pure (P.wrap (P.text name <> "is not a valid branch name."))
-  InvalidLibName name -> pure (P.wrap (P.text name <> "is not a valid lib name."))
   ProjectNameAlreadyExists name ->
     pure . P.wrap $
       "Project" <> prettyProjectName name <> "already exists."

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -872,6 +872,7 @@ notifyUser dir = \case
       --       defs in the codebase.  In some cases it's fine for bindings to
       --       shadow codebase names, but you don't want it to capture them in
       --       the decompiled output.
+
         let prettyBindings =
               P.bracket . P.lines $
                 P.wrap "The watch expression(s) reference these definitions:"

--- a/unison-cli/src/Unison/Main.hs
+++ b/unison-cli/src/Unison/Main.hs
@@ -79,12 +79,13 @@ import Unison.CommandLine.Main qualified as CommandLine
 import Unison.CommandLine.Types qualified as CommandLine
 import Unison.CommandLine.Welcome (CodebaseInitStatus (..))
 import Unison.CommandLine.Welcome qualified as Welcome
-import Unison.Core.Project (ProjectAndBranch (..), ProjectBranchName (..), ProjectName (..))
+import Unison.Core.Project (ProjectAndBranch (..), ProjectName (..))
 import Unison.LSP qualified as LSP
 import Unison.LSP.Util.Signal qualified as Signal
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
 import Unison.PrettyTerminal qualified as PT
+import Unison.Project (defaultBranchName)
 import Unison.Runtime.Exception (RuntimeExn (..))
 import Unison.Runtime.Interface qualified as RTI
 import Unison.Server.Backend qualified as Backend
@@ -325,7 +326,7 @@ main version = do
                               [ "I've started the Codebase API server at",
                                 P.text $ Server.urlFor Server.Api baseUrl,
                                 "and the Codebase UI at",
-                                P.text $ Server.urlFor (Server.ProjectBranchUI (ProjectAndBranch (UnsafeProjectName "scratch") (UnsafeProjectBranchName "main")) Path.Root Nothing) baseUrl
+                                P.text $ Server.urlFor (Server.ProjectBranchUI (ProjectAndBranch (UnsafeProjectName "scratch") defaultBranchName) Path.Root Nothing) baseUrl
                               ]
                         PT.putPrettyLn $
                           P.string "Running the codebase manager headless with "

--- a/unison-core/src/Unison/Project.hs
+++ b/unison-core/src/Unison/Project.hs
@@ -25,6 +25,7 @@ module Unison.Project
     projectAndBranchNamesParser2,
     projectNameParser,
     projectBranchNameParser,
+    defaultBranchName,
 
     -- ** Semver
     Semver (..),
@@ -550,3 +551,8 @@ userSlugParser = do
   c1 <- Megaparsec.takeWhileP Nothing (\c -> Char.isAlpha c || Char.isDigit c || c == '-')
   _ <- Megaparsec.char '/'
   pure (Text.Builder.char c0 <> Text.Builder.text c1)
+
+----
+
+defaultBranchName :: ProjectBranchName
+defaultBranchName = UnsafeProjectBranchName "main"

--- a/unison-share-api/src/Unison/Server/Local/Endpoints/Current.hs
+++ b/unison-share-api/src/Unison/Server/Local/Endpoints/Current.hs
@@ -12,8 +12,8 @@ import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Path qualified as Path
 import Unison.Codebase.ProjectPath qualified as PP
 import Unison.Core.Project (ProjectBranchName (..), ProjectName (..))
-import Unison.Project (defaultBranchName)
 import Unison.Prelude
+import Unison.Project (defaultBranchName)
 import Unison.Server.Backend
 import Unison.Server.Types (APIGet)
 

--- a/unison-share-api/src/Unison/Server/Local/Endpoints/Current.hs
+++ b/unison-share-api/src/Unison/Server/Local/Endpoints/Current.hs
@@ -12,6 +12,7 @@ import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Path qualified as Path
 import Unison.Codebase.ProjectPath qualified as PP
 import Unison.Core.Project (ProjectBranchName (..), ProjectName (..))
+import Unison.Project (defaultBranchName)
 import Unison.Prelude
 import Unison.Server.Backend
 import Unison.Server.Types (APIGet)
@@ -33,7 +34,7 @@ instance ToSample Current where
     [ ( "Current ucm state",
         Current
           (Just $ UnsafeProjectName "@unison/base")
-          (Just $ UnsafeProjectBranchName "main")
+          (Just $ defaultBranchName)
           (Path.Absolute $ Path.unsafeParseText "my.path")
       )
     ]

--- a/unison-src/transcripts/base_release_transcript.output.md
+++ b/unison-src/transcripts/base_release_transcript.output.md
@@ -3,8 +3,8 @@
 ``` ucm
 scratch/main> lib.install @unison/base/releases/3.35.0
 
-  I installed @unison/base/releases/3.35.0 as
-  unison_base_3_35_0.
+  I installed @unison/base/releases/3.35.0 into
+  lib.unison_base_3_35_0
 ```
 
 This just verifies that a `Map` prints out nicely, as a call to `Map.fromList`:

--- a/unison-src/transcripts/idempotent/help.md
+++ b/unison-src/transcripts/idempotent/help.md
@@ -517,6 +517,62 @@ scratch/main> help
                                               `topic` branch of
                                               `@unison/base`
 
+  lib.install.local (or install.lib.local)
+  The `lib.install.local` command installs a local project
+  branch into the `lib` namespace of the current branch.
+
+  `lib.install.local myproject`                            installs
+                                                           the
+                                                           `main`
+                                                           branch
+                                                           of
+                                                           `myproject`
+                                                           in
+                                                           your
+                                                           codebase
+                                                           into
+                                                           the
+                                                           current
+                                                           branch's
+                                                           lib
+                                                           directory
+                                                           at
+                                                           `lib.myproject`
+  `lib.install.local myproject/feature`                    installs
+                                                           the
+                                                           `feature`
+                                                           branch
+                                                           of
+                                                           `myproject`
+                                                           in
+                                                           your
+                                                           codebase
+                                                           into
+                                                           the
+                                                           current
+                                                           branch's
+                                                           lib
+                                                           directory
+                                                           at
+                                                           `lib.myproject`
+  `lib.install.local myproject/development myproject_dev`  installs
+                                                           the
+                                                           `development`
+                                                           branch
+                                                           of
+                                                           `myproject`
+                                                           in
+                                                           your
+                                                           codebase
+                                                           into
+                                                           the
+                                                           current
+                                                           branch's
+                                                           lib
+                                                           directory
+                                                           at
+                                                           `lib.myproject_dev`
+
   list (or ls, dir)
   `list`       lists definitions and namespaces in the current
                namespace.

--- a/unison-src/transcripts/idempotent/lib-install-local.md
+++ b/unison-src/transcripts/idempotent/lib-install-local.md
@@ -31,11 +31,11 @@ scratch/main> update
 
 myproject/main> lib.install.local scratch
 
-  I installed scratch/main into lib.scratch
+  I installed scratch/main into lib.scratch_main
 
 myproject/main> ls lib
 
-  1. scratch/ (584 terms, 101 types)
+  1. scratch_main/ (584 terms, 101 types)
 
 -- Can also specify a custom destination location
 
@@ -46,7 +46,7 @@ myproject/main> lib.install.local scratch/main coolerscratch
 myproject/main> ls lib
 
   1. coolerscratch/ (584 terms, 101 types)
-  2. scratch/       (584 terms, 101 types)
+  2. scratch_main/  (584 terms, 101 types)
 
 -- Installed libs should be squashed.
 
@@ -57,5 +57,5 @@ myproject/main> history lib.scratch
 
 
 
-  □ 1. #0ga4v1i12o (start of history)
+  □ 1. #sg60bvjo91 (start of history)
 ```

--- a/unison-src/transcripts/idempotent/lib-install-local.md
+++ b/unison-src/transcripts/idempotent/lib-install-local.md
@@ -31,7 +31,7 @@ scratch/main> update
 
 myproject/main> lib.install.local scratch
 
-  I installed scratch/main as scratch.
+  I installed scratch/main into lib.scratch
 
 myproject/main> ls lib
 
@@ -41,7 +41,7 @@ myproject/main> ls lib
 
 myproject/main> lib.install.local scratch/main coolerscratch
 
-  I installed scratch/main as coolerscratch.
+  I installed scratch/main into lib.coolerscratch
 
 myproject/main> ls lib
 

--- a/unison-src/transcripts/idempotent/lib-install-local.md
+++ b/unison-src/transcripts/idempotent/lib-install-local.md
@@ -1,0 +1,61 @@
+# lib.install.local
+
+``` ucm :hide
+scratch/main> builtins.merge
+```
+
+``` unison :hide
+myTerm = 1
+type MyType = Con
+```
+
+``` ucm :hide
+scratch/main> update
+```
+
+Add some history so we can see if we're squashing as expected.
+
+``` unison :hide
+myTerm = 2
+```
+
+``` ucm
+scratch/main> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+
+-- Simplest version should install main branch under the lib name
+
+myproject/main> lib.install.local scratch
+
+  I installed scratch/main as scratch.
+
+myproject/main> ls lib
+
+  1. scratch/ (584 terms, 101 types)
+
+-- Can also specify a custom destination location
+
+myproject/main> lib.install.local scratch/main coolerscratch
+
+  I installed scratch/main as coolerscratch.
+
+myproject/main> ls lib
+
+  1. coolerscratch/ (584 terms, 101 types)
+  2. scratch/       (584 terms, 101 types)
+
+-- Installed libs should be squashed.
+
+myproject/main> history lib.scratch
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+
+
+
+  □ 1. #0ga4v1i12o (start of history)
+```

--- a/unison-src/transcripts/idempotent/lib-install-local.output.md
+++ b/unison-src/transcripts/idempotent/lib-install-local.output.md
@@ -1,0 +1,74 @@
+# lib.install.local
+
+``` ucm
+scratch/main> builtins.merge
+
+  Done.
+```
+
+``` unison
+myTerm = 1
+type MyType = Con
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  + type MyType
+
+  + myTerm : Nat
+
+  Run `update` to apply these changes to your codebase.
+```
+
+``` ucm
+scratch/main> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+```
+
+Add some history so we can see if we're squashing as expected.
+
+``` unison
+myTerm = 2
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  ~ myTerm : Nat
+
+  ~ (modified)
+
+  Run `update` to apply these changes to your codebase.
+```
+
+``` ucm
+scratch/main> update
+-- Simplest version should install main branch under the lib name
+myproject/main> lib.install.local scratch
+myproject/main> ls lib
+-- Can also specify a custom destination location
+myproject/main> lib.install.local scratch/main coolerscratch
+myproject/main> ls lib
+-- Installed libs should be squashed.
+myproject/main> history lib.scratch
+```
+
+🛑
+
+The transcript failed due to an error in the stanza above. The error is:
+
+``` 
+⚠️
+
+Sorry, I wasn’t sure how to process your request:
+
+  I expected a project or branch, but couldn’t recognize “scratch” as one.
+
+You can run `help lib.install.local` for more information on
+using `lib.install.local`.
+```

--- a/unison-src/transcripts/idempotent/pull-errors.md
+++ b/unison-src/transcripts/idempotent/pull-errors.md
@@ -5,8 +5,8 @@ test/main> pull @aryairani/test-almost-empty/main lib.base_latest
   Going forward, you can use
   `lib.install @aryairani/test-almost-empty/main`.
 
-  I installed @aryairani/test-almost-empty/main as
-  aryairani_test_almost_empty_main.
+  I installed @aryairani/test-almost-empty/main into
+  lib.aryairani_test_almost_empty_main
 
 test/main> pull @aryairani/test-almost-empty/main a.b
 


### PR DESCRIPTION
## Overview

There's currently no good way to install a local project as a lib in another local project.

See [this Discord conversation](https://discord.com/channels/862108724948500490/1200119393061969951/1401861986534297600)

And provides a better workflow for: https://github.com/unisonweb/unison/issues/5099

## Implementation notes

* Adds new command `lib.install.local`
* The new command is effectively a `branch.squash` but from a different local project into the current lib.
* Slight alteration to the success message from: `I installed foo as bar.` -> `I installed foo into lib.bar`; IMO it's a little clearer where to look for things after they're installed, but happy to change it if others feel differently.

## Interesting/controversial decisions

The controversial thing I could think of is if we just want to do something better, but that's a big design space and I think it's worth having this very practical fix in the meantime :)

Also, I didn't add any sort of checks for any existing lib that may be overwritten by a `lib.install.local`, I wanted it to be low friction when iterating on local deps a lot, and figure the user can always just undo if needed.

## Test coverage

Added transcripts

## Loose ends

I'd love to have some sort of local sym-link support or something, but that's a bigger separate discussion.