### PR TITLE
Improve an error message when an ability variable can't be solved.

### DIFF
--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -631,6 +631,23 @@ renderTypeError e env src = case e of
         "\n\n",
         debugSummary note
       ]
+  AbilityInstantiationFailure _v want site _ ->
+    mconcat
+      [ "I wasn't able to solve for an implicit effect variable when checking\n",
+        "the definition:",
+        "\n\n",
+        showSourceMaybes src [(,Type1) <$> rangeForAnnotated site],
+        "\n\n",
+        "This is likely due to a recursive function using abilities where the\n",
+        "signature does not specify the abilities used.",
+        "\n\n",
+        "I think the abilities should be similar to\n\n",
+        Pr.indentN 4 . style Type1 $
+          "{" <> commas (renderType' env) want <> "}",
+        "\n\n",
+        "Please adjust the signature to include the ability annotation on the\n",
+        "arrow."
+      ]
   UnguardedLetRecCycle vs locs _ ->
     mconcat
       [ "These definitions depend on each other cyclically but aren't guarded ",

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -3258,7 +3258,8 @@ subAbilities want have = do
   have <- expandAbilities have
   (extra, want) <- traverse expandWanted =<< pruneAbilities want have
   have <- expandAbilities have
-  scope (InSubAbilities (snd <$> want) have)
+  scope
+    (InSubAbilities (snd <$> want) have)
     case (want, mapMaybe ex have) of
       ([], _) -> pure extra
       (want@((_, w) : _), [(b, ve, tv)]) ->

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -319,6 +319,7 @@ data CompilerBug v loc
 data PathElement v loc
   = InSynthesize (Term v loc)
   | InSubtype (Type v loc) (Type v loc)
+  | InSubAbilities [Type v loc] [Type v loc] -- want, have
   | InEquate (Type v loc) (Type v loc)
   | InCheck (Term v loc) (Type v loc)
   | InInstantiateL v (Type v loc)
@@ -3257,11 +3258,12 @@ subAbilities want have = do
   have <- expandAbilities have
   (extra, want) <- traverse expandWanted =<< pruneAbilities want have
   have <- expandAbilities have
-  case (want, mapMaybe ex have) of
-    ([], _) -> pure extra
-    (want@((_, w) : _), [(b, ve, tv)]) ->
-      extra <$ refineEffectVar (loc w) (snd <$> want) b ve tv -- `orElse` die src w
-    ((src, w) : _, _) -> die src w
+  scope (InSubAbilities (snd <$> want) have)
+    case (want, mapMaybe ex have) of
+      ([], _) -> pure extra
+      (want@((_, w) : _), [(b, ve, tv)]) ->
+        extra <$ refineEffectVar (loc w) (snd <$> want) b ve tv
+      ((src, w) : _, _) -> die src w
   where
     ex t@(Type.Var' (TypeVar.Existential b v)) = Just (b, v, t)
     ex _ = Nothing

--- a/parser-typechecker/src/Unison/Typechecker/TypeError.hs
+++ b/parser-typechecker/src/Unison/Typechecker/TypeError.hs
@@ -83,6 +83,12 @@ data TypeError v loc
         mismatchSite :: C.Term v loc,
         note :: C.ErrorNote v loc
       }
+  | AbilityInstantiationFailure
+      { var :: v,
+        inst :: [C.Type v loc],
+        instSite :: C.Term v loc,
+        note :: C.ErrorNote v loc
+      }
   | UnguardedLetRecCycle
       { cycle :: [v],
         cycleLocs :: [loc],
@@ -146,6 +152,7 @@ allErrors =
       generalMismatch,
       abilityCheckFailure,
       abilityEqFailure,
+      badEffectInstantiation,
       unguardedCycle,
       unknownType,
       unknownTerm,
@@ -216,6 +223,36 @@ unknownTerm = do
   (loc, v, suggs, typ) <- Ex.unknownTerm
   n <- Ex.errorNote
   pure $ UnknownTerm v loc suggs (Type.cleanup typ) n
+
+data EffInst v loc
+  = Eff [C.Type v loc] [C.Type v loc] -- want, have
+  | Normal
+
+-- checks if the top of the path was an instantiation, and indicates
+-- whether it was from an ability variable.
+instantiation ::
+  (Var v, Ord loc) =>
+  Ex.ErrorExtractor v loc (v, C.Type v loc, EffInst v loc)
+instantiation = Ex.path >>= \case
+    C.InInstantiateR ty v : path -> pure $ classify v ty path
+    C.InInstantiateL v ty : path -> pure $ classify v ty path
+    _ -> mzero
+  where
+    classify v ty (C.InSubAbilities want have : _) =
+      (v, ty, Eff want have)
+    classify v ty _ = (v, ty, Normal)
+
+badEffectInstantiation ::
+  (Var v, Ord loc) => Ex.ErrorExtractor v loc (TypeError v loc)
+badEffectInstantiation = do
+  ctx <- Ex.typeMismatch
+  let sub t = C.apply ctx t
+  (v, _ty, isEff) <- instantiation
+  Eff want _ <- pure isEff
+  n <- Ex.errorNote
+  site <- Ex.innermostTerm
+  pure $
+    AbilityInstantiationFailure v (Type.cleanups $ sub <$> want) site n
 
 generalMismatch :: (Var v, Ord loc) => Ex.ErrorExtractor v loc (TypeError v loc)
 generalMismatch = do

--- a/parser-typechecker/src/Unison/Typechecker/TypeError.hs
+++ b/parser-typechecker/src/Unison/Typechecker/TypeError.hs
@@ -233,7 +233,8 @@ data EffInst v loc
 instantiation ::
   (Var v, Ord loc) =>
   Ex.ErrorExtractor v loc (v, C.Type v loc, EffInst v loc)
-instantiation = Ex.path >>= \case
+instantiation =
+  Ex.path >>= \case
     C.InInstantiateR ty v : path -> pure $ classify v ty path
     C.InInstantiateL v ty : path -> pure $ classify v ty path
     _ -> mzero

--- a/unison-cli/src/Unison/LSP/FileAnalysis.hs
+++ b/unison-cli/src/Unison/LSP/FileAnalysis.hs
@@ -290,6 +290,8 @@ analyseNotes fileUri ppe src notes = do
                 let locs = [ABT.annotation expectedSite, ABT.annotation mismatchSite]
                 (r, rs) <- withNeighbours (locs >>= aToR)
                 pure (r, ("mismatch",) <$> rs)
+              TypeError.AbilityInstantiationFailure _ _ site _ ->
+                singleRange $ ABT.annotation site
               TypeError.UnguardedLetRecCycle {cycleLocs} -> do
                 let ranges :: [Range]
                     ranges = cycleLocs >>= aToR

--- a/unison-src/transcripts/idempotent/fix5655.md
+++ b/unison-src/transcripts/idempotent/fix5655.md
@@ -1,0 +1,30 @@
+Tests output of an error message when an ability variable can't be solved.
+
+``` unison :error
+foo : '{g} r -> ()
+foo th =
+  _ = !th
+  foo th
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I wasn't able to solve for an implicit effect variable when checking
+  the definition:
+
+      2 | foo th =
+      3 |   _ = !th
+      4 |   foo th
+
+
+  This is likely due to a recursive function using abilities where the
+  signature does not specify the abilities used.
+
+  I think the abilities should be similar to
+
+      {g}
+
+  Please adjust the signature to include the ability annotation on the
+  arrow.
+```


### PR DESCRIPTION
In definitions like:

    foo : '{g} a -> ()
    foo th =
      !th
      foo th

we end up in a situation where we can't actually solve to the type `'{g} a ->{g} ()`. The reason is that we make up the existential variable immediately so that we can type check the recursive function with a specified type of `'{g} a ->{e} ()`. The `g` that `e` needs to be solved to ends up later in the context, so the solution is not allowed.

This change introduces a new error message that detects this situation and suggests an ability set for the signature. There was a previous 'pretty' error message that had been disabled for this situation, but it was fairly uninformative, and might have been just as useless as the ugly error message we were currently displaying.

Fixes #5655 and #5025

Note: this problem only occurs with recursive definitions. We actually take steps to avoid this problem in other situations (do `existentializeArrows` _after_ unbinding the foralls). But this isn't an option for recursive let, because the control flow adds the existentials and type signatures to the context before checking _any_ definitions in the binding group.