### PR TITLE
Parse UCM commands without an explicit context

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,7 +17,7 @@ a = 1
 Here I try to pass an argument to `update`, which fails:
 
 ``` ucm :error
-scratch/main> update a
+> update a
 
 ```
 

--- a/unison-cli-integration/integration-tests/IntegrationTests/transcript.md
+++ b/unison-cli-integration/integration-tests/IntegrationTests/transcript.md
@@ -1,9 +1,9 @@
 # Integration test: transcript
 
 ``` ucm :hide
-scratch/main> builtins.mergeio lib.builtins
-scratch/main> load ./unison-src/transcripts-using-base/base.u
-scratch/main> add
+> builtins.mergeio lib.builtins
+> load ./unison-src/transcripts-using-base/base.u
+> add
 ```
 
 ``` unison
@@ -34,6 +34,6 @@ main = do
 ```
 
 ``` ucm
-scratch/main> add
-scratch/main> compile main ./unison-cli-integration/integration-tests/IntegrationTests/main
+> add
+> compile main ./unison-cli-integration/integration-tests/IntegrationTests/main
 ```

--- a/unison-cli-integration/integration-tests/IntegrationTests/transcript.output.md
+++ b/unison-cli-integration/integration-tests/IntegrationTests/transcript.output.md
@@ -1,11 +1,11 @@
 # Integration test: transcript
 
 ``` ucm :hide
-scratch/main> builtins.mergeio lib.builtins
+> builtins.mergeio lib.builtins
 
-scratch/main> load ./unison-src/transcripts-using-base/base.u
+> load ./unison-src/transcripts-using-base/base.u
 
-scratch/main> add
+> add
 ```
 
 ``` unison
@@ -48,9 +48,9 @@ main = do
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Done.
 
-scratch/main> compile main ./unison-cli-integration/integration-tests/IntegrationTests/main
+> compile main ./unison-cli-integration/integration-tests/IntegrationTests/main
 ```

--- a/unison-cli/src/Unison/Codebase/Transcript.hs
+++ b/unison-cli/src/Unison/Codebase/Transcript.hs
@@ -42,7 +42,10 @@ data UcmLine
 
 -- | Where a command is run: a project branch (myproject/mybranch>).
 data UcmContext
-  = UcmContextProject (ProjectAndBranch ProjectName ProjectBranchName)
+  = -- | Use the current project & branch
+    UcmContextEmpty
+  | -- | Explicit project & branch
+    UcmContextProject (ProjectAndBranch ProjectName ProjectBranchName)
   deriving (Eq, Show)
 
 data APIRequest

--- a/unison-cli/src/Unison/Codebase/Transcript/Parser.hs
+++ b/unison-cli/src/Unison/Codebase/Transcript/Parser.hs
@@ -42,6 +42,7 @@ formatUcmLine = \case
   UcmComment txt -> "--" <> txt <> "\n"
   UcmOutputLine txt -> Text.unlines . fmap padIfNonEmpty $ Text.lines txt
   where
+    formatContext UcmContextEmpty = ""
     formatContext (UcmContextProject projectAndBranch) = into @Text projectAndBranch
 
 formatStanzas :: [Stanza] -> Text
@@ -77,8 +78,8 @@ ucmLine = ucmOutputLine <|> ucmComment <|> ucmCommand
     ucmCommand =
       UcmCommand
         <$> fmap
-          UcmContextProject
-          (fullyQualifiedProjectAndBranchNamesParser <* lineToken (P.chunk ">") <* nonNewlineSpaces)
+          (maybe UcmContextEmpty UcmContextProject)
+          (optional fullyQualifiedProjectAndBranchNamesParser <* lineToken (P.chunk ">") <* nonNewlineSpaces)
         <*> restOfLine
 
     ucmComment :: P UcmLine

--- a/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
+++ b/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
@@ -294,6 +294,7 @@ run isTest verbosity dir codebase runtime sbRuntime ucmVersion baseURL stanzas =
             -- We're either going to run the command now (because we're in the right context), else we'll switch to
             -- the right context first, then run the command next.
             maybeSwitchCommand <- case context of
+              UcmContextEmpty -> pure Nothing
               UcmContextProject (ProjectAndBranch projectName branchName) -> Cli.runTransaction do
                 Project {projectId, name = projectName} <-
                   Q.loadProjectByName projectName

--- a/unison-src/builtin-tests/base.md
+++ b/unison-src/builtin-tests/base.md
@@ -5,7 +5,7 @@ Thus, make sure the contents of this file define the contents of the cache
 (e.g. don't pull `latest`.)
 
 ``` ucm
-scratch/main> pull @unison/base/releases/2.5.0 .base
-scratch/main> builtins.mergeio
-scratch/main> undo
+> pull @unison/base/releases/2.5.0 .base
+> builtins.mergeio
+> undo
 ```

--- a/unison-src/builtin-tests/interpreter-tests.output.md
+++ b/unison-src/builtin-tests/interpreter-tests.output.md
@@ -5,15 +5,15 @@ If you want to add or update tests, you can create a branch of that project, and
 Before merging the PR on Github, we'll merge your branch on Share and restore `runtime_tests_version` to /main or maybe a release.
 
 ``` ucm :hide :error
-scratch/main> this is a hack to trigger an error, in order to swallow any error on the next line.
+> this is a hack to trigger an error, in order to swallow any error on the next line.
 
-scratch/main> we delete the project to avoid any merge conflicts or complaints from ucm.
+> we delete the project to avoid any merge conflicts or complaints from ucm.
 
-scratch/main> delete.project runtime-tests
+> delete.project runtime-tests
 ```
 
 ``` ucm :hide
-scratch/main> clone @unison/runtime-tests/releases/0.0.3 runtime-tests/selected
+> clone @unison/runtime-tests/releases/0.0.3 runtime-tests/selected
 ```
 
 ``` ucm
@@ -21,7 +21,7 @@ runtime-tests/selected> run tests
 
   ()
 
-runtime-tests/selected> run tests.interpreter.only
+> run tests.interpreter.only
 
   ()
 ```

--- a/unison-src/builtin-tests/interpreter-tests.tpl.md
+++ b/unison-src/builtin-tests/interpreter-tests.tpl.md
@@ -5,15 +5,15 @@ If you want to add or update tests, you can create a branch of that project, and
 Before merging the PR on Github, we'll merge your branch on Share and restore `runtime_tests_version` to /main or maybe a release.
 
 ``` ucm :hide:error
-scratch/main> this is a hack to trigger an error, in order to swallow any error on the next line.
-scratch/main> we delete the project to avoid any merge conflicts or complaints from ucm.
-scratch/main> delete.project runtime-tests
+> this is a hack to trigger an error, in order to swallow any error on the next line.
+> we delete the project to avoid any merge conflicts or complaints from ucm.
+> delete.project runtime-tests
 ```
 ``` ucm :hide
-scratch/main> clone ${runtime_tests_version} runtime-tests/selected
+> clone ${runtime_tests_version} runtime-tests/selected
 ```
 
 ``` ucm
 runtime-tests/selected> run tests
-runtime-tests/selected> run tests.interpreter.only
+> run tests.interpreter.only
 ```

--- a/unison-src/tests/fix5507.md
+++ b/unison-src/tests/fix5507.md
@@ -1,5 +1,5 @@
 ```ucm :hide
-scratch/main> builtins.merge lib.builtin
+> builtins.merge lib.builtin
 ```
 
 ```unison :hide
@@ -8,7 +8,7 @@ Nat.toBytesLittleEndian = encodeNat64le
 ```
 
 ```ucm :hide
-scratch/main> add
+> add
 ```
 
 `Nat.toBytesLittleEndian` gets inlined, but it should still be found in the code cache when this is compiled and re-loaded.
@@ -23,6 +23,6 @@ main = do
 ```
 
 ```ucm :hide
-scratch/main> add
-scratch/main> compile main fix5507
+> add
+> compile main fix5507
 ```

--- a/unison-src/transcripts-manual/benchmarks.md
+++ b/unison-src/transcripts-manual/benchmarks.md
@@ -1,6 +1,6 @@
 ``` ucm :hide
-scratch/main> pull unison.public.base.releases.M4d base
-scratch/main> pull runarorama.public.sort.data sort
+> pull unison.public.base.releases.M4d base
+> pull runarorama.public.sort.data sort
 ```
 
 ``` unison :hide
@@ -34,63 +34,63 @@ prepare = do
 ```
 
 ``` ucm :hide
-scratch/main> add
-scratch/main> run prepare
+> add
+> run prepare
 ```
 
 ## Benchmarks
 
 ``` ucm
-scratch/main> load unison-src/transcripts-manual/benchmarks/each.u
-scratch/main> run main
+> load unison-src/transcripts-manual/benchmarks/each.u
+> run main
 ```
 
 ``` ucm
-scratch/main> load unison-src/transcripts-manual/benchmarks/listmap.u
-scratch/main> run main
+> load unison-src/transcripts-manual/benchmarks/listmap.u
+> run main
 ```
 
 ``` ucm
-scratch/main> load unison-src/transcripts-manual/benchmarks/listfilter.u
-scratch/main> run main
+> load unison-src/transcripts-manual/benchmarks/listfilter.u
+> run main
 ```
 
 ``` ucm
-scratch/main> load unison-src/transcripts-manual/benchmarks/random.u
-scratch/main> run main
+> load unison-src/transcripts-manual/benchmarks/random.u
+> run main
 ```
 
 ``` ucm
-scratch/main> load unison-src/transcripts-manual/benchmarks/simpleloop.u
-scratch/main> run main
+> load unison-src/transcripts-manual/benchmarks/simpleloop.u
+> run main
 ```
 
 ``` ucm
-scratch/main> load unison-src/transcripts-manual/benchmarks/fibonacci.u
-scratch/main> run main
+> load unison-src/transcripts-manual/benchmarks/fibonacci.u
+> run main
 ```
 
 ``` ucm
-scratch/main> load unison-src/transcripts-manual/benchmarks/map.u
-scratch/main> run main
+> load unison-src/transcripts-manual/benchmarks/map.u
+> run main
 ```
 
 ``` ucm
-scratch/main> load unison-src/transcripts-manual/benchmarks/natmap.u
-scratch/main> run main
+> load unison-src/transcripts-manual/benchmarks/natmap.u
+> run main
 ```
 
 ``` ucm
-scratch/main> load unison-src/transcripts-manual/benchmarks/stm.u
-scratch/main> run main
+> load unison-src/transcripts-manual/benchmarks/stm.u
+> run main
 ```
 
 ``` ucm
-scratch/main> load unison-src/transcripts-manual/benchmarks/tmap.u
-scratch/main> run main
+> load unison-src/transcripts-manual/benchmarks/tmap.u
+> run main
 ```
 
 ``` ucm
-scratch/main> load unison-src/transcripts-manual/benchmarks/array-sort.u
-scratch/main> run main
+> load unison-src/transcripts-manual/benchmarks/array-sort.u
+> run main
 ```

--- a/unison-src/transcripts-manual/docs.to-html.md
+++ b/unison-src/transcripts-manual/docs.to-html.md
@@ -1,5 +1,5 @@
 ``` ucm
-test-html-docs/main> builtins.mergeio lib.builtins
+> builtins.mergeio lib.builtins
 ```
 
 ``` unison
@@ -14,6 +14,6 @@ some.outside = 3
 ```
 
 ``` ucm
-test-html-docs/main> add
-test-html-docs/main> docs.to-html some.ns unison-src/transcripts-manual/docs.to-html
+> add
+> docs.to-html some.ns unison-src/transcripts-manual/docs.to-html
 ```

--- a/unison-src/transcripts-manual/docs.to-html.output.md
+++ b/unison-src/transcripts-manual/docs.to-html.output.md
@@ -1,5 +1,5 @@
 ``` ucm
-test-html-docs/main> builtins.mergeio lib.builtins
+> builtins.mergeio lib.builtins
 
   Done.
 ```
@@ -29,9 +29,9 @@ some.outside = 3
 ```
 
 ``` ucm
-test-html-docs/main> add
+> add
 
   Done.
 
-test-html-docs/main> docs.to-html some.ns unison-src/transcripts-manual/docs.to-html
+> docs.to-html some.ns unison-src/transcripts-manual/docs.to-html
 ```

--- a/unison-src/transcripts-manual/public-tests.md
+++ b/unison-src/transcripts-manual/public-tests.md
@@ -4,15 +4,15 @@ It turns out that pulling releases is very fast compared to actually running the
 
 ```ucm
 x/base> pull @unison/base/releases/latest
-x/base> test
+> test
 
 x/json> pull @unison/json/releases/latest
-x/json> test
+> test
 
 x/cloud> pull @unison/cloud/releases/latest
-x/cloud> test
-x/cloud> io.test internal.tests.cloud.runAllLocally
+> test
+> io.test internal.tests.cloud.runAllLocally
 
 x/orderator> pull @pchiusano/orderator/releases/latest
-x/orderator> test
-``` 
+> test
+```

--- a/unison-src/transcripts-manual/remote-tab-completion.md
+++ b/unison-src/transcripts-manual/remote-tab-completion.md
@@ -3,9 +3,9 @@
 Note: this makes a network call to share to get completions. It seems to be nonfunctioning at the moment, hence the `:bug` tags.
 
 ``` ucm :bug
-scratch/main> debug.tab-complete pull @uniso
+> debug.tab-complete pull @uniso
 ```
 
 ``` ucm :bug
-scratch/main> debug.tab-complete pull @unison/ba
+> debug.tab-complete pull @unison/ba
 ```

--- a/unison-src/transcripts-manual/remote-tab-completion.output.md
+++ b/unison-src/transcripts-manual/remote-tab-completion.output.md
@@ -3,11 +3,11 @@
 Note: this makes a network call to share to get completions. It seems to be nonfunctioning at the moment, hence the `:bug` tags.
 
 ``` ucm :bug
-scratch/main> debug.tab-complete pull @uniso
+> debug.tab-complete pull @uniso
 
 ```
 
 ``` ucm :bug
-scratch/main> debug.tab-complete pull @unison/ba
+> debug.tab-complete pull @unison/ba
 
 ```

--- a/unison-src/transcripts-manual/rewrites.md
+++ b/unison-src/transcripts-manual/rewrites.md
@@ -1,7 +1,7 @@
 ``` ucm :hide
-scratch/main> builtins.mergeio
-scratch/main> load unison-src/transcripts-using-base/base.u
-scratch/main> add
+> builtins.mergeio
+> load unison-src/transcripts-using-base/base.u
+> add
 ```
 
 ## Structural find and replace
@@ -36,19 +36,19 @@ rule2 x = @rewrite signature Optional ==> Optional2
 Let's rewrite these:
 
 ``` ucm
-scratch/main> rewrite rule1
-scratch/main> rewrite eitherToOptional
+> rewrite rule1
+> rewrite eitherToOptional
 ```
 
 ``` ucm :hide
-scratch/main> load
-scratch/main> add
+> load
+> add
 ```
 
 After adding to the codebase, here's the rewritten source:
 
 ``` ucm
-scratch/main> view ex1 Either.mapRight rule1
+> view ex1 Either.mapRight rule1
 ```
 
 Another example, showing that we can rewrite to definitions that only exist in the file:
@@ -74,18 +74,18 @@ blah2 = 456
 Let's apply the rewrite `woot1to2`:
 
 ``` ucm
-scratch/main> rewrite woot1to2
+> rewrite woot1to2
 ```
 
 ``` ucm :hide
-scratch/main> load
-scratch/main> add
+> load
+> add
 ```
 
 After adding the rewritten form to the codebase, here's the rewritten `Woot1` to `Woot2`:
 
 ``` ucm
-scratch/main> view wootEx
+> view wootEx
 ```
 
 This example shows that rewrite rules can to refer to term definitions that only exist in the file:
@@ -110,15 +110,15 @@ sameFileEx =
 ```
 
 ``` ucm :hide
-scratch/main> rewrite rule
-scratch/main> load
-scratch/main> add
+> rewrite rule
+> load
+> add
 ```
 
 After adding the rewritten form to the codebase, here's the rewritten definitions:
 
 ``` ucm
-scratch/main> view foo1 foo2 sameFileEx
+> view foo1 foo2 sameFileEx
 ```
 
 ## Capture avoidance
@@ -144,13 +144,13 @@ sameFileEx =
 In the above example, `bar2` is locally bound by the rule, so when applied, it should not refer to the `bar2` top level binding.
 
 ``` ucm
-scratch/main> rewrite rule
+> rewrite rule
 ```
 
 Instead, it should be an unbound free variable, which doesn't typecheck:
 
 ``` ucm :error
-scratch/main> load
+> load
 ```
 
 In this example, the `a` is locally bound by the rule, so it shouldn't capture the `a = 39494` binding which is in scope at the point of the replacement:
@@ -166,13 +166,13 @@ rule a = @rewrite
 ```
 
 ``` ucm
-scratch/main> rewrite rule
+> rewrite rule
 ```
 
 The `a` introduced will be freshened to not capture the `a` in scope, so it remains as an unbound variable and is a type error:
 
 ``` ucm :error
-scratch/main> load
+> load
 ```
 
 ## Structural find
@@ -182,7 +182,7 @@ eitherEx = Left ("hello", "there")
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ``` unison :hide
@@ -191,7 +191,7 @@ findEitherFailure = @rewrite signature a . Either Failure a ==> ()
 ```
 
 ``` ucm
-scratch/main> sfind findEitherEx
-scratch/main> sfind findEitherFailure
-scratch/main> find 1-5
+> sfind findEitherEx
+> sfind findEitherFailure
+> find 1-5
 ```

--- a/unison-src/transcripts-manual/rewrites.output.md
+++ b/unison-src/transcripts-manual/rewrites.output.md
@@ -1,9 +1,9 @@
 ``` ucm :hide
-scratch/main> builtins.mergeio
+> builtins.mergeio
 
-scratch/main> load unison-src/transcripts-using-base/base.u
+> load unison-src/transcripts-using-base/base.u
 
-scratch/main> add
+> add
 ```
 
 ## Structural find and replace
@@ -38,7 +38,7 @@ rule2 x = @rewrite signature Optional ==> Optional2
 Let's rewrite these:
 
 ``` ucm
-scratch/main> rewrite rule1
+> rewrite rule1
 
   ☝️
 
@@ -46,7 +46,7 @@ scratch/main> rewrite rule1
 
   The rewritten file has been added to the top of scratch.u
 
-scratch/main> rewrite eitherToOptional
+> rewrite eitherToOptional
 
   ☝️
 
@@ -117,15 +117,15 @@ rule2 x = @rewrite signature Optional ==> Optional2
 ```
 
 ``` ucm :hide
-scratch/main> load
+> load
 
-scratch/main> add
+> add
 ```
 
 After adding to the codebase, here's the rewritten source:
 
 ``` ucm
-scratch/main> view ex1 Either.mapRight rule1
+> view ex1 Either.mapRight rule1
 
   Either.mapRight : (a ->{g} b) -> Optional a ->{g} Optional b
   Either.mapRight f = cases
@@ -171,7 +171,7 @@ blah2 = 456
 Let's apply the rewrite `woot1to2`:
 
 ``` ucm
-scratch/main> rewrite woot1to2
+> rewrite woot1to2
 
   ☝️
 
@@ -207,15 +207,15 @@ blah2 = 456
 ```
 
 ``` ucm :hide
-scratch/main> load
+> load
 
-scratch/main> add
+> add
 ```
 
 After adding the rewritten form to the codebase, here's the rewritten `Woot1` to `Woot2`:
 
 ``` ucm
-scratch/main> view wootEx
+> view wootEx
 
   wootEx : Nat ->{Woot2} Nat
   wootEx a =
@@ -245,17 +245,17 @@ sameFileEx =
 ```
 
 ``` ucm :hide
-scratch/main> rewrite rule
+> rewrite rule
 
-scratch/main> load
+> load
 
-scratch/main> add
+> add
 ```
 
 After adding the rewritten form to the codebase, here's the rewritten definitions:
 
 ``` ucm
-scratch/main> view foo1 foo2 sameFileEx
+> view foo1 foo2 sameFileEx
 
   foo1 : Nat
   foo1 =
@@ -296,7 +296,7 @@ sameFileEx =
 In the above example, `bar2` is locally bound by the rule, so when applied, it should not refer to the `bar2` top level binding.
 
 ``` ucm
-scratch/main> rewrite rule
+> rewrite rule
 
   ☝️
 
@@ -330,7 +330,7 @@ sameFileEx =
 Instead, it should be an unbound free variable, which doesn't typecheck:
 
 ``` ucm :error
-scratch/main> load
+> load
 
   Loading changes detected in scratch.u.
 
@@ -357,7 +357,7 @@ rule a = @rewrite
 ```
 
 ``` ucm
-scratch/main> rewrite rule
+> rewrite rule
 
   ☝️
 
@@ -383,7 +383,7 @@ rule a =
 The `a` introduced will be freshened to not capture the `a` in scope, so it remains as an unbound variable and is a type error:
 
 ``` ucm :error
-scratch/main> load
+> load
 
   Loading changes detected in scratch.u.
 
@@ -406,7 +406,7 @@ eitherEx = Left ("hello", "there")
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ``` unison :hide
@@ -415,7 +415,7 @@ findEitherFailure = @rewrite signature a . Either Failure a ==> ()
 ```
 
 ``` ucm
-scratch/main> sfind findEitherEx
+> sfind findEitherEx
 
   🔎
 
@@ -425,7 +425,7 @@ scratch/main> sfind findEitherEx
 
   Tip: Try `edit 1` to bring this into your scratch file.
 
-scratch/main> sfind findEitherFailure
+> sfind findEitherFailure
 
   🔎
 
@@ -440,7 +440,7 @@ scratch/main> sfind findEitherFailure
   Tip: Try `edit 1` or `edit 1-5` to bring these into your
        scratch file.
 
-scratch/main> find 1-5
+> find 1-5
 
   1. Exception.catch : '{g, Exception} a ->{g} Either Failure a
   2. Exception.reraise : Either Failure a ->{Exception} a

--- a/unison-src/transcripts-using-base/_base.md
+++ b/unison-src/transcripts-using-base/_base.md
@@ -10,9 +10,9 @@ transcripts which contain less boilerplate.
 ## Usage
 
 ``` ucm :hide
-scratch/main> builtins.mergeio
-scratch/main> load unison-src/transcripts-using-base/base.u
-scratch/main> add
+> builtins.mergeio
+> load unison-src/transcripts-using-base/base.u
+> add
 ```
 
 The test shows that `hex (fromHex str) == str` as expected.
@@ -24,7 +24,7 @@ test> hex.tests.ex1 = checks let
 ```
 
 ``` ucm :hide
-scratch/main> test
+> test
 ```
 
 Lets do some basic testing of our test harness to make sure its
@@ -50,6 +50,6 @@ testAutoClean _ =
 ```
 
 ``` ucm
-scratch/main> add
-scratch/main> io.test testAutoClean
+> add
+> io.test testAutoClean
 ```

--- a/unison-src/transcripts-using-base/_base.output.md
+++ b/unison-src/transcripts-using-base/_base.output.md
@@ -10,11 +10,11 @@ transcripts which contain less boilerplate.
 ## Usage
 
 ``` ucm :hide
-scratch/main> builtins.mergeio
+> builtins.mergeio
 
-scratch/main> load unison-src/transcripts-using-base/base.u
+> load unison-src/transcripts-using-base/base.u
 
-scratch/main> add
+> add
 ```
 
 The test shows that `hex (fromHex str) == str` as expected.
@@ -26,7 +26,7 @@ test> hex.tests.ex1 = checks let
 ```
 
 ``` ucm :hide
-scratch/main> test
+> test
 ```
 
 Lets do some basic testing of our test harness to make sure its
@@ -60,14 +60,14 @@ testAutoClean _ =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test testAutoClean
+> io.test testAutoClean
 
     New test results:
 

--- a/unison-src/transcripts-using-base/all-base-hashes.md
+++ b/unison-src/transcripts-using-base/all-base-hashes.md
@@ -1,5 +1,5 @@
 This transcript is intended to make visible accidental changes to the hashing algorithm.
 
 ``` ucm
-scratch/main> find.verbose
+> find.verbose
 ```

--- a/unison-src/transcripts-using-base/all-base-hashes.output.md
+++ b/unison-src/transcripts-using-base/all-base-hashes.output.md
@@ -1,7 +1,7 @@
 This transcript is intended to make visible accidental changes to the hashing algorithm.
 
 ``` ucm
-scratch/main> find.verbose
+> find.verbose
 
   1.    -- #sgesq8035ut22q779pl1g4gqsg8c81894jjonmrq1bjltphkath225up841hk8dku59tnnc4laj9nggbofamgei4klof0ldc20uj2oo
         <| : (i ->{g} o) -> i ->{g} o

--- a/unison-src/transcripts-using-base/binary-encoding-nats.md
+++ b/unison-src/transcripts-using-base/binary-encoding-nats.md
@@ -54,6 +54,6 @@ testABunchOfNats _ =
 ```
 
 ``` ucm
-scratch/main> add
-scratch/main> io.test testABunchOfNats
+> add
+> io.test testABunchOfNats
 ```

--- a/unison-src/transcripts-using-base/binary-encoding-nats.output.md
+++ b/unison-src/transcripts-using-base/binary-encoding-nats.output.md
@@ -72,14 +72,14 @@ testABunchOfNats _ =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test testABunchOfNats
+> io.test testABunchOfNats
 
     New test results:
 

--- a/unison-src/transcripts-using-base/codeops.md
+++ b/unison-src/transcripts-using-base/codeops.md
@@ -192,7 +192,7 @@ swapped name link =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 ```
 
 ``` unison
@@ -310,9 +310,9 @@ we gain the ability to capture output in a transcript, it can be modified
 to actual show that the serialization works.
 
 ``` ucm
-scratch/main> add
-scratch/main> io.test tests
-scratch/main> io.test badLoad
+> add
+> io.test tests
+> io.test badLoad
 ```
 
 ``` unison
@@ -379,8 +379,8 @@ codeTests =
 ```
 
 ``` ucm
-scratch/main> add
-scratch/main> io.test codeTests
+> add
+> io.test codeTests
 ```
 
 ``` unison
@@ -410,6 +410,6 @@ vtests _ =
 ```
 
 ``` ucm
-scratch/main> add
-scratch/main> io.test vtests
+> add
+> io.test vtests
 ```

--- a/unison-src/transcripts-using-base/codeops.output.md
+++ b/unison-src/transcripts-using-base/codeops.output.md
@@ -260,7 +260,7 @@ swapped name link =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -404,14 +404,14 @@ we gain the ability to capture output in a transcript, it can be modified
 to actual show that the serialization works.
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test tests
+> io.test tests
 
     New test results:
 
@@ -455,7 +455,7 @@ scratch/main> io.test tests
 
   Tip: Use view 1 to view the source of a test.
 
-scratch/main> io.test badLoad
+> io.test badLoad
 
     New test results:
 
@@ -538,14 +538,14 @@ codeTests =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test codeTests
+> io.test codeTests
 
     New test results:
 
@@ -640,14 +640,14 @@ vtests _ =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test vtests
+> io.test vtests
 
     New test results:
 

--- a/unison-src/transcripts-using-base/doc.md
+++ b/unison-src/transcripts-using-base/doc.md
@@ -33,9 +33,9 @@ Notice that an anonymous documentation block `{{ ... }}` before a definition `Im
 You can preview what docs will look like when rendered to the console using the `display` or `docs` commands:
 
 ``` ucm
-scratch/main> display d1
-scratch/main> docs ImportantConstant
-scratch/main> docs DayOfWeek
+> display d1
+> docs ImportantConstant
+> docs DayOfWeek
 ```
 
 The `docs ImportantConstant` command will look for `ImportantConstant.doc` in the file or codebase. You can do this instead of explicitly linking docs to definitions.
@@ -45,11 +45,11 @@ The `docs ImportantConstant` command will look for `ImportantConstant.doc` in th
 First, we'll load the `syntax.u` file which has examples of all the syntax:
 
 ``` ucm
-scratch/main> load ./unison-src/transcripts-using-base/doc.md.files/syntax.u
+> load ./unison-src/transcripts-using-base/doc.md.files/syntax.u
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 Now we can review different portions of the guide.
@@ -57,25 +57,25 @@ we'll show both the pretty-printed source using `view`
 and the rendered output using `display`:
 
 ``` ucm
-scratch/main> view basicFormatting
-scratch/main> display basicFormatting
-scratch/main> view lists
-scratch/main> display lists
-scratch/main> view evaluation
-scratch/main> display evaluation
-scratch/main> view includingSource
-scratch/main> display includingSource
-scratch/main> view nonUnisonCodeBlocks
-scratch/main> display nonUnisonCodeBlocks
-scratch/main> view otherElements
-scratch/main> display otherElements
+> view basicFormatting
+> display basicFormatting
+> view lists
+> display lists
+> view evaluation
+> display evaluation
+> view includingSource
+> display includingSource
+> view nonUnisonCodeBlocks
+> display nonUnisonCodeBlocks
+> view otherElements
+> display otherElements
 ```
 
 Lastly, it's common to build longer documents including subdocuments via `{{ subdoc }}`. We can stitch together the full syntax guide in this way:
 
 ``` ucm
-scratch/main> view doc.guide
-scratch/main> display doc.guide
+> view doc.guide
+> display doc.guide
 ```
 
 🌻 THE END

--- a/unison-src/transcripts-using-base/doc.output.md
+++ b/unison-src/transcripts-using-base/doc.output.md
@@ -47,15 +47,15 @@ Notice that an anonymous documentation block `{{ ... }}` before a definition `Im
 You can preview what docs will look like when rendered to the console using the `display` or `docs` commands:
 
 ``` ucm
-scratch/main> display d1
+> display d1
 
   Hello there Alice!
 
-scratch/main> docs ImportantConstant
+> docs ImportantConstant
 
   An important constant, equal to `42`
 
-scratch/main> docs DayOfWeek
+> docs DayOfWeek
 
   The 7 days of the week, defined as:
 
@@ -69,7 +69,7 @@ The `docs ImportantConstant` command will look for `ImportantConstant.doc` in th
 First, we'll load the `syntax.u` file which has examples of all the syntax:
 
 ``` ucm
-scratch/main> load ./unison-src/transcripts-using-base/doc.md.files/syntax.u
+> load ./unison-src/transcripts-using-base/doc.md.files/syntax.u
 
   Loading changes detected in
   ./unison-src/transcripts-using-base/doc.md.files/syntax.u.
@@ -87,7 +87,7 @@ scratch/main> load ./unison-src/transcripts-using-base/doc.md.files/syntax.u
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 Now we can review different portions of the guide.
@@ -95,7 +95,7 @@ we'll show both the pretty-printed source using `view`
 and the rendered output using `display`:
 
 ```` ucm
-scratch/main> view basicFormatting
+> view basicFormatting
 
   basicFormatting : Doc2
   basicFormatting =
@@ -125,7 +125,7 @@ scratch/main> view basicFormatting
       __Next up:__ {lists}
     }}
 
-scratch/main> display basicFormatting
+> display basicFormatting
 
   # Basic formatting
 
@@ -150,7 +150,7 @@ scratch/main> display basicFormatting
 
     *Next up:* lists
 
-scratch/main> view lists
+> view lists
 
   lists : Doc2
   lists =
@@ -193,7 +193,7 @@ scratch/main> view lists
          3. Get dressed.
     }}
 
-scratch/main> display lists
+> display lists
 
   # Lists
 
@@ -232,7 +232,7 @@ scratch/main> display lists
       2. Take shower.
       3. Get dressed.
 
-scratch/main> view evaluation
+> view evaluation
 
   evaluation : Doc2
   evaluation =
@@ -267,7 +267,7 @@ scratch/main> view evaluation
       ```
     }}
 
-scratch/main> display evaluation
+> display evaluation
 
   # Evaluation
 
@@ -295,7 +295,7 @@ scratch/main> display evaluation
         cube : Nat -> Nat
         cube x = x * x * x
 
-scratch/main> view includingSource
+> view includingSource
 
   includingSource : Doc2
   includingSource =
@@ -336,7 +336,7 @@ scratch/main> view includingSource
            {{ docExample 1 do x -> sqr x }}.
     }}
 
-scratch/main> display includingSource
+> display includingSource
 
   # Including Unison source code
 
@@ -382,7 +382,7 @@ scratch/main> display includingSource
         application, you can put it in double backticks, like
         so: `sqr x`. This is equivalent to `sqr x`.
 
-scratch/main> view nonUnisonCodeBlocks
+> view nonUnisonCodeBlocks
 
   nonUnisonCodeBlocks : Doc2
   nonUnisonCodeBlocks =
@@ -415,7 +415,7 @@ scratch/main> view nonUnisonCodeBlocks
       ```
     }}
 
-scratch/main> display nonUnisonCodeBlocks
+> display nonUnisonCodeBlocks
 
   # Non-Unison code blocks
 
@@ -444,7 +444,7 @@ scratch/main> display nonUnisonCodeBlocks
       xs.foldLeft(Nil : List[A])((acc,a) => a +: acc)
     ```
 
-scratch/main> view otherElements
+> view otherElements
 
   otherElements : Doc2
   otherElements =
@@ -501,7 +501,7 @@ scratch/main> view otherElements
       ] }}
     }}
 
-scratch/main> display otherElements
+> display otherElements
 
   There are also asides, callouts, tables, tooltips, and more.
   These don't currently have special syntax; just use the
@@ -544,7 +544,7 @@ scratch/main> display otherElements
 Lastly, it's common to build longer documents including subdocuments via `{{ subdoc }}`. We can stitch together the full syntax guide in this way:
 
 ```` ucm
-scratch/main> view doc.guide
+> view doc.guide
 
   doc.guide : Doc2
   doc.guide =
@@ -564,7 +564,7 @@ scratch/main> view doc.guide
       {{ otherElements }}
     }}
 
-scratch/main> display doc.guide
+> display doc.guide
 
   # Unison computable documentation
 

--- a/unison-src/transcripts-using-base/failure-tests.md
+++ b/unison-src/transcripts-using-base/failure-tests.md
@@ -19,13 +19,13 @@ test2 = do
 ```
 
 ``` ucm
-scratch/main> add
+> add
 ```
 
 ``` ucm :error
-scratch/main> io.test test1
+> io.test test1
 ```
 
 ``` ucm :error
-scratch/main> io.test test2
+> io.test test2
 ```

--- a/unison-src/transcripts-using-base/failure-tests.output.md
+++ b/unison-src/transcripts-using-base/failure-tests.output.md
@@ -28,7 +28,7 @@ test2 = do
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -37,7 +37,7 @@ scratch/main> add
 ```
 
 ``` ucm :error
-scratch/main> io.test test1
+> io.test test1
 
   💔💥
 
@@ -53,7 +53,7 @@ scratch/main> io.test test1
 ```
 
 ``` ucm :error
-scratch/main> io.test test2
+> io.test test2
 
   💔💥
 

--- a/unison-src/transcripts-using-base/fix-2805.md
+++ b/unison-src/transcripts-using-base/fix-2805.md
@@ -8,7 +8,7 @@ main _ = "Hello " ++ Optional.getOrBug "definitely passed an arg" (List.head !ge
 First we run it with no numbered results in the history, so if number expansion is applied, it should end up calling `main` with zero args, whereas without number expansion, we get a single argument, “1”, passed to it.
 
 ``` ucm
-scratch/main> run main 1
+> run main 1
 
   "Hello 1!"
 ```
@@ -16,8 +16,8 @@ scratch/main> run main 1
 Now we set it up so there _are_ numbered results in the history. If number expansion is applied here, we will get an error “`run` can’t accept a numbered argument […]”, and otherwise our expected "1".
 
 ``` ucm
-scratch/main> find.all isLeft
-scratch/main> run main 1
+> find.all isLeft
+> run main 1
 
   "Hello 1!"
 ```

--- a/unison-src/transcripts-using-base/fix-2805.output.md
+++ b/unison-src/transcripts-using-base/fix-2805.output.md
@@ -16,7 +16,7 @@ main _ = "Hello " ++ Optional.getOrBug "definitely passed an arg" (List.head !ge
 First we run it with no numbered results in the history, so if number expansion is applied, it should end up calling `main` with zero args, whereas without number expansion, we get a single argument, “1”, passed to it.
 
 ``` ucm
-scratch/main> run main 1
+> run main 1
 
   "Hello 1!"
 ```
@@ -24,11 +24,11 @@ scratch/main> run main 1
 Now we set it up so there *are* numbered results in the history. If number expansion is applied here, we will get an error “`run` can’t accept a numbered argument \[…\]”, and otherwise our expected "1".
 
 ``` ucm
-scratch/main> find.all isLeft
+> find.all isLeft
 
   1. Either.isLeft : Either a b -> Boolean
 
-scratch/main> run main 1
+> run main 1
 
   "Hello 1!"
 ```

--- a/unison-src/transcripts-using-base/fix2358.md
+++ b/unison-src/transcripts-using-base/fix2358.md
@@ -9,5 +9,5 @@ timingApp2 _ =
 ```
 
 ``` ucm
-scratch/main> run timingApp2
+> run timingApp2
 ```

--- a/unison-src/transcripts-using-base/fix2358.output.md
+++ b/unison-src/transcripts-using-base/fix2358.output.md
@@ -17,7 +17,7 @@ timingApp2 _ =
 ```
 
 ``` ucm
-scratch/main> run timingApp2
+> run timingApp2
 
   ()
 ```

--- a/unison-src/transcripts-using-base/fix2944.md
+++ b/unison-src/transcripts-using-base/fix2944.md
@@ -7,7 +7,7 @@ ability Foo where
 ```
 
 ```ucm
-scratch/main> add
+> add
 ```
 
 ````unison
@@ -19,7 +19,7 @@ bar = {{
 ````
 
 ``` ucm
-scratch/main> display bar
+> display bar
 ```
 
 Previously would get rendered as:

--- a/unison-src/transcripts-using-base/fix2944.output.md
+++ b/unison-src/transcripts-using-base/fix2944.output.md
@@ -15,7 +15,7 @@ ability Foo where
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -40,7 +40,7 @@ bar = {{
 ```
 
 ``` ucm
-scratch/main> display bar
+> display bar
 
       0 |> foo |> foo
 ```

--- a/unison-src/transcripts-using-base/fix3939.md
+++ b/unison-src/transcripts-using-base/fix3939.md
@@ -6,7 +6,7 @@ meh = 9
 ```
 
 ``` ucm
-scratch/main> add
-scratch/main> find meh
-scratch/main> docs 1
+> add
+> find meh
+> docs 1
 ```

--- a/unison-src/transcripts-using-base/fix3939.output.md
+++ b/unison-src/transcripts-using-base/fix3939.output.md
@@ -15,19 +15,19 @@ meh = 9
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> find meh
+> find meh
 
   1. meh : Nat
   2. meh.doc : Doc2
 
-scratch/main> docs 1
+> docs 1
 
   A simple doc.
 ```

--- a/unison-src/transcripts-using-base/fix5129.md
+++ b/unison-src/transcripts-using-base/fix5129.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.mergeio lib.builtins
+> builtins.mergeio lib.builtins
 ```
 
 Checks for some bad type checking behavior. Some ability subtyping was

--- a/unison-src/transcripts-using-base/fix5129.output.md
+++ b/unison-src/transcripts-using-base/fix5129.output.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.mergeio lib.builtins
+> builtins.mergeio lib.builtins
 ```
 
 Checks for some bad type checking behavior. Some ability subtyping was

--- a/unison-src/transcripts-using-base/fix5178.md
+++ b/unison-src/transcripts-using-base/fix5178.md
@@ -5,7 +5,7 @@ foo = {{
 ```
 
 ``` ucm
-scratch/main> add
+> add
 ```
 
 Viewing `foo` via `scratch/main> ui` shows the correct source, but `display foo` gives us an error message (but not an error – this is incorrectly considered a successful result)
@@ -16,5 +16,5 @@ I think there are two separate issues here:
 2. this should actually work like `ui` and give us the source of the ability member, not complain about there being no such term in the codebase.
 
 ``` ucm :error :bug
-scratch/main> display foo
+> display foo
 ```

--- a/unison-src/transcripts-using-base/fix5178.output.md
+++ b/unison-src/transcripts-using-base/fix5178.output.md
@@ -13,7 +13,7 @@ foo = {{
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -29,7 +29,7 @@ I think there are two separate issues here:
 2.  this should actually work like `ui` and give us the source of the ability member, not complain about there being no such term in the codebase.
 
 ``` ucm :error :bug
-scratch/main> display foo
+> display foo
 
       -- The name #rfi1v9429f is assigned to the reference
       ShortHash {prefix =

--- a/unison-src/transcripts-using-base/hashing.md
+++ b/unison-src/transcripts-using-base/hashing.md
@@ -3,7 +3,7 @@
 Unison has cryptographic builtins for hashing and computing [HMACs](https://en.wikipedia.org/wiki/HMAC) (hash-based message authentication codes). This transcript shows their usage and has some test cases.
 
 ``` ucm
-scratch/main> ls builtin.Bytes
+> ls builtin.Bytes
 ```
 Notice the `fromBase16` and `toBase16` functions. Here's some convenience functions for converting `Bytes` to and from base-16 `Text`.
 
@@ -43,7 +43,7 @@ ex5 = crypto.hmac Sha2_256 mysecret f |> hex
 And here's the full API:
 
 ``` ucm
-scratch/main> find-in builtin.crypto
+> find-in builtin.crypto
 ```
 
 Note that the universal versions of `hash` and `hmac` are currently unimplemented and will bomb at runtime:
@@ -189,11 +189,11 @@ test> crypto.hash.numTests =
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ``` ucm
-scratch/main> test
+> test
 ```
 
 ## HMAC tests
@@ -251,9 +251,9 @@ test> md5.tests.ex3 =
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ``` ucm
-scratch/main> test
+> test
 ```

--- a/unison-src/transcripts-using-base/hashing.output.md
+++ b/unison-src/transcripts-using-base/hashing.output.md
@@ -3,7 +3,7 @@
 Unison has cryptographic builtins for hashing and computing [HMACs](https://en.wikipedia.org/wiki/HMAC) (hash-based message authentication codes). This transcript shows their usage and has some test cases.
 
 ``` ucm
-scratch/main> ls builtin.Bytes
+> ls builtin.Bytes
 
   1.  ++                    (Bytes -> Bytes -> Bytes)
   2.  at                    (Nat -> Bytes -> Optional Nat)
@@ -112,7 +112,7 @@ ex5 = crypto.hmac Sha2_256 mysecret f |> hex
 And here's the full API:
 
 ``` ucm
-scratch/main> find-in builtin.crypto
+> find-in builtin.crypto
 
   1.  type CryptoFailure
   2.  Ed25519.sign.impl : Bytes
@@ -297,11 +297,11 @@ test> crypto.hash.numTests =
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ``` ucm
-scratch/main> test
+> test
 
   Cached test results (`help testcache` to learn more)
 
@@ -447,11 +447,11 @@ test> md5.tests.ex3 =
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ``` ucm
-scratch/main> test
+> test
 
   Cached test results (`help testcache` to learn more)
 

--- a/unison-src/transcripts-using-base/mvar.md
+++ b/unison-src/transcripts-using-base/mvar.md
@@ -51,6 +51,6 @@ testMvars _ =
   runTest test
 ```
 ``` ucm
-scratch/main> add
-scratch/main> io.test testMvars
+> add
+> io.test testMvars
 ```

--- a/unison-src/transcripts-using-base/mvar.output.md
+++ b/unison-src/transcripts-using-base/mvar.output.md
@@ -60,14 +60,14 @@ testMvars _ =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test testMvars
+> io.test testMvars
 
     New test results:
 

--- a/unison-src/transcripts-using-base/nat-coersion.md
+++ b/unison-src/transcripts-using-base/nat-coersion.md
@@ -33,6 +33,6 @@ test = 'let
 ```
 
 ``` ucm
-scratch/main> add
-scratch/main> io.test test
+> add
+> io.test test
 ```

--- a/unison-src/transcripts-using-base/nat-coersion.output.md
+++ b/unison-src/transcripts-using-base/nat-coersion.output.md
@@ -45,14 +45,14 @@ test = 'let
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test test
+> io.test test
 
     New test results:
 

--- a/unison-src/transcripts-using-base/net.md
+++ b/unison-src/transcripts-using-base/net.md
@@ -10,7 +10,7 @@ socketAccept = compose reraise socketAccept.impl
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 # Tests for network related builtins
@@ -93,8 +93,8 @@ testDefaultPort _ =
   runTest test
 ```
 ``` ucm
-scratch/main> add
-scratch/main> io.test testDefaultPort
+> add
+> io.test testDefaultPort
 ```
 
 This example demonstrates connecting a TCP client socket to a TCP server socket. A thread is started for both client and server. The server socket asks for any availalbe port (by passing "0" as the port number). The server thread then queries for the actual assigned port number, and puts that into an MVar which the client thread can read. The client thread then reads a string from the server and reports it back to the main thread via a different MVar.
@@ -149,6 +149,6 @@ testTcpConnect = 'let
 ```
 ``` ucm
 
-scratch/main> add
-scratch/main> io.test testTcpConnect
+> add
+> io.test testTcpConnect
 ```

--- a/unison-src/transcripts-using-base/net.output.md
+++ b/unison-src/transcripts-using-base/net.output.md
@@ -10,7 +10,7 @@ socketAccept = compose reraise socketAccept.impl
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 # Tests for network related builtins
@@ -107,14 +107,14 @@ testDefaultPort _ =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test testDefaultPort
+> io.test testDefaultPort
 
     New test results:
 
@@ -189,14 +189,14 @@ testTcpConnect = 'let
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test testTcpConnect
+> io.test testTcpConnect
 
     New test results:
 

--- a/unison-src/transcripts-using-base/random-deserial.md
+++ b/unison-src/transcripts-using-base/random-deserial.md
@@ -63,6 +63,6 @@ serialTests = do
 ```
 
 ``` ucm
-scratch/main> add
-scratch/main> io.test serialTests
+> add
+> io.test serialTests
 ```

--- a/unison-src/transcripts-using-base/random-deserial.output.md
+++ b/unison-src/transcripts-using-base/random-deserial.output.md
@@ -76,14 +76,14 @@ serialTests = do
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test serialTests
+> io.test serialTests
 
     New test results:
 

--- a/unison-src/transcripts-using-base/ref-promise.md
+++ b/unison-src/transcripts-using-base/ref-promise.md
@@ -27,8 +27,8 @@ casTest = do
 ```
 
 ``` ucm
-scratch/main> add
-scratch/main> io.test casTest
+> add
+> io.test casTest
 ```
 
 Promise is a simple one-shot awaitable condition.
@@ -62,9 +62,9 @@ promiseConcurrentTest = do
 ```
 
 ``` ucm
-scratch/main> add
-scratch/main> io.test promiseSequentialTest
-scratch/main> io.test promiseConcurrentTest
+> add
+> io.test promiseSequentialTest
+> io.test promiseConcurrentTest
 ```
 
 CAS can be used to write an atomic update function.
@@ -78,7 +78,7 @@ atomicUpdate ref f =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 ```
 
 Promise can be used to write an operation that spawns N concurrent
@@ -99,7 +99,7 @@ spawnN n fa =
   map Promise.read (go n [])
 ```
 ``` ucm
-scratch/main> add
+> add
 ```
 
 We can use these primitives to write a more interesting example, where
@@ -131,6 +131,6 @@ fullTest = do
 ```
 
 ``` ucm
-scratch/main> add
-scratch/main> io.test fullTest
+> add
+> io.test fullTest
 ```

--- a/unison-src/transcripts-using-base/ref-promise.output.md
+++ b/unison-src/transcripts-using-base/ref-promise.output.md
@@ -35,14 +35,14 @@ casTest = do
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test casTest
+> io.test casTest
 
     New test results:
 
@@ -96,14 +96,14 @@ promiseConcurrentTest = do
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test promiseSequentialTest
+> io.test promiseSequentialTest
 
     New test results:
 
@@ -114,7 +114,7 @@ scratch/main> io.test promiseSequentialTest
 
   Tip: Use view 1 to view the source of a test.
 
-scratch/main> io.test promiseConcurrentTest
+> io.test promiseConcurrentTest
 
     New test results:
 
@@ -144,7 +144,7 @@ atomicUpdate ref f =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -179,7 +179,7 @@ spawnN n fa =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -224,14 +224,14 @@ fullTest = do
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test fullTest
+> io.test fullTest
 
     New test results:
 

--- a/unison-src/transcripts-using-base/replacements.md
+++ b/unison-src/transcripts-using-base/replacements.md
@@ -1,4 +1,3 @@
-
 Tests related to automatic replacement of unison types/functions by
 builtins.
 
@@ -20,6 +19,6 @@ mapTests = do [!testIt]
 ```
 
 ``` ucm
-scratch/main> add
-scratch/main> io.test mapTests
+> add
+> io.test mapTests
 ```

--- a/unison-src/transcripts-using-base/replacements.output.md
+++ b/unison-src/transcripts-using-base/replacements.output.md
@@ -42,14 +42,14 @@ mapTests = do [!testIt]
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test mapTests
+> io.test mapTests
 
     New test results:
 

--- a/unison-src/transcripts-using-base/serial-test-00.md
+++ b/unison-src/transcripts-using-base/serial-test-00.md
@@ -69,6 +69,6 @@ mkTestCase = do
 ```
 
 ``` ucm
-scratch/main> add
-scratch/main> run mkTestCase
+> add
+> run mkTestCase
 ```

--- a/unison-src/transcripts-using-base/serial-test-00.output.md
+++ b/unison-src/transcripts-using-base/serial-test-00.output.md
@@ -92,14 +92,14 @@ mkTestCase = do
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> run mkTestCase
+> run mkTestCase
 
   ()
 ```

--- a/unison-src/transcripts-using-base/serial-test-01.md
+++ b/unison-src/transcripts-using-base/serial-test-01.md
@@ -17,6 +17,6 @@ mkTestCase = do
 ```
 
 ``` ucm
-scratch/main> add
-scratch/main> run mkTestCase
+> add
+> run mkTestCase
 ```

--- a/unison-src/transcripts-using-base/serial-test-01.output.md
+++ b/unison-src/transcripts-using-base/serial-test-01.output.md
@@ -29,14 +29,14 @@ mkTestCase = do
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> run mkTestCase
+> run mkTestCase
 
   ()
 ```

--- a/unison-src/transcripts-using-base/serial-test-02.md
+++ b/unison-src/transcripts-using-base/serial-test-02.md
@@ -31,6 +31,6 @@ mkTestCase = do
 ```
 
 ``` ucm
-scratch/main> add
-scratch/main> run mkTestCase
+> add
+> run mkTestCase
 ```

--- a/unison-src/transcripts-using-base/serial-test-02.output.md
+++ b/unison-src/transcripts-using-base/serial-test-02.output.md
@@ -46,14 +46,14 @@ mkTestCase = do
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> run mkTestCase
+> run mkTestCase
 
   ()
 ```

--- a/unison-src/transcripts-using-base/serial-test-03.md
+++ b/unison-src/transcripts-using-base/serial-test-03.md
@@ -45,6 +45,6 @@ mkTestCase = do
 ```
 
 ``` ucm
-scratch/main> add
-scratch/main> run mkTestCase
+> add
+> run mkTestCase
 ```

--- a/unison-src/transcripts-using-base/serial-test-03.output.md
+++ b/unison-src/transcripts-using-base/serial-test-03.output.md
@@ -64,14 +64,14 @@ mkTestCase = do
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> run mkTestCase
+> run mkTestCase
 
   ()
 ```

--- a/unison-src/transcripts-using-base/serial-test-04.md
+++ b/unison-src/transcripts-using-base/serial-test-04.md
@@ -15,6 +15,6 @@ mkTestCase = do
 ```
 
 ``` ucm
-scratch/main> add
-scratch/main> run mkTestCase
+> add
+> run mkTestCase
 ```

--- a/unison-src/transcripts-using-base/serial-test-04.output.md
+++ b/unison-src/transcripts-using-base/serial-test-04.output.md
@@ -25,14 +25,14 @@ mkTestCase = do
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> run mkTestCase
+> run mkTestCase
 
   ()
 ```

--- a/unison-src/transcripts-using-base/stm.md
+++ b/unison-src/transcripts-using-base/stm.md
@@ -28,7 +28,7 @@ body k out v =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 ```
 
 Test case.
@@ -67,6 +67,6 @@ tests = '(map spawn nats)
 ```
 
 ``` ucm
-scratch/main> add
-scratch/main> io.test tests
+> add
+> io.test tests
 ```

--- a/unison-src/transcripts-using-base/stm.output.md
+++ b/unison-src/transcripts-using-base/stm.output.md
@@ -40,7 +40,7 @@ body k out v =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -95,14 +95,14 @@ tests = '(map spawn nats)
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test tests
+> io.test tests
 
     New test results:
 

--- a/unison-src/transcripts-using-base/thread.md
+++ b/unison-src/transcripts-using-base/thread.md
@@ -19,8 +19,8 @@ testBasicFork = 'let
 See if we can get another thread to stuff a value into a MVar
 
 ``` ucm :hide
-scratch/main> add
-scratch/main> io.test testBasicFork
+> add
+> io.test testBasicFork
 ```
 
 ``` unison
@@ -48,8 +48,8 @@ testBasicMultiThreadMVar = 'let
 ```
 
 ``` ucm
-scratch/main> add
-scratch/main> io.test testBasicMultiThreadMVar
+> add
+> io.test testBasicMultiThreadMVar
 ```
 
 ``` unison
@@ -91,6 +91,6 @@ testTwoThreads = 'let
 ```
 
 ``` ucm
-scratch/main> add
-scratch/main> io.test testTwoThreads
+> add
+> io.test testTwoThreads
 ```

--- a/unison-src/transcripts-using-base/thread.output.md
+++ b/unison-src/transcripts-using-base/thread.output.md
@@ -28,9 +28,9 @@ testBasicFork = 'let
 See if we can get another thread to stuff a value into a MVar
 
 ``` ucm :hide
-scratch/main> add
+> add
 
-scratch/main> io.test testBasicFork
+> io.test testBasicFork
 ```
 
 ``` unison
@@ -67,14 +67,14 @@ testBasicMultiThreadMVar = 'let
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test testBasicMultiThreadMVar
+> io.test testBasicMultiThreadMVar
 
     New test results:
 
@@ -135,14 +135,14 @@ testTwoThreads = 'let
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test testTwoThreads
+> io.test testTwoThreads
 
     New test results:
 

--- a/unison-src/transcripts-using-base/tls.md
+++ b/unison-src/transcripts-using-base/tls.md
@@ -12,7 +12,7 @@ not_a_cert = "-----BEGIN SCHERMIFICATE-----\n-----END SCHERMIFICATE-----"
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 # Using an alternative certificate store
@@ -32,8 +32,8 @@ what_should_work _ = this_should_work ++ this_should_not_work
 ```
 
 ``` ucm
-scratch/main> add
-scratch/main> io.test what_should_work
+> add
+> io.test what_should_work
 ```
 
 Test handshaking a client/server a local TCP connection using our
@@ -191,8 +191,8 @@ testCNReject _ =
 ```
 
 ``` ucm
-scratch/main> add
-scratch/main> io.test testConnectSelfSigned
-scratch/main> io.test testCAReject
-scratch/main> io.test testCNReject
+> add
+> io.test testConnectSelfSigned
+> io.test testCAReject
+> io.test testCNReject
 ```

--- a/unison-src/transcripts-using-base/tls.output.md
+++ b/unison-src/transcripts-using-base/tls.output.md
@@ -12,7 +12,7 @@ not_a_cert = "-----BEGIN SCHERMIFICATE-----\n-----END SCHERMIFICATE-----"
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 # Using an alternative certificate store
@@ -42,14 +42,14 @@ what_should_work _ = this_should_work ++ this_should_not_work
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test what_should_work
+> io.test what_should_work
 
     New test results:
 
@@ -231,14 +231,14 @@ testCNReject _ =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test testConnectSelfSigned
+> io.test testConnectSelfSigned
 
     New test results:
 
@@ -248,7 +248,7 @@ scratch/main> io.test testConnectSelfSigned
 
   Tip: Use view 1 to view the source of a test.
 
-scratch/main> io.test testCAReject
+> io.test testCAReject
 
     New test results:
 
@@ -258,7 +258,7 @@ scratch/main> io.test testCAReject
 
   Tip: Use view 1 to view the source of a test.
 
-scratch/main> io.test testCNReject
+> io.test testCNReject
 
     New test results:
 

--- a/unison-src/transcripts-using-base/utf8.md
+++ b/unison-src/transcripts-using-base/utf8.md
@@ -3,7 +3,7 @@ Test for new Text -> Bytes conversions explicitly using UTF-8 as the encoding
 Unison has function for converting between `Text` and a UTF-8 `Bytes` encoding of the Text.
 
 ``` ucm
-scratch/main> find Utf8
+> find Utf8
 ```
 
 ascii characters are encoded as single bytes (in the range 0-127).

--- a/unison-src/transcripts-using-base/utf8.output.md
+++ b/unison-src/transcripts-using-base/utf8.output.md
@@ -3,7 +3,7 @@ Test for new Text -\> Bytes conversions explicitly using UTF-8 as the encoding
 Unison has function for converting between `Text` and a UTF-8 `Bytes` encoding of the Text.
 
 ``` ucm
-scratch/main> find Utf8
+> find Utf8
 
   1. builtin.Text.toUtf8 : Text -> Bytes
   2. Text.fromUtf8 : Bytes ->{Exception} Text

--- a/unison-src/transcripts/alias-many.md
+++ b/unison-src/transcripts/alias-many.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge lib.builtins
+> builtins.merge lib.builtins
 ```
 ``` unison :hide-all
 List.adjacentPairs : [a] -> [(a, a)]
@@ -95,14 +95,14 @@ List.takeWhile p xs =
   go xs []
 ```
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 The `alias.many` command can be used to copy definitions from the current namespace into your curated one.
 The names that will be used in the target namespace are the names you specify, relative to the current namespace:
 
 ```
-scratch/main> help alias.many
+> help alias.many
 
   alias.many (or copy)
   `alias.many <relative1> [relative2...] <namespace>` creates aliases `relative1`, `relative2`, ...
@@ -113,8 +113,8 @@ scratch/main> help alias.many
 Let's try it!
 
 ``` ucm
-scratch/main> alias.many List.adjacentPairs List.all List.any List.chunk List.chunksOf List.dropWhile List.first List.init List.intersperse List.isEmpty List.last List.replicate List.splitAt List.tail List.takeWhile mylib
-scratch/main> find-in mylib
+> alias.many List.adjacentPairs List.all List.any List.chunk List.chunksOf List.dropWhile List.first List.init List.intersperse List.isEmpty List.last List.replicate List.splitAt List.tail List.takeWhile mylib
+> find-in mylib
 ```
 
 Thanks, `alias.many`!

--- a/unison-src/transcripts/alias-many.output.md
+++ b/unison-src/transcripts/alias-many.output.md
@@ -1,16 +1,16 @@
 ``` ucm :hide
-scratch/main> builtins.merge lib.builtins
+> builtins.merge lib.builtins
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 The `alias.many` command can be used to copy definitions from the current namespace into your curated one.
 The names that will be used in the target namespace are the names you specify, relative to the current namespace:
 
 ``` 
-scratch/main> help alias.many
+> help alias.many
 
   alias.many (or copy)
   `alias.many <relative1> [relative2...] <namespace>` creates aliases `relative1`, `relative2`, ...
@@ -21,7 +21,7 @@ scratch/main> help alias.many
 Let's try it\!
 
 ``` ucm
-scratch/main> alias.many List.adjacentPairs List.all List.any List.chunk List.chunksOf List.dropWhile List.first List.init List.intersperse List.isEmpty List.last List.replicate List.splitAt List.tail List.takeWhile mylib
+> alias.many List.adjacentPairs List.all List.any List.chunk List.chunksOf List.dropWhile List.first List.init List.intersperse List.isEmpty List.last List.replicate List.splitAt List.tail List.takeWhile mylib
 
   Here's what changed in mylib :
 
@@ -50,7 +50,7 @@ scratch/main> alias.many List.adjacentPairs List.all List.any List.chunk List.ch
   Tip: You can use `undo` or use a hash from `reflog` to undo
        this change.
 
-scratch/main> find-in mylib
+> find-in mylib
 
   1.  List.adjacentPairs : [a] -> [(a, a)]
   2.  List.all : (a ->{g} Boolean) -> [a] ->{g} Boolean

--- a/unison-src/transcripts/base_release_transcript.md
+++ b/unison-src/transcripts/base_release_transcript.md
@@ -1,8 +1,7 @@
-
 # Testing functions that use the base library
 
 ``` ucm
-scratch/main> lib.install @unison/base/releases/3.35.0
+> lib.install @unison/base/releases/3.35.0
 ```
 
 This just verifies that a `Map` prints out nicely, as a call to `Map.fromList`:

--- a/unison-src/transcripts/base_release_transcript.output.md
+++ b/unison-src/transcripts/base_release_transcript.output.md
@@ -1,7 +1,7 @@
 # Testing functions that use the base library
 
 ``` ucm
-scratch/main> lib.install @unison/base/releases/3.35.0
+> lib.install @unison/base/releases/3.35.0
 
   I installed @unison/base/releases/3.35.0 into
   lib.unison_base_3_35_0

--- a/unison-src/transcripts/errors/dont-hide-unexpected-ucm-errors.md
+++ b/unison-src/transcripts/errors/dont-hide-unexpected-ucm-errors.md
@@ -1,20 +1,20 @@
 Since this code block is expecting an error, we still hide it. It seems unusual to want to hide an error, but maybe it’s just too verbose or something. This follows the author’s intent.
 
 ``` ucm :hide :error
-scratch/main> help pull
-scratch/main> not.a.command
+> help pull
+> not.a.command
 ```
 
 For comparison, here’s what we get without `:hide`.
 
 ``` ucm :error
-scratch/main> help pull
-scratch/main> not.a.command
+> help pull
+> not.a.command
 ```
 
 Even though this code block has `:hide` on it, we should still see the error output, because it wasn’t expecting an error. But we should continue to hide the output _before_ the error.
 
 ``` ucm :hide
-scratch/main> help pull
-scratch/main> not.a.command
+> help pull
+> not.a.command
 ```

--- a/unison-src/transcripts/errors/dont-hide-unexpected-ucm-errors.output.md
+++ b/unison-src/transcripts/errors/dont-hide-unexpected-ucm-errors.output.md
@@ -1,15 +1,15 @@
 Since this code block is expecting an error, we still hide it. It seems unusual to want to hide an error, but maybe it’s just too verbose or something. This follows the author’s intent.
 
 ``` ucm :hide :error
-scratch/main> help pull
+> help pull
 
-scratch/main> not.a.command
+> not.a.command
 ```
 
 For comparison, here’s what we get without `:hide`.
 
 ``` ucm :error
-scratch/main> help pull
+> help pull
 
   pull
   The `pull` command merges a remote namespace into a local
@@ -34,7 +34,7 @@ scratch/main> help pull
     Contributor Branch                     `@unison/base/@johnsmith/feature`
     Project Release                        `@unison/base/releases/1.0.0`
 
-scratch/main> not.a.command
+> not.a.command
 
   ⚠️
   I don't know how to not.a.command. Type `help` or `?` to get
@@ -44,8 +44,8 @@ scratch/main> not.a.command
 Even though this code block has `:hide` on it, we should still see the error output, because it wasn’t expecting an error. But we should continue to hide the output *before* the error.
 
 ``` ucm :hide
-scratch/main> help pull
-scratch/main> not.a.command
+> help pull
+> not.a.command
 ```
 
 🛑

--- a/unison-src/transcripts/errors/missing-result-typed.md
+++ b/unison-src/transcripts/errors/missing-result-typed.md
@@ -5,7 +5,7 @@ then the transcript parser should print the stanza
 and surface a helpful message.
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison :hide-all

--- a/unison-src/transcripts/errors/missing-result-typed.output.md
+++ b/unison-src/transcripts/errors/missing-result-typed.output.md
@@ -5,7 +5,7 @@ then the transcript parser should print the stanza
 and surface a helpful message.
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison :hide-all

--- a/unison-src/transcripts/errors/no-abspath-in-ucm.md
+++ b/unison-src/transcripts/errors/no-abspath-in-ucm.md
@@ -1,5 +1,5 @@
 ``` ucm :error
-scratch/main> builtins.merge
+> builtins.merge
 -- As of 0.5.25, we no longer allow loose code paths for UCM commands.
 .> ls .
 ```

--- a/unison-src/transcripts/errors/no-abspath-in-ucm.output.md
+++ b/unison-src/transcripts/errors/no-abspath-in-ucm.output.md
@@ -3,4 +3,4 @@
 4 | .> ls .
   | ^^
 unexpected ".>"
-expecting "  ", " <newline>", '@', comment (delimited with “--”), end of input, or newline
+expecting "  ", " <newline>", '>', '@', comment (delimited with “--”), end of input, or newline

--- a/unison-src/transcripts/errors/obsolete-bug.md
+++ b/unison-src/transcripts/errors/obsolete-bug.md
@@ -1,5 +1,5 @@
 This transcript will error, because we’re claiming that the stanza has a bug, but `help` works as expected.
 
 ``` ucm :bug
-scratch/main> help edit
+> help edit
 ```

--- a/unison-src/transcripts/errors/obsolete-bug.output.md
+++ b/unison-src/transcripts/errors/obsolete-bug.output.md
@@ -1,7 +1,7 @@
 This transcript will error, because we’re claiming that the stanza has a bug, but `help` works as expected.
 
 ``` ucm :bug
-scratch/main> help edit
+> help edit
 
   edit
   `edit foo` prepends the definition of `foo` to the top of the most recently saved file.

--- a/unison-src/transcripts/errors/obsolete-error-bug.md
+++ b/unison-src/transcripts/errors/obsolete-error-bug.md
@@ -1,5 +1,5 @@
 This transcript will fail, because we’re claiming that the stanza has a bug, but `do.something` errors as expected.
 
 ``` ucm :error :bug
-scratch/main> do.something
+> do.something
 ```

--- a/unison-src/transcripts/errors/obsolete-error-bug.output.md
+++ b/unison-src/transcripts/errors/obsolete-error-bug.output.md
@@ -1,7 +1,7 @@
 This transcript will fail, because we’re claiming that the stanza has a bug, but `do.something` errors as expected.
 
 ``` ucm :error :bug
-scratch/main> do.something
+> do.something
 ```
 
 🎉

--- a/unison-src/transcripts/errors/ucm-hide-all-error.md
+++ b/unison-src/transcripts/errors/ucm-hide-all-error.md
@@ -7,5 +7,5 @@ then the transcript parser should print the stanza
 and surface a helpful message.
 
 ``` ucm :hide-all :error
-scratch/main> history
+> history
 ```

--- a/unison-src/transcripts/errors/ucm-hide-all-error.output.md
+++ b/unison-src/transcripts/errors/ucm-hide-all-error.output.md
@@ -7,7 +7,7 @@ then the transcript parser should print the stanza
 and surface a helpful message.
 
 ``` ucm :hide-all :error
-scratch/main> history
+> history
 ```
 
 🛑

--- a/unison-src/transcripts/errors/ucm-hide-all.md
+++ b/unison-src/transcripts/errors/ucm-hide-all.md
@@ -7,5 +7,5 @@ then the transcript parser should print the stanza
 and surface a helpful message.
 
 ``` ucm :hide-all
-scratch/main> move.namespace foo bar
+> move.namespace foo bar
 ```

--- a/unison-src/transcripts/errors/ucm-hide-all.output.md
+++ b/unison-src/transcripts/errors/ucm-hide-all.output.md
@@ -7,7 +7,7 @@ then the transcript parser should print the stanza
 and surface a helpful message.
 
 ``` ucm :hide-all
-scratch/main> move.namespace foo bar
+> move.namespace foo bar
 ```
 
 🛑

--- a/unison-src/transcripts/errors/ucm-hide-error.md
+++ b/unison-src/transcripts/errors/ucm-hide-error.md
@@ -7,5 +7,5 @@ then the transcript parser should print the stanza
 and surface a helpful message.
 
 ``` ucm :hide:error
-scratch/main> history
+> history
 ```

--- a/unison-src/transcripts/errors/ucm-hide-error.output.md
+++ b/unison-src/transcripts/errors/ucm-hide-error.output.md
@@ -7,7 +7,7 @@ then the transcript parser should print the stanza
 and surface a helpful message.
 
 ``` ucm :hide :error
-scratch/main> history
+> history
 ```
 
 🛑

--- a/unison-src/transcripts/errors/ucm-hide.md
+++ b/unison-src/transcripts/errors/ucm-hide.md
@@ -7,5 +7,5 @@ then the transcript parser should print the stanza
 and surface a helpful message.
 
 ``` ucm :hide
-scratch/main> move.namespace foo bar
+> move.namespace foo bar
 ```

--- a/unison-src/transcripts/errors/ucm-hide.output.md
+++ b/unison-src/transcripts/errors/ucm-hide.output.md
@@ -7,7 +7,7 @@ then the transcript parser should print the stanza
 and surface a helpful message.
 
 ``` ucm :hide
-scratch/main> move.namespace foo bar
+> move.namespace foo bar
 ```
 
 🛑

--- a/unison-src/transcripts/fix2840.md
+++ b/unison-src/transcripts/fix2840.md
@@ -1,7 +1,7 @@
 This bugfix addresses an issue where embedded Unison code in UCM was expected to be present in the active codebase when the `display` command was used render `Doc` values.
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 First, a few \[hidden] definitions necessary for typechecking a simple Doc2.
@@ -63,7 +63,7 @@ syntax.docWord = Word
 ```
 
 ``` ucm
-scratch/main> add
+> add
 ```
 
 Next, define and display a simple Doc:
@@ -74,7 +74,7 @@ Hi
 ```
 
 ``` ucm
-scratch/main> display README
+> display README
 ```
 
 Previously, the error was:

--- a/unison-src/transcripts/fix2840.output.md
+++ b/unison-src/transcripts/fix2840.output.md
@@ -1,13 +1,13 @@
 This bugfix addresses an issue where embedded Unison code in UCM was expected to be present in the active codebase when the `display` command was used render `Doc` values.
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 First, a few \[hidden\] definitions necessary for typechecking a simple Doc2.
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -24,7 +24,7 @@ Hi
 ```
 
 ``` ucm
-scratch/main> display README
+> display README
 
   Hi
 ```

--- a/unison-src/transcripts/hello.md
+++ b/unison-src/transcripts/hello.md
@@ -1,7 +1,7 @@
 # Hello!
 
 ```ucm :hide
-scratch/main> builtins.mergeio
+> builtins.mergeio
 ```
 
 This markdown file is also a Unison transcript file. Transcript files are an easy way to create self-documenting Unison programs, libraries, and tutorials.
@@ -32,8 +32,8 @@ x = 42
 Let's go ahead and add that to the codebase, then make sure it's there:
 
 ``` ucm
-scratch/main> add
-scratch/main> view x
+> add
+> view x
 ```
 
 If `view` returned no results, the transcript would fail at this point.
@@ -49,7 +49,7 @@ y = 99
 This works for `ucm` blocks as well.
 
 ``` ucm :hide
-scratch/main> rename.term x answerToUltimateQuestionOfLife
+> rename.term x answerToUltimateQuestionOfLife
 ```
 
 Doing `unison :hide-all` hides the block altogether, both input and output - this is useful for doing behind-the-scenes control of `ucm`'s state.

--- a/unison-src/transcripts/hello.output.md
+++ b/unison-src/transcripts/hello.output.md
@@ -1,7 +1,7 @@
 # Hello\!
 
 ``` ucm :hide
-scratch/main> builtins.mergeio
+> builtins.mergeio
 ```
 
 This markdown file is also a Unison transcript file. Transcript files are an easy way to create self-documenting Unison programs, libraries, and tutorials.
@@ -40,14 +40,14 @@ x = 42
 Let's go ahead and add that to the codebase, then make sure it's there:
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> view x
+> view x
 
   x : Nat
   x = 42
@@ -66,7 +66,7 @@ y = 99
 This works for `ucm` blocks as well.
 
 ``` ucm :hide
-scratch/main> rename.term x answerToUltimateQuestionOfLife
+> rename.term x answerToUltimateQuestionOfLife
 ```
 
 Doing `unison :hide-all` hides the block altogether, both input and output - this is useful for doing behind-the-scenes control of `ucm`'s state.

--- a/unison-src/transcripts/idempotent/abilities.md
+++ b/unison-src/transcripts/idempotent/abilities.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 Some random ability stuff to ensure things work.
@@ -22,7 +22,7 @@ ha = cases
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/ability-order-doesnt-affect-hash.md
+++ b/unison-src/transcripts/idempotent/ability-order-doesnt-affect-hash.md
@@ -15,14 +15,14 @@ term2 _ = ()
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> names term1
+> names term1
 
   'term1':
   Hash          Kind   Names

--- a/unison-src/transcripts/idempotent/add-run.md
+++ b/unison-src/transcripts/idempotent/add-run.md
@@ -3,7 +3,7 @@
 ## Basic usage
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison :hide
@@ -20,7 +20,7 @@ is2even = '(even 2)
 it errors if there isn't a previous run
 
 ``` ucm :error
-scratch/main> add.run foo
+> add.run foo
 
   ⚠️
 
@@ -29,7 +29,7 @@ scratch/main> add.run foo
 ```
 
 ``` ucm
-scratch/main> run is2even
+> run is2even
 
   true
 ```
@@ -38,7 +38,7 @@ it errors if the desired result name conflicts with a name in the
 unison file
 
 ``` ucm :error
-scratch/main> add.run is2even
+> add.run is2even
 
   ⚠️
 
@@ -49,7 +49,7 @@ scratch/main> add.run is2even
 otherwise, the result is successfully persisted
 
 ``` ucm
-scratch/main> add.run foo.bar.baz
+> add.run foo.bar.baz
 
   ⍟ I've added these definitions:
 
@@ -57,7 +57,7 @@ scratch/main> add.run foo.bar.baz
 ```
 
 ``` ucm
-scratch/main> view foo.bar.baz
+> view foo.bar.baz
 
   foo.bar.baz : Boolean
   foo.bar.baz = true
@@ -87,11 +87,11 @@ main _ = y
 ```
 
 ``` ucm
-scratch/main> run main
+> run main
 
   a b -> a Nat.+ b Nat.+ z 10
 
-scratch/main> add.run result
+> add.run result
 
   ⍟ I've added these definitions:
 
@@ -115,7 +115,7 @@ inc x = x + 1
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -129,17 +129,17 @@ main _ x = inc x
 ```
 
 ``` ucm
-scratch/main> run main
+> run main
 
   inc
 
-scratch/main> add.run natfoo
+> add.run natfoo
 
   ⍟ I've added these definitions:
 
     natfoo : Nat -> Nat
 
-scratch/main> view natfoo
+> view natfoo
 
   natfoo : Nat -> Nat
   natfoo = inc
@@ -164,7 +164,7 @@ main = 'y
 ```
 
 ``` ucm
-scratch/main> run main
+> run main
 
   2
 ```
@@ -176,13 +176,13 @@ x = 50
 this saves 2 to xres, rather than 100
 
 ``` ucm
-scratch/main> add.run xres
+> add.run xres
 
   ⍟ I've added these definitions:
 
     xres : Nat
 
-scratch/main> view xres
+> view xres
 
   xres : Nat
   xres = 2
@@ -195,11 +195,11 @@ main = '5
 ```
 
 ``` ucm :error
-scratch/main> run main
+> run main
 
   5
 
-scratch/main> add.run xres
+> add.run xres
 
   x These definitions failed:
 
@@ -216,17 +216,17 @@ main = '5
 ```
 
 ``` ucm
-scratch/main> run main
+> run main
 
   5
 
-scratch/main> add.run .an.absolute.name
+> add.run .an.absolute.name
 
   ⍟ I've added these definitions:
 
     .an.absolute.name : Nat
 
-scratch/main> view .an.absolute.name
+> view .an.absolute.name
 
   .an.absolute.name : Nat
   .an.absolute.name = 5

--- a/unison-src/transcripts/idempotent/add-test-watch-roundtrip.md
+++ b/unison-src/transcripts/idempotent/add-test-watch-roundtrip.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.mergeio
+> builtins.mergeio
 ```
 
 ``` unison :hide
@@ -10,14 +10,14 @@ foo = []
 Apparently when we add a test watch, we add a type annotation to it, even if it already has one. We don't want this to happen though\!
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> view foo
+> view foo
 
   foo : [Result]
   foo : [Result]

--- a/unison-src/transcripts/idempotent/addupdatemessages.md
+++ b/unison-src/transcripts/idempotent/addupdatemessages.md
@@ -3,7 +3,7 @@
 Let's set up some definitions to start:
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison
@@ -29,7 +29,7 @@ structural type Y = Two Nat Nat
 Expected: `x` and `y`, `X`, and `Y` exist as above. UCM tells you this.
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -60,7 +60,7 @@ Expected: `z` is now `1`. UCM tells you that this definition is also called `x`.
 Also, `Z` is an alias for `X`.
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -91,7 +91,7 @@ structural type X = Three Nat Nat Nat
 Expected: `x` is now `3` and `X` has constructor `Three`. UCM tells you the old definitions were also called `z` and `Z` and these names have also been updated.
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -126,7 +126,7 @@ structural type X = Two Nat Nat
 Expected: `x` is now `2` and `X` is `Two`. UCM says the old definition was also named `z/Z`, and was also updated. And it says the new definition is also named `y/Y`.
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/affine-handlers.md
+++ b/unison-src/transcripts/idempotent/affine-handlers.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 This transcript gives some examples of affine handlers and tests that
@@ -152,14 +152,14 @@ count'test = do
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test count'test
+> io.test count'test
 
     New test results:
 
@@ -216,14 +216,14 @@ fail'count'test = do
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test fail'count'test
+> io.test fail'count'test
 
     New test results:
 
@@ -274,14 +274,14 @@ local'count'test = do
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test local'count'test
+> io.test local'count'test
 
     New test results:
 
@@ -356,14 +356,14 @@ elaborate'test = do
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test elaborate'test
+> io.test elaborate'test
 
     New test results:
 

--- a/unison-src/transcripts/idempotent/alias-term.md
+++ b/unison-src/transcripts/idempotent/alias-term.md
@@ -1,15 +1,15 @@
 `alias.term` makes a new name for a term.
 
 ``` ucm :hide
-project/main> builtins.mergeio lib.builtins
+> builtins.mergeio lib.builtins
 ```
 
 ``` ucm
-project/main> alias.term lib.builtins.bug foo
+> alias.term lib.builtins.bug foo
 
   Done.
 
-project/main> ls .
+> ls .
 
   1. foo  (a -> b)
   2. lib/ (755 terms, 118 types)
@@ -18,7 +18,7 @@ project/main> ls .
 It won't create a conflicted name, though.
 
 ``` ucm :error
-project/main> alias.term lib.builtins.todo foo
+> alias.term lib.builtins.todo foo
 
   ⚠️
 
@@ -26,7 +26,7 @@ project/main> alias.term lib.builtins.todo foo
 ```
 
 ``` ucm
-project/main> ls .
+> ls .
 
   1. foo  (a -> b)
   2. lib/ (755 terms, 118 types)
@@ -35,11 +35,11 @@ project/main> ls .
 You can use `debug.alias.term.force` for that.
 
 ``` ucm
-project/main> debug.alias.term.force lib.builtins.todo foo
+> debug.alias.term.force lib.builtins.todo foo
 
   Done.
 
-project/main> ls .
+> ls .
 
   1. foo  (a -> b)
   2. foo  (a -> b)

--- a/unison-src/transcripts/idempotent/alias-type.md
+++ b/unison-src/transcripts/idempotent/alias-type.md
@@ -1,15 +1,15 @@
 `alias.type` makes a new name for a type.
 
 ``` ucm :hide
-project/main> builtins.mergeio lib.builtins
+> builtins.mergeio lib.builtins
 ```
 
 ``` ucm
-project/main> alias.type lib.builtins.Nat Foo
+> alias.type lib.builtins.Nat Foo
 
   Done.
 
-project/main> ls .
+> ls .
 
   1. Foo  (builtin type)
   2. lib/ (755 terms, 118 types)
@@ -18,7 +18,7 @@ project/main> ls .
 It won't create a conflicted name, though.
 
 ``` ucm :error
-project/main> alias.type lib.builtins.Int Foo
+> alias.type lib.builtins.Int Foo
 
   ⚠️
 
@@ -26,7 +26,7 @@ project/main> alias.type lib.builtins.Int Foo
 ```
 
 ``` ucm
-project/main> ls .
+> ls .
 
   1. Foo  (builtin type)
   2. lib/ (755 terms, 118 types)
@@ -35,11 +35,11 @@ project/main> ls .
 You can use `debug.alias.type.force` for that.
 
 ``` ucm
-project/main> debug.alias.type.force lib.builtins.Int Foo
+> debug.alias.type.force lib.builtins.Int Foo
 
   Done.
 
-project/main> ls .
+> ls .
 
   1. Foo  (builtin type)
   2. Foo  (builtin type)

--- a/unison-src/transcripts/idempotent/anf-tests.md
+++ b/unison-src/transcripts/idempotent/anf-tests.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 This tests a variable related bug in the ANF compiler.
@@ -42,7 +42,7 @@ foo _ =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/api-doc-rendering.md
+++ b/unison-src/transcripts/idempotent/api-doc-rendering.md
@@ -1,7 +1,7 @@
 # Doc rendering
 
 ``` ucm :hide
-scratch/main> builtins.mergeio
+> builtins.mergeio
 ```
 
 ``` unison :hide
@@ -82,11 +82,11 @@ term = 42
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ``` ucm
-scratch/main> display term.doc
+> display term.doc
 
   # Heading
 

--- a/unison-src/transcripts/idempotent/api-find.md
+++ b/unison-src/transcripts/idempotent/api-find.md
@@ -19,7 +19,7 @@ joey.yaml.zz = 45
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/api-getDefinition.md
+++ b/unison-src/transcripts/idempotent/api-getDefinition.md
@@ -1,7 +1,7 @@
 # Get Definitions Test
 
 ``` ucm :hide
-scratch/main> builtins.mergeio lib.builtins
+> builtins.mergeio lib.builtins
 ```
 
 ``` unison :hide
@@ -10,7 +10,7 @@ nested.names.x = 42
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ``` api
@@ -225,7 +225,7 @@ doctest.otherstuff.thing = "A different thing"
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 Only docs for the term we request should be returned, even if there are other term docs with the same suffix.

--- a/unison-src/transcripts/idempotent/api-namespace-details.md
+++ b/unison-src/transcripts/idempotent/api-namespace-details.md
@@ -1,7 +1,7 @@
 # Namespace Details Test
 
 ``` ucm :hide
-scratch/main> builtins.mergeio
+> builtins.mergeio
 ```
 
 ``` unison
@@ -24,7 +24,7 @@ Here's a *README*!
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/api-namespace-list.md
+++ b/unison-src/transcripts/idempotent/api-namespace-list.md
@@ -1,7 +1,7 @@
 # Namespace list api
 
 ``` ucm :hide
-scratch/main> builtins.mergeio
+> builtins.mergeio
 ```
 
 ``` unison
@@ -22,7 +22,7 @@ nested.names.readme = {{ I'm a readme! }}
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/api-summaries.md
+++ b/unison-src/transcripts/idempotent/api-summaries.md
@@ -1,7 +1,7 @@
 # Definition Summary APIs
 
 ``` ucm :hide
-scratch/main> builtins.mergeio
+> builtins.mergeio
 ```
 
 ``` unison :hide
@@ -24,11 +24,11 @@ structural ability Stream s where
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 
-scratch/main> alias.type ##Nat Nat
+> alias.type ##Nat Nat
 
-scratch/main> alias.term ##IO.putBytes.impl.v3 putBytesImpl
+> alias.term ##IO.putBytes.impl.v3 putBytesImpl
 ```
 
 ## Term Summary APIs

--- a/unison-src/transcripts/idempotent/avro.md
+++ b/unison-src/transcripts/idempotent/avro.md
@@ -1,12 +1,12 @@
 ``` ucm :hide
-scratch/main> lib.install @runarorama/avroSpeedTest/releases/1.0.1
+> lib.install @runarorama/avroSpeedTest/releases/1.0.1
 ```
 
 This transcript checks that the function replacements are improving the
 performance of Avro decoding.
 
 ``` ucm
-scratch/main> test.io checkRuntimeOptimizations
+> test.io checkRuntimeOptimizations
 
     New test results:
 

--- a/unison-src/transcripts/idempotent/blocks.md
+++ b/unison-src/transcripts/idempotent/blocks.md
@@ -1,7 +1,7 @@
 ## Blocks and scoping
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ### Names introduced by a block shadow names introduced in outer scopes

--- a/unison-src/transcripts/idempotent/boolean-op-pretty-print-2819.md
+++ b/unison-src/transcripts/idempotent/boolean-op-pretty-print-2819.md
@@ -1,7 +1,7 @@
 Regression test for https://github.com/unisonweb/unison/pull/2819
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison
@@ -20,14 +20,14 @@ hangExample =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> view hangExample
+> view hangExample
 
   hangExample : Boolean
   hangExample =

--- a/unison-src/transcripts/idempotent/bug-fix-4354.md
+++ b/unison-src/transcripts/idempotent/bug-fix-4354.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison

--- a/unison-src/transcripts/idempotent/bug-strange-closure.md
+++ b/unison-src/transcripts/idempotent/bug-strange-closure.md
@@ -1,13 +1,13 @@
 ``` ucm :hide
-scratch/main> builtins.mergeio lib.builtins
+> builtins.mergeio lib.builtins
 
-scratch/main> load unison-src/transcripts-using-base/doc.md.files/syntax.u
+> load unison-src/transcripts-using-base/doc.md.files/syntax.u
 ```
 
 We can display the guide before and after adding it to the codebase:
 
 ```` ucm
-scratch/main> display doc.guide
+> display doc.guide
 
   # Unison computable documentation
 
@@ -205,14 +205,14 @@ scratch/main> display doc.guide
                             rendered table.
     Some text   More text   Zounds!
 
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> display doc.guide
+> display doc.guide
 
   # Unison computable documentation
 
@@ -426,7 +426,7 @@ rendered = Pretty.get (docFormatConsole doc.guide)
 ```
 
 ```` ucm
-scratch/main> display rendered
+> display rendered
 
   # Unison computable documentation
 
@@ -624,14 +624,14 @@ scratch/main> display rendered
                             rendered table.
     Some text   More text   Zounds!
 
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> display rendered
+> display rendered
 
   # Unison computable documentation
 
@@ -829,7 +829,7 @@ scratch/main> display rendered
                             rendered table.
     Some text   More text   Zounds!
 
-scratch/main> undo
+> undo
 
   Here are the changes I undid
 

--- a/unison-src/transcripts/idempotent/bug.md
+++ b/unison-src/transcripts/idempotent/bug.md
@@ -1,7 +1,7 @@
 This tests that `:bug` behaves similarly to `:error` when the stanza fails.
 
 ``` ucm :bug
-scratch/main> do.something
+> do.something
 
   ⚠️
   I don't know how to do.something. Type `help` or `?` to get
@@ -11,7 +11,7 @@ scratch/main> do.something
 And when combined with `:error`, it should expect a successful result.
 
 ``` ucm :error :bug
-scratch/main> help edit
+> help edit
 
   edit
   `edit foo` prepends the definition of `foo` to the top of the most recently saved file.

--- a/unison-src/transcripts/idempotent/builtins-merge.md
+++ b/unison-src/transcripts/idempotent/builtins-merge.md
@@ -1,11 +1,11 @@
 The `builtins.merge` command adds the known builtins to the specified subnamespace within the current namespace.
 
 ``` ucm
-scratch/main> builtins.merge builtins
+> builtins.merge builtins
 
   Done.
 
-scratch/main> ls builtins
+> ls builtins
 
   1.  Any                 (builtin type)
   2.  Any/                (2 terms)

--- a/unison-src/transcripts/idempotent/builtins.md
+++ b/unison-src/transcripts/idempotent/builtins.md
@@ -1,11 +1,11 @@
 # Unit tests for builtin functions
 
 ``` ucm :hide
-scratch/main> builtins.mergeio
+> builtins.mergeio
 
-scratch/main> load unison-src/transcripts-using-base/base.u
+> load unison-src/transcripts-using-base/base.u
 
-scratch/main> add
+> add
 ```
 
 This transcript defines unit tests for builtin functions. There's a single `scratch/main> test` execution at the end that will fail the transcript with a nice report if any of the tests fail.
@@ -90,7 +90,7 @@ test> Int.tests.conversions =
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ## `Nat` functions
@@ -165,7 +165,7 @@ test> Nat.tests.conversions =
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ## `Boolean` functions
@@ -193,7 +193,7 @@ test> Boolean.tests.notTable =
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ## `Text` functions
@@ -294,7 +294,7 @@ test> Text.tests.indexOfEmoji =
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ## `Bytes` functions
@@ -355,7 +355,7 @@ test> Bytes.tests.indexOf =
 
    ]
 
-test> Bytes.tests.byteArray = 
+test> Bytes.tests.byteArray =
   bs = 0xs0102030405
   checks [
     ImmutableByteArray.toBytes (ImmutableByteArray.fromBytes bs) 0 5 == bs
@@ -364,7 +364,7 @@ test> Bytes.tests.byteArray =
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ## `List` comparison
@@ -383,7 +383,7 @@ test> checks [
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 Other list functions
@@ -426,7 +426,7 @@ test> Any.test2 = checks [(not (Any "hi" == Any 42))]
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ## Sandboxing functions
@@ -483,7 +483,7 @@ openFile]
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ``` unison
@@ -508,14 +508,14 @@ openFilesIO = do
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test openFilesIO
+> io.test openFilesIO
 
     New test results:
 
@@ -552,7 +552,7 @@ test> Universal.murmurHash.tests = checks [Universal.murmurHash [1,2,3] == Unive
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ## Run the tests
@@ -560,7 +560,7 @@ scratch/main> add
 Now that all the tests have been added to the codebase, let's view the test report. This will fail the transcript (with a nice message) if any of the tests are failing.
 
 ``` ucm
-scratch/main> test
+> test
 
   Cached test results (`help testcache` to learn more)
 

--- a/unison-src/transcripts/idempotent/bytesFromList.md
+++ b/unison-src/transcripts/idempotent/bytesFromList.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 This should render as `Bytes.fromList [1,2,3,4]`, not `##Bytes.fromSequence [1,2,3,4]`:

--- a/unison-src/transcripts/idempotent/check763.md
+++ b/unison-src/transcripts/idempotent/check763.md
@@ -1,7 +1,7 @@
 Regression test for https://github.com/unisonweb/unison/issues/763
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison
@@ -18,18 +18,18 @@ scratch/main> builtins.merge
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> move.term +-+ boppitybeep
+> move.term +-+ boppitybeep
 
   Done.
 
-scratch/main> move.term boppitybeep +-+
+> move.term boppitybeep +-+
 
   Done.
 ```

--- a/unison-src/transcripts/idempotent/check873.md
+++ b/unison-src/transcripts/idempotent/check873.md
@@ -1,7 +1,7 @@
 See [this ticket](https://github.com/unisonweb/unison/issues/873); the point being, this shouldn't crash the runtime. :)
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison
@@ -17,7 +17,7 @@ scratch/main> builtins.merge
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/constructor-applied-to-unit.md
+++ b/unison-src/transcripts/idempotent/constructor-applied-to-unit.md
@@ -1,7 +1,7 @@
 ``` ucm :hide
-scratch/main> alias.type ##Nat Nat
+> alias.type ##Nat Nat
 
-scratch/main> alias.term ##Any.Any Any
+> alias.term ##Any.Any Any
 ```
 
 ``` unison

--- a/unison-src/transcripts/idempotent/contrabilities.md
+++ b/unison-src/transcripts/idempotent/contrabilities.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison

--- a/unison-src/transcripts/idempotent/create-author.md
+++ b/unison-src/transcripts/idempotent/create-author.md
@@ -1,11 +1,11 @@
 ``` ucm :hide
-scratch/main> builtins.mergeio
+> builtins.mergeio
 ```
 
 Demonstrating `create.author`:
 
 ``` ucm
-scratch/main> create.author alicecoder "Alice McGee"
+> create.author alicecoder "Alice McGee"
 
   Added definitions:
 
@@ -15,7 +15,7 @@ scratch/main> create.author alicecoder "Alice McGee"
 
   Tip: Add License values for alicecoder under metadata.
 
-scratch/main> find alicecoder
+> find alicecoder
 
   1. metadata.authors.alicecoder : Author
   2. metadata.copyrightHolders.alicecoder : CopyrightHolder

--- a/unison-src/transcripts/idempotent/cycle-update-1.md
+++ b/unison-src/transcripts/idempotent/cycle-update-1.md
@@ -1,7 +1,7 @@
 Update a member of a cycle, but retain the cycle.
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison
@@ -22,7 +22,7 @@ pong _ = !ping + 2
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -46,7 +46,7 @@ ping _ = !pong + 3
 ```
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -57,7 +57,7 @@ scratch/main> update
 
   Done.
 
-scratch/main> view ping pong
+> view ping pong
 
   ping : 'Nat
   ping _ =

--- a/unison-src/transcripts/idempotent/cycle-update-2.md
+++ b/unison-src/transcripts/idempotent/cycle-update-2.md
@@ -1,7 +1,7 @@
 Update a member of a cycle with a type-preserving update, but sever the cycle.
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison
@@ -22,7 +22,7 @@ pong _ = !ping + 2
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -46,7 +46,7 @@ ping _ = 3
 ```
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -57,7 +57,7 @@ scratch/main> update
 
   Done.
 
-scratch/main> view ping pong
+> view ping pong
 
   ping : 'Nat
   ping _ = 3

--- a/unison-src/transcripts/idempotent/cycle-update-3.md
+++ b/unison-src/transcripts/idempotent/cycle-update-3.md
@@ -1,7 +1,7 @@
 Update a member of a cycle with a type-changing update, thus severing the cycle.
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison
@@ -22,7 +22,7 @@ pong _ = !ping + 2
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -46,7 +46,7 @@ ping = 3
 ```
 
 ``` ucm :error
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/cycle-update-4.md
+++ b/unison-src/transcripts/idempotent/cycle-update-4.md
@@ -1,7 +1,7 @@
 `update` properly discovers and establishes new cycles.
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison
@@ -22,7 +22,7 @@ pong _ = !ping + 2
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -50,7 +50,7 @@ clang _ = !pong + 3
 ```
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -61,7 +61,7 @@ scratch/main> update
 
   Done.
 
-scratch/main> view ping pong clang
+> view ping pong clang
 
   clang : 'Nat
   clang _ =

--- a/unison-src/transcripts/idempotent/debug-definitions.md
+++ b/unison-src/transcripts/idempotent/debug-definitions.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison :hide
@@ -17,22 +17,22 @@ ability Ask a where
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> debug.term.abt Nat.+
+> debug.term.abt Nat.+
 
   Builtin term: ##Nat.+
 
-scratch/main> debug.term.abt y
+> debug.term.abt y
 
   (let Ref(ReferenceBuiltin "Nat.+") Ref(ReferenceDerived (Id "qpo3o788girkkbb43uf6ggqberfduhtnqbt7096eojlrp27jieco09mdasb7b0b06ej9hj60a00nnbbdo8he0b4e0m7vtopifiuhdig" 0)) 2 in (User "z". Ref(ReferenceBuiltin "Nat.+") (Var User "z") 10)):ReferenceBuiltin "Nat"
 
-scratch/main> debug.term.abt Some
+> debug.term.abt Some
 
   Constructor #0 of the following type:
   DataDeclaration
@@ -62,7 +62,7 @@ scratch/main> debug.term.abt Some
           ]
       }
 
-scratch/main> debug.term.abt ask
+> debug.term.abt ask
 
   Constructor #0 of the following type:
   EffectDeclaration
@@ -91,11 +91,11 @@ scratch/main> debug.term.abt ask
           }
       }
 
-scratch/main> debug.type.abt Nat
+> debug.type.abt Nat
 
   Builtin type: ##Nat
 
-scratch/main> debug.type.abt Optional
+> debug.type.abt Optional
 
   DataDeclaration
       { modifier = Structural
@@ -124,7 +124,7 @@ scratch/main> debug.type.abt Optional
           ]
       }
 
-scratch/main> debug.type.abt Ask
+> debug.type.abt Ask
 
   EffectDeclaration
       { toDataDecl = DataDeclaration

--- a/unison-src/transcripts/idempotent/debug-name-diffs.md
+++ b/unison-src/transcripts/idempotent/debug-name-diffs.md
@@ -24,14 +24,14 @@ structural type a.b.Baz = Boo
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> delete.term.verbose a.b.one
+> delete.term.verbose a.b.one
 
   Removed definitions:
 
@@ -40,15 +40,15 @@ scratch/main> delete.term.verbose a.b.one
   Tip: You can use `undo` or use a hash from `reflog` to undo
        this change.
 
-scratch/main> alias.term a.two a.newtwo
+> alias.term a.two a.newtwo
 
   Done.
 
-scratch/main> move.namespace a.x a.y
+> move.namespace a.x a.y
 
   Done.
 
-scratch/main> history
+> history
 
   Note: The most recent namespace hash is immediately below this
         message.
@@ -83,7 +83,7 @@ scratch/main> history
 
   □ 4. #gss5s88mo3 (start of history)
 
-scratch/main> debug.name-diff 4 1
+> debug.name-diff 4 1
 
   Kind   Name          Change    Ref
   Term   a.newtwo      Added     #dcgdua2lj6upd1ah5v0qp09gjsej0d77d87fu6qn8e2qrssnlnmuinoio46hiu53magr7qn8vnqke8ndt0v76700o5u8gcvo7st28jg

--- a/unison-src/transcripts/idempotent/definition-diff-api.md
+++ b/unison-src/transcripts/idempotent/definition-diff-api.md
@@ -1,13 +1,13 @@
 ``` ucm
-diffs/main> builtins.mergeio lib.builtins
+> builtins.mergeio lib.builtins
 
   Done.
 
-diffs/main> alias.term lib.builtins.Nat.gt lib.builtins.Nat.>
+> alias.term lib.builtins.Nat.gt lib.builtins.Nat.>
 
   Done.
 
-diffs/main> alias.term lib.builtins.Nat.drop lib.builtins.Nat.-
+> alias.term lib.builtins.Nat.drop lib.builtins.Nat.-
 
   Done.
 ```
@@ -53,14 +53,14 @@ unitCase = id (x -> 1)
 ```
 
 ``` ucm
-diffs/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-diffs/main> branch.create new
+> branch.create new
 
   Done. I've created the new branch based off of main.
 
@@ -112,7 +112,7 @@ unitCase = id (x -> (1, ()))
 ```
 
 ``` ucm
-diffs/new> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -123,7 +123,7 @@ diffs/new> update
 Diff terms
 
 ``` api
-GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=term&newTerm=term
+GET /api/projects/scratch/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=term&newTerm=term
   {
       "diff": {
           "contents": [
@@ -630,14 +630,14 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=te
               "term"
           ]
       },
-      "project": "diffs"
+      "project": "scratch"
   }
 ```
 
 More complex diff
 
 ``` api
-GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=take&newTerm=take
+GET /api/projects/scratch/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=take&newTerm=take
   {
       "diff": {
           "contents": [
@@ -3342,14 +3342,14 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=ta
               "take"
           ]
       },
-      "project": "diffs"
+      "project": "scratch"
   }
 ```
 
 Regression test for weird behavior w/r to unit and parens.
 
 ``` api
-GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=unitCase&newTerm=unitCase
+GET /api/projects/scratch/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=unitCase&newTerm=unitCase
   {
       "diff": {
           "contents": [
@@ -3970,14 +3970,14 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=un
               "unitCase"
           ]
       },
-      "project": "diffs"
+      "project": "scratch"
   }
 ```
 
 Diff types
 
 ``` api
-GET /api/projects/diffs/diff/types?oldBranchRef=main&newBranchRef=new&oldType=Type&newType=Type
+GET /api/projects/scratch/diff/types?oldBranchRef=main&newBranchRef=new&oldType=Type&newType=Type
   {
       "diff": {
           "contents": [
@@ -4218,6 +4218,6 @@ GET /api/projects/diffs/diff/types?oldBranchRef=main&newBranchRef=new&oldType=Ty
               "Type"
           ]
       },
-      "project": "diffs"
+      "project": "scratch"
   }
 ```

--- a/unison-src/transcripts/idempotent/delete-namespace-dependents-check.md
+++ b/unison-src/transcripts/idempotent/delete-namespace-dependents-check.md
@@ -5,7 +5,7 @@
 This is a regression test, previously `delete.namespace` allowed a delete as long as the deletions had a name *anywhere* in your codebase, it should only check the current project branch.
 
 ``` ucm :hide
-myproject/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison
@@ -24,21 +24,21 @@ dependent = dependency + 99
 ```
 
 ``` ucm :error
-myproject/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-myproject/main> branch /new
+> branch /new
 
   Done. I've created the new branch based off of main.
 
   Tip: To merge your work back into the main branch, first
        `switch /main` then `merge /new`.
 
-myproject/new> delete.namespace sub
+> delete.namespace sub
 
   ⚠️
 
@@ -51,7 +51,7 @@ myproject/new> delete.namespace sub
   If you want to proceed anyways and leave those definitions
   without names, use delete.namespace.force
 
-myproject/new> view dependent
+> view dependent
 
   dependent : Nat
   dependent =

--- a/unison-src/transcripts/idempotent/delete-namespace.md
+++ b/unison-src/transcripts/idempotent/delete-namespace.md
@@ -1,7 +1,7 @@
 # delete.namespace.force
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison :hide
@@ -15,13 +15,13 @@ dependents.usage2 = dependencies.term1 * dependencies.term2
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 Deleting a namespace with no external dependencies should succeed.
 
 ``` ucm
-scratch/main> delete.namespace no_dependencies
+> delete.namespace no_dependencies
 
   Done.
 ```
@@ -29,7 +29,7 @@ scratch/main> delete.namespace no_dependencies
 Deleting a namespace with external dependencies should fail and list all dependents.
 
 ``` ucm :error
-scratch/main> delete.namespace dependencies
+> delete.namespace dependencies
 
   ⚠️
 
@@ -50,7 +50,7 @@ scratch/main> delete.namespace dependencies
 Deleting a namespace with external dependencies should succeed when using `delete.namespace.force`
 
 ``` ucm
-scratch/main> delete.namespace.force dependencies
+> delete.namespace.force dependencies
 
   Done.
 
@@ -70,7 +70,7 @@ scratch/main> delete.namespace.force dependencies
 I should be able to view an affected dependency by number
 
 ``` ucm
-scratch/main> view 2
+> view 2
 
   dependents.usage2 : Nat
   dependents.usage2 =
@@ -81,7 +81,7 @@ scratch/main> view 2
 Deleting the root namespace should require confirmation if not forced.
 
 ``` ucm
-scratch/main> delete.namespace .
+> delete.namespace .
 
   ⚠️
 
@@ -89,7 +89,7 @@ scratch/main> delete.namespace .
   You could use `project.create` to switch to a new project
   instead, or delete the current branch with `delete.branch`
 
-scratch/main> delete.namespace .
+> delete.namespace .
 
   Okay, I deleted everything except the history. Use `undo` to
   undo, or `builtins.merge` to restore the absolute basics to
@@ -97,7 +97,7 @@ scratch/main> delete.namespace .
 
 -- Should have an empty history
 
-scratch/main> history .
+> history .
 
   Note: The most recent namespace hash is immediately below this
         message.
@@ -110,7 +110,7 @@ scratch/main> history .
 Deleting the root namespace shouldn't require confirmation if forced.
 
 ``` ucm
-scratch/main> delete.namespace.force .
+> delete.namespace.force .
 
   Okay, I deleted everything except the history. Use `undo` to
   undo, or `builtins.merge` to restore the absolute basics to
@@ -118,7 +118,7 @@ scratch/main> delete.namespace.force .
 
 -- Should have an empty history
 
-scratch/main> history .
+> history .
 
   Note: The most recent namespace hash is immediately below this
         message.

--- a/unison-src/transcripts/idempotent/delete-silent.md
+++ b/unison-src/transcripts/idempotent/delete-silent.md
@@ -1,5 +1,5 @@
 ``` ucm :error
-scratch/main> delete foo
+> delete foo
 
   ⚠️
 
@@ -13,22 +13,22 @@ structural type Foo = Foo ()
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> delete foo
+> delete foo
 
   Done.
 
-scratch/main> delete.type Foo
+> delete.type Foo
 
   Done.
 
-scratch/main> delete.term Foo.Foo
+> delete.term Foo.Foo
 
   Done.
 ```

--- a/unison-src/transcripts/idempotent/delete.md
+++ b/unison-src/transcripts/idempotent/delete.md
@@ -1,7 +1,7 @@
 # Delete
 
 ``` ucm :hide
-scratch/main> builtins.merge lib.builtins
+> builtins.merge lib.builtins
 ```
 
 The delete command can delete both terms and types.
@@ -10,7 +10,7 @@ First, let's make sure it complains when we try to delete a name that doesn't
 exist.
 
 ``` ucm :error
-scratch/main> delete.verbose foo
+> delete.verbose foo
 
   ⚠️
 
@@ -27,14 +27,14 @@ structural type Foo = Foo ()
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> delete.verbose foo
+> delete.verbose foo
 
   Removed definitions:
 
@@ -43,7 +43,7 @@ scratch/main> delete.verbose foo
   Tip: You can use `undo` or use a hash from `reflog` to undo
        this change.
 
-scratch/main> delete.verbose Foo
+> delete.verbose Foo
 
   Removed definitions:
 
@@ -52,7 +52,7 @@ scratch/main> delete.verbose Foo
   Tip: You can use `undo` or use a hash from `reflog` to undo
        this change.
 
-scratch/main> delete.verbose Foo.Foo
+> delete.verbose Foo.Foo
 
   Removed definitions:
 
@@ -70,14 +70,14 @@ a.bar = 2
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> debug.alias.term.force a.bar a.foo
+> debug.alias.term.force a.bar a.foo
 
   Done.
 ```
@@ -85,7 +85,7 @@ scratch/main> debug.alias.term.force a.bar a.foo
 A delete should remove both versions of the term.
 
 ``` ucm
-scratch/main> delete.verbose a.foo
+> delete.verbose a.foo
 
   Removed definitions:
 
@@ -100,7 +100,7 @@ scratch/main> delete.verbose a.foo
   Tip: You can use `undo` or use a hash from `reflog` to undo
        this change.
 
-scratch/main> ls a
+> ls a
 
   1. bar (Nat)
 ```
@@ -113,18 +113,18 @@ structural type a.Bar = Bar
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> debug.alias.type.force a.Bar a.Foo
+> debug.alias.type.force a.Bar a.Foo
 
   Done.
 
-scratch/main> delete.verbose a.Foo
+> delete.verbose a.Foo
 
   Removed definitions:
 
@@ -140,7 +140,7 @@ scratch/main> delete.verbose a.Foo
   Tip: You can use `undo` or use a hash from `reflog` to undo
        this change.
 
-scratch/main> delete.verbose a.Foo.Foo
+> delete.verbose a.Foo.Foo
 
   Removed definitions:
 
@@ -158,14 +158,14 @@ structural type foo = Foo ()
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> delete.verbose foo
+> delete.verbose foo
 
   Removed definitions:
 
@@ -175,7 +175,7 @@ scratch/main> delete.verbose foo
   Tip: You can use `undo` or use a hash from `reflog` to undo
        this change.
 
-scratch/main> delete foo.Foo
+> delete foo.Foo
 
   Done.
 ```
@@ -189,14 +189,14 @@ c = "c"
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> delete.verbose a b c
+> delete.verbose a b c
 
   Removed definitions:
 
@@ -218,14 +218,14 @@ c = "c"
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> delete.verbose a b c Foo
+> delete.verbose a b c Foo
 
   Removed definitions:
 
@@ -237,7 +237,7 @@ scratch/main> delete.verbose a b c Foo
   Tip: You can use `undo` or use a hash from `reflog` to undo
        this change.
 
-scratch/main> delete.verbose Foo.Foo
+> delete.verbose Foo.Foo
 
   Removed definitions:
 
@@ -254,14 +254,14 @@ structural type Foo = Foo ()
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> delete.verbose Foo Foo.Foo
+> delete.verbose Foo Foo.Foo
 
   Removed definitions:
 
@@ -282,14 +282,14 @@ d = a + b + c
 ```
 
 ``` ucm :error
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> delete.verbose a b c
+> delete.verbose a b c
 
   ⚠️
 
@@ -312,14 +312,14 @@ h = e + f + g
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> delete.verbose e f g h
+> delete.verbose e f g h
 
   Removed definitions:
 
@@ -343,14 +343,14 @@ incrementFoo = cases
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> delete.verbose Foo Foo.Foo incrementFoo
+> delete.verbose Foo Foo.Foo incrementFoo
 
   Removed definitions:
 
@@ -372,14 +372,14 @@ h = e + f + g
 ```
 
 ``` ucm :error
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> delete.verbose e f gg
+> delete.verbose e f gg
 
   ⚠️
 
@@ -395,14 +395,14 @@ pong _ = 4 Nat.+ !ping
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> delete.verbose ping
+> delete.verbose ping
 
   Removed definitions:
 
@@ -411,7 +411,7 @@ scratch/main> delete.verbose ping
   Tip: You can use `undo` or use a hash from `reflog` to undo
        this change.
 
-scratch/main> view pong
+> view pong
 
   pong : 'Nat
   pong _ =

--- a/unison-src/transcripts/idempotent/dependents-dependencies-debugfile.md
+++ b/unison-src/transcripts/idempotent/dependents-dependencies-debugfile.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ### `debug.file`
@@ -21,7 +21,7 @@ inside.r = d
 ```
 
 ``` ucm
-scratch/main> debug.file
+> debug.file
 
   type inside.M#h37a56c5ep
   type outside.A#6l6krl7n4l
@@ -40,18 +40,18 @@ This will help me make progress in some situations when UCM is being deficient o
 But wait, there's more.  I can check the dependencies and dependents of a definition:
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> dependents q
+> dependents q
 
   q has no dependents.
 
-scratch/main> dependencies q
+> dependencies q
 
   Dependencies of: q
 
@@ -68,7 +68,7 @@ scratch/main> dependencies q
   Tip: Try `view 4` to see the source of any numbered item in
        the above list.
 
-scratch/main> dependencies B
+> dependencies B
 
   Dependencies of: type B, B
 
@@ -80,7 +80,7 @@ scratch/main> dependencies B
   Tip: Try `view 2` to see the source of any numbered item in
        the above list.
 
-scratch/main> dependencies d
+> dependencies d
 
   Dependencies of: d
 
@@ -98,7 +98,7 @@ scratch/main> dependencies d
   Tip: Try `view 5` to see the source of any numbered item in
        the above list.
 
-scratch/main> dependents d
+> dependents d
 
   Dependents of: d
 

--- a/unison-src/transcripts/idempotent/destructuring-binds.md
+++ b/unison-src/transcripts/idempotent/destructuring-binds.md
@@ -1,7 +1,7 @@
 # Destructuring binds
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 Here's a couple examples:
@@ -28,14 +28,14 @@ ex1 tup =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> view ex0 ex1
+> view ex0 ex1
 
   ex0 : Nat -> Nat
   ex0 n =
@@ -115,14 +115,14 @@ ex5a _ = match (99 + 1, "hi") with
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> view ex5 ex5a
+> view ex5 ex5a
 
   ex5 : 'Text
   ex5 _ = match 99 Nat.+ 1 with
@@ -147,14 +147,14 @@ ex6 x = match x with
 For clarity, the pretty-printer leaves this alone, even though in theory it could be written `(x,y) = x; x + y`:
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> view ex6
+> view ex6
 
   ex6 : (Nat, Nat) -> Nat
   ex6 = cases (x, y) -> x Nat.+ y

--- a/unison-src/transcripts/idempotent/doc-formatting.md
+++ b/unison-src/transcripts/idempotent/doc-formatting.md
@@ -3,7 +3,7 @@ This transcript explains a few minor details about doc parsing and pretty-printi
 Docs can be used as inline code comments.
 
 ``` ucm :hide
-scratch/main> builtins.mergeio
+> builtins.mergeio
 ```
 
 ``` unison
@@ -22,11 +22,11 @@ foo n =
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ``` ucm
-scratch/main> view foo
+> view foo
 
   foo : Nat -> Nat
   foo n =
@@ -50,11 +50,11 @@ escaping = {{ Docs look `{{ like {this} }}` }}
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ``` ucm
-scratch/main> view escaping
+> view escaping
 
   escaping : Doc2
   escaping = {{ Docs look `{{ like {this} }}` }}
@@ -81,11 +81,11 @@ commented = {{
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ``` ucm
-scratch/main> view commented
+> view commented
 
   commented : Doc2
   commented =
@@ -116,11 +116,11 @@ doc1 = {{   hi   }}
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ``` ucm
-scratch/main> view doc1
+> view doc1
 
   doc1 : Doc2
   doc1 = {{ hi }}
@@ -148,11 +148,11 @@ doc2 = {{ hello
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ``` ucm
-scratch/main> view doc2
+> view doc2
 
   doc2 : Doc2
   doc2 =
@@ -190,11 +190,11 @@ Note that because of the special treatment of the first line mentioned above, wh
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ``` ucm
-scratch/main> view doc3
+> view doc3
 
   doc3 : Doc2
   doc3 =
@@ -235,11 +235,11 @@ doc4 = {{ Here's another example of some paragraphs.
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ``` ucm
-scratch/main> view doc4
+> view doc4
 
   doc4 : Doc2
   doc4 =
@@ -271,11 +271,11 @@ doc5 = {{   - foo
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ``` ucm
-scratch/main> view doc5
+> view doc5
 
   doc5 : Doc2
   doc5 =
@@ -306,11 +306,11 @@ doc6 = {{
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ``` ucm
-scratch/main> view doc6
+> view doc6
 
   doc6 : Doc2
   doc6 =
@@ -341,11 +341,11 @@ expr = foo 1
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ``` ucm
-scratch/main> view empty
+> view empty
 
   empty : Doc2
   empty = {{  }}
@@ -404,11 +404,11 @@ para line lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolo
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ``` ucm
-scratch/main> view test1
+> view test1
 
   test1 : Doc2
   test1 =
@@ -493,11 +493,11 @@ reg1363 = {{ `{List.take} foo` bar
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ``` ucm
-scratch/main> view reg1363
+> view reg1363
 
   reg1363 : Doc2
   reg1363 = {{ `{List.take} foo` bar baz }}
@@ -523,13 +523,13 @@ test2 = {{
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 View is fine.
 
 ``` ucm
-scratch/main> view test2
+> view test2
 
   test2 : Doc2
   test2 =
@@ -543,7 +543,7 @@ scratch/main> view test2
 But note it's not obvious how display should best be handling this.  At the moment it just does the simplest thing:
 
 ``` ucm
-scratch/main> display test2
+> display test2
 
   Take a look at this:
 

--- a/unison-src/transcripts/idempotent/doc-type-link-keywords.md
+++ b/unison-src/transcripts/idempotent/doc-type-link-keywords.md
@@ -7,7 +7,7 @@ not the ability `Patterns`; the lexer should see this as a single identifier.
 See https://github.com/unisonweb/unison/issues/2642 for an example.
 
 ``` ucm :hide
-scratch/main> builtins.mergeio
+> builtins.mergeio
 ```
 
 ``` unison :hide
@@ -28,25 +28,25 @@ docs.example4 = {{A doc that links to the {type Labels} type}}
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 Now we check that each doc links to the object of the correct name:
 
 ``` ucm
-scratch/main> display docs.example1
+> display docs.example1
 
   A doc that links to the abilityPatterns term
 
-scratch/main> display docs.example2
+> display docs.example2
 
   A doc that links to the Patterns ability
 
-scratch/main> display docs.example3
+> display docs.example3
 
   A doc that links to the typeLabels term
 
-scratch/main> display docs.example4
+> display docs.example4
 
   A doc that links to the Labels type
 ```

--- a/unison-src/transcripts/idempotent/doc1.md
+++ b/unison-src/transcripts/idempotent/doc1.md
@@ -1,13 +1,13 @@
 # Documenting Unison code
 
 ``` ucm :hide
-scratch/main> builtins.mergeio lib.builtins
+> builtins.mergeio lib.builtins
 ```
 
 Unison documentation is written in Unison. Documentation is a value of the following type:
 
 ``` ucm
-scratch/main> view lib.builtins.Doc
+> view lib.builtins.Doc
 
   type lib.builtins.Doc
     = Blob Text
@@ -79,7 +79,7 @@ take 2 [1,2,3,4,5]
 Let's add it to the codebase.
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -90,7 +90,7 @@ scratch/main> add
 We can view it with `docs`, which shows the `Doc` value that is associated with a definition.
 
 ``` ucm
-scratch/main> docs List.take
+> docs List.take
 
   `List.take n xs` returns the first `n` elements of `xs`. (No
   need to add line breaks manually. The display command will do
@@ -111,7 +111,7 @@ scratch/main> docs List.take
 Note that if we view the source of the documentation, the various references are *not* expanded.
 
 ``` ucm
-scratch/main> view List.take
+> view List.take
 
   builtin lib.builtins.List.take :
     lib.builtins.Nat -> [a] -> [a]

--- a/unison-src/transcripts/idempotent/doc2.md
+++ b/unison-src/transcripts/idempotent/doc2.md
@@ -1,7 +1,7 @@
 # Test parsing and round-trip of doc2 syntax elements
 
 ``` ucm :hide
-scratch/main> builtins.mergeio
+> builtins.mergeio
 ```
 
 ``` unison :hide
@@ -114,7 +114,7 @@ Inline '' text literal with 1 space of padding '' in the middle of a sentence.
 Format it to check that everything pretty-prints in a valid way.
 
 ``` ucm
-scratch/main> debug.format
+> debug.format
 ```
 
 ``` unison :added-by-ucm scratch.u

--- a/unison-src/transcripts/idempotent/doc2markdown.md
+++ b/unison-src/transcripts/idempotent/doc2markdown.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.mergeio
+> builtins.mergeio
 ```
 
 ``` unison :hide
@@ -86,11 +86,11 @@ Table
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ```` ucm
-scratch/main> debug.doc-to-markdown fulldoc
+> debug.doc-to-markdown fulldoc
 
   Heres some text with a soft line break
 

--- a/unison-src/transcripts/idempotent/duplicate-names.md
+++ b/unison-src/transcripts/idempotent/duplicate-names.md
@@ -1,7 +1,7 @@
 # Duplicate names in scratch file.
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 Term and ability constructor collisions should cause a parse error.
@@ -114,14 +114,14 @@ X = ()
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> view X
+> view X
 
   structural type X = Z
 

--- a/unison-src/transcripts/idempotent/duplicate-term-detection.md
+++ b/unison-src/transcripts/idempotent/duplicate-term-detection.md
@@ -1,7 +1,7 @@
 # Duplicate Term Detection
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 Trivial duplicate terms should be detected:

--- a/unison-src/transcripts/idempotent/ed25519.md
+++ b/unison-src/transcripts/idempotent/ed25519.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison

--- a/unison-src/transcripts/idempotent/edit-command.md
+++ b/unison-src/transcripts/idempotent/edit-command.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison
@@ -21,14 +21,14 @@ mytest = [Ok "ok"]
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> edit.new foo bar
+> edit.new foo bar
 
   ☝️
 
@@ -37,7 +37,7 @@ scratch/main> edit.new foo bar
   You can edit them there, then run `update` to replace the
   definitions currently in this namespace.
 
-scratch/main> edit.new mytest
+> edit.new mytest
 
   ☝️
 
@@ -60,7 +60,7 @@ test> mytest = [Ok "ok"]
 ```
 
 ``` ucm :error
-scratch/main> edit.new missing
+> edit.new missing
 
   ⚠️
 
@@ -69,7 +69,7 @@ scratch/main> edit.new missing
 ```
 
 ``` ucm :hide
-scratch/main> project.delete scratch
+> project.delete scratch
 ```
 
 # `edit`
@@ -105,7 +105,7 @@ baz = 19
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -125,7 +125,7 @@ bar = 18
 ```
 
 ``` ucm
-scratch/main> edit bar baz
+> edit bar baz
 
   ☝️
 
@@ -141,5 +141,5 @@ baz = 19
 ```
 
 ``` ucm :hide
-scratch/main> project.delete scratch
+> project.delete scratch
 ```

--- a/unison-src/transcripts/idempotent/edit-dependents-command.md
+++ b/unison-src/transcripts/idempotent/edit-dependents-command.md
@@ -4,7 +4,7 @@ The `edit.dependents` command is like `edit`, but it adds a definition and all o
 (being careful not to add anything that's already there).
 
 ``` ucm :hide
-scratch/main> builtins.mergeio lib.builtin
+> builtins.mergeio lib.builtin
 ```
 
 ``` unison
@@ -30,7 +30,7 @@ baz x = x
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -60,7 +60,7 @@ type Bar = { bar : Nat }
 ```
 
 ``` ucm
-scratch/main> edit.dependents Foo
+> edit.dependents Foo
 
   Loading branch...
 
@@ -84,5 +84,5 @@ baz x = x
 ```
 
 ``` ucm :hide
-scratch/main> project.delete scratch
+> project.delete scratch
 ```

--- a/unison-src/transcripts/idempotent/edit-namespace.md
+++ b/unison-src/transcripts/idempotent/edit-namespace.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-project/main> builtins.mergeio lib.builtin
+> builtins.mergeio lib.builtin
 ```
 
 ``` unison
@@ -45,7 +45,7 @@ unique type Foo = { bar : Nat, baz : Nat }
 ```
 
 ``` ucm
-project/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -56,7 +56,7 @@ project/main> add
 `edit.namespace` edits the whole namespace (minus the top-level `lib`).
 
 ``` ucm
-project/main> edit.namespace .
+> edit.namespace .
 
   ☝️
 
@@ -98,7 +98,7 @@ toplevel = "hi"
 `edit.namespace` can also accept explicit paths
 
 ``` ucm
-project/main> edit.namespace nested simple
+> edit.namespace nested simple
 
   ☝️
 

--- a/unison-src/transcripts/idempotent/empty-namespaces.md
+++ b/unison-src/transcripts/idempotent/empty-namespaces.md
@@ -5,21 +5,21 @@ mynamespace.x = 1
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 
-scratch/main> delete.namespace mynamespace
+> delete.namespace mynamespace
 ```
 
 The deleted namespace shouldn't appear in `ls` output.
 
 ``` ucm :error
-scratch/main> ls .
+> ls .
 
   nothing to show
 ```
 
 ``` ucm :error
-scratch/main> find.verbose
+> find.verbose
 
   ☝️
 
@@ -36,7 +36,7 @@ scratch/main> find.verbose
 ```
 
 ``` ucm :error
-scratch/main> find mynamespace
+> find mynamespace
 
   ☝️
 
@@ -57,7 +57,7 @@ scratch/main> find mynamespace
 The history of the namespace should be empty.
 
 ``` ucm
-scratch/main> history mynamespace
+> history mynamespace
 
   Note: The most recent namespace hash is immediately below this
         message.
@@ -75,9 +75,9 @@ stuff.thing = 2
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 
-scratch/main> delete.namespace deleted
+> delete.namespace deleted
 ```
 
 ## fork
@@ -85,7 +85,7 @@ scratch/main> delete.namespace deleted
 I should be allowed to fork over a deleted namespace
 
 ``` ucm
-scratch/main> fork stuff deleted
+> fork stuff deleted
 
   Done.
 ```
@@ -93,7 +93,7 @@ scratch/main> fork stuff deleted
 The history from the `deleted` namespace should have been overwritten by the history from `stuff`.
 
 ``` ucm
-scratch/main> history stuff
+> history stuff
 
   Note: The most recent namespace hash is immediately below this
         message.
@@ -102,7 +102,7 @@ scratch/main> history stuff
 
   □ 1. #q2dq4tsno1 (start of history)
 
-scratch/main> history deleted
+> history deleted
 
   Note: The most recent namespace hash is immediately below this
         message.
@@ -120,18 +120,18 @@ moveme.y = 2
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 I should be able to move a namespace over-top of a deleted namespace.
 The history should be that of the moved namespace.
 
 ``` ucm
-scratch/main> delete.namespace moveoverme
+> delete.namespace moveoverme
 
   Done.
 
-scratch/main> history moveme
+> history moveme
 
   Note: The most recent namespace hash is immediately below this
         message.
@@ -140,11 +140,11 @@ scratch/main> history moveme
 
   □ 1. #c5uisu4kll (start of history)
 
-scratch/main> move.namespace moveme moveoverme
+> move.namespace moveme moveoverme
 
   Done.
 
-scratch/main> history moveoverme
+> history moveoverme
 
   Note: The most recent namespace hash is immediately below this
         message.

--- a/unison-src/transcripts/idempotent/emptyCodebase.md
+++ b/unison-src/transcripts/idempotent/emptyCodebase.md
@@ -7,7 +7,7 @@ Not even `Nat` or `+`\!
 BEHOLD\!\!\!
 
 ``` ucm :error
-scratch/main> ls .
+> ls .
 
   nothing to show
 ```
@@ -15,11 +15,11 @@ scratch/main> ls .
 Technically, the definitions all exist, but they have no names. `builtins.merge` brings them into existence, under the current namespace:
 
 ``` ucm
-scratch/main> builtins.merge lib.builtins
+> builtins.merge lib.builtins
 
   Done.
 
-scratch/main> ls lib
+> ls lib
 
   1. builtins/ (582 terms, 100 types)
 ```
@@ -27,11 +27,11 @@ scratch/main> ls lib
 And for a limited time, you can get even more builtin goodies:
 
 ``` ucm
-scratch/main> builtins.mergeio lib.builtinsio
+> builtins.mergeio lib.builtinsio
 
   Done.
 
-scratch/main> ls lib
+> ls lib
 
   1. builtins/   (582 terms, 100 types)
   2. builtinsio/ (755 terms, 118 types)

--- a/unison-src/transcripts/idempotent/error-messages.md
+++ b/unison-src/transcripts/idempotent/error-messages.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 This file contains programs with parse errors and type errors, for visual inspection of error message quality and to check for regressions or changes to error reporting.

--- a/unison-src/transcripts/idempotent/find-by-type.md
+++ b/unison-src/transcripts/idempotent/find-by-type.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> alias.type ##Text builtin.Text
+> alias.type ##Text builtin.Text
 ```
 
 ``` unison :hide
@@ -17,29 +17,29 @@ baz = cases
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> find : Text -> A
+> find : Text -> A
 
   1. bar : Text -> A
   2. A.A : Text -> A
 
-scratch/main> find : A -> Text
+> find : A -> Text
 
   1. baz : A -> Text
 
-scratch/main> find : A
+> find : A
 
   1. foo : A
 ```
 
 ``` ucm :error
-scratch/main> find : Text
+> find : Text
 
   ☝️
 

--- a/unison-src/transcripts/idempotent/find-command.md
+++ b/unison-src/transcripts/idempotent/find-command.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge lib.builtin
+> builtins.merge lib.builtin
 ```
 
 ``` unison :hide
@@ -13,49 +13,49 @@ somewhere.bar = 7
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ``` ucm
-scratch/main> find foo
+> find foo
 
   1. cat.foo : Nat
   2. foo : Nat
 
-scratch/main> view 1
+> view 1
 
   cat.foo : Nat
   cat.foo = 4
 
-scratch/main> find.all foo
+> find.all foo
 
   1. cat.foo : Nat
   2. cat.lib.foo : Nat
   3. lib.foo : Nat
   4. foo : Nat
 
-scratch/main> view 1
+> view 1
 
   cat.foo : Nat
   cat.foo = 4
 ```
 
 ``` ucm
-scratch/main> find-in cat foo
+> find-in cat foo
 
   1. foo : Nat
 
-scratch/main> view 1
+> view 1
 
   cat.foo : Nat
   cat.foo = 4
 
-scratch/main> find-in.all cat foo
+> find-in.all cat foo
 
   1. lib.foo : Nat
   2. foo : Nat
 
-scratch/main> view 1
+> view 1
 
   cat.lib.foo : Nat
   cat.lib.foo = 5
@@ -64,11 +64,11 @@ scratch/main> view 1
 Finding within a namespace
 
 ``` ucm
-scratch/main> find bar
+> find bar
 
   1. somewhere.bar : Nat
 
-scratch/other> debug.find.global bar
+> debug.find.global bar
 
   Found results in scratch/main
 
@@ -76,13 +76,13 @@ scratch/other> debug.find.global bar
   2. .lib.bar : Nat
   3. .somewhere.bar : Nat
 
-scratch/main> find-in somewhere bar
+> find-in somewhere bar
 
   1. bar : Nat
 ```
 
 ``` ucm :error
-scratch/main> find baz
+> find baz
 
   ☝️
 

--- a/unison-src/transcripts/idempotent/fix-1381-excess-propagate.md
+++ b/unison-src/transcripts/idempotent/fix-1381-excess-propagate.md
@@ -8,7 +8,7 @@ X.foo = "a namespace"
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -23,7 +23,7 @@ a = "an update"
 ```
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -34,7 +34,7 @@ scratch/main> update
 As of the time of this writing, the history for `X` should be a single node, `#4eeuo5bsfr`;
 
 ``` ucm
-scratch/main> history X
+> history X
 
   Note: The most recent namespace hash is immediately below this
         message.
@@ -47,7 +47,7 @@ scratch/main> history X
 however, as of release/M1i, we saw an extraneous node appear.  If your `ucm` is fixed, you won't see it below:
 
 ``` ucm :error
-scratch/main> history #7nl6ppokhg
+> history #7nl6ppokhg
 
   😶
 

--- a/unison-src/transcripts/idempotent/fix-2258-if-as-list-element.md
+++ b/unison-src/transcripts/idempotent/fix-2258-if-as-list-element.md
@@ -1,7 +1,7 @@
 Tests that `if` statements can appear as list and tuple elements.
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison :hide

--- a/unison-src/transcripts/idempotent/fix-3982.md
+++ b/unison-src/transcripts/idempotent/fix-3982.md
@@ -1,5 +1,5 @@
 ``` ucm
-scratch/main> builtins.mergeio lib.builtin
+> builtins.mergeio lib.builtin
 
   Done.
 ```

--- a/unison-src/transcripts/idempotent/fix-4536.md
+++ b/unison-src/transcripts/idempotent/fix-4536.md
@@ -1,5 +1,5 @@
 ``` ucm
-scratch/main> builtins.merge lib.builtin
+> builtins.merge lib.builtin
 
   Done.
 ```

--- a/unison-src/transcripts/idempotent/fix-5267.md
+++ b/unison-src/transcripts/idempotent/fix-5267.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge lib.builtin
+> builtins.merge lib.builtin
 ```
 
 ``` unison
@@ -24,14 +24,14 @@ Here, `bar` renders as `foo + foo`, even though there are two names with suffix 
 indirect dependency. It used to render as `direct.foo + direct.foo`.
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> view bar
+> view bar
 
   bar : Nat
   bar =
@@ -59,14 +59,14 @@ type Bar = MkBar direct.Foo
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> view Bar
+> view Bar
 
   type Bar = MkBar Foo
 ```

--- a/unison-src/transcripts/idempotent/fix-5301.md
+++ b/unison-src/transcripts/idempotent/fix-5301.md
@@ -2,7 +2,7 @@ This transcripts demonstrates that pattern matching on a "constructor" (defined 
 letter) that is either not found or ambiguouus fails. Previously, it would be treated as a variable binding.
 
 ``` ucm
-scratch/main> builtins.merge
+> builtins.merge
 
   Done.
 ```

--- a/unison-src/transcripts/idempotent/fix-5312.md
+++ b/unison-src/transcripts/idempotent/fix-5312.md
@@ -2,7 +2,7 @@ This transcript demonstrates that dependents of an update are suffixified proper
 render as `c = y + 1` (ambiguous).
 
 ``` ucm
-scratch/main> builtins.merge lib.builtin
+> builtins.merge lib.builtin
 
   Done.
 ```
@@ -28,7 +28,7 @@ c = b.y + 1
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -51,7 +51,7 @@ x = 100
 ```
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/fix-5320.md
+++ b/unison-src/transcripts/idempotent/fix-5320.md
@@ -1,5 +1,5 @@
 ``` ucm
-scratch/main> builtins.merge lib.builtin
+> builtins.merge lib.builtin
 
   Done.
 ```

--- a/unison-src/transcripts/idempotent/fix-5323.md
+++ b/unison-src/transcripts/idempotent/fix-5323.md
@@ -2,7 +2,7 @@ This transcript demonstrates that dependents of an upgrade are suffixified prope
 render as `c = y + 1` (ambiguous).
 
 ``` ucm
-scratch/main> builtins.merge lib.builtin
+> builtins.merge lib.builtin
 
   Done.
 ```
@@ -30,7 +30,7 @@ c = b.y + 1
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -39,7 +39,7 @@ scratch/main> add
 ```
 
 ``` ucm
-scratch/main> upgrade old new
+> upgrade old new
 
   I upgraded old to new, and removed old.
 ```

--- a/unison-src/transcripts/idempotent/fix-5340.md
+++ b/unison-src/transcripts/idempotent/fix-5340.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge lib.builtin
+> builtins.merge lib.builtin
 ```
 
 ``` unison
@@ -23,7 +23,7 @@ lib.dep.lib.dep.foo = 18
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/fix-5354.md
+++ b/unison-src/transcripts/idempotent/fix-5354.md
@@ -1,5 +1,5 @@
 ``` ucm
-scratch/main> builtins.mergeio
+> builtins.mergeio
 
   Done.
 ```
@@ -30,7 +30,7 @@ foo = 42
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/fix-5357.md
+++ b/unison-src/transcripts/idempotent/fix-5357.md
@@ -18,7 +18,7 @@ foo =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -41,14 +41,14 @@ lib.base.ignore _ = ()
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> edit.namespace .
+> edit.namespace .
 
   ☝️
 
@@ -57,7 +57,7 @@ scratch/main> edit.namespace .
   You can edit them there, then run `update` to replace the
   definitions currently in this namespace.
 
-scratch/main> load
+> load
 
   Loading changes detected in scratch.u.
 

--- a/unison-src/transcripts/idempotent/fix-5369.md
+++ b/unison-src/transcripts/idempotent/fix-5369.md
@@ -1,5 +1,5 @@
 ``` ucm
-scratch/main> builtins.merge
+> builtins.merge
 
   Done.
 ```
@@ -22,7 +22,7 @@ two.foo = "blah"
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/fix-5374.md
+++ b/unison-src/transcripts/idempotent/fix-5374.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge lib.builtin
+> builtins.merge lib.builtin
 ```
 
 ``` unison
@@ -20,14 +20,14 @@ thing = indirect.foo + indirect.foo
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> view thing
+> view thing
 
   thing : Nat
   thing =
@@ -35,7 +35,7 @@ scratch/main> view thing
     use indirect foo
     foo + foo
 
-scratch/main> edit.new thing
+> edit.new thing
 
   ☝️
 

--- a/unison-src/transcripts/idempotent/fix-5380.md
+++ b/unison-src/transcripts/idempotent/fix-5380.md
@@ -1,5 +1,5 @@
 ``` ucm
-scratch/main> builtins.merge lib.builtin
+> builtins.merge lib.builtin
 
   Done.
 ```
@@ -25,18 +25,18 @@ bar =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> move.term foo qux
+> move.term foo qux
 
   Done.
 
-scratch/main> view bar
+> view bar
 
   bar : Nat
   bar =

--- a/unison-src/transcripts/idempotent/fix-5427.md
+++ b/unison-src/transcripts/idempotent/fix-5427.md
@@ -1,7 +1,7 @@
 # Issue 1
 
 ``` ucm
-scratch/main> builtins.merge lib.builtin
+> builtins.merge lib.builtin
 
   Done.
 ```
@@ -28,14 +28,14 @@ bar =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> view bar
+> view bar
 
   bar : Nat
   bar =
@@ -46,13 +46,13 @@ scratch/main> view bar
 ```
 
 ``` ucm :hide
-scratch/main> delete.project scratch
+> delete.project scratch
 ```
 
 # Issue 2
 
 ``` ucm
-scratch/main> builtins.merge lib.builtin
+> builtins.merge lib.builtin
 
   Done.
 ```
@@ -81,7 +81,7 @@ baz = foo + foo
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -113,7 +113,7 @@ bar =
 Previously, `bar` would incorrectly print with a `foo = foo` line. Now, it works.
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -124,7 +124,7 @@ scratch/main> update
 
   Done.
 
-scratch/main> view bar
+> view bar
 
   bar : Nat
   bar =

--- a/unison-src/transcripts/idempotent/fix-5433.md
+++ b/unison-src/transcripts/idempotent/fix-5433.md
@@ -1,7 +1,7 @@
 This used to cause a "duplicate effects" error because we weren't de-duping ability lists after binding names.
 
 ``` ucm :hide
-scratch/main> builtins.merge lib.builtin
+> builtins.merge lib.builtin
 ```
 
 ``` unison
@@ -18,7 +18,7 @@ ability foo.Bar where
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/fix-5446.md
+++ b/unison-src/transcripts/idempotent/fix-5446.md
@@ -1,7 +1,7 @@
 Previously `delete.namespace` would refuse to delete a namespace if it would leave any nameless references in `lib`.
 
 ``` ucm :hide
-scratch/main> builtins.merge lib.builtin
+> builtins.merge lib.builtin
 ```
 
 ``` unison
@@ -19,7 +19,7 @@ lib.two.bar = foo Nat.+ foo
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -28,7 +28,7 @@ scratch/main> add
 ```
 
 ``` ucm
-scratch/main> delete.namespace lib.one
+> delete.namespace lib.one
 
   Done.
 ```

--- a/unison-src/transcripts/idempotent/fix-5464.md
+++ b/unison-src/transcripts/idempotent/fix-5464.md
@@ -1,5 +1,5 @@
 ``` ucm
-scratch/main> builtins.merge lib.builtin
+> builtins.merge lib.builtin
 
   Done.
 ```
@@ -28,7 +28,7 @@ qux = foo + foo
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -62,7 +62,7 @@ This update used to fail because `foo` would incorrectly print with a `use bar b
 to `bar.baz` to be captured by its locally-bound `baz`.
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/fix-5489.md
+++ b/unison-src/transcripts/idempotent/fix-5489.md
@@ -12,7 +12,7 @@ type Foo = Foo
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/fix-5575.md
+++ b/unison-src/transcripts/idempotent/fix-5575.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge lib.builtin
+> builtins.merge lib.builtin
 ```
 
 A first `:error` block works as expected.

--- a/unison-src/transcripts/idempotent/fix-annotated-lambdas.md
+++ b/unison-src/transcripts/idempotent/fix-annotated-lambdas.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 Tests an erroneous lambda floating case involving annotations.
@@ -23,7 +23,7 @@ bar k = k (x -> x)
 ```
 
 ``` ucm
-scratch/main> display foo
+> display foo
 
   x -> bar (f -> f x)
 ```

--- a/unison-src/transcripts/idempotent/fix-big-list-crash.md
+++ b/unison-src/transcripts/idempotent/fix-big-list-crash.md
@@ -1,7 +1,7 @@
 #### Big list crash
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 Big lists have been observed to crash, while in the garbage collection step.

--- a/unison-src/transcripts/idempotent/fix-ls.md
+++ b/unison-src/transcripts/idempotent/fix-ls.md
@@ -1,5 +1,5 @@
 ``` ucm
-test-ls/main> builtins.merge
+> builtins.merge
 
   Done.
 ```
@@ -20,18 +20,18 @@ foo.bar.subtract x y = x Int.- y
 ```
 
 ``` ucm
-test-ls/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-test-ls/main> ls foo
+> ls foo
 
   1. bar/ (2 terms)
 
-test-ls/main> ls 1
+> ls 1
 
   1. add      (Int -> Int -> Int)
   2. subtract (Int -> Int -> Int)

--- a/unison-src/transcripts/idempotent/fix-pattern-capture.md
+++ b/unison-src/transcripts/idempotent/fix-pattern-capture.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 Checks a case that was resulting in variable capture when compiling

--- a/unison-src/transcripts/idempotent/fix1063.md
+++ b/unison-src/transcripts/idempotent/fix1063.md
@@ -1,7 +1,7 @@
 Tests that functions named `.` are rendered correctly.
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison
@@ -22,14 +22,14 @@ noop = not `.` not
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> view noop
+> view noop
 
   noop : Boolean -> Boolean
   noop =

--- a/unison-src/transcripts/idempotent/fix1327.md
+++ b/unison-src/transcripts/idempotent/fix1327.md
@@ -18,19 +18,19 @@ bar = 5
 Now `ls` returns a pair of the absolute search directory and the result relative to that search directory, so it can be used in both absolute and relative contexts.
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> ls .
+> ls .
 
   1. bar (##Nat)
   2. foo (##Nat)
 
-scratch/main> alias.many 1-2 .ns1_nohistory
+> alias.many 1-2 .ns1_nohistory
 
   Here's what changed in .ns1_nohistory :
 

--- a/unison-src/transcripts/idempotent/fix1334.md
+++ b/unison-src/transcripts/idempotent/fix1334.md
@@ -5,11 +5,11 @@ With this PR, the source of an alias can be a short hash (even of a definition t
 Let's make some hash-only aliases, now that we can. :mad-with-power-emoji:
 
 ``` ucm
-scratch/main> alias.type ##Nat Cat
+> alias.type ##Nat Cat
 
   Done.
 
-scratch/main> alias.term ##Nat.+ please_fix_763.+
+> alias.term ##Nat.+ please_fix_763.+
 
   Done.
 ```

--- a/unison-src/transcripts/idempotent/fix1390.md
+++ b/unison-src/transcripts/idempotent/fix1390.md
@@ -1,5 +1,5 @@
 ``` ucm
-scratch/main> builtins.merge
+> builtins.merge
 
   Done.
 ```
@@ -22,14 +22,14 @@ List.map f =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> view List.map
+> view List.map
 
   List.map : (i ->{g} o) -> [i] ->{g} [o]
   List.map f =

--- a/unison-src/transcripts/idempotent/fix1421.md
+++ b/unison-src/transcripts/idempotent/fix1421.md
@@ -1,9 +1,9 @@
 ``` ucm
-scratch/main> alias.type ##Nat Nat
+> alias.type ##Nat Nat
 
   Done.
 
-scratch/main> alias.term ##Nat.+ Nat.+
+> alias.term ##Nat.+ Nat.+
 
   Done.
 ```

--- a/unison-src/transcripts/idempotent/fix1532.md
+++ b/unison-src/transcripts/idempotent/fix1532.md
@@ -1,5 +1,5 @@
 ``` ucm
-scratch/main> builtins.merge
+> builtins.merge
 
   Done.
 ```
@@ -23,7 +23,7 @@ bar.z = x + y
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -34,7 +34,7 @@ scratch/main> add
 Let's see what we have created...
 
 ``` ucm
-scratch/main> ls .
+> ls .
 
   1. bar/     (1 term)
   2. builtin/ (582 terms, 100 types)
@@ -44,7 +44,7 @@ scratch/main> ls .
 Now, if we try deleting the namespace `foo`, we get an error, as expected.
 
 ``` ucm :error
-scratch/main> delete.namespace foo
+> delete.namespace foo
 
   ⚠️
 
@@ -63,7 +63,7 @@ scratch/main> delete.namespace foo
 Any numbered arguments should refer to `bar.z`.
 
 ``` ucm
-scratch/main> debug.numberedArgs
+> debug.numberedArgs
 
   1. bar.z
   2. bar.z
@@ -72,11 +72,11 @@ scratch/main> debug.numberedArgs
 We can then delete the dependent term, and then delete `foo`.
 
 ``` ucm
-scratch/main> delete.term 1
+> delete.term 1
 
   Done.
 
-scratch/main> delete.namespace foo
+> delete.namespace foo
 
   Done.
 ```

--- a/unison-src/transcripts/idempotent/fix1696.md
+++ b/unison-src/transcripts/idempotent/fix1696.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison :error

--- a/unison-src/transcripts/idempotent/fix1709.md
+++ b/unison-src/transcripts/idempotent/fix1709.md
@@ -16,7 +16,7 @@ id2 x =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/fix1731.md
+++ b/unison-src/transcripts/idempotent/fix1731.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison :hide
@@ -9,7 +9,7 @@ structural ability CLI where
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 The `input` here should parse as a wildcard, not as `CLI.input`.

--- a/unison-src/transcripts/idempotent/fix1800.md
+++ b/unison-src/transcripts/idempotent/fix1800.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison :hide
@@ -25,34 +25,34 @@ Testing a few variations here:
   - Should be able to run annotated and unannotated main functions from the codebase.
 
 ``` ucm
-scratch/main> run main1
+> run main1
 
   ()
 
-scratch/main> run main2
+> run main2
 
   ()
 
-scratch/main> run main3
+> run main3
 
   ()
 
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> rename.term main1 code.main1
+> rename.term main1 code.main1
 
   Done.
 
-scratch/main> rename.term main2 code.main2
+> rename.term main2 code.main2
 
   Done.
 
-scratch/main> rename.term main3 code.main3
+> rename.term main3 code.main3
 
   Done.
 ```
@@ -60,15 +60,15 @@ scratch/main> rename.term main3 code.main3
 The renaming just ensures that when running `code.main1`, it has to get that main from the codebase rather than the scratch file:
 
 ``` ucm
-scratch/main> run code.main1
+> run code.main1
 
   ()
 
-scratch/main> run code.main2
+> run code.main2
 
   ()
 
-scratch/main> run code.main3
+> run code.main3
 
   ()
 ```
@@ -86,7 +86,7 @@ main5 _ = ()
 This shouldn't work since `main4` and `main5` don't have the right type.
 
 ``` ucm :error
-scratch/main> run main4
+> run main4
 
   😶
 
@@ -100,7 +100,7 @@ scratch/main> run main4
 ```
 
 ``` ucm :error
-scratch/main> run main5
+> run main5
 
   😶
 

--- a/unison-src/transcripts/idempotent/fix1926.md
+++ b/unison-src/transcripts/idempotent/fix1926.md
@@ -1,5 +1,5 @@
 ``` ucm
-scratch/main> builtins.merge
+> builtins.merge
 
   Done.
 ```

--- a/unison-src/transcripts/idempotent/fix2026.md
+++ b/unison-src/transcripts/idempotent/fix2026.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.mergeio
+> builtins.mergeio
 ```
 
 ``` unison
@@ -61,7 +61,7 @@ Exception.unsafeRun! e _ =
 ```
 
 ``` ucm
-scratch/main> run ex
+> run ex
 
   ()
 ```

--- a/unison-src/transcripts/idempotent/fix2027.md
+++ b/unison-src/transcripts/idempotent/fix2027.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison
@@ -72,7 +72,7 @@ myServer = unsafeRun! '(hello "127.0.0.1" "0")
 ```
 
 ``` ucm :error
-scratch/main> run myServer
+> run myServer
 
   💔💥
 

--- a/unison-src/transcripts/idempotent/fix2049.md
+++ b/unison-src/transcripts/idempotent/fix2049.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison
@@ -111,14 +111,14 @@ tests _ =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test tests
+> io.test tests
 
     New test results:
 

--- a/unison-src/transcripts/idempotent/fix2053.md
+++ b/unison-src/transcripts/idempotent/fix2053.md
@@ -1,9 +1,9 @@
 ``` ucm :hide
-scratch/main> builtins.mergeio
+> builtins.mergeio
 ```
 
 ``` ucm
-scratch/main> display List.map
+> display List.map
 
   f a ->
     let

--- a/unison-src/transcripts/idempotent/fix2156.md
+++ b/unison-src/transcripts/idempotent/fix2156.md
@@ -2,7 +2,7 @@ Tests for a case where bad eta reduction was causing erroneous watch
 output/caching.
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison

--- a/unison-src/transcripts/idempotent/fix2167.md
+++ b/unison-src/transcripts/idempotent/fix2167.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 This is just a simple transcript to regression check an ability

--- a/unison-src/transcripts/idempotent/fix2187.md
+++ b/unison-src/transcripts/idempotent/fix2187.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison

--- a/unison-src/transcripts/idempotent/fix2231.md
+++ b/unison-src/transcripts/idempotent/fix2231.md
@@ -7,7 +7,7 @@ the choices may not work equally well with the type checking
 strategies.
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison
@@ -36,7 +36,7 @@ txt = foldl (Text.++) "" ["a", "b", "c"]
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/fix2238.md
+++ b/unison-src/transcripts/idempotent/fix2238.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.mergeio
+> builtins.mergeio
 ```
 
 This should not typecheck - the inline `@eval` expression uses abilities.

--- a/unison-src/transcripts/idempotent/fix2244.md
+++ b/unison-src/transcripts/idempotent/fix2244.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.mergeio
+> builtins.mergeio
 ```
 
 Ensure closing token is emitted by closing brace in doc eval block.
@@ -26,5 +26,5 @@ let
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```

--- a/unison-src/transcripts/idempotent/fix2268.md
+++ b/unison-src/transcripts/idempotent/fix2268.md
@@ -3,7 +3,7 @@ inferred types that didn't contain arrows, so effects that just yield
 a value weren't getting disambiguated.
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison

--- a/unison-src/transcripts/idempotent/fix2334.md
+++ b/unison-src/transcripts/idempotent/fix2334.md
@@ -2,7 +2,7 @@ Tests an issue where pattern matching matrices involving built-in
 types was discarding default cases in some branches.
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison

--- a/unison-src/transcripts/idempotent/fix2344.md
+++ b/unison-src/transcripts/idempotent/fix2344.md
@@ -4,7 +4,7 @@ The binds were causing some sequences of lets to be unnecessarily
 recursive.
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison

--- a/unison-src/transcripts/idempotent/fix2353.md
+++ b/unison-src/transcripts/idempotent/fix2353.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison

--- a/unison-src/transcripts/idempotent/fix2354.md
+++ b/unison-src/transcripts/idempotent/fix2354.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 Tests that delaying an un-annotated higher-rank type gives a normal

--- a/unison-src/transcripts/idempotent/fix2355.md
+++ b/unison-src/transcripts/idempotent/fix2355.md
@@ -1,7 +1,7 @@
 Tests for a loop that was previously occurring in the type checker.
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison :error

--- a/unison-src/transcripts/idempotent/fix2378.md
+++ b/unison-src/transcripts/idempotent/fix2378.md
@@ -3,7 +3,7 @@ checking wanted vs. provided abilities. It was necessary to re-check
 rows until a fixed point is reached.
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison

--- a/unison-src/transcripts/idempotent/fix2423.md
+++ b/unison-src/transcripts/idempotent/fix2423.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison

--- a/unison-src/transcripts/idempotent/fix2474.md
+++ b/unison-src/transcripts/idempotent/fix2474.md
@@ -19,7 +19,7 @@ should be typed in the following way:
     the ability that contains `e`.
 
 ``` ucm
-scratch/main> builtins.merge
+> builtins.merge
 
   Done.
 ```

--- a/unison-src/transcripts/idempotent/fix2628.md
+++ b/unison-src/transcripts/idempotent/fix2628.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> alias.type ##Nat lib.base.Nat
+> alias.type ##Nat lib.base.Nat
 ```
 
 ``` unison :hide
@@ -9,14 +9,14 @@ unique type foo.bar.baz.MyRecord = {
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> find : Nat -> MyRecord
+> find : Nat -> MyRecord
 
   1. foo.bar.baz.MyRecord.MyRecord : Nat -> MyRecord
 ```

--- a/unison-src/transcripts/idempotent/fix2663.md
+++ b/unison-src/transcripts/idempotent/fix2663.md
@@ -9,7 +9,7 @@ T p1 p3 p3
 and z would end up referring to the first p3 rather than the second.
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison

--- a/unison-src/transcripts/idempotent/fix2693.md
+++ b/unison-src/transcripts/idempotent/fix2693.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison
@@ -22,7 +22,7 @@ range = loop []
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/fix2712.md
+++ b/unison-src/transcripts/idempotent/fix2712.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison
@@ -20,7 +20,7 @@ mapWithKey f m = Tip
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/fix2795.md
+++ b/unison-src/transcripts/idempotent/fix2795.md
@@ -1,5 +1,5 @@
 ``` ucm
-scratch/main> builtins.mergeio
+> builtins.mergeio
 
   Done.
 ```
@@ -29,7 +29,7 @@ t1 = "hi"
 ```
 
 ``` ucm
-scratch/main> display test
+> display test
 
       t : Text
       t = "hi"

--- a/unison-src/transcripts/idempotent/fix2822.md
+++ b/unison-src/transcripts/idempotent/fix2822.md
@@ -1,7 +1,7 @@
 # Inability to reference a term or type with a name that has segments starting with an underscore
 
 ``` ucm :hide
-scratch/main> builtins.mergeio
+> builtins.mergeio
 ```
 
 There should be no issue having terms with an underscore-led component

--- a/unison-src/transcripts/idempotent/fix2826.md
+++ b/unison-src/transcripts/idempotent/fix2826.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.mergeio
+> builtins.mergeio
 ```
 
 Supports fences that are longer than three backticks.
@@ -25,14 +25,14 @@ doc = {{
 And round-trips properly.
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> edit.new doc
+> edit.new doc
 
   ☝️
 
@@ -41,7 +41,7 @@ scratch/main> edit.new doc
   You can edit them there, then run `update` to replace the
   definitions currently in this namespace.
 
-scratch/main> load scratch.u
+> load scratch.u
 
   Loading changes detected in scratch.u.
 

--- a/unison-src/transcripts/idempotent/fix2970.md
+++ b/unison-src/transcripts/idempotent/fix2970.md
@@ -1,7 +1,7 @@
 Also fixes \#1519 (it's the same issue).
 
 ``` ucm
-scratch/main> builtins.merge
+> builtins.merge
 
   Done.
 ```

--- a/unison-src/transcripts/idempotent/fix3037.md
+++ b/unison-src/transcripts/idempotent/fix3037.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 Tests for an unsound case of ability checking that was erroneously being

--- a/unison-src/transcripts/idempotent/fix3171.md
+++ b/unison-src/transcripts/idempotent/fix3171.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 Tests an case where decompiling could cause function arguments to occur in the

--- a/unison-src/transcripts/idempotent/fix3196.md
+++ b/unison-src/transcripts/idempotent/fix3196.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 Tests ability checking in scenarios where one side is concrete and the other is

--- a/unison-src/transcripts/idempotent/fix3215.md
+++ b/unison-src/transcripts/idempotent/fix3215.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 Tests a case where concrete abilities were appearing multiple times in an

--- a/unison-src/transcripts/idempotent/fix3244.md
+++ b/unison-src/transcripts/idempotent/fix3244.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 This tests an previously erroneous case in the pattern compiler. It was assuming

--- a/unison-src/transcripts/idempotent/fix3265.md
+++ b/unison-src/transcripts/idempotent/fix3265.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 Tests cases that produced bad decompilation output previously. There

--- a/unison-src/transcripts/idempotent/fix3424.md
+++ b/unison-src/transcripts/idempotent/fix3424.md
@@ -1,5 +1,5 @@
 ``` ucm
-scratch/main> builtins.merge lib.builtins
+> builtins.merge lib.builtins
 
   Done.
 ```
@@ -11,14 +11,14 @@ c = "World"
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> run a
+> run a
 
   "Hello, World!"
 ```
@@ -29,7 +29,7 @@ c = "Unison"
 ```
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -40,7 +40,7 @@ scratch/main> update
 
   Done.
 
-scratch/main> run a
+> run a
 
   "Hello, Unison!"
 ```

--- a/unison-src/transcripts/idempotent/fix3634.md
+++ b/unison-src/transcripts/idempotent/fix3634.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.mergeio
+> builtins.mergeio
 ```
 
 ``` unison
@@ -25,14 +25,14 @@ d = {{
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> display d
+> display d
 
   `x -> J x`
 

--- a/unison-src/transcripts/idempotent/fix3678.md
+++ b/unison-src/transcripts/idempotent/fix3678.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 Array comparison was indexing out of bounds.

--- a/unison-src/transcripts/idempotent/fix3752.md
+++ b/unison-src/transcripts/idempotent/fix3752.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 These were failing to type check before, because id was not

--- a/unison-src/transcripts/idempotent/fix3773.md
+++ b/unison-src/transcripts/idempotent/fix3773.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison

--- a/unison-src/transcripts/idempotent/fix3977.md
+++ b/unison-src/transcripts/idempotent/fix3977.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 Pretty-printing previously didn’t compensate for extra characters on a line that was about to be wrapped, resulting in a line-break without sufficient indentation. Now pretty-printing indents based on the starting column of the wrapped expression, not simply “prevIndent + 2”.
@@ -11,14 +11,14 @@ foo = Left (failure ("a loooooooooooooooooooooooooooooooooong" ++ "message with 
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> edit.new foo
+> edit.new foo
 
   ☝️
 
@@ -27,7 +27,7 @@ scratch/main> edit.new foo
   You can edit them there, then run `update` to replace the
   definitions currently in this namespace.
 
-scratch/main> load scratch.u
+> load scratch.u
 
   Loading changes detected in scratch.u.
 

--- a/unison-src/transcripts/idempotent/fix4172.md
+++ b/unison-src/transcripts/idempotent/fix4172.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison
@@ -31,14 +31,14 @@ allowDebug = debug [1,2,3]
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> test
+> test
 
   Cached test results (`help testcache` to learn more)
 
@@ -64,13 +64,13 @@ bool = false
 ```
 
 ``` ucm :error
-scratch/main> update.old
+> update.old
 
   ⚠️
   I don't know how to update.old. Type `help` or `?` to get
   help.
 
-scratch/main> test
+> test
 
   Cached test results (`help testcache` to learn more)
 

--- a/unison-src/transcripts/idempotent/fix4280.md
+++ b/unison-src/transcripts/idempotent/fix4280.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison

--- a/unison-src/transcripts/idempotent/fix4424.md
+++ b/unison-src/transcripts/idempotent/fix4424.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 Some basics:
@@ -13,7 +13,7 @@ countCat = cases
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -28,7 +28,7 @@ unique type Rat.Dog = Bird | Mouse
 ```
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/fix4482.md
+++ b/unison-src/transcripts/idempotent/fix4482.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-myproj/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison
@@ -23,14 +23,14 @@ mybar = bar + bar
 ```
 
 ``` ucm :error
-myproj/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-myproj/main> upgrade foo0 foo1
+> upgrade foo0 foo1
 
   I couldn't automatically upgrade foo0 to foo1. However, I've
   added the definitions that need attention to the top of

--- a/unison-src/transcripts/idempotent/fix4498.md
+++ b/unison-src/transcripts/idempotent/fix4498.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison
@@ -21,14 +21,14 @@ myterm = foo + 2
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> view myterm
+> view myterm
 
   myterm : Nat
   myterm =

--- a/unison-src/transcripts/idempotent/fix4515.md
+++ b/unison-src/transcripts/idempotent/fix4515.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-myproject/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison
@@ -25,7 +25,7 @@ useBar = cases
 ```
 
 ``` ucm
-myproject/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -48,7 +48,7 @@ unique type Foo = Foo1 | Foo2
 ```
 
 ``` ucm
-myproject/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/fix4528.md
+++ b/unison-src/transcripts/idempotent/fix4528.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-foo/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison
@@ -20,14 +20,14 @@ main _ = MkFoo 5
 ```
 
 ``` ucm
-foo/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-foo/main> run main
+> run main
 
   MkFoo 5
 ```

--- a/unison-src/transcripts/idempotent/fix4556.md
+++ b/unison-src/transcripts/idempotent/fix4556.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison
@@ -21,7 +21,7 @@ hey = foo.hello
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -44,7 +44,7 @@ thing = 2
 ```
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/fix4592.md
+++ b/unison-src/transcripts/idempotent/fix4592.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.mergeio
+> builtins.mergeio
 ```
 
 ``` unison

--- a/unison-src/transcripts/idempotent/fix4618.md
+++ b/unison-src/transcripts/idempotent/fix4618.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison
@@ -18,7 +18,7 @@ unique type Bugs.Zonk = Bugs
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -44,7 +44,7 @@ unique type Bugs =
 ```
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/fix4711.md
+++ b/unison-src/transcripts/idempotent/fix4711.md
@@ -1,7 +1,7 @@
 # Delayed Int literal doesn't round trip
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison
@@ -22,14 +22,14 @@ thisDoesNotWork = ['(+1)]
 Since this is fixed, `thisDoesNotWork` now does work.
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> edit.new thisWorks thisDoesNotWork
+> edit.new thisWorks thisDoesNotWork
 
   ☝️
 
@@ -38,7 +38,7 @@ scratch/main> edit.new thisWorks thisDoesNotWork
   You can edit them there, then run `update` to replace the
   definitions currently in this namespace.
 
-scratch/main> load
+> load
 
   Loading changes detected in scratch.u.
 

--- a/unison-src/transcripts/idempotent/fix4722.md
+++ b/unison-src/transcripts/idempotent/fix4722.md
@@ -8,7 +8,7 @@ expected type into each case, allowing top-level annotations to act
 like annotations on each case.
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison

--- a/unison-src/transcripts/idempotent/fix4731.md
+++ b/unison-src/transcripts/idempotent/fix4731.md
@@ -11,7 +11,7 @@ structural type Void =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/fix4780.md
+++ b/unison-src/transcripts/idempotent/fix4780.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 Just a simple test case to see whether partially applied

--- a/unison-src/transcripts/idempotent/fix4898.md
+++ b/unison-src/transcripts/idempotent/fix4898.md
@@ -1,5 +1,5 @@
 ``` ucm
-scratch/main> builtins.merge
+> builtins.merge
 
   Done.
 ```
@@ -22,14 +22,14 @@ redouble x = double x + double x
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> dependents double
+> dependents double
 
   Dependents of: double
 
@@ -40,7 +40,7 @@ scratch/main> dependents double
   Tip: Try `view 1` to see the source of any numbered item in
        the above list.
 
-scratch/main> delete.term 1
+> delete.term 1
 
   Done.
 ```

--- a/unison-src/transcripts/idempotent/fix5055.md
+++ b/unison-src/transcripts/idempotent/fix5055.md
@@ -1,5 +1,5 @@
 ``` ucm
-test-5055/main> builtins.merge
+> builtins.merge
 
   Done.
 ```
@@ -20,19 +20,19 @@ foo.subtract x y = x Int.- y
 ```
 
 ``` ucm
-test-5055/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-test-5055/main> ls foo
+> ls foo
 
   1. add      (Int -> Int -> Int)
   2. subtract (Int -> Int -> Int)
 
-test-5055/main> view 1
+> view 1
 
   foo.add : Int -> Int -> Int
   foo.add x y =

--- a/unison-src/transcripts/idempotent/fix5076.md
+++ b/unison-src/transcripts/idempotent/fix5076.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.mergeio
+> builtins.mergeio
 ```
 
 Nested call to code lexer wasn’t terminating inline examples containing blocks properly.

--- a/unison-src/transcripts/idempotent/fix5080.md
+++ b/unison-src/transcripts/idempotent/fix5080.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge lib.builtins
+> builtins.merge lib.builtins
 ```
 
 ``` unison
@@ -25,14 +25,14 @@ test> fix5080.tests.failure = [Fail "fail"]
 ```
 
 ``` ucm :error
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> test
+> test
 
   Cached test results (`help testcache` to learn more)
 
@@ -46,11 +46,11 @@ scratch/main> test
 ```
 
 ``` ucm
-scratch/main> delete.term 2
+> delete.term 2
 
   Done.
 
-scratch/main> test
+> test
 
   Cached test results (`help testcache` to learn more)
 

--- a/unison-src/transcripts/idempotent/fix5337.md
+++ b/unison-src/transcripts/idempotent/fix5337.md
@@ -1,5 +1,5 @@
 ``` ucm
-scratch/main> builtins.mergeio
+> builtins.mergeio
 
   Done.
 ```

--- a/unison-src/transcripts/idempotent/fix5349.md
+++ b/unison-src/transcripts/idempotent/fix5349.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.mergeio
+> builtins.mergeio
 ```
 
 Empty code blocks are invalid in Unison, but shouldn’t crash the parser.

--- a/unison-src/transcripts/idempotent/fix5419.md
+++ b/unison-src/transcripts/idempotent/fix5419.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 Below is an example of variable capture occuring from pattern matching.

--- a/unison-src/transcripts/idempotent/fix5448.md
+++ b/unison-src/transcripts/idempotent/fix5448.md
@@ -6,7 +6,7 @@ main = do NewType
 You shouldn't have to `update` a type before using it with `run`.
 
 ``` ucm
-scratch/main> run main
+> run main
 
   NewType
 ```

--- a/unison-src/transcripts/idempotent/fix5506.md
+++ b/unison-src/transcripts/idempotent/fix5506.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.mergeio
+> builtins.mergeio
 ```
 
 ``` unison
@@ -26,7 +26,7 @@ printLine t =
 ```
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -48,7 +48,7 @@ hmmm = {{ I'll try {printLine}. That's a good trick. }}
 ```
 
 ``` ucm
-scratch/main> display hmmm
+> display hmmm
 
   I'll try printLine. That's a good trick.
 ```

--- a/unison-src/transcripts/idempotent/fix5538.md
+++ b/unison-src/transcripts/idempotent/fix5538.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-fresh/main> builtins.merge
+> builtins.merge
 ```
 
 Check that `Value.value` works in watch expressions:
@@ -31,14 +31,14 @@ test> foo.test =
 ```
 
 ``` ucm
-fresh/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-fresh/main> test
+> test
 
   Cached test results (`help testcache` to learn more)
 
@@ -68,14 +68,14 @@ bar.test =
 ```
 
 ``` ucm
-fresh/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-fresh/main> test
+> test
 
     
     Cached test results (`help testcache` to learn more)

--- a/unison-src/transcripts/idempotent/fix5566.md
+++ b/unison-src/transcripts/idempotent/fix5566.md
@@ -18,7 +18,7 @@ type T2 = T2C
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -56,7 +56,7 @@ bomb = do
 ```
 
 ``` ucm
-scratch/main> run bomb
+> run bomb
 
   ()
 ```

--- a/unison-src/transcripts/idempotent/fix614.md
+++ b/unison-src/transcripts/idempotent/fix614.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 This transcript demonstrates that Unison forces actions in blocks to have a return type of `()`.
@@ -26,7 +26,7 @@ ex1 = do
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 This does not typecheck, we've accidentally underapplied `Stream.emit`:

--- a/unison-src/transcripts/idempotent/fix689.md
+++ b/unison-src/transcripts/idempotent/fix689.md
@@ -1,7 +1,7 @@
 Tests the fix for https://github.com/unisonweb/unison/issues/689
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison

--- a/unison-src/transcripts/idempotent/fix693.md
+++ b/unison-src/transcripts/idempotent/fix693.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison
@@ -20,7 +20,7 @@ structural ability Abort where
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/fix845.md
+++ b/unison-src/transcripts/idempotent/fix845.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 Add `List.zonk` to the codebase:
@@ -22,7 +22,7 @@ Text.zonk txt = txt ++ "!! "
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 Now, typecheck a file with a reference to `Blah.zonk` (which doesn't exist in the codebase). This should fail:

--- a/unison-src/transcripts/idempotent/fix849.md
+++ b/unison-src/transcripts/idempotent/fix849.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 See [this ticket](https://github.com/unisonweb/unison/issues/849).

--- a/unison-src/transcripts/idempotent/fix942.md
+++ b/unison-src/transcripts/idempotent/fix942.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 First we add some code:
@@ -21,7 +21,7 @@ z = y + 2
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -46,7 +46,7 @@ x = 7
 ```
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -57,7 +57,7 @@ scratch/main> update
 
   Done.
 
-scratch/main> view x y z
+> view x y z
 
   x : Nat
   x = 7
@@ -92,14 +92,14 @@ test> t1 = if z == 3 then [Fail "nooo!!!"] else [Ok "great"]
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> test
+> test
 
   Cached test results (`help testcache` to learn more)
 

--- a/unison-src/transcripts/idempotent/fix987.md
+++ b/unison-src/transcripts/idempotent/fix987.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 First we'll add a definition:
@@ -27,7 +27,7 @@ spaceAttack1 x =
 Add it to the codebase:
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -53,7 +53,7 @@ spaceAttack2 x =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/formatter.md
+++ b/unison-src/transcripts/idempotent/formatter.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.mergeio
+> builtins.mergeio
 ```
 
 ``` unison :hide
@@ -88,7 +88,7 @@ with a strike-through block~
 ```
 
 ``` ucm
-scratch/main> debug.format
+> debug.format
 ```
 
 ``` unison :added-by-ucm scratch.u
@@ -204,5 +204,5 @@ brokenDoc = {{ hello }} + 1
 ```
 
 ``` ucm
-scratch/main> debug.format
+> debug.format
 ```

--- a/unison-src/transcripts/idempotent/fuzzy-options.md
+++ b/unison-src/transcripts/idempotent/fuzzy-options.md
@@ -7,7 +7,7 @@ If an argument is required but doesn't have a fuzzy resolver, the command should
 
 -- So it should print the arg parsing error.
 
-scratch/main> move.term
+> move.term
 
   ⚠️
 
@@ -24,7 +24,7 @@ If a fuzzy resolver doesn't have any options available it should print a message
 opening an empty fuzzy-select.
 
 ``` ucm :error
-scratch/empty> view
+> view
 
   ⚠️
 
@@ -44,14 +44,14 @@ nested.optionTwo = 2
 Definition args
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> debug.fuzzy-options view _
+> debug.fuzzy-options view _
 
   Select a definition to view or press <esc> to cancel:
     * optionOne
@@ -61,7 +61,7 @@ scratch/main> debug.fuzzy-options view _
 Namespace args
 
 ``` ucm
-scratch/main> debug.fuzzy-options find-in _
+> debug.fuzzy-options find-in _
 
   Select a namespace or press <esc> to cancel:
     * .

--- a/unison-src/transcripts/idempotent/help.md
+++ b/unison-src/transcripts/idempotent/help.md
@@ -1,7 +1,7 @@
 # Shows `help` output
 
 ``` ucm
-scratch/main> help
+> help
 
   add.run
   `add.run name` adds to the codebase the result of the most recent `run` command as `name`.
@@ -961,7 +961,7 @@ scratch/main> help
   `view.global foo` prints definitions of `foo` within your codebase.
   `view.global` without arguments invokes a search to select definitions to view, which requires that `fzf` can be found within your PATH.
 
-scratch/main> help-topics
+> help-topics
 
   🌻
 
@@ -976,7 +976,7 @@ scratch/main> help-topics
 
   Example: use `help-topics filestatus` to learn more about that topic.
 
-scratch/main> help-topic filestatus
+> help-topic filestatus
 
   📓
 
@@ -1006,7 +1006,7 @@ scratch/main> help-topic filestatus
                        a dependency of a definition explicitly
                        selected.
 
-scratch/main> help-topic messages.disallowedAbsolute
+> help-topic messages.disallowedAbsolute
 
   🤖
 
@@ -1018,7 +1018,7 @@ scratch/main> help-topic messages.disallowedAbsolute
   As a workaround, you can give definitions with a relative name
   temporarily (like `exports.blah.foo`) and then use `move.*`.
 
-scratch/main> help-topic namespaces
+> help-topic namespaces
 
   🧐
 
@@ -1044,7 +1044,7 @@ scratch/main> help-topic namespaces
 
     answerToLifeTheUniverseAndEverything = .foo.bar.x + 1
 
-scratch/main> help-topic projects
+> help-topic projects
 
   A project is a versioned collection of code that can be
   edited, published, and depended on other projects. Unison
@@ -1065,7 +1065,7 @@ scratch/main> help-topic projects
   For full documentation, see
   https://unison-lang.org/learn/projects
 
-scratch/main> help-topic remotes
+> help-topic remotes
 
   🤖
 
@@ -1080,7 +1080,7 @@ scratch/main> help-topic remotes
   created by `clone`. If the project was created locally then
   the relationship will be established on the first `push`.
 
-scratch/main> help-topic testcache
+> help-topic testcache
 
   🎈
 

--- a/unison-src/transcripts/idempotent/higher-rank.md
+++ b/unison-src/transcripts/idempotent/higher-rank.md
@@ -1,11 +1,11 @@
 This transcript does some testing of higher-rank types. Regression tests related to higher-rank types can be added here.
 
 ``` ucm :hide
-scratch/main> alias.type ##Nat Nat
+> alias.type ##Nat Nat
 
-scratch/main> alias.type ##Text Text
+> alias.type ##Text Text
 
-scratch/main> alias.type ##IO IO
+> alias.type ##IO IO
 ```
 
 In this example, a higher-rank function is defined, `f`. No annotation is needed at the call-site of `f`, because the lambda is being checked against the polymorphic type `forall a . a -> a`, rather than inferred:
@@ -126,14 +126,14 @@ structural type HigherRanked = HigherRanked (forall a. a -> a)
 We should be able to add and view records with higher-rank fields.
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> view HigherRanked
+> view HigherRanked
 
   structural type HigherRanked = HigherRanked (∀ a. a -> a)
 ```

--- a/unison-src/transcripts/idempotent/implicit-project-context.md
+++ b/unison-src/transcripts/idempotent/implicit-project-context.md
@@ -1,0 +1,242 @@
+First we define some simple terms
+
+``` unison
+x = ()
+y = ((), ())
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  + x : ()
+  + y : ((), ())
+
+  Run `update` to apply these changes to your codebase.
+```
+
+And then add them to the default project & branch.
+
+``` ucm
+> add
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+```
+
+Now, we do different definitions in an explicit project
+
+``` unison
+q = ()
+r = ((), ())
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  + q : ()
+      (also named x)
+  + r : ((), ())
+      (also named y)
+
+  Run `update` to apply these changes to your codebase.
+```
+
+And then add them to the default project & branch.
+
+**NB**: The implicit `load` occurs in the previous project & branch (which is why it says “also named” in the block above here). But this is also the case with explicit project context, so if it’s a problem, it’s outside the scope of this feature.
+
+``` ucm
+other/trunk> add
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+```
+
+Now, later UCM blocks should maintain the last-mentioned project.
+
+``` ucm
+> view q
+
+  q : ()
+  q = ()
+
+> view r
+
+  r : ((), ())
+  r = ((), ())
+```
+
+And it shouldn’t contain these definitions
+
+``` ucm :error
+> view x
+
+  ⚠️
+
+  The following names were not found in the codebase. Check your spelling.
+    x
+```
+
+``` ucm :error
+> view y
+
+  ⚠️
+
+  The following names were not found in the codebase. Check your spelling.
+    y
+```
+
+But the default project & branch should be “scratch/main”, so we can see the original definitions there:
+
+``` ucm
+scratch/main> view x
+
+  x : ()
+  x = ()
+
+scratch/main> view y
+
+  y : ((), ())
+  y = ((), ())
+
+> view y
+
+  y : ((), ())
+  y = ((), ())
+```
+
+And the other project’s definitions should no longer be available.
+
+``` ucm :error
+> view q
+
+  ⚠️
+
+  The following names were not found in the codebase. Check your spelling.
+    q
+```
+
+``` ucm :error
+> view r
+
+  ⚠️
+
+  The following names were not found in the codebase. Check your spelling.
+    r
+```
+
+Creating a project should also change the current project & branch.
+
+``` ucm
+> project.create yet-another
+
+  🎉 I've created the project yet-another.
+
+  I'll now fetch the latest version of the base Unison
+  library...
+
+  🎨 Type `ui` to explore this project's code in your browser.
+  🔭 Discover libraries at https://share.unison-lang.org
+  📖 Use `help-topic projects` to learn more about projects.
+
+  Write your first Unison code with UCM:
+
+    1. Open scratch.u.
+    2. Write some Unison code and save the file.
+    3. In UCM, type `update` to save it to your new project.
+
+  🎉 🥳 Happy coding!
+```
+
+The definitions from other projects shouldn’t be here.
+
+``` ucm :error
+> view x
+
+  ⚠️
+
+  The following names were not found in the codebase. Check your spelling.
+    x
+```
+
+``` ucm :error
+> view r
+
+  ⚠️
+
+  The following names were not found in the codebase. Check your spelling.
+    r
+```
+
+So add some definitions to the created project
+
+``` unison
+a = ()
+b = ((), ())
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  + a : ()
+  + b : ((), ())
+
+  Run `update` to apply these changes to your codebase.
+```
+
+``` ucm
+> add
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+
+> view a
+
+  a : ()
+  a = ()
+
+> view b
+
+  b : ((), ())
+  b = ((), ())
+```
+
+We shouldn’t see these new definitions in our other projects
+
+``` ucm :error
+scratch/main> view a
+
+  ⚠️
+
+  The following names were not found in the codebase. Check your spelling.
+    a
+```
+
+``` ucm :error
+other/trunk> view a
+
+  ⚠️
+
+  The following names were not found in the codebase. Check your spelling.
+    a
+```
+
+But if we explicitly use the new name, we’re back to our project.
+
+``` ucm
+yet-another/main> view a
+
+  a : ()
+  a = ()
+
+> view b
+
+  b : ((), ())
+  b = ((), ())
+```

--- a/unison-src/transcripts/idempotent/input-parse-errors.md
+++ b/unison-src/transcripts/idempotent/input-parse-errors.md
@@ -22,7 +22,7 @@ todo:
 aliasTerm
 
 ``` 
-scratch/main> alias.term ##Nat.+ Nat.+
+> alias.term ##Nat.+ Nat.+
 ```
 
 aliasTermForce,

--- a/unison-src/transcripts/idempotent/io-test-command.md
+++ b/unison-src/transcripts/idempotent/io-test-command.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 The `io.test` command should run all of the tests within the current namespace, excluding libs.
@@ -20,13 +20,13 @@ lib.ioAndExceptionTestInLib  = do
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 Run a IO tests one by one
 
 ``` ucm
-scratch/main> io.test ioAndExceptionTest
+> io.test ioAndExceptionTest
 
     New test results:
 
@@ -36,7 +36,7 @@ scratch/main> io.test ioAndExceptionTest
 
   Tip: Use view 1 to view the source of a test.
 
-scratch/main> io.test ioTest
+> io.test ioTest
 
     New test results:
 
@@ -50,7 +50,7 @@ scratch/main> io.test ioTest
 `io.test` doesn't cache results
 
 ``` ucm
-scratch/main> io.test ioAndExceptionTest
+> io.test ioAndExceptionTest
 
     New test results:
 
@@ -64,7 +64,7 @@ scratch/main> io.test ioAndExceptionTest
 `io.test.all` will run all matching tests except those in the `lib` namespace.
 
 ``` ucm
-scratch/main> io.test.all
+> io.test.all
 
 
 

--- a/unison-src/transcripts/idempotent/io.md
+++ b/unison-src/transcripts/idempotent/io.md
@@ -1,11 +1,11 @@
 # tests for built-in IO functions
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 
-scratch/main> builtins.mergeio
+> builtins.mergeio
 
-scratch/main> load unison-src/transcripts-using-base/base.u
+> load unison-src/transcripts-using-base/base.u
 ```
 
 Tests for IO builtins which wired to foreign haskell calls.
@@ -18,7 +18,7 @@ TempDirs/autoCleaned is an ability/hanlder which allows you to easily
 create a scratch directory which will automatically get cleaned up.
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ## Basic File Functions
@@ -68,14 +68,14 @@ testCreateRename _ =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test testCreateRename
+> io.test testCreateRename
 
     New test results:
 
@@ -148,14 +148,14 @@ testOpenClose _ =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test testOpenClose
+> io.test testOpenClose
 
     New test results:
 
@@ -236,14 +236,14 @@ testGetSomeBytes _ =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test testGetSomeBytes
+> io.test testGetSomeBytes
 
     New test results:
 
@@ -351,14 +351,14 @@ testAppend _ =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test testSeek
+> io.test testSeek
 
     New test results:
 
@@ -374,7 +374,7 @@ scratch/main> io.test testSeek
 
   Tip: Use view 1 to view the source of a test.
 
-scratch/main> io.test testSetEcho
+> io.test testSetEcho
 
     New test results:
 
@@ -384,7 +384,7 @@ scratch/main> io.test testSetEcho
 
   Tip: Use view 1 to view the source of a test.
 
-scratch/main> io.test testAppend
+> io.test testAppend
 
     New test results:
 
@@ -416,14 +416,14 @@ testSystemTime _ =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test testSystemTime
+> io.test testSystemTime
 
     New test results:
 
@@ -447,14 +447,14 @@ testGetTempDirectory _ =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test testGetTempDirectory
+> io.test testGetTempDirectory
 
     New test results:
 
@@ -479,14 +479,14 @@ testGetCurrentDirectory _ =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test testGetCurrentDirectory
+> io.test testGetCurrentDirectory
 
     New test results:
 
@@ -513,14 +513,14 @@ testDirContents _ =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test testDirContents
+> io.test testDirContents
 
     New test results:
 
@@ -547,14 +547,14 @@ testGetEnv _ =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test testGetEnv
+> io.test testGetEnv
 
     New test results:
 
@@ -603,22 +603,22 @@ testGetArgs.runMeWithTwoArgs = 'let
 Test that they can be run with the right number of args.
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> run runMeWithNoArgs
+> run runMeWithNoArgs
 
   ()
 
-scratch/main> run runMeWithOneArg foo
+> run runMeWithOneArg foo
 
   ()
 
-scratch/main> run runMeWithTwoArgs foo bar
+> run runMeWithTwoArgs foo bar
 
   ()
 ```
@@ -626,7 +626,7 @@ scratch/main> run runMeWithTwoArgs foo bar
 Calling our examples with the wrong number of args will error.
 
 ``` ucm :error
-scratch/main> run runMeWithNoArgs foo
+> run runMeWithNoArgs foo
 
   💔💥
 
@@ -639,7 +639,7 @@ scratch/main> run runMeWithNoArgs foo
 ```
 
 ``` ucm :error
-scratch/main> run runMeWithOneArg
+> run runMeWithOneArg
 
   💔💥
 
@@ -652,7 +652,7 @@ scratch/main> run runMeWithOneArg
 ```
 
 ``` ucm :error
-scratch/main> run runMeWithOneArg foo bar
+> run runMeWithOneArg foo bar
 
   💔💥
 
@@ -666,7 +666,7 @@ scratch/main> run runMeWithOneArg foo bar
 ```
 
 ``` ucm :error
-scratch/main> run runMeWithTwoArgs
+> run runMeWithTwoArgs
 
   💔💥
 
@@ -688,14 +688,14 @@ testTimeZone = do
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> run testTimeZone
+> run testTimeZone
 
   ()
 ```
@@ -712,14 +712,14 @@ testRandom = do
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test testGetEnv
+> io.test testGetEnv
 
     New test results:
 

--- a/unison-src/transcripts/idempotent/kind-inference.md
+++ b/unison-src/transcripts/idempotent/kind-inference.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ## A type param cannot have conflicting kind constraints within a single decl

--- a/unison-src/transcripts/idempotent/lambdacase.md
+++ b/unison-src/transcripts/idempotent/lambdacase.md
@@ -1,7 +1,7 @@
 # Lambda case syntax
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 This function takes a single argument and immediately pattern matches on it. As we'll see below, it can be written using `cases` syntax:
@@ -21,7 +21,7 @@ isEmpty x = match x with
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 Here's the same function written using `cases` syntax:
@@ -44,7 +44,7 @@ isEmpty2 = cases
 Notice that Unison detects this as an alias of `isEmpty`, and if we view `isEmpty`
 
 ``` ucm
-scratch/main> view isEmpty
+> view isEmpty
 
   isEmpty : [t] -> Boolean
   isEmpty = cases
@@ -69,7 +69,7 @@ merge xs ys = match (xs, ys) with
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -101,7 +101,7 @@ merge2 = cases
 Notice that Unison detects this as an alias of `merge`, and if we view `merge`
 
 ``` ucm
-scratch/main> view merge
+> view merge
 
   merge : [a] -> [a] -> [a]
   merge = cases
@@ -176,14 +176,14 @@ merge3 = cases
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> view merge3
+> view merge3
 
   merge3 : [a] -> [a] -> [a]
   merge3 = cases

--- a/unison-src/transcripts/idempotent/lsp-fold-ranges.md
+++ b/unison-src/transcripts/idempotent/lsp-fold-ranges.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.mergeio
+> builtins.mergeio
 ```
 
 ``` unison :hide
@@ -29,7 +29,7 @@ test> z = let
 ```
 
 ``` ucm
-scratch/main> debug.lsp.fold-ranges
+> debug.lsp.fold-ranges
 
 
   《{{ Type doc }}》

--- a/unison-src/transcripts/idempotent/lsp-name-completion.md
+++ b/unison-src/transcripts/idempotent/lsp-name-completion.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge lib.builtins
+> builtins.merge lib.builtins
 ```
 
 ``` unison :hide
@@ -16,7 +16,7 @@ other = "other"
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 Completion should find all the `foldMap` definitions in the codebase,
@@ -26,7 +26,7 @@ Individual LSP clients may still handle sorting differently, e.g. doing a fuzzy 
 prioritizing exact matches over partial matches. We don't have any control over that.
 
 ``` ucm
-scratch/main> debug.lsp-name-completion foldMap
+> debug.lsp-name-completion foldMap
 
   Matching Path   Name                             Hash
   foldMap         foldMap                          #o38ps8p4q6
@@ -39,7 +39,7 @@ scratch/main> debug.lsp-name-completion foldMap
 Should still find the term which has a matching hash to a better name if the better name doesn't match.
 
 ``` ucm
-scratch/main> debug.lsp-name-completion transitive_same_hash.foldMap
+> debug.lsp-name-completion transitive_same_hash.foldMap
 
   Matching Path                  Name                                       Hash
   transitive_same_hash.foldMap   lib.dep.lib.transitive_same_hash.foldMap   #o38ps8p4q6

--- a/unison-src/transcripts/idempotent/name-resolution-fuzzy.md
+++ b/unison-src/transcripts/idempotent/name-resolution-fuzzy.md
@@ -3,7 +3,7 @@
 ## Setup
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ## When given a term with the right name and the right type
@@ -98,7 +98,7 @@ long.fully.qualified.name.foo.bar.biz.bite = 123
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ``` unison :error

--- a/unison-src/transcripts/idempotent/name-segment-escape.md
+++ b/unison-src/transcripts/idempotent/name-segment-escape.md
@@ -1,14 +1,14 @@
 You can use a keyword or reserved operator as a name segment if you surround it with backticks.
 
 ``` ucm :error
-scratch/main> view `match`
+> view `match`
 
   ⚠️
 
   The following names were not found in the codebase. Check your spelling.
     `match`
 
-scratch/main> view `=`
+> view `=`
 
   ⚠️
 
@@ -21,14 +21,14 @@ You can also use backticks to expand the set of valid symbols in a symboly name 
 This allows you to spell `.` or `()` as name segments (which historically have appeared in the namespace).
 
 ``` ucm :error
-scratch/main> view `.`
+> view `.`
 
   ⚠️
 
   The following names were not found in the codebase. Check your spelling.
     `.`
 
-scratch/main> view `()`
+> view `()`
 
   ⚠️
 

--- a/unison-src/transcripts/idempotent/name-test-sandbox-violators.md
+++ b/unison-src/transcripts/idempotent/name-test-sandbox-violators.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-fresh/main> builtins.merge
+> builtins.merge
 ```
 
 This passes, because the IO sandbox doesn't seem to apply to `test>` watch expressions.
@@ -24,7 +24,7 @@ test> foo.test =
 ```
 
 ``` ucm
-fresh/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -35,7 +35,7 @@ fresh/main> add
 The `test` command succeeds, because the result of `foo.test` is already cached, which skips the IO sandbox.
 
 ``` ucm
-fresh/main> test
+> test
 
   Cached test results (`help testcache` to learn more)
 
@@ -65,7 +65,7 @@ bar.test =
 ```
 
 ``` ucm
-fresh/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -74,7 +74,7 @@ fresh/main> add
 ```
 
 ``` ucm :error
-fresh/main> test
+> test
 
     
     Cached test results (`help testcache` to learn more)

--- a/unison-src/transcripts/idempotent/namespace-deletion-regression.md
+++ b/unison-src/transcripts/idempotent/namespace-deletion-regression.md
@@ -8,23 +8,23 @@ Previously the following sequence delete the current namespace
 unexpectedly 😬.
 
 ``` ucm
-scratch/main> alias.term ##Nat.+ Nat.+
+> alias.term ##Nat.+ Nat.+
 
   Done.
 
-scratch/main> ls Nat
+> ls Nat
 
   1. + (##Nat -> ##Nat -> ##Nat)
 
-scratch/main> move.namespace Nat Nat.operators
+> move.namespace Nat Nat.operators
 
   Done.
 
-scratch/main> ls Nat
+> ls Nat
 
   1. operators/ (1 term)
 
-scratch/main> ls Nat.operators
+> ls Nat.operators
 
   1. + (##Nat -> ##Nat -> ##Nat)
 ```

--- a/unison-src/transcripts/idempotent/namespace-dependencies.md
+++ b/unison-src/transcripts/idempotent/namespace-dependencies.md
@@ -1,7 +1,7 @@
 # namespace.dependencies command
 
 ``` ucm
-scratch/main> builtins.merge lib.builtins
+> builtins.merge lib.builtins
 
   Done.
 ```
@@ -13,14 +13,14 @@ mynamespace.dependsOnText = const external.mynat 10
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> namespace.dependencies mynamespace
+> namespace.dependencies mynamespace
 
   External dependency   Dependents in scratch/main:.mynamespace
   lib.builtins.Nat      1. dependsOnText

--- a/unison-src/transcripts/idempotent/namespace-directive.md
+++ b/unison-src/transcripts/idempotent/namespace-directive.md
@@ -6,7 +6,7 @@ It affects the contents of the file as follows:
     the full bindings' names.
 
 ``` ucm
-scratch/main> builtins.mergeio lib.builtins
+> builtins.mergeio lib.builtins
 
   Done.
 ```
@@ -51,14 +51,14 @@ longer.evil.factorial n = n
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> view factorial
+> view factorial
 
   foo.factorial : Int -> Int
   foo.factorial = cases
@@ -96,7 +96,7 @@ type longer.foo.Baz = { qux : Nat }
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -142,14 +142,14 @@ hasTypeLink =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> view RefersToFoo refersToBar refersToQux hasTypeLink
+> view RefersToFoo refersToBar refersToQux hasTypeLink
 
   type foo.RefersToFoo = RefersToFoo foo.Foo
 
@@ -165,7 +165,7 @@ scratch/main> view RefersToFoo refersToBar refersToQux hasTypeLink
     use foo.Baz qux
     qux baz + qux baz
 
-scratch/main> todo
+> todo
 
   You have no pending todo items. Good work! ✅
 ```

--- a/unison-src/transcripts/idempotent/numbered-args.md
+++ b/unison-src/transcripts/idempotent/numbered-args.md
@@ -1,7 +1,7 @@
 # Using numbered arguments in UCM
 
 ``` ucm :hide
-scratch/main> alias.type ##Text Text
+> alias.type ##Text Text
 ```
 
 First lets add some contents to our codebase.
@@ -29,7 +29,7 @@ corge = "corge"
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -41,7 +41,7 @@ We can get the list of things in the namespace, and UCM will give us a numbered
 list:
 
 ``` ucm
-scratch/main> find
+> find
 
   1. bar : Text
   2. baz : Text
@@ -55,7 +55,7 @@ scratch/main> find
 We can ask to `view` the second element of this list:
 
 ``` ucm
-scratch/main> find
+> find
 
   1. bar : Text
   2. baz : Text
@@ -65,7 +65,7 @@ scratch/main> find
   6. qux : Text
   7. builtin type Text
 
-scratch/main> view 2
+> view 2
 
   baz : Text
   baz = "baz"
@@ -74,7 +74,7 @@ scratch/main> view 2
 And we can `view` multiple elements by separating with spaces:
 
 ``` ucm
-scratch/main> find
+> find
 
   1. bar : Text
   2. baz : Text
@@ -84,7 +84,7 @@ scratch/main> find
   6. qux : Text
   7. builtin type Text
 
-scratch/main> view 2 3 5
+> view 2 3 5
 
   baz : Text
   baz = "baz"
@@ -99,7 +99,7 @@ scratch/main> view 2 3 5
 We can also ask for a range:
 
 ``` ucm
-scratch/main> find
+> find
 
   1. bar : Text
   2. baz : Text
@@ -109,7 +109,7 @@ scratch/main> find
   6. qux : Text
   7. builtin type Text
 
-scratch/main> view 2-4
+> view 2-4
 
   baz : Text
   baz = "baz"
@@ -124,7 +124,7 @@ scratch/main> view 2-4
 And we can ask for multiple ranges and use mix of ranges and numbers:
 
 ``` ucm
-scratch/main> find
+> find
 
   1. bar : Text
   2. baz : Text
@@ -134,7 +134,7 @@ scratch/main> find
   6. qux : Text
   7. builtin type Text
 
-scratch/main> view 1-3 4 5-6
+> view 1-3 4 5-6
 
   bar : Text
   bar = "bar"

--- a/unison-src/transcripts/idempotent/old-fold-right.md
+++ b/unison-src/transcripts/idempotent/old-fold-right.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison

--- a/unison-src/transcripts/idempotent/pattern-match-coverage.md
+++ b/unison-src/transcripts/idempotent/pattern-match-coverage.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 # Basics
@@ -616,7 +616,7 @@ unit2t = cases
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -664,7 +664,7 @@ evil = bug ""
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -699,7 +699,7 @@ unique type SomeType = A
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/pattern-pretty-print-2345.md
+++ b/unison-src/transcripts/idempotent/pattern-pretty-print-2345.md
@@ -1,7 +1,7 @@
 Regression test for https://github.com/unisonweb/unison/pull/2377
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison
@@ -87,101 +87,101 @@ doc = cases
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> view dopey
+> view dopey
 
   dopey : Char -> ()
   dopey = cases
     ?0 -> ()
     _  -> ()
 
-scratch/main> view grumpy
+> view grumpy
 
   grumpy : ff284oqf651 -> ()
   grumpy = cases d -> ()
 
-scratch/main> view happy
+> view happy
 
   happy : Boolean -> ()
   happy = cases
     true  -> ()
     false -> ()
 
-scratch/main> view sneezy
+> view sneezy
 
   sneezy : Int -> ()
   sneezy = cases
     +1 -> ()
     _  -> ()
 
-scratch/main> view bashful
+> view bashful
 
   bashful : Optional a -> ()
   bashful = cases
     Some a -> ()
     _      -> ()
 
-scratch/main> view mouthy
+> view mouthy
 
   mouthy : [t] -> ()
   mouthy = cases
     [] -> ()
     _  -> ()
 
-scratch/main> view pokey
+> view pokey
 
   pokey : [t] -> ()
   pokey = cases
     h +: t -> ()
     _      -> ()
 
-scratch/main> view sleepy
+> view sleepy
 
   sleepy : [t] -> ()
   sleepy = cases
     i :+ l -> ()
     _      -> ()
 
-scratch/main> view demure
+> view demure
 
   demure : [Nat] -> ()
   demure = cases
     [0] -> ()
     _   -> ()
 
-scratch/main> view angry
+> view angry
 
   angry : [t] -> ()
   angry = cases a ++ [] -> ()
 
-scratch/main> view tremulous
+> view tremulous
 
   tremulous : (Nat, Nat) -> ()
   tremulous = cases
     (0, 1) -> ()
     _      -> ()
 
-scratch/main> view throaty
+> view throaty
 
   throaty : Request {g, Ab} x -> ()
   throaty = cases
     { Ab.a a -> k } -> ()
     { _ }           -> ()
 
-scratch/main> view agitated
+> view agitated
 
   agitated : Nat -> ()
   agitated = cases
     a | a == 2 -> ()
     _ -> ()
 
-scratch/main> view doc
+> view doc
 
   doc : Nat -> ()
   doc = cases

--- a/unison-src/transcripts/idempotent/patternMatchTls.md
+++ b/unison-src/transcripts/idempotent/patternMatchTls.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 We had bugs in the calling conventions for both send and terminate which would
@@ -34,14 +34,14 @@ assertRight = cases
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> run frank
+> run frank
 
   ()
 ```

--- a/unison-src/transcripts/idempotent/patterns.md
+++ b/unison-src/transcripts/idempotent/patterns.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 Some tests of pattern behavior.

--- a/unison-src/transcripts/idempotent/propagate.md
+++ b/unison-src/transcripts/idempotent/propagate.md
@@ -1,7 +1,7 @@
 # Propagating type edits
 
 ``` ucm :hide
-scratch/main> builtins.merge lib.builtins
+> builtins.merge lib.builtins
 ```
 
 We introduce a type `Foo` with a function dependent `fooToInt`.
@@ -26,14 +26,14 @@ fooToInt _ = +42
 And then we add it.
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> find.verbose
+> find.verbose
 
   1. -- #j743idicb1sf7udts85812agaml4rkfi3iss6lstvmvgufibd40blq5qtmoh9ndrtkvkaqkurn7npgc61ob8j2louj04j8slkppsl90
      type Foo
@@ -45,7 +45,7 @@ scratch/main> find.verbose
      fooToInt : Foo -> Int
      
 
-scratch/main> view fooToInt
+> view fooToInt
 
   fooToInt : Foo -> Int
   fooToInt _ = +42
@@ -70,7 +70,7 @@ unique type Foo = Foo | Bar
 and update the codebase to use the new type `Foo`...
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -85,7 +85,7 @@ scratch/main> update
 ... it should automatically propagate the type to `fooToInt`.
 
 ``` ucm
-scratch/main> view fooToInt
+> view fooToInt
 
   fooToInt : Foo -> Int
   fooToInt _ = +42
@@ -116,7 +116,7 @@ preserve.otherTerm y = someTerm y
 Add that to the codebase:
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -144,7 +144,7 @@ preserve.someTerm _ = None
 Update...
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -160,12 +160,12 @@ Now the type of `someTerm` should be `Optional x -> Optional x` and the
 type of `otherTerm` should remain the same.
 
 ``` ucm
-scratch/main> view preserve.someTerm
+> view preserve.someTerm
 
   preserve.someTerm : Optional x -> Optional x
   preserve.someTerm _ = None
 
-scratch/main> view preserve.otherTerm
+> view preserve.otherTerm
 
   preserve.otherTerm : Optional baz -> Optional baz
   preserve.otherTerm y = someTerm y

--- a/unison-src/transcripts/idempotent/pull-errors.md
+++ b/unison-src/transcripts/idempotent/pull-errors.md
@@ -1,5 +1,5 @@
 ``` ucm :error
-test/main> pull @aryairani/test-almost-empty/main lib.base_latest
+> pull @aryairani/test-almost-empty/main lib.base_latest
 
   The use of `pull` to install libraries is now deprecated.
   Going forward, you can use
@@ -8,7 +8,7 @@ test/main> pull @aryairani/test-almost-empty/main lib.base_latest
   I installed @aryairani/test-almost-empty/main into
   lib.aryairani_test_almost_empty_main
 
-test/main> pull @aryairani/test-almost-empty/main a.b
+> pull @aryairani/test-almost-empty/main a.b
 
   ⚠️
 
@@ -20,13 +20,13 @@ test/main> pull @aryairani/test-almost-empty/main a.b
 
   You can run `help pull` for more information on using `pull`.
 
-test/main> pull @aryairani/test-almost-empty/main a
+> pull @aryairani/test-almost-empty/main a
 
   I think you want to merge @aryairani/test-almost-empty/main
   into the a branch, but it doesn't exist. If you want, you can
   create it with `branch.empty a`, and then `pull` again.
 
-test/main> pull @aryairani/test-almost-empty/main .a
+> pull @aryairani/test-almost-empty/main .a
 
   ⚠️
 

--- a/unison-src/transcripts/idempotent/quad-handlers.md
+++ b/unison-src/transcripts/idempotent/quad-handlers.md
@@ -1,7 +1,7 @@
 This transcript checks cases for the warning about quadratic handlers.
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison

--- a/unison-src/transcripts/idempotent/records.md
+++ b/unison-src/transcripts/idempotent/records.md
@@ -1,9 +1,9 @@
 Ensure that Records keep their syntax after being added to the codebase
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 
-scratch/main> load unison-src/transcripts-using-base/base.u
+> load unison-src/transcripts-using-base/base.u
 ```
 
 ## Record with 1 field
@@ -13,11 +13,11 @@ unique type Record1 = { a : Text }
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ``` ucm
-scratch/main> view Record1
+> view Record1
 
   type Record1 = { a : Text }
 ```
@@ -29,11 +29,11 @@ unique type Record2 = { a : Text, b : Int }
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ``` ucm
-scratch/main> view Record2
+> view Record2
 
   type Record2 = { a : Text, b : Int }
 ```
@@ -45,11 +45,11 @@ unique type Record3 = { a : Text, b : Int, c : Nat }
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ``` ucm
-scratch/main> view Record3
+> view Record3
 
   type Record3 = { a : Text, b : Int, c : Nat }
 ```
@@ -69,11 +69,11 @@ unique type Record4 =
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ``` ucm
-scratch/main> view Record4
+> view Record4
 
   type Record4
     = { a : Text,
@@ -114,11 +114,11 @@ unique type Record5 = {
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ``` ucm
-scratch/main> view Record5
+> view Record5
 
   type Record5
     = { zero : Nat,
@@ -155,13 +155,13 @@ unique type RecordWithUserType = { a : Text, b : Record4, c : UserType }
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 If you `view` or `edit` it, it *should* be treated as a record type, but it does not (which is a bug)
 
 ``` ucm
-scratch/main> view RecordWithUserType
+> view RecordWithUserType
 
   type RecordWithUserType
     = { a : Text, b : Record4, c : UserType }

--- a/unison-src/transcripts/idempotent/release-draft-command.md
+++ b/unison-src/transcripts/idempotent/release-draft-command.md
@@ -1,7 +1,7 @@
 The `release.draft` command drafts a release from the current branch.
 
 ``` ucm :hide
-foo/main> builtins.merge
+> builtins.merge
 ```
 
 Some setup:
@@ -19,7 +19,7 @@ someterm = 18
 ```
 
 ``` ucm
-foo/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -32,7 +32,7 @@ Now, the `release.draft` demo:
 `release.draft` accepts a single semver argument.
 
 ``` ucm
-foo/main> release.draft 1.2.3
+> release.draft 1.2.3
 
   😎 Great! I've created a draft release for you at
   /releases/drafts/1.2.3.
@@ -52,8 +52,8 @@ foo/main> release.draft 1.2.3
 It's an error to try to create a `releases/drafts/x.y.z` branch that already exists.
 
 ``` ucm :error
-foo/main> release.draft 1.2.3
+> release.draft 1.2.3
 
-  foo/releases/drafts/1.2.3 already exists. You can switch to it
-  with `switch foo/releases/drafts/1.2.3`.
+  scratch/releases/drafts/1.2.3 already exists. You can switch
+  to it with `switch scratch/releases/drafts/1.2.3`.
 ```

--- a/unison-src/transcripts/idempotent/resolution-failures.md
+++ b/unison-src/transcripts/idempotent/resolution-failures.md
@@ -5,7 +5,7 @@ This transcript tests the errors printed to the user when a name cannot be resol
 ## Codebase Setup
 
 ``` ucm
-scratch/main> builtins.merge lib.builtins
+> builtins.merge lib.builtins
 
   Done.
 ```
@@ -33,7 +33,7 @@ two.ambiguousTerm = "term two"
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/rsa.md
+++ b/unison-src/transcripts/idempotent/rsa.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison

--- a/unison-src/transcripts/idempotent/runtime-tests.md
+++ b/unison-src/transcripts/idempotent/runtime-tests.md
@@ -1,7 +1,7 @@
 # An assortment of regression tests that exercise various interesting cases within the runtime.
 
 ``` ucm :hide
-scratch/main> builtins.merge lib.builtins
+> builtins.merge lib.builtins
 ```
 
 ``` unison

--- a/unison-src/transcripts/idempotent/scope-ref.md
+++ b/unison-src/transcripts/idempotent/scope-ref.md
@@ -1,7 +1,7 @@
 A short script to test mutable references with local scope.
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison

--- a/unison-src/transcripts/idempotent/suffixes.md
+++ b/unison-src/transcripts/idempotent/suffixes.md
@@ -1,7 +1,7 @@
 # Suffix-based resolution of names
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 Any unique name suffix can be used to refer to a definition. For instance:
@@ -20,14 +20,14 @@ optional.isNone = cases
 This also affects commands like find. Notice lack of qualified names in output:
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> find take
+> find take
 
   1. builtin.Bytes.take : Nat -> Bytes -> Bytes
   2. builtin.List.take : Nat -> [a] -> [a]
@@ -39,11 +39,11 @@ scratch/main> find take
 The `view` and `display` commands also benefit from this:
 
 ``` ucm
-scratch/main> view List.drop
+> view List.drop
 
   builtin builtin.List.drop : builtin.Nat -> [a] -> [a]
 
-scratch/main> display bar.a
+> display bar.a
 
   +99
 ```
@@ -53,7 +53,7 @@ In the signature, we don't see `base.Nat`, just `Nat`. The full declaration name
 Type-based search also benefits from this, we can just say `Nat` rather than `.base.Nat`:
 
 ``` ucm
-scratch/main> find : Nat -> [a] -> [a]
+> find : Nat -> [a] -> [a]
 
   1. builtin.List.drop : Nat -> [a] -> [a]
   2. builtin.List.take : Nat -> [a] -> [a]
@@ -82,7 +82,7 @@ lib.distributed.lib.baz.qux = "indirect dependency"
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -126,7 +126,7 @@ scratch/main> add
 ```
 
 ``` ucm
-scratch/main> view abra.cadabra
+> view abra.cadabra
 
   cool.abra.cadabra : Text
   cool.abra.cadabra = "my project"
@@ -134,7 +134,7 @@ scratch/main> view abra.cadabra
   lib.distributed.abra.cadabra : Text
   lib.distributed.abra.cadabra = "direct dependency 1"
 
-scratch/main> view baz.qux
+> view baz.qux
 
   lib.distributed.baz.qux : Text
   lib.distributed.baz.qux = "direct dependency 2"
@@ -143,12 +143,12 @@ scratch/main> view baz.qux
 Note that we can always still view indirect dependencies by using more name segments:
 
 ``` ucm
-scratch/main> view distributed.abra.cadabra
+> view distributed.abra.cadabra
 
   lib.distributed.abra.cadabra : Text
   lib.distributed.abra.cadabra = "direct dependency 1"
 
-scratch/main> names distributed.lib.baz.qux
+> names distributed.lib.baz.qux
 
   'distributed.lib.baz.qux':
   Hash          Kind   Names

--- a/unison-src/transcripts/idempotent/sum-type-update-conflicts.md
+++ b/unison-src/transcripts/idempotent/sum-type-update-conflicts.md
@@ -3,7 +3,7 @@
 https://github.com/unisonweb/unison/issues/2786
 
 ``` ucm :hide
-scratch/main> builtins.merge lib.builtins
+> builtins.merge lib.builtins
 ```
 
 First we add a sum-type to the codebase.
@@ -21,7 +21,7 @@ structural type X = x
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -59,7 +59,7 @@ This update should succeed since the conflicted constructor
 is removed in the same update that the new term is being added.
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/test-command.md
+++ b/unison-src/transcripts/idempotent/test-command.md
@@ -1,7 +1,7 @@
 Merge builtins so we get enough names for the testing stuff.
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 The `test` command should run all of the tests in the current directory.
@@ -24,11 +24,11 @@ foo.test2 = [Ok "test2"]
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ``` ucm
-scratch/main> test
+> test
 
   ✅  
 
@@ -49,7 +49,7 @@ scratch/main> test
 Tests should be cached if unchanged.
 
 ``` ucm
-scratch/main> test
+> test
 
   Cached test results (`help testcache` to learn more)
 
@@ -77,11 +77,11 @@ lib.dep.testInLib = [Ok "testInLib"]
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ``` ucm
-scratch/main> test
+> test
 
   Cached test results (`help testcache` to learn more)
 
@@ -92,7 +92,7 @@ scratch/main> test
 
   Tip: Use view 1 to view the source of a test.
 
-scratch/main> test.all
+> test.all
 
     
     Cached test results (`help testcache` to learn more)
@@ -118,7 +118,7 @@ scratch/main> test.all
 `test` WILL run tests within `lib` if specified explicitly.
 
 ``` ucm
-scratch/main> test lib.dep
+> test lib.dep
 
   Cached test results (`help testcache` to learn more)
 
@@ -132,7 +132,7 @@ scratch/main> test lib.dep
 `test` can be given a relative path, in which case it will only run tests found somewhere in that namespace.
 
 ``` ucm
-scratch/main> test foo
+> test foo
 
   Cached test results (`help testcache` to learn more)
 

--- a/unison-src/transcripts/idempotent/text-literals.md
+++ b/unison-src/transcripts/idempotent/text-literals.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 This transcript shows some syntax for raw text literals.
@@ -82,14 +82,14 @@ lit2 = """"
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> view lit1 lit2
+> view lit1 lit2
 
   lit1 : Text
   lit1 =

--- a/unison-src/transcripts/idempotent/textfind.md
+++ b/unison-src/transcripts/idempotent/textfind.md
@@ -1,13 +1,13 @@
 # The `text.find` command
 
 ``` ucm :hide
-scratch/main> builtins.merge lib.builtin
+> builtins.merge lib.builtin
 ```
 
 The `text.find` (or `grep`) command can be used to search for text or numeric literals appearing anywhere in your project. Just supply one or more tokens to search for. Unlike regular grep over the text of your code, this ignores local variables and function names that happen to match your search tokens (use `dependents` or `find` for that purpose). It's only searching for text or numeric literals that match.
 
 ``` ucm
-scratch/main> help grep
+> help grep
 
   text.find (or grep)
   `text.find token1 "99" token2` finds terms with literals (text
@@ -20,7 +20,7 @@ scratch/main> help grep
 ```
 
 ``` ucm
-scratch/main> help text.find.all
+> help text.find.all
 
   text.find.all (or grep.all)
   `text.find.all token1 "99" token2` finds terms with literals
@@ -65,11 +65,11 @@ lib.bar = 3
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 ``` ucm
-scratch/main> grep hi
+> grep hi
 
   🔎
 
@@ -79,7 +79,7 @@ scratch/main> grep hi
 
   Tip: Try `edit 1` to bring this into your scratch file.
 
-scratch/main> view 1
+> view 1
 
   bar : Nat
   bar = match "well hi there" with
@@ -87,7 +87,7 @@ scratch/main> view 1
     "booga" -> 23
     _       -> 0
 
-scratch/main> grep "hi"
+> grep "hi"
 
   🔎
 
@@ -97,7 +97,7 @@ scratch/main> grep "hi"
 
   Tip: Try `edit 1` to bring this into your scratch file.
 
-scratch/main> text.find.all hi
+> text.find.all hi
 
   🔎
 
@@ -109,7 +109,7 @@ scratch/main> text.find.all hi
   Tip: Try `edit 1` or `edit 1-2` to bring these into your
        scratch file.
 
-scratch/main> view 1-5
+> view 1-5
 
   bar : Nat
   bar = match "well hi there" with
@@ -120,7 +120,7 @@ scratch/main> view 1-5
   lib.foo : [Any]
   lib.foo = [Any 46, Any "hi", Any "zoink"]
 
-scratch/main> grep oog
+> grep oog
 
   🔎
 
@@ -130,7 +130,7 @@ scratch/main> grep oog
 
   Tip: Try `edit 1` to bring this into your scratch file.
 
-scratch/main> view 1
+> view 1
 
   bar : Nat
   bar = match "well hi there" with
@@ -140,7 +140,7 @@ scratch/main> view 1
 ```
 
 ``` ucm
-scratch/main> grep quaffle
+> grep quaffle
 
   🔎
 
@@ -150,12 +150,12 @@ scratch/main> grep quaffle
 
   Tip: Try `edit 1` to bring this into your scratch file.
 
-scratch/main> view 1-5
+> view 1-5
 
   baz : [Text]
   baz = ["an", "quaffle", "tres"]
 
-scratch/main> text.find "interesting const"
+> text.find "interesting const"
 
   🔎
 
@@ -165,14 +165,14 @@ scratch/main> text.find "interesting const"
 
   Tip: Try `edit 1` to bring this into your scratch file.
 
-scratch/main> view 1-5
+> view 1-5
 
   foo : Nat
   foo =
     _ = "an interesting constant"
     1
 
-scratch/main> text.find "99" "23"
+> text.find "99" "23"
 
   🔎
 
@@ -182,7 +182,7 @@ scratch/main> text.find "99" "23"
 
   Tip: Try `edit 1` to bring this into your scratch file.
 
-scratch/main> view 1
+> view 1
 
   bar : Nat
   bar = match "well hi there" with
@@ -194,7 +194,7 @@ scratch/main> view 1
 Now some failed searches:
 
 ``` ucm :error
-scratch/main> grep lsdkfjlskdjfsd
+> grep lsdkfjlskdjfsd
 
   😶 I couldn't find any matches.
 
@@ -204,7 +204,7 @@ scratch/main> grep lsdkfjlskdjfsd
 Notice it gives the tip about `text.find.all`. But not here:
 
 ``` ucm :error
-scratch/main> grep.all lsdkfjlskdjfsd
+> grep.all lsdkfjlskdjfsd
 
   😶 I couldn't find any matches.
 ```

--- a/unison-src/transcripts/idempotent/todo-bug-builtins.md
+++ b/unison-src/transcripts/idempotent/todo-bug-builtins.md
@@ -1,7 +1,7 @@
 # The `todo` and `bug` builtin
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 `todo` and `bug` have type `a -> b`. They take a message or a value of type `a` and crash during runtime displaying `a` in ucm.

--- a/unison-src/transcripts/idempotent/top-level-exceptions.md
+++ b/unison-src/transcripts/idempotent/top-level-exceptions.md
@@ -1,13 +1,13 @@
 A simple transcript to test the use of exceptions that bubble to the top level.
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 FYI, here are the `Exception` and `Failure` types:
 
 ``` ucm
-scratch/main> view Exception Failure
+> view Exception Failure
 
   structural ability builtin.Exception where
     raise : Failure ->{Exception} x
@@ -37,18 +37,18 @@ mytest _ = [Ok "Great"]
 ```
 
 ``` ucm
-scratch/main> run main
+> run main
 
   ()
 
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test mytest
+> io.test mytest
 
     New test results:
 
@@ -83,7 +83,7 @@ unique type RuntimeError =
 ```
 
 ``` ucm :error
-scratch/main> run main2
+> run main2
 
   💔💥
 

--- a/unison-src/transcripts/idempotent/transcript-parser-commands.md
+++ b/unison-src/transcripts/idempotent/transcript-parser-commands.md
@@ -1,7 +1,7 @@
 ### Transcript parser operations
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 The transcript parser is meant to parse `ucm` and `unison` blocks.
@@ -19,7 +19,7 @@ x = 1
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -32,7 +32,7 @@ z
 ```
 
 ``` ucm :error
-scratch/main> delete foo
+> delete foo
 
   ⚠️
 
@@ -41,7 +41,7 @@ scratch/main> delete foo
 ```
 
 ``` ucm :error
-scratch/main> delete lineToken.call
+> delete lineToken.call
 
   ⚠️
 

--- a/unison-src/transcripts/idempotent/type-deps.md
+++ b/unison-src/transcripts/idempotent/type-deps.md
@@ -3,7 +3,7 @@
 https://github.com/unisonweb/unison/pull/2821
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 Define a type.
@@ -13,7 +13,7 @@ structural type Y = Y
 ```
 
 ``` ucm :hide
-scratch/main> add
+> add
 ```
 
 Now, we update `Y`, and add a new type `Z` which depends on it.
@@ -35,7 +35,7 @@ structural type Y = Y Nat
 ```
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -48,7 +48,7 @@ scratch/main> update
 
 -- This shouldn't exist, because it should've been blocked.
 
-scratch/main> view Z
+> view Z
 
   structural type Z = Z Y
 ```

--- a/unison-src/transcripts/idempotent/type-modifier-are-optional.md
+++ b/unison-src/transcripts/idempotent/type-modifier-are-optional.md
@@ -1,7 +1,7 @@
 # Type modifiers are optional, `unique` is the default.
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 Types and abilities may be prefixed with either `unique` or `structural`. When left unspecified, `unique` is assumed.

--- a/unison-src/transcripts/idempotent/unique-type-churn.md
+++ b/unison-src/transcripts/idempotent/unique-type-churn.md
@@ -19,7 +19,7 @@ unique type C = C B
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -43,7 +43,7 @@ unique type C = C B
 If the name stays the same, the churn is even prevented if the type is updated and then reverted to the original form.
 
 ``` ucm
-scratch/main> names A
+> names A
 
   'A':
   Hash            Kind   Names
@@ -66,14 +66,14 @@ unique type A = A ()
 ```
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> names A
+> names A
 
   'A':
   Hash            Kind   Names
@@ -98,14 +98,14 @@ unique type A = A
 Note that `A` is back to its original hash.
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> names A
+> names A
 
   'A':
   Hash            Kind   Names

--- a/unison-src/transcripts/idempotent/unitnamespace.md
+++ b/unison-src/transcripts/idempotent/unitnamespace.md
@@ -11,22 +11,22 @@
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> find
+> find
 
   1. `()`.foo : ##Text
 
-scratch/main> find-in `()`
+> find-in `()`
 
   1. foo : ##Text
 
-scratch/main> delete.namespace `()`
+> delete.namespace `()`
 
   Done.
 ```

--- a/unison-src/transcripts/idempotent/universal-cmp.md
+++ b/unison-src/transcripts/idempotent/universal-cmp.md
@@ -2,7 +2,7 @@ File for test cases making sure that universal equality/comparison
 cases exist for built-in types. Just making sure they don't crash.
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison
@@ -25,14 +25,14 @@ threadEyeDeez _ =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> run threadEyeDeez
+> run threadEyeDeez
 
   (false, true)
 ```

--- a/unison-src/transcripts/idempotent/unsafe-coerce.md
+++ b/unison-src/transcripts/idempotent/unsafe-coerce.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison
@@ -26,18 +26,18 @@ main _ =
 ```
 
 ``` ucm
-scratch/main> find unsafe.coerceAbilities
+> find unsafe.coerceAbilities
 
   1. builtin.unsafe.coerceAbilities : (a ->{e1} b) -> a -> b
 
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> io.test main
+> io.test main
 
     New test results:
 

--- a/unison-src/transcripts/idempotent/update-ignores-lib-namespace.md
+++ b/unison-src/transcripts/idempotent/update-ignores-lib-namespace.md
@@ -3,7 +3,7 @@ the project organization convention that dependencies are put in "lib"; it's muc
 one's own code if the "lib" namespace is simply ignored.
 
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 ``` unison
@@ -21,7 +21,7 @@ lib.foo = 100
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -45,14 +45,14 @@ foo = 200
 ```
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> names foo
+> names foo
 
   'foo':
   Hash          Kind   Names

--- a/unison-src/transcripts/idempotent/update-on-conflict.md
+++ b/unison-src/transcripts/idempotent/update-on-conflict.md
@@ -3,7 +3,7 @@
 Conflicted definitions prevent `update` from succeeding.
 
 ``` ucm :hide
-scratch/main> builtins.merge lib.builtins
+> builtins.merge lib.builtins
 ```
 
 ``` unison
@@ -21,18 +21,18 @@ temp = 2
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> debug.alias.term.force temp x
+> debug.alias.term.force temp x
 
   Done.
 
-scratch/main> delete.term temp
+> delete.term temp
 
   Done.
 ```
@@ -52,7 +52,7 @@ x = 3
 ```
 
 ``` ucm :error
-scratch/main> update
+> update
 
   This branch has more than one term with the name `x`. Please
   delete or rename all but one of them, then try the update

--- a/unison-src/transcripts/idempotent/update-suffixifies-properly.md
+++ b/unison-src/transcripts/idempotent/update-suffixifies-properly.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-myproject/main> builtins.merge lib.builtin
+> builtins.merge lib.builtin
 ```
 
 ``` unison
@@ -25,7 +25,7 @@ bar = a.x.x.x.x + c.y.y.y.y
 ```
 
 ``` ucm
-myproject/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -48,7 +48,7 @@ foo = +30
 ```
 
 ``` ucm :error
-myproject/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/update-term-aliases-in-different-ways.md
+++ b/unison-src/transcripts/idempotent/update-term-aliases-in-different-ways.md
@@ -1,5 +1,5 @@
 ``` ucm
-scratch/main> builtins.merge
+> builtins.merge
 
   Done.
 ```
@@ -22,7 +22,7 @@ bar = 5
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -50,14 +50,14 @@ bar = 7
 ```
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> view foo bar
+> view foo bar
 
   bar : Nat
   bar = 7

--- a/unison-src/transcripts/idempotent/update-term-to-different-type.md
+++ b/unison-src/transcripts/idempotent/update-term-to-different-type.md
@@ -1,5 +1,5 @@
 ``` ucm
-scratch/main> builtins.merge
+> builtins.merge
 
   Done.
 ```
@@ -18,7 +18,7 @@ foo = 5
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -42,14 +42,14 @@ foo = +5
 ```
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> view foo
+> view foo
 
   foo : Int
   foo = +5

--- a/unison-src/transcripts/idempotent/update-term-with-alias.md
+++ b/unison-src/transcripts/idempotent/update-term-with-alias.md
@@ -1,5 +1,5 @@
 ``` ucm
-scratch/main> builtins.merge
+> builtins.merge
 
   Done.
 ```
@@ -22,7 +22,7 @@ bar = 5
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -47,14 +47,14 @@ foo = 6
 ```
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> view foo bar
+> view foo bar
 
   bar : Nat
   bar = 5

--- a/unison-src/transcripts/idempotent/update-term-with-dependent-to-different-type.md
+++ b/unison-src/transcripts/idempotent/update-term-with-dependent-to-different-type.md
@@ -1,5 +1,5 @@
 ``` ucm
-scratch/main> builtins.merge
+> builtins.merge
 
   Done.
 ```
@@ -22,7 +22,7 @@ bar = foo + 10
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -46,7 +46,7 @@ foo = +5
 ```
 
 ``` ucm :error
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/update-term-with-dependent.md
+++ b/unison-src/transcripts/idempotent/update-term-with-dependent.md
@@ -1,5 +1,5 @@
 ``` ucm
-scratch/main> builtins.merge
+> builtins.merge
 
   Done.
 ```
@@ -22,7 +22,7 @@ bar = foo + 10
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -46,7 +46,7 @@ foo = 6
 ```
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -57,7 +57,7 @@ scratch/main> update
 
   Done.
 
-scratch/main> view bar
+> view bar
 
   bar : Nat
   bar =

--- a/unison-src/transcripts/idempotent/update-term.md
+++ b/unison-src/transcripts/idempotent/update-term.md
@@ -1,5 +1,5 @@
 ``` ucm
-scratch/main> builtins.merge
+> builtins.merge
 
   Done.
 ```
@@ -18,7 +18,7 @@ foo = 5
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -42,14 +42,14 @@ foo = 6
 ```
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> view foo
+> view foo
 
   foo : Nat
   foo = 6

--- a/unison-src/transcripts/idempotent/update-test-to-non-test.md
+++ b/unison-src/transcripts/idempotent/update-test-to-non-test.md
@@ -1,5 +1,5 @@
 ``` ucm
-scratch/main> builtins.merge
+> builtins.merge
 
   Done.
 ```
@@ -22,14 +22,14 @@ test> foo = []
 After adding the test `foo`, we expect `view` to render it like a test. (Bug: It doesn't.)
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> view foo
+> view foo
 
   foo : [Result]
   foo = []
@@ -52,14 +52,14 @@ foo = 1
 After updating `foo` to not be a test, we expect `view` to not render it like a test.
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> view foo
+> view foo
 
   foo : Nat
   foo = 1

--- a/unison-src/transcripts/idempotent/update-test-watch-roundtrip.md
+++ b/unison-src/transcripts/idempotent/update-test-watch-roundtrip.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge
+> builtins.merge
 ```
 
 Given a test that depends on another definition,
@@ -13,7 +13,7 @@ test> mynamespace.foo.test =
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -38,7 +38,7 @@ foo n = "hello, world!"
 ```
 
 ``` ucm :error
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/update-type-add-constructor.md
+++ b/unison-src/transcripts/idempotent/update-type-add-constructor.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge lib.builtin
+> builtins.merge lib.builtin
 ```
 
 ``` unison
@@ -16,7 +16,7 @@ unique type Foo
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -41,18 +41,18 @@ unique type Foo
 ```
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> view Foo
+> view Foo
 
   type Foo = Baz Nat Nat | Bar Nat
 
-scratch/main> find.verbose
+> find.verbose
 
   1. -- #id3p6do8f7ssln9npa3gs3c2i8uors25ffts92pr4nsh9k9bn3no50e4d1b053c2d0vei64pbtcpdld9gk6drsvptnpfqr6tp8v4qh0
      type Foo

--- a/unison-src/transcripts/idempotent/update-type-add-field.md
+++ b/unison-src/transcripts/idempotent/update-type-add-field.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge lib.builtin
+> builtins.merge lib.builtin
 ```
 
 ``` unison
@@ -15,7 +15,7 @@ unique type Foo = Bar Nat
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -38,18 +38,18 @@ unique type Foo = Bar Nat Nat
 ```
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> view Foo
+> view Foo
 
   type Foo = Bar Nat Nat
 
-scratch/main> find.verbose
+> find.verbose
 
   1. -- #hlhjq1lf1cvfevkvb9d441kkubn0f6s43gvrd4gcff0r739vomehjnov4b3qe8506fb5bm8m5ba0sol9mbljgkk3gb2qt2u02v6i2vo
      type Foo

--- a/unison-src/transcripts/idempotent/update-type-add-new-record.md
+++ b/unison-src/transcripts/idempotent/update-type-add-new-record.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge lib.builtins
+> builtins.merge lib.builtins
 ```
 
 ``` unison
@@ -19,14 +19,14 @@ unique type Foo = { bar : Nat }
 ```
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> view Foo
+> view Foo
 
   type Foo = { bar : Nat }
 ```

--- a/unison-src/transcripts/idempotent/update-type-add-record-field.md
+++ b/unison-src/transcripts/idempotent/update-type-add-record-field.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge lib.builtin
+> builtins.merge lib.builtin
 ```
 
 ``` unison
@@ -19,7 +19,7 @@ unique type Foo = { bar : Nat }
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -49,18 +49,18 @@ unique type Foo = { bar : Nat, baz : Int }
 ```
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> view Foo
+> view Foo
 
   type Foo = { bar : Nat, baz : Int }
 
-scratch/main> find.verbose
+> find.verbose
 
   1. -- #m0tpa159pbsdld5ea0marnq9614dnmjjc72n1evi4bsk45a1hl84qprt6vdvejuuiuc3f5o23olc1t19tk1dt8mjobmr0chqc3svij8
      type Foo

--- a/unison-src/transcripts/idempotent/update-type-constructor-alias.md
+++ b/unison-src/transcripts/idempotent/update-type-constructor-alias.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge lib.builtin
+> builtins.merge lib.builtin
 ```
 
 ``` unison
@@ -15,14 +15,14 @@ unique type Foo = Bar Nat
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> alias.term Foo.Bar Foo.BarAlias
+> alias.term Foo.Bar Foo.BarAlias
 
   Done.
 ```
@@ -42,7 +42,7 @@ unique type Foo = Bar Nat Nat
 ```
 
 ``` ucm :error
-scratch/main> update
+> update
 
   Sorry, I wasn't able to perform the update:
 

--- a/unison-src/transcripts/idempotent/update-type-delete-constructor-with-dependent.md
+++ b/unison-src/transcripts/idempotent/update-type-delete-constructor-with-dependent.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge lib.builtin
+> builtins.merge lib.builtin
 ```
 
 ``` unison
@@ -24,7 +24,7 @@ foo = cases
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -48,7 +48,7 @@ unique type Foo
 ```
 
 ``` ucm :error
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/update-type-delete-constructor.md
+++ b/unison-src/transcripts/idempotent/update-type-delete-constructor.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge lib.builtin
+> builtins.merge lib.builtin
 ```
 
 ``` unison
@@ -17,7 +17,7 @@ unique type Foo
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -41,18 +41,18 @@ unique type Foo
 ```
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> view Foo
+> view Foo
 
   type Foo = Bar Nat
 
-scratch/main> find.verbose
+> find.verbose
 
   1. -- #h88o5sirfn0a8f4o81sb012p2rha5h8r73n8bloc8qq94kqmltjq94iiep2e6dj7ppuulc8jce2f0vmddqp76nm0hqs9jh53s502v4g
      type Foo

--- a/unison-src/transcripts/idempotent/update-type-missing-constructor.md
+++ b/unison-src/transcripts/idempotent/update-type-missing-constructor.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge lib.builtin
+> builtins.merge lib.builtin
 ```
 
 ``` unison
@@ -15,14 +15,14 @@ unique type Foo = Bar Nat
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> delete.term Foo.Bar
+> delete.term Foo.Bar
 
   Done.
 ```
@@ -44,11 +44,11 @@ unique type Foo = Bar Nat Nat
 ```
 
 ``` ucm :error
-scratch/main> view Foo
+> view Foo
 
   type Foo = #5mod0n8ps2#0 Nat
 
-scratch/main> update
+> update
 
   Sorry, I wasn't able to perform the update:
 

--- a/unison-src/transcripts/idempotent/update-type-nested-decl-aliases.md
+++ b/unison-src/transcripts/idempotent/update-type-nested-decl-aliases.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge lib.builtin
+> builtins.merge lib.builtin
 ```
 
 ``` unison
@@ -20,7 +20,7 @@ structural type A = B.TheOtherAlias Foo
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -43,7 +43,7 @@ unique type Foo = Bar Nat Nat
 ```
 
 ``` ucm :error
-scratch/main> update
+> update
 
   The type A.B is an alias of A. I'm not able to perform an
   update when a type exists nested under an alias of itself.

--- a/unison-src/transcripts/idempotent/update-type-no-op-record.md
+++ b/unison-src/transcripts/idempotent/update-type-no-op-record.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge lib.builtin
+> builtins.merge lib.builtin
 ```
 
 ``` unison
@@ -19,7 +19,7 @@ unique type Foo = { bar : Nat }
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/update-type-stray-constructor-alias.md
+++ b/unison-src/transcripts/idempotent/update-type-stray-constructor-alias.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge lib.builtin
+> builtins.merge lib.builtin
 ```
 
 ``` unison
@@ -15,14 +15,14 @@ unique type Foo = Bar Nat
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> alias.term Foo.Bar Stray.BarAlias
+> alias.term Foo.Bar Stray.BarAlias
 
   Done.
 ```
@@ -42,7 +42,7 @@ unique type Foo = Bar Nat Nat
 ```
 
 ``` ucm :error
-scratch/main> update
+> update
 
   Sorry, I wasn't able to perform the update, because I need all
   constructor names to be nested somewhere beneath the

--- a/unison-src/transcripts/idempotent/update-type-stray-constructor.md
+++ b/unison-src/transcripts/idempotent/update-type-stray-constructor.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge lib.builtin
+> builtins.merge lib.builtin
 ```
 
 ``` unison
@@ -15,14 +15,14 @@ unique type Foo = Bar Nat
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> move.term Foo.Bar Stray.Bar
+> move.term Foo.Bar Stray.Bar
 
   Done.
 ```
@@ -46,11 +46,11 @@ unique type Foo = Bar Nat Nat
 Note that the constructor name shown here (implied to be called `Foo.Stray.Bar`) doesn't really exist, it's just showing up due to a pretty-printer bug.
 
 ``` ucm :error
-scratch/main> view Foo
+> view Foo
 
   type Foo = Stray.Bar Nat
 
-scratch/main> update
+> update
 
   Sorry, I wasn't able to perform the update:
 

--- a/unison-src/transcripts/idempotent/update-type-turn-constructor-into-smart-constructor.md
+++ b/unison-src/transcripts/idempotent/update-type-turn-constructor-into-smart-constructor.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge lib.builtin
+> builtins.merge lib.builtin
 ```
 
 ``` unison
@@ -20,7 +20,7 @@ makeFoo n = Bar (n+10)
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -48,7 +48,7 @@ Foo.Bar n = internal.Bar n
 ```
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -59,11 +59,11 @@ scratch/main> update
 
   Done.
 
-scratch/main> view Foo
+> view Foo
 
   type Foo = internal.Bar Nat
 
-scratch/main> find.verbose
+> find.verbose
 
   1. -- #oebc8v8v9lob5bnq7go1pjhfjbtnh8dmfhontua90t3mji0cl91t1dqaece9quofrk1vsbq6g0ukfigoi0vmvc01v8roceppejlgbs8
      type Foo

--- a/unison-src/transcripts/idempotent/update-type-turn-non-record-into-record.md
+++ b/unison-src/transcripts/idempotent/update-type-turn-non-record-into-record.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge lib.builtin
+> builtins.merge lib.builtin
 ```
 
 ``` unison
@@ -15,7 +15,7 @@ unique type Foo = Nat
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -42,18 +42,18 @@ unique type Foo = { bar : Nat }
 ```
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> view Foo
+> view Foo
 
   type Foo = { bar : Nat }
 
-scratch/main> find.verbose
+> find.verbose
 
   1. -- #5mod0n8ps2emue478fdroo6adp4ovt41qogtmduta8vgv1v8mi8ep2ho0rc1mg699j1feojmv0oe9ndbul5t64menchhnklpgji45o0
      type Foo

--- a/unison-src/transcripts/idempotent/update-type-with-dependent-term.md
+++ b/unison-src/transcripts/idempotent/update-type-with-dependent-term.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge lib.builtin
+> builtins.merge lib.builtin
 ```
 
 ``` unison
@@ -20,7 +20,7 @@ incrFoo = cases Bar n -> Bar (n+1)
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -43,7 +43,7 @@ unique type Foo = Bar Nat Nat
 ```
 
 ``` ucm :error
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/update-type-with-dependent-type-to-different-kind.md
+++ b/unison-src/transcripts/idempotent/update-type-with-dependent-type-to-different-kind.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge lib.builtin
+> builtins.merge lib.builtin
 ```
 
 ``` unison
@@ -17,7 +17,7 @@ unique type Baz = Qux Foo
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -40,7 +40,7 @@ unique type Foo a = Bar Nat a
 ```
 
 ``` ucm :error
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/update-type-with-dependent-type.md
+++ b/unison-src/transcripts/idempotent/update-type-with-dependent-type.md
@@ -1,5 +1,5 @@
 ``` ucm :hide
-scratch/main> builtins.merge lib.builtin
+> builtins.merge lib.builtin
 ```
 
 ``` unison
@@ -17,7 +17,7 @@ unique type Baz = Qux Foo
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -40,7 +40,7 @@ unique type Foo = Bar Nat Nat
 ```
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -51,15 +51,15 @@ scratch/main> update
 
   Done.
 
-scratch/main> view Foo
+> view Foo
 
   type Foo = Bar Nat Nat
 
-scratch/main> view Baz
+> view Baz
 
   type Baz = Qux Foo
 
-scratch/main> find.verbose
+> find.verbose
 
   1. -- #1uosg6rv85ql7rbohtfvqqacgjl5pp2faj0t3k3dkrtn0t3jqdh2m2om8earv0jh8m8j86vv6bv1h17jl8a2lfa857pm6n27hnisi1g
      type Baz

--- a/unison-src/transcripts/idempotent/update-watch.md
+++ b/unison-src/transcripts/idempotent/update-watch.md
@@ -13,7 +13,7 @@
 ```
 
 ``` ucm
-scratch/main> update
+> update
 
   Okay, I'm searching the branch for code that needs to be
   updated...

--- a/unison-src/transcripts/idempotent/watch-expressions.md
+++ b/unison-src/transcripts/idempotent/watch-expressions.md
@@ -1,5 +1,5 @@
 ``` ucm
-scratch/main> builtins.mergeio
+> builtins.mergeio
 
   Done.
 ```
@@ -21,7 +21,7 @@ test> pass = [Ok "Passed"]
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
@@ -44,14 +44,14 @@ test> pass = [Ok "Passed"]
 ```
 
 ``` ucm
-scratch/main> add
+> add
 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
   Done.
 
-scratch/main> test
+> test
 
   Cached test results (`help testcache` to learn more)
 

--- a/unison-src/transcripts/pretty-print-libraries.md
+++ b/unison-src/transcripts/pretty-print-libraries.md
@@ -3,11 +3,11 @@ This transcript is to detect changes in the pretty-printer for a few major publi
 We clone releases and not dev branches to avoid external changes, and also to reduce the time needed to clone the libraries.
 
 ```ucm
-scratch/main> clone @unison/base/releases/3.19.0
+> clone @unison/base/releases/3.19.0
 @unison/base/releases/3.19.0> edit.namespace .
 ```
 
 ```ucm
-scratch/main> clone @unison/http/releases/3.3.2
+> clone @unison/http/releases/3.3.2
 @unison/http/releases/3.3.2> edit.namespace .
 ```

--- a/unison-src/transcripts/pretty-print-libraries.output.md
+++ b/unison-src/transcripts/pretty-print-libraries.output.md
@@ -3,7 +3,7 @@ This transcript is to detect changes in the pretty-printer for a few major publi
 We clone releases and not dev branches to avoid external changes, and also to reduce the time needed to clone the libraries.
 
 ``` ucm
-scratch/main> clone @unison/base/releases/3.19.0
+> clone @unison/base/releases/3.19.0
 
   Cloned @unison/base/releases/3.19.0.
 
@@ -83165,7 +83165,7 @@ Void.doc =
 ````
 
 ``` ucm
-scratch/main> clone @unison/http/releases/3.3.2
+> clone @unison/http/releases/3.3.2
 
   Cloned @unison/http/releases/3.3.2.
 

--- a/unison-src/transcripts/project-outputs/.github/ISSUE_TEMPLATE/bug_report.output.md
+++ b/unison-src/transcripts/project-outputs/.github/ISSUE_TEMPLATE/bug_report.output.md
@@ -18,7 +18,7 @@ a = 1
 Here I try to pass an argument to `update`, which fails:
 
 ``` ucm :error
-scratch/main> update a
+> update a
 
   ⚠️
 

--- a/unison-src/transcripts/project-outputs/docs/mcp.output.md
+++ b/unison-src/transcripts/project-outputs/docs/mcp.output.md
@@ -1,0 +1,47 @@
+# MCP Setup
+
+UCM comes packaged with a built-in MCP server for use with AI agents.
+It includes tools for allowing an AI agent to inspect and search your code, write and typecheck new code, search Share
+for projects and definitions, and more\!
+
+## Setup
+
+To configure the MCP for use with Claude, edit your Claude Desktop config JSON file, which is found:
+
+  - On Mac: `~/Library/Application Support/Claude/claude_desktop_config.json`
+  - On Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+
+Add the following as a key in the `mcpServers` mapping there. Replace `<path-to-ucm>` with the path to your `ucm` executable.
+E.g. on Mac this is likely `/opt/homebrew/bin/ucm`.
+
+``` json
+{
+  "mcpServers": {
+    "unison": {
+      "command": "<path-to-ucm>",
+      "args": ["mcp"]
+    }
+}
+```
+
+E.g. my complete file on Mac looks like this:
+
+``` 
+{
+  "mcpServers": {
+    "unison": {
+      "command": "/opt/homebrew/bin/ucm",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+After saving the file, restart the Claude Desktop app. You should now see a new "unison" option in the MCP server list.
+
+## Usage
+
+By default, Claude will now automatically use the Unison MCP server when it deems it appropriate, however
+if you're planning to ask Claude to write some Unison code it's recommended you use one of the Unison MCP prompts
+to kick off your interaction. You can find them by clicking the "plus" icon next to the prompt input box, and then
+choosing `Add from unison` and selecting the appropriate prompt.


### PR DESCRIPTION
## Overview

This implements part of #5792.

It allows the “project/branch” prefix to be omitted before UCM commands.

E.g.,

``` ucm
scratch/main> builtins.merge
```

can be written

``` ucm
> builtins.merge
```

## Interesting/controversial decisions

I updated all transcripts that don’t do anything too complicated with the context to omit the context. We can drop these, or some of them, if desired.

## Test coverage

There’s a new transcript that tests various aspects of the behavior. Also, all the updated transcripts work (although most of them never switch from “scratch/main”).