### PR TITLE
Fix loading of certain version 5 serialized values

### DIFF
--- a/unison-runtime/src/Unison/Runtime/Machine.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine.hs
@@ -1658,9 +1658,8 @@ reifyValue cc val = do
   where
     f False r = (mempty, S.singleton r)
     f True r = (S.singleton r, mempty)
-    (tyLinks, tmLinks) = case val of
-      WithRefs tys tms _ -> (Set.fromList tys, Set.fromList tms)
-      Plain val -> valueLinks f val
+
+    (tyLinks, tmLinks) = valueLinks f (dereference val)
 
 reifyValue1 ::
   (EnumMap Word64 MCombs, M.Map Reference Word64, M.Map Reference Word64) ->

--- a/unison-src/transcripts-using-base/base.u
+++ b/unison-src/transcripts-using-base/base.u
@@ -121,6 +121,14 @@ List.reverse =
     x +: xs -> loop (x +: acc) xs
   loop []
 
+List.foldMap0 : (a ->{e} [b]) -> [b] -> [a] ->{e} [b]
+List.foldMap0 f acc = cases
+  [] -> acc
+  x +: xs -> foldMap0 f (acc ++ f x) xs
+
+List.foldMap : (a ->{e} [b]) -> [a] ->{e} [b]
+List.foldMap f xs = foldMap0 f [] xs
+
 Optional.getOrBug msg = cases
   None -> bug msg
   Some a -> a
@@ -155,6 +163,8 @@ isNone = cases
   Some _ -> false
   None -> true
 
+when : Boolean -> '{e} () ->{e} ()
+when b th = if b then !th else ()
 
 structural ability Stream a where
    emit: a -> ()
@@ -168,7 +178,7 @@ Stream.toList.handler =
 
   go []
 
-Stream.toList : '{Stream a} r -> [a]
+Stream.toList : '{e, Stream a} r ->{e} [a]
 Stream.toList s = handle !s with toList.handler
 
 Stream.collect.handler : Request {Stream a} r -> ([a],r)

--- a/unison-src/transcripts-using-base/random-deserial.md
+++ b/unison-src/transcripts-using-base/random-deserial.md
@@ -12,8 +12,8 @@ gen seed k =
   a = 6364136223846793005
   (mod seed k, a * seed + c)
 
-shuffle : Nat -> [a] -> [a]
-shuffle =
+shuffle0 : Nat -> [a] -> [a]
+shuffle0 =
   pick acc seed = cases
     l | lteq (List.size l) 1 -> acc ++ l
       | otherwise -> match gen seed (size l) with
@@ -23,43 +23,49 @@ shuffle =
 
   pick []
 
-runTestCase : Text ->{Exception,IO} (Text, Test.Result)
+shuffle : [a] -> [a]
+shuffle xs = shuffle0 (toRepresentation !systemTimeMicroseconds) xs
+
+collectFailures : Text -> Nat -> Text ->{Exception, IO} [Text]
+collectFailures name version target =
+  vname = name ++ ".v" ++ toText version
+  sfile = directory ++ vname ++ ".ser"
+  hfile = directory ++ vname ++ ".hash"
+
+  Stream.toList do
+    when (fileExists sfile) do
+      p@(f, i) = loadSelfContained sfile
+      when (not (f i == target)) do
+        emit (vname ++ " output mismatch")
+      when (fileExists hfile) do
+        h = readFile hfile
+        when (not (h == toBase32 (crypto.hash Sha3_512 p))) do
+          emit (vname ++ " hash mismatch")
+
+runTestCase : Text ->{Exception,IO} (Text, [Test.Result])
 runTestCase name =
-  sfile = directory ++ name ++ ".v4.ser"
-  ls3file = directory ++ name ++ ".v3.ser"
   ofile = directory ++ name ++ ".out"
-  hfile = directory ++ name ++ ".v4.hash"
-  s5file = directory ++ name ++ ".v5.ser"
 
-  p@(f, i) = loadSelfContained sfile
-  pl3@(fl3, il3) =
-    if fileExists ls3file
-    then loadSelfContained ls3file
-    else p
-  p5@(f5, i5) =
-    if fileExists s5file
-    then loadSelfContained s5file
-    else p
-  o = fromUtf8 (readFile ofile)
-  h = readFile hfile
+  target = fromUtf8 (readFile ofile)
 
-  result =
-    if not (f i == o)
-    then Fail (name ++ " output mismatch")
-    else if not (toBase32 (crypto.hash Sha3_512 p) == h)
-    then Fail (name ++ " hash mismatch")
-    else if not (fl3 il3 == f i)
-    then Fail (name ++ " legacy v3 mismatch")
-    else if not (f5 i5 == f i)
-    then Fail (name ++ " v5 mismatch")
-    else Ok name
-  (name, result)
+  test : Nat -> (Nat, [Text])
+  test ver = (ver, collectFailures name ver target)
+
+  failures : [(Nat,[Text])]
+  failures = bSort (List.map test (shuffle [3, 4, 5]))
+
+  result : (Nat, [Text]) -> [Test.Result]
+  result = cases
+    (ver, []) -> [Ok (name ++ " v" ++ toText ver)]
+    (_, fails) -> List.map Fail fails
+
+  (name, foldMap result failures)
 
 serialTests : '{IO,Exception} [Test.Result]
 serialTests = do
   l = !availableCases
-  cs = shuffle (toRepresentation !systemTimeMicroseconds) l
-  List.map snd (bSort (List.map runTestCase cs))
+  cs = shuffle l
+  List.foldMap snd (bSort (List.map runTestCase cs))
 ```
 
 ``` ucm

--- a/unison-src/transcripts-using-base/random-deserial.output.md
+++ b/unison-src/transcripts-using-base/random-deserial.output.md
@@ -12,8 +12,8 @@ gen seed k =
   a = 6364136223846793005
   (mod seed k, a * seed + c)
 
-shuffle : Nat -> [a] -> [a]
-shuffle =
+shuffle0 : Nat -> [a] -> [a]
+shuffle0 =
   pick acc seed = cases
     l | lteq (List.size l) 1 -> acc ++ l
       | otherwise -> match gen seed (size l) with
@@ -23,54 +23,65 @@ shuffle =
 
   pick []
 
-runTestCase : Text ->{Exception,IO} (Text, Test.Result)
+shuffle : [a] -> [a]
+shuffle xs = shuffle0 (toRepresentation !systemTimeMicroseconds) xs
+
+collectFailures : Text -> Nat -> Text ->{Exception, IO} [Text]
+collectFailures name version target =
+  vname = name ++ ".v" ++ toText version
+  sfile = directory ++ vname ++ ".ser"
+  hfile = directory ++ vname ++ ".hash"
+
+  Stream.toList do
+    when (fileExists sfile) do
+      p@(f, i) = loadSelfContained sfile
+      when (not (f i == target)) do
+        emit (vname ++ " output mismatch")
+      when (fileExists hfile) do
+        h = readFile hfile
+        when (not (h == toBase32 (crypto.hash Sha3_512 p))) do
+          emit (vname ++ " hash mismatch")
+
+runTestCase : Text ->{Exception,IO} (Text, [Test.Result])
 runTestCase name =
-  sfile = directory ++ name ++ ".v4.ser"
-  ls3file = directory ++ name ++ ".v3.ser"
   ofile = directory ++ name ++ ".out"
-  hfile = directory ++ name ++ ".v4.hash"
-  s5file = directory ++ name ++ ".v5.ser"
 
-  p@(f, i) = loadSelfContained sfile
-  pl3@(fl3, il3) =
-    if fileExists ls3file
-    then loadSelfContained ls3file
-    else p
-  p5@(f5, i5) =
-    if fileExists s5file
-    then loadSelfContained s5file
-    else p
-  o = fromUtf8 (readFile ofile)
-  h = readFile hfile
+  target = fromUtf8 (readFile ofile)
 
-  result =
-    if not (f i == o)
-    then Fail (name ++ " output mismatch")
-    else if not (toBase32 (crypto.hash Sha3_512 p) == h)
-    then Fail (name ++ " hash mismatch")
-    else if not (fl3 il3 == f i)
-    then Fail (name ++ " legacy v3 mismatch")
-    else if not (f5 i5 == f i)
-    then Fail (name ++ " v5 mismatch")
-    else Ok name
-  (name, result)
+  test : Nat -> (Nat, [Text])
+  test ver = (ver, collectFailures name ver target)
+
+  failures : [(Nat,[Text])]
+  failures = bSort (List.map test (shuffle [3, 4, 5]))
+
+  result : (Nat, [Text]) -> [Test.Result]
+  result = cases
+    (ver, []) -> [Ok (name ++ " v" ++ toText ver)]
+    (_, fails) -> List.map Fail fails
+
+  (name, foldMap result failures)
 
 serialTests : '{IO,Exception} [Test.Result]
 serialTests = do
   l = !availableCases
-  cs = shuffle (toRepresentation !systemTimeMicroseconds) l
-  List.map snd (bSort (List.map runTestCase cs))
+  cs = shuffle l
+  List.foldMap snd (bSort (List.map runTestCase cs))
 ```
 
 ``` ucm :added-by-ucm
   Loading changes detected in scratch.u.
 
-  + availableCases : '{IO, Exception} [Text]
-  + directory      : Text
-  + gen            : Nat -> Nat -> (Nat, Nat)
-  + runTestCase    : Text ->{IO, Exception} (Text, Result)
-  + serialTests    : '{IO, Exception} [Result]
-  + shuffle        : Nat -> [a] -> [a]
+  + availableCases  : '{IO, Exception} [Text]
+  + collectFailures : Text
+                      -> Nat
+                      -> Text
+                      ->{IO, Exception} [Text]
+  + directory       : Text
+  + gen             : Nat -> Nat -> (Nat, Nat)
+  + runTestCase     : Text ->{IO, Exception} (Text, [Result])
+  + serialTests     : '{IO, Exception} [Result]
+  + shuffle         : [a] ->{IO} [a]
+  + shuffle0        : Nat -> [a] -> [a]
 
   Run `update` to apply these changes to your codebase.
 ```
@@ -87,13 +98,23 @@ scratch/main> io.test serialTests
 
     New test results:
 
-    1. serialTests   ◉ case-00
-                     ◉ case-01
-                     ◉ case-02
-                     ◉ case-03
-                     ◉ case-04
+    1. serialTests   ◉ case-00 v3
+                     ◉ case-00 v4
+                     ◉ case-00 v5
+                     ◉ case-01 v3
+                     ◉ case-01 v4
+                     ◉ case-01 v5
+                     ◉ case-02 v3
+                     ◉ case-02 v4
+                     ◉ case-02 v5
+                     ◉ case-03 v3
+                     ◉ case-03 v4
+                     ◉ case-03 v5
+                     ◉ case-04 v3
+                     ◉ case-04 v4
+                     ◉ case-04 v5
 
-  ✅ 5 test(s) passing
+  ✅ 15 test(s) passing
 
   Tip: Use view 1 to view the source of a test.
 ```


### PR DESCRIPTION
This fixes an oversight that was preventing loading of serialized values in the new format.

During loading, we check if we know all the references necessary to make sense of the values _as values_. So, for example, if you are loading a `Code`, you just need to know the `Code` reference.

Version 5 has _all_ the references mentioned anywhere in the value lifted out to the top. At some point, I thought I could just return those, but this is wrong. For instance, a `Code` value will have all the references mentioned in the code there. And a term link value will have the reference from the term link, which you do _not_ need to have loaded in the runtime just to talk _about_ the link (it would be impossible to ever load new code if this were the case).

So, I've changed it back to doing the correct traversal and collecting the necessary references.

I also changed the `random-deserial` transcript to randomize the order we load different versions in. Those are the tests designed to catch problems like this, but since v4 was always loaded before v5, the references would always be known (because the v4 loading would add them).