### PR TITLE
Add to an error message to address issue #5722

### DIFF
--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -632,22 +632,33 @@ renderTypeError e env src = case e of
         debugSummary note
       ]
   AbilityInstantiationFailure _v want site _ ->
-    mconcat
-      [ "I wasn't able to solve for an implicit effect variable when checking\n",
-        "the definition:",
+    mconcat $
+      [ Pr.wrap . mconcat $
+          [ "I wasn't able to solve for an implicit effect variable ",
+            "when checking the definition:"
+          ],
         "\n\n",
         showSourceMaybes src [(,Type1) <$> rangeForAnnotated site],
+        "\n",
+        Pr.wrap . mconcat $
+          [ "This is likely due to a recursive function using ",
+            "abilities where the signature does not specify the ",
+            "abilities used. It may also be from a variable ",
+            "introduced by an ability match escaping its scope."
+          ],
         "\n\n",
-        "This is likely due to a recursive function using abilities where the\n",
-        "signature does not specify the abilities used. It may also be from a\n",
-        "variable introduced by an ability match escaping its scope.",
+        Pr.wrap . mconcat $
+          [ "In the first case, I think the abilities should be",
+            "similar to"
+          ],
         "\n\n",
-        "In the first case, I think the abilities should be similar to\n\n",
         Pr.indentN 4 . style Type1 $
           "{" <> commas (renderType' env) want <> "}",
         "\n\n",
-        "Please adjust the signature to include the ability annotation on the\n",
-        "arrow."
+        Pr.wrap . mconcat $
+          [ "Please adjust the signature to include the ability ",
+            "annotation on the arrow."
+          ]
       ]
   UnguardedLetRecCycle vs locs _ ->
     mconcat

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -639,9 +639,10 @@ renderTypeError e env src = case e of
         showSourceMaybes src [(,Type1) <$> rangeForAnnotated site],
         "\n\n",
         "This is likely due to a recursive function using abilities where the\n",
-        "signature does not specify the abilities used.",
+        "signature does not specify the abilities used. It may also be from a\n",
+        "variable introduced by an ability match escaping its scope.",
         "\n\n",
-        "I think the abilities should be similar to\n\n",
+        "In the first case, I think the abilities should be similar to\n\n",
         Pr.indentN 4 . style Type1 $
           "{" <> commas (renderType' env) want <> "}",
         "\n\n",

--- a/unison-src/transcripts/idempotent/fix5655.md
+++ b/unison-src/transcripts/idempotent/fix5655.md
@@ -10,21 +10,22 @@ foo th =
 ``` ucm :added-by-ucm
   Loading changes detected in scratch.u.
 
-  I wasn't able to solve for an implicit effect variable when checking
-  the definition:
+  I wasn't able to solve for an implicit effect variable when
+  checking the definition:
 
       2 | foo th =
       3 |   _ = !th
       4 |   foo th
 
+  This is likely due to a recursive function using abilities
+  where the signature does not specify the abilities used. It
+  may also be from a variable introduced by an ability match
+  escaping its scope.
 
-  This is likely due to a recursive function using abilities where the
-  signature does not specify the abilities used.
-
-  I think the abilities should be similar to
+  In the first case, I think the abilities should be similar to
 
       {g}
 
-  Please adjust the signature to include the ability annotation on the
-  arrow.
+  Please adjust the signature to include the ability annotation
+  on the arrow.
 ```


### PR DESCRIPTION
This adjusts the error message from #5825 to address the situation in in #5722. The latter triggers the same failure in the type checker, but the reason is different. In this case it's just an ability match introducing a type variable that is not allowed to escape the scope, but will as written.