### PR TITLE
Treat `{g}` as `g` in kind checker's `lookupType`

### DIFF
--- a/parser-typechecker/src/Unison/KindInference/Generate/Monad.hs
+++ b/parser-typechecker/src/Unison/KindInference/Generate/Monad.hs
@@ -17,6 +17,7 @@ import Data.List.NonEmpty (NonEmpty ((:|)))
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
+import Unison.ABT (Term (Term), ABT (Tm))
 import Unison.KindInference.Constraint.Provenance (Provenance)
 import Unison.KindInference.Constraint.Unsolved (Constraint (..))
 import Unison.KindInference.UVar (UVar (..))
@@ -78,7 +79,12 @@ pushType t = do
 lookupType :: (Var v) => T.Type v loc -> Gen v loc (Maybe (UVar v loc))
 lookupType t = do
   GenState {typeMap} <- get
-  pure (NonEmpty.head <$> Map.lookup t typeMap)
+  pure (NonEmpty.head <$> lookups t typeMap)
+  where
+  lookups t typeMap
+    | r@(Just _) <- Map.lookup t typeMap = r
+  lookups (Term _ _ (Tm (T.Effects [v]))) typeMap = lookups v typeMap
+  lookups _ _ = Nothing
 
 -- | Remove a @Type@ from the context
 popType :: (Var v) => T.Type v loc -> Gen v loc ()

--- a/parser-typechecker/src/Unison/KindInference/Generate/Monad.hs
+++ b/parser-typechecker/src/Unison/KindInference/Generate/Monad.hs
@@ -17,7 +17,7 @@ import Data.List.NonEmpty (NonEmpty ((:|)))
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
-import Unison.ABT (Term (Term), ABT (Tm))
+import Unison.ABT (ABT (Tm), Term (Term))
 import Unison.KindInference.Constraint.Provenance (Provenance)
 import Unison.KindInference.Constraint.Unsolved (Constraint (..))
 import Unison.KindInference.UVar (UVar (..))
@@ -81,10 +81,10 @@ lookupType t = do
   GenState {typeMap} <- get
   pure (NonEmpty.head <$> lookups t typeMap)
   where
-  lookups t typeMap
-    | r@(Just _) <- Map.lookup t typeMap = r
-  lookups (Term _ _ (Tm (T.Effects [v]))) typeMap = lookups v typeMap
-  lookups _ _ = Nothing
+    lookups t typeMap
+      | r@(Just _) <- Map.lookup t typeMap = r
+    lookups (Term _ _ (Tm (T.Effects [v]))) typeMap = lookups v typeMap
+    lookups _ _ = Nothing
 
 -- | Remove a @Type@ from the context
 popType :: (Var v) => T.Type v loc -> Gen v loc ()

--- a/unison-src/transcripts/idempotent/fix5453.md
+++ b/unison-src/transcripts/idempotent/fix5453.md
@@ -1,0 +1,15 @@
+Checks that wrapping parameter variables in braces works in the body
+of an ability.
+
+``` unison
+ability MyAbility g where
+  get : '{MyAbility {g}} ()
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  + ability MyAbility g
+
+  Run `update` to apply these changes to your codebase.
+```


### PR DESCRIPTION
Fixes #5453, test included.