### PR TITLE
Use full type when reporting a mismatch error

### DIFF
--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -426,8 +426,8 @@ renderTypeError e env src = case e of
   Mismatch {..} ->
     mconcat
       [ Pr.lines
-          [ "I found a value  of type:  " <> style Type1 (renderType' env foundLeaf),
-            "where I expected to find:  " <> style Type2 (renderType' env expectedLeaf)
+          [ "I found a value  of type:  " <> style Type1 (renderType' env foundType),
+            "where I expected to find:  " <> style Type2 (renderType' env expectedType)
           ],
         "\n\n",
         showSourceMaybes

--- a/unison-src/transcripts/idempotent/fix614.md
+++ b/unison-src/transcripts/idempotent/fix614.md
@@ -40,7 +40,7 @@ ex2 = do
 ``` ucm :added-by-ucm
   Loading changes detected in scratch.u.
 
-  I found a value  of type:  a ->{Stream a} Unit
+  I found a value  of type:  a1 ->{Stream a1} Unit
   where I expected to find:  Unit
 
       2 |   Stream.emit

--- a/unison-src/transcripts/idempotent/name-resolution-fuzzy.md
+++ b/unison-src/transcripts/idempotent/name-resolution-fuzzy.md
@@ -36,8 +36,8 @@ myFunction = truncate
 ``` ucm :added-by-ucm
   Loading changes detected in scratch.u.
 
-  I found a value  of type:  Int
-  where I expected to find:  Nat
+  I found a value  of type:  Float -> Int
+  where I expected to find:  Float ->{𝕖} Nat
 
       2 | myFunction : Float -> Nat
       3 | myFunction = truncate


### PR DESCRIPTION
The leaf mismatch is the innermost piece of the type that failed to match, but that can occur after the type has been pulled apart multiple times. The full type is the entry point to the subtyping check, and is more likely to correspond to an actual code value.

This fixes #5440. See the changed transcript output for a somewhat different example (where there the kinds made sense to talk about "a value" but there was actually no such value in the code). It might not be 100% guaranteed to never say something that sounds like a kind error, but it's less likely.

One thing I'm not sure about is if you have a _really big_ subtyping call, it might be hard to spot the actual difference in the full types. So maybe I should still include the leaf mismatch with different verbage?