### PR TITLE
Handle case where a handler's type is an existential variable

### DIFF
--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -1325,6 +1325,25 @@ synthesizeWanted (Term.Handle' h body) = do
       let (oes, o') = Type.stripEffect o
       want <- checkWanted Nothing (fmap (Just h,) oes) body rt
       pure (o', want)
+    -- another degenerate case, handler has completely unknown type
+    v0@(Type.Var' (TypeVar.Existential _ _)) -> do
+      r <- extendExistential Var.inferInput
+      e <- extendExistential Var.inferAbility
+      o <- extendExistential Var.inferOutput
+      let lo = loc v0
+          rt = existentialp lo r
+          ot = existentialp lo o
+          et = existentialp lo e
+          eff =
+            Type.apps
+              (Type.ref lo Type.effectRef)
+              [(lo, Type.effects lo [et]), (lo, rt)]
+          hndt = Type.arrow lo eff ot
+      subtype hndt v0
+      ot <- applyM ot
+      let (oes, ot') = Type.stripEffect ot
+      want <- checkWanted Nothing (fmap (Just h,) oes) body rt
+      pure (ot', want)
     _ -> failWith $ HandlerOfUnexpectedType (loc h) ht
 synthesizeWanted (Term.Ann' e t) = checkScoped e t
 synthesizeWanted tm@(Term.Apps' f args) = do

--- a/unison-src/transcripts/idempotent/fix5304.md
+++ b/unison-src/transcripts/idempotent/fix5304.md
@@ -1,0 +1,50 @@
+``` ucm :hide
+scratch/main> builtins.merge
+```
+
+``` unison :error
+
+ability Abort where
+  abort : r
+
+pesto = do
+  handle abort with marinara
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I couldn't figure out what marinara refers to here:
+
+      6 |   handle abort with marinara
+
+  I think its type should be:
+
+      Request {𝕖} 𝕒 -> 𝕣
+
+  Some common causes of this error include:
+    * Your current namespace is too deep to contain the
+      definition in its subtree
+    * The definition is part of a library which hasn't been
+      added to this project
+    * You have a typo in the name
+```
+
+``` unison
+
+ability Abort where
+  abort : r
+
+pesto marinara = do
+  handle abort with marinara
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  + ability Abort
+
+  + pesto : (Request {g} a -> r) -> '{Abort} r
+
+  Run `update` to apply these changes to your codebase.
+```


### PR DESCRIPTION
Previously this would just error out. Instead, we now do a subtyping check against a fabricated handler request type. This allows type checking to progress, so you can reach other error error states. So for instance, if the handler is a blank, as in #5304, it will now properly report that it doesn't know what the handler is referring to, instead of being a type error.

Fixes #5304