### PR TITLE
Don’t override hashtables version in stack.yaml

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -66,8 +66,10 @@ extra-deps:
   - numerals-0.4.1@sha256:f138b4a0efbde3b3c6cbccb788eff683cb8a5d046f449729712fd174c5ee8a78,11430
   - network-udp-0.0.0@sha256:408d2d4fa1a25e49e95752ee124cca641993404bb133ae10fb81daef22d876ae,1075
 
-  # The version in lts-22.26 (1.3.1) doesn’t work with newer GCC releases
-  - hashtables-1.4.2@65107f0c970351b971ea1f676a5e00b61e37c298a4c83c867d937f2a774501eb
+  # TODO: The revision pinned here doesn’t exist in the Nix snapshot of Hackage we use. Uncomment this once we update
+  #       the Nix inputs (likely via #5796).
+  # # The version in lts-22.26 (1.3.1) doesn’t work with newer GCC releases
+  # - hashtables-1.4.2@sha256:4940cab94a15d469845ccf5225f9cb3d354c15e8127ebb58425c8b681f7721d9,10386
 
 flags:
   haskeline:


### PR DESCRIPTION
The Nix snapshot of Hackage we use doesn’t contain that version. Since stack.yaml is used to generate the Nix derivations, this is a problem. So, temporarily let the Stack and Cabal versions get out of sync.