### PR TITLE
Avoid redundant re-hashing when squashing an already squashed branch

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -97,6 +97,7 @@ where
 
 import Control.Lens hiding (children, cons, transform, uncons)
 import Data.Map qualified as Map
+import Data.Monoid (Any (..))
 import Data.Semialign qualified as Align
 import Data.These (These (..))
 import U.Codebase.Branch.Type (NamespaceStats (..))
@@ -269,16 +270,33 @@ namespaceStats b =
 head_ :: Lens' (Branch m) (Branch0 m)
 head_ = history_ . Causal.head_
 
+-- | Discards the history of a Branch0, or returns the same branch if
+-- there was already no history.
+--
+-- Returns whether any history was actually discarded, so we may avoid
+-- unnecessary re-hashing.
+discardHistoryIfNecessary :: (Applicative m) => Branch m -> (Any, Branch m)
+discardHistoryIfNecessary b =
+  case _history b of
+    Causal.One _ _ b0 -> do
+      let (Any changed, b0') = discardHistory0IfNecessary b0
+      -- Avoid re-hashing things by returning the original if nothing actually changed
+      if changed
+        then (Any True, one b0')
+        else (Any False, b)
+    _ -> (Any True, one $ discardHistory0 (head b))
+
+discardHistory0IfNecessary :: (Applicative m) => Branch0 m -> (Any, Branch0 m)
+discardHistory0IfNecessary b0 = do
+  b0 & children_ . traversed %%~ discardHistoryIfNecessary
+
 -- | Discards the history of a Branch0's children, recursively
 discardHistory0 :: (Applicative m) => Branch0 m -> Branch0 m
-discardHistory0 = over children_ (fmap tweak)
-  where
-    tweak b = one (discardHistory0 (head b))
+discardHistory0 b0 = snd $ discardHistory0IfNecessary b0
 
 -- | Discards the history of a Branch and its children, recursively
 discardHistory :: (Applicative m) => Branch m -> Branch m
-discardHistory b =
-  one (discardHistory0 (head b))
+discardHistory b = snd $ discardHistoryIfNecessary b
 
 -- | `before b1 b2` is true if `b2` incorporates all of `b1`
 before :: (Monad m) => Branch m -> Branch m -> m Bool

--- a/unison-cli/src/Unison/Share/SyncV2.hs
+++ b/unison-cli/src/Unison/Share/SyncV2.hs
@@ -201,7 +201,7 @@ validateAndSave shouldValidate codebase entities = do
   -- Validation is slow, so we run it in parallel with insertion (which can also be slow),
   -- but we don't commit the transaction until we're done validation to avoid inserting invalid entities.
   ExceptT . liftIO $ IO.withAsync validateEntities \validationTask -> do
-    Timing.time "Inserting entities" $ Codebase.runTransactionExceptT codebase do
+    Codebase.runTransactionExceptT codebase do
       for_ entities \(hash, entity) -> do
         void . lift $ Q.saveTempEntityInMain v2HashHandle hash entity
       lift (Sqlite.unsafeIO (IO.wait validationTask)) >>= \case


### PR DESCRIPTION
## Overview

`discardHistory` and friends was squashing branches in such a way that we'd _always_ rehash them.
This change avoids redundant re-hashing where possible.
This speeds up `pull.without-history` ; maybe `update` and `lib.install` in very specific situations.

For Cody's situation, this speeds it up from 29s -> 2.6s; still too slow, but much better!

## Implementation notes

This changes it so if a branch is already squashed we return it as-is from `discardHistory`, which avoids memory redundancy and, more importantly, avoids re-hashing the whole subtree which is very expensive on branches with tons of dependencies.

## Test coverage

I tested performance on this issue Cody opened: 
fixes #5866 

## Loose ends

Everywhere using `discardHistory` should maybe just be using `squashCausal` which can use the squash-result table for caching, but that's all V2 machinery so it may take a bit more finesse to add that; I'll take a look in a separate change.