### PR TITLE
Don’t prettify exceptions written to the stack

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ on:
 
 env:
   ## Some version numbers that are used during CI
-  runtime_tests_version: "@unison/runtime-tests/releases/0.0.4"
+  runtime_tests_version: "@unison/runtime-tests/releases/0.0.3"
 
   ## Some cached directories
   # a temp path for caching a built `ucm`

--- a/unison-runtime/src/Unison/Runtime/Machine.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine.hs
@@ -73,7 +73,7 @@ import Unison.Runtime.ANF.Serialize (serializeCode, deserializeCode)
 #endif
 import Unison.Runtime.Array as PA
 import Unison.Runtime.Builtin hiding (unitValue)
-import Unison.Runtime.Exception (RuntimeExn (BU, PE), die, peStr, prettyRuntimeExnSansCtx)
+import Unison.Runtime.Exception (RuntimeExn (BU, PE), die, peStr)
 import Unison.Runtime.Foreign
 import Unison.Runtime.Foreign.Function
   ( decodeVal,
@@ -496,21 +496,18 @@ encodeExn stk exc = do
       stk <- bumpn stk 3
       pokeTag stk 0
       bpokeOff stk 1 $ Foreign (Wrap Rf.typeLinkRef link)
-      pokeOffBi stk 2 =<< msg
+      pokeOffBi stk 2 msg
       stk <$ pokeOff stk 3 extra
       where
-        disp :: (Exception e) => e -> IO Util.Text.Text
-        disp = pure . Util.Text.pack . show
+        disp :: (Exception e) => e -> Util.Text.Text
+        disp = Util.Text.pack . show
         (link, msg, extra)
           | Just (ioe :: IOException) <- fromException exn =
               (Rf.ioFailureRef, disp ioe, unitValue)
-          | Just re <- fromException exn =
-              ( Rf.runtimeFailureRef,
-                Util.Text.pack . P.toPlain 0 <$> prettyRuntimeExnSansCtx re,
-                case re of
-                  PE _ _ _ -> unitValue
-                  BU _ _ val -> val
-              )
+          | Just re <- fromException exn = case re of
+              PE _stk _issues msg ->
+                (Rf.runtimeFailureRef, Util.Text.pack $ P.toPlain 0 msg, unitValue)
+              BU _ tx val -> (Rf.runtimeFailureRef, Util.Text.fromText tx, val)
           | Just (ae :: ArithException) <- fromException exn =
               (Rf.arithmeticFailureRef, disp ae, unitValue)
           | Just (nae :: NestedAtomically) <- fromException exn =
@@ -523,7 +520,7 @@ encodeExn stk exc = do
               (Rf.threadKilledFailureRef, disp ie, unitValue)
           | Just (Panic msg v) <- fromException exn,
             msg <- Util.Text.pack $ "panic: " ++ msg =
-              (Rf.miscFailureRef, pure msg, fromMaybe unitValue v)
+              (Rf.miscFailureRef, msg, fromMaybe unitValue v)
           | otherwise = (Rf.miscFailureRef, disp exn, unitValue)
 
 -- | Evaluate a section

--- a/unison-runtime/src/Unison/Runtime/Machine/Types.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine/Types.hs
@@ -43,7 +43,6 @@ import Unison.Runtime.Referenced
 import Unison.Runtime.Stack
 import Unison.Symbol
 import Unison.Util.EnumContainers as EC
-import Unison.Util.Pretty qualified as Pretty
 import Unison.Util.Text as UText
 
 -- | A ref storing every currently active thread.
@@ -318,7 +317,7 @@ codeValidate cc tml = do
       rns = RN (refLookup "ty" rty) (refLookup "tm" rtm) (const Nothing)
       combinate (n, (r, g)) = evaluate $ emitCombs rns r n g
   (Nothing <$ traverse_ combinate (zip [ftm ..] tml))
-    `catch` \ce@(Exception.CE cs _ _) -> do
-      msg <- fmap (UText.pack . Pretty.toPlain 0) $ Exception.prettyCompileExn ce
-      let extra = UText.pack $ show cs
-      pure . Just $ Failure ioFailureRef msg extra
+    `catch` \(Exception.CE cs _issues perr) ->
+      let msg = UText.pack perr
+          extra = UText.pack $ show cs
+       in pure . Just $ Failure ioFailureRef msg extra

--- a/unison-src/builtin-tests/interpreter-tests.output.md
+++ b/unison-src/builtin-tests/interpreter-tests.output.md
@@ -13,7 +13,7 @@ Before merging the PR on Github, we'll merge your branch on Share and restore `r
 ```
 
 ``` ucm :hide
-> clone @unison/runtime-tests/releases/0.0.4 runtime-tests/selected
+> clone @unison/runtime-tests/releases/0.0.3 runtime-tests/selected
 ```
 
 ``` ucm

--- a/unison-src/builtin-tests/interpreter-tests.sh
+++ b/unison-src/builtin-tests/interpreter-tests.sh
@@ -8,7 +8,7 @@ else
   ucm="$1"
 fi
 
-runtime_tests_version="@unison/runtime-tests/releases/0.0.4"
+runtime_tests_version="@unison/runtime-tests/releases/0.0.3"
 
 codebase=${XDG_CACHE_HOME:-"$HOME/.cache"}/unisonlanguage/runtime-tests.unison
 

--- a/unison-src/transcripts-using-base/failure-tests.output.md
+++ b/unison-src/transcripts-using-base/failure-tests.output.md
@@ -59,10 +59,7 @@ test2 = do
 
   The program halted with an unhandled exception:
 
-    Failure
-      (typeLink RuntimeFailure)
-      "💔💥\n\nI've encountered a call to builtin.bug with the following value:\n\n  \"whoa\"\n\nStack trace:\n  #00b3gl0n7k"
-      (Any "whoa")
+    Failure (typeLink RuntimeFailure) "builtin.bug" (Any "whoa")
 
   Stack trace:
     ##raise


### PR DESCRIPTION
In #5661, exceptions were made much prettier, but also accidentally double-prettified in cases where they were written to then read back off the stack. This reverts that double-prettification.

Fixes #5864.