### PR TITLE
Defer error serialization

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ on:
 
 env:
   ## Some version numbers that are used during CI
-  runtime_tests_version: "@unison/runtime-tests/releases/0.0.4"
+  runtime_tests_version: "@unison/runtime-tests/releases/0.0.3"
 
   ## Some cached directories
   # a temp path for caching a built `ucm`

--- a/parser-typechecker/src/Unison/Codebase/Runtime.hs
+++ b/parser-typechecker/src/Unison/Codebase/Runtime.hs
@@ -26,14 +26,12 @@ import Unison.Var qualified as Var
 import Unison.WatchKind (WatchKind)
 import Unison.WatchKind qualified as WK
 
-type Error = P.Pretty P.ColorText
-
-data Response
-  = DecompErrs [Error]
+data Response e
+  = DecompErrs [e]
   | Profile (P.Pretty P.ColorText)
   | EmptyResponse
 
-instance Semigroup Response where
+instance Semigroup (Response e) where
   DecompErrs l <> DecompErrs r = DecompErrs (l <> r)
   d@(DecompErrs _) <> _ = d
   _ <> d@(DecompErrs _) = d
@@ -41,7 +39,7 @@ instance Semigroup Response where
   _ <> p@(Profile _) = p
   EmptyResponse <> r = r
 
-instance Monoid Response where
+instance Monoid (Response e) where
   mempty = EmptyResponse
 
 type Term v = Term.Term v ()
@@ -53,21 +51,21 @@ data CompileOpts = COpts
 defaultCompileOpts :: CompileOpts
 defaultCompileOpts = COpts {profile = False}
 
-data Runtime v = Runtime
+data Runtime e e' v = Runtime
   { terminate :: IO (),
     evaluate ::
       CL.CodeLookup v IO () ->
       PPE.PrettyPrintEnv ->
       ProfileSpec ->
       Term v ->
-      IO (Either Error (Response, Term v)),
+      IO (Either e (Response e', Term v)),
     compileTo ::
       CompileOpts ->
       CL.CodeLookup v IO () ->
       PPE.PrettyPrintEnv ->
       Reference ->
       FilePath ->
-      IO (Maybe Error),
+      IO (Maybe e),
     mainType :: Type v Ann,
     ioTestTypes :: NESet (Type v Ann)
   }
@@ -77,16 +75,15 @@ type IsCacheHit = Bool
 noCache :: Reference.Id -> IO (Maybe (Term v))
 noCache _ = pure Nothing
 
-type WatchResults v a =
-  ( Either
-      Error
-      -- Bindings:
-      ( [(v, Term v)],
-        -- Map watchName (loc, hash, expression, value, isHit)
-        Response,
-        Map v (a, WatchKind, Reference.Id, Term v, Term v, IsCacheHit)
-      )
-  )
+type WatchResults e e' v a =
+  Either
+    e
+    -- Bindings:
+    ( [(v, Term v)],
+      -- Map watchName (loc, hash, expression, value, isHit)
+      Response e',
+      Map v (a, WatchKind, Reference.Id, Term v, Term v, IsCacheHit)
+    )
 
 -- Evaluates the watch expressions in the file, returning a `Map` of their
 -- results. This has to be a bit fancy to handle that the definitions in the
@@ -97,15 +94,15 @@ type WatchResults v a =
 -- `evaluationCache`. If that returns a result, evaluation of that definition
 -- can be skipped.
 evaluateWatches ::
-  forall v a.
+  forall e e' v a.
   (Var v) =>
   CL.CodeLookup v IO a ->
   PPE.PrettyPrintEnv ->
   ProfileSpec ->
   (Reference.Id -> IO (Maybe (Term v))) ->
-  Runtime v ->
+  Runtime e e' v ->
   TypecheckedUnisonFile v a ->
-  IO (WatchResults v a)
+  IO (WatchResults e e' v a)
 evaluateWatches code ppe prof evaluationCache rt tuf = do
   -- 1. compute hashes for everything in the file
   let m :: Map v (Reference.Id, Term.Term v a)
@@ -170,9 +167,9 @@ evaluateTerm' ::
   (Reference.Id -> IO (Maybe (Term v))) ->
   PPE.PrettyPrintEnv ->
   ProfileSpec ->
-  Runtime v ->
+  Runtime e e' v ->
   Term.Term v a ->
-  IO (Either Error (Response, Term v))
+  IO (Either e (Response e', Term v))
 evaluateTerm' codeLookup cache ppe prof rt tm = do
   result <- cache (Hashing.hashClosedTerm tm)
   case result of
@@ -196,7 +193,7 @@ evaluateTerm ::
   CL.CodeLookup v IO a ->
   PPE.PrettyPrintEnv ->
   ProfileSpec ->
-  Runtime v ->
+  Runtime e e' v ->
   Term.Term v a ->
-  IO (Either Error (Response, Term v))
+  IO (Either e (Response e', Term v))
 evaluateTerm codeLookup = evaluateTerm' codeLookup noCache

--- a/unison-cli/package.yaml
+++ b/unison-cli/package.yaml
@@ -39,6 +39,7 @@ library:
     - frontmatter
     - fsnotify
     - generic-lens
+    - github
     - haskeline
     - hs-mcp
     - http-client >= 0.7.6

--- a/unison-cli/src/Unison/Cli/Monad.hs
+++ b/unison-cli/src/Unison/Cli/Monad.hs
@@ -78,13 +78,13 @@ import Unison.Codebase.Editor.Output (NumberedArgs, NumberedOutput, Output)
 import Unison.Codebase.Editor.UCMVersion (UCMVersion)
 import Unison.Codebase.Path qualified as Path
 import Unison.Codebase.ProjectPath qualified as PP
-import Unison.Codebase.Runtime (Runtime)
 import Unison.CommandLine.OutputMessages qualified as OutputMessages
 import Unison.Core.Project (ProjectAndBranch (..))
 import Unison.Debug qualified as Debug
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
 import Unison.PrettyTerminal qualified as PrettyTerminal
+import Unison.Runtime (Runtime)
 import Unison.Server.CodebaseServer qualified as Server
 import Unison.Sqlite qualified as Sqlite
 import Unison.Symbol (Symbol)
@@ -420,7 +420,7 @@ withRespondRegionIO action = do
       with_ Console.Regions.displayConsoleRegions do
         with (Console.Regions.withConsoleRegion Console.Regions.Linear) \region ->
           action \output -> do
-            string <- (OutputMessages.notifyUser (pure ".") output)
+            string <- (OutputMessages.notifyUser (pure ".") OutputMessages.showIssueUrl output)
             width <- PrettyTerminal.getAvailableWidth
             Console.Regions.setConsoleRegion region (Pretty.toANSI width (Pretty.border 2 string))
     True -> action env.notify

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1203,7 +1203,7 @@ doCompile profile output main = do
     ( liftIO $
         Runtime.compileTo runtime copts codeLookup ppe ref outf
     )
-    (Cli.returnEarly . EvaluationFailure)
+    (Cli.returnEarly . EvaluationFailure id)
 
 delete ::
   Input ->
@@ -1333,7 +1333,7 @@ displayI outputLoc hq = do
       let suffixifiedFilePPE = PPE.biasTo bias $ PPE.suffixifiedPPE filePPED
       (_, watches) <-
         evalUnisonFile Sandboxed suffixifiedFilePPE unisonFile [] & onLeftM \err ->
-          Cli.returnEarly (Output.EvaluationFailure err)
+          Cli.returnEarly (Output.EvaluationFailure id err)
       (_, _, _, _, tm, _) <-
         Map.lookup toDisplay watches & onNothing (error $ "Evaluation dropped a watch expression: " <> Text.unpack (HQ.toText hq))
       let ns = UF.addNamesFromTypeCheckedUnisonFile unisonFile names

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Load.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Load.hs
@@ -60,6 +60,7 @@ import Unison.Reference qualified as Reference
 import Unison.Referent (Referent)
 import Unison.Referent qualified as Referent
 import Unison.Result qualified as Result
+import Unison.Runtime (Error)
 import Unison.Sqlite qualified as Sqlite
 import Unison.Symbol (Symbol)
 import Unison.Syntax.Name qualified as Name
@@ -186,7 +187,7 @@ loadUnisonFile sourceName text = do
           when (not (null e)) do
             let f (ann, kind, _hash, _uneval, eval, isHit) = (ann, kind, eval, isHit)
             Cli.respond $ Output.Evaluated text newPpe bindings (Map.map f e)
-        Left err -> Cli.respond (Output.EvaluationFailure err)
+        Left err -> Cli.respond (Output.EvaluationFailure id err)
 
   #latestTypecheckedFile .= Just (Right unisonFile)
 
@@ -427,7 +428,7 @@ evalUnisonFile ::
   [String] ->
   Cli
     ( Either
-        Runtime.Error
+        Error
         ( [(Symbol, Term Symbol ())],
           Map Symbol (Ann, WK.WatchKind, Reference.Id, Term Symbol (), Term Symbol (), Bool)
         )

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Run.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Run.hs
@@ -59,7 +59,7 @@ handleRun prof main args = do
   let mode = Permissive prof
   (_, xs) <-
     evalUnisonFile mode suffixifiedPPE unisonFile args & onLeftM \err ->
-      Cli.returnEarly (Output.EvaluationFailure err)
+      Cli.returnEarly (Output.EvaluationFailure id err)
   mainRes :: Term Symbol () <-
     case lookup magicMainWatcherString (map bonk (Map.toList xs)) of
       Nothing ->

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/RuntimeUtils.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/RuntimeUtils.hs
@@ -27,6 +27,9 @@ import Unison.Prelude
 import Unison.PrettyPrintEnv qualified as PPE
 import Unison.Reference qualified as Reference
 import Unison.Referent qualified as Referent
+import Unison.Runtime (Error)
+import Unison.Runtime.Decompile (DecompError)
+import Unison.Runtime.Interface (Runtime, renderDecompError)
 import Unison.Symbol (Symbol)
 import Unison.Term (Term)
 import Unison.Term qualified as Term
@@ -35,7 +38,7 @@ import Unison.WatchKind qualified as WK
 
 data EvalMode = Sandboxed | Permissive ProfileSpec
 
-selectRuntime :: EvalMode -> Cli (Runtime.Runtime Symbol)
+selectRuntime :: EvalMode -> Cli (Runtime Symbol)
 selectRuntime mode =
   ask <&> \Cli.Env {runtime, sandboxedRuntime} -> case mode of
     Permissive _ -> runtime
@@ -45,16 +48,17 @@ modeProfSpec :: EvalMode -> ProfileSpec
 modeProfSpec Sandboxed = NoProf
 modeProfSpec (Permissive prof) = prof
 
-displayDecompileErrors :: [Runtime.Error] -> Cli ()
-displayDecompileErrors errs = Cli.respond (PrintMessage msg)
+displayDecompileErrors :: [DecompError] -> Cli ()
+displayDecompileErrors =
+  Cli.respond . PrintMessage . msg . fmap (P.indentN 2 . P.indentN 2 . renderDecompError)
   where
-    msg =
+    msg em = do
       P.lines $
         [ P.warnCallout "I had trouble decompiling some results.",
           "",
           "The following errors were encountered:"
         ]
-          ++ fmap (P.indentN 2) errs
+          ++ em
 
 -- | Evaluate a single closed definition.
 evalUnisonTermE ::
@@ -62,7 +66,7 @@ evalUnisonTermE ::
   PPE.PrettyPrintEnv ->
   Bool ->
   Term Symbol Ann ->
-  Cli (Either Runtime.Error (Term Symbol Ann))
+  Cli (Either Error (Term Symbol Ann))
 evalUnisonTermE mode ppe useCache tm = do
   Cli.Env {codebase} <- ask
   theRuntime <- selectRuntime mode
@@ -90,7 +94,7 @@ evalUnisonTermE mode ppe useCache tm = do
       Left _ -> pure ()
   pure $ r <&> Term.amap (\() -> Ann.External) . snd
 
-displayResponse :: Runtime.Response -> Cli ()
+displayResponse :: Runtime.Response DecompError -> Cli ()
 displayResponse (Runtime.DecompErrs errs)
   | not $ null errs = displayDecompileErrors errs
 displayResponse (Runtime.Profile prof) = Cli.respond (PrintMessage msg)
@@ -106,14 +110,13 @@ evalUnisonTerm ::
   Term Symbol Ann ->
   Cli (Term Symbol Ann)
 evalUnisonTerm mode ppe useCache tm =
-  evalUnisonTermE mode ppe useCache tm & onLeftM \err ->
-    Cli.returnEarly (EvaluationFailure err)
+  evalUnisonTermE mode ppe useCache tm & onLeftM (Cli.returnEarly . EvaluationFailure id)
 
 evalPureUnison ::
   PPE.PrettyPrintEnv ->
   Bool ->
   Term Symbol Ann ->
-  Cli (Either Runtime.Error (Term Symbol Ann))
+  Cli (Either Error (Term Symbol Ann))
 evalPureUnison ppe useCache tm =
   evalUnisonTermE mode ppe useCache tm'
   where

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Tests.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Tests.hs
@@ -121,8 +121,7 @@ handleTest TestInput {includeLibNamespace, path, showFailures, showSuccesses} = 
             Left e -> do
               Cli.respond $ TestIncrementalOutputEnd fqnPPE (n, total) r False
               let testName = (Cli.prettyTermName fqnPPE (Referent.fromTermReferenceId r))
-                  e' = P.callout ("Error while evaluating test " <> P.backticked testName) e
-              Cli.returnEarly (EvaluationFailure e')
+              Cli.returnEarly $ EvaluationFailure (P.callout ("Error while evaluating test " <> P.backticked testName <> ":") . P.indentN 2) e
             Right tm' -> do
               -- After evaluation, cache the result of the test
               Cli.runTransaction (Codebase.putWatch WK.TestWatch r tm')
@@ -145,9 +144,13 @@ handleIOTest main = do
   (fails, oks) <-
     Foldable.foldrM
       ( \(ref, typ) (f, o) -> do
-          when (not $ isIOTest typ) $
-            Cli.returnEarly (BadMainFunction "io.test" main typ suffixifiedPPE (Foldable.toList $ Runtime.ioTestTypes runtime))
-          bimap (\ts -> if null ts then f else Map.insert ref ts f) (\ts -> if null ts then o else Map.insert ref ts o) <$> runIOTest suffixifiedPPE ref
+          when (not $ isIOTest typ)
+            . Cli.returnEarly
+            . BadMainFunction "io.test" main typ suffixifiedPPE
+            . Foldable.toList
+            $ Runtime.ioTestTypes runtime
+          bimap (\ts -> if null ts then f else Map.insert ref ts f) (\ts -> if null ts then o else Map.insert ref ts o)
+            <$> runIOTest suffixifiedPPE ref
       )
       (Map.empty, Map.empty)
       refs

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -75,6 +75,7 @@ import Unison.Project (ProjectAndBranch, ProjectBranchName, ProjectName, Semver)
 import Unison.Reference (Reference, TermReference, TermReferenceId, TypeReference)
 import Unison.Reference qualified as Reference
 import Unison.Referent (Referent)
+import Unison.Runtime (Error)
 import Unison.Server.Backend (ShallowListEntry (..))
 import Unison.Server.SearchResultPrime (SearchResult')
 import Unison.Share.Sync.Types qualified as Sync
@@ -273,7 +274,10 @@ data Output
   | TypeWarns Path.Absolute Text PPE.PrettyPrintEnv [Context.Warn Symbol Ann]
   | CompilerBugs Text PPE.PrettyPrintEnv [Context.CompilerBug Symbol Ann]
   | DisplayConflicts (Relation Name Referent) (Relation Name Reference)
-  | EvaluationFailure Runtime.Error
+  | EvaluationFailure
+      -- | A function to apply to the `Error` after serializing it, allowing more context to be added.
+      (P.Pretty P.ColorText -> P.Pretty P.ColorText)
+      Error
   | Evaluated
       SourceFileContents
       PPE.PrettyPrintEnv

--- a/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
+++ b/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
@@ -43,7 +43,6 @@ import Unison.Codebase.Editor.Input (Event (UnisonFileChanged), Input (..))
 import Unison.Codebase.Editor.Output qualified as Output
 import Unison.Codebase.Editor.UCMVersion (UCMVersion)
 import Unison.Codebase.ProjectPath qualified as PP
-import Unison.Codebase.Runtime qualified as Runtime
 import Unison.Codebase.Transcript
 import Unison.Codebase.Transcript.Parser qualified as Transcript
 import Unison.Codebase.Verbosity (Verbosity, isSilent)
@@ -52,7 +51,7 @@ import Unison.CommandLine
 import Unison.CommandLine.FuzzySelect qualified as Fuzzy
 import Unison.CommandLine.InputPattern (aliases, patternName)
 import Unison.CommandLine.InputPatterns qualified as IP
-import Unison.CommandLine.OutputMessages (notifyNumbered, notifyUser)
+import Unison.CommandLine.OutputMessages (notifyNumbered, notifyUser, showIssueUrl)
 import Unison.CommandLine.Welcome (asciiartUnison)
 import Unison.Debug qualified as Debug
 import Unison.MCP qualified as MCP
@@ -134,7 +133,7 @@ withRunner isTest verbosity ucmVersion action = do
                   credMan
                   stanzas
   where
-    withRuntimes :: (Runtime.Runtime Symbol -> Runtime.Runtime Symbol -> m a) -> m a
+    withRuntimes :: (RTI.Runtime Symbol -> RTI.Runtime Symbol -> m a) -> m a
     withRuntimes action =
       RTI.withRuntime False RTI.Persistent ucmVersion \runtime ->
         RTI.withRuntime True RTI.Persistent ucmVersion \sbRuntime ->
@@ -153,8 +152,8 @@ run ::
   Bool ->
   Verbosity ->
   Codebase IO Symbol Ann ->
-  Runtime.Runtime Symbol ->
-  Runtime.Runtime Symbol ->
+  RTI.Runtime Symbol ->
+  RTI.Runtime Symbol ->
   UCMVersion ->
   Text ->
   AuthN.AuthenticatedHttpClient ->
@@ -461,7 +460,7 @@ run isTest verbosity codebase runtime sbRuntime ucmVersion baseURL authenticated
       print o = do
         -- NB: We have a directory, but we don’t pass it to the notifier because it’s a temp dir, and if it ends up in
         --     transcript output, it makes transcripts non-reproducible.
-        msg <- notifyUser Nothing o
+        msg <- notifyUser Nothing showIssueUrl o
         outputUcmResult msg
         when (Output.isFailure o) $ maybeDieWithMsg msg
 

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -35,17 +35,17 @@ import Unison.Codebase.Editor.Input (Event (UnisonFileChanged), Input (..))
 import Unison.Codebase.Editor.Output (NumberedArgs, Output)
 import Unison.Codebase.Editor.UCMVersion (UCMVersion)
 import Unison.Codebase.ProjectPath qualified as PP
-import Unison.Codebase.Runtime qualified as Runtime
 import Unison.Codebase.Watch qualified as Watch
 import Unison.CommandLine
 import Unison.CommandLine.Completion (haskelineTabComplete)
 import Unison.CommandLine.InputPatterns qualified as IP
-import Unison.CommandLine.OutputMessages (notifyNumbered, notifyUser)
+import Unison.CommandLine.OutputMessages (fetchIssueFromGitHub, notifyNumbered, notifyUser)
 import Unison.CommandLine.Types (ShouldWatchFiles (..))
 import Unison.CommandLine.Welcome qualified as Welcome
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
 import Unison.PrettyTerminal
+import Unison.Runtime (Runtime)
 import Unison.Runtime.IOSource qualified as IOSource
 import Unison.Server.CodebaseServer qualified as Server
 import Unison.Share.Codeserver (isCustomCodeserver)
@@ -137,8 +137,8 @@ main ::
   Welcome.Welcome ->
   PP.ProjectPathIds ->
   [Either Event Input] ->
-  Runtime.Runtime Symbol ->
-  Runtime.Runtime Symbol ->
+  Runtime Symbol ->
+  Runtime Symbol ->
   Codebase IO Symbol Ann ->
   Maybe Server.BaseUrl ->
   UCMVersion ->
@@ -207,7 +207,7 @@ main dir welcome ppIds initialInputs runtime sbRuntime codebase serverBaseUrl uc
               else return Cli.InvalidSourceNameError
       let notify :: Output -> IO ()
           notify =
-            notifyUser (pure dir)
+            notifyUser (pure dir) fetchIssueFromGitHub
               >=> ( \o ->
                       ifM
                         (readIORef pageOutput)

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -28,6 +28,7 @@ import Data.Tuple (swap)
 import Data.Tuple.Extra (dupe)
 import Data.Void (absurd)
 import Debug.RecoverRTTI qualified as RTTI
+import GitHub qualified as GH
 import Network.HTTP.Types qualified as Http
 import Servant.Client qualified as Servant
 import System.Console.ANSI qualified as ANSI
@@ -118,6 +119,7 @@ import Unison.Referent (Referent)
 import Unison.Referent qualified as Referent
 import Unison.ReferentPrime qualified as Referent
 import Unison.Result qualified as Result
+import Unison.Runtime.Interface (prettyError)
 import Unison.Server.Backend (ShallowListEntry (..), TypeEntry (..))
 import Unison.Server.Backend qualified as Backend
 import Unison.Server.SearchResultPrime qualified as SR'
@@ -515,14 +517,31 @@ undoTip =
       <> IP.makeExample' IP.branchReflog
       <> "to undo this change."
 
+issueUrl :: Word -> P.Pretty P.ColorText
+issueUrl = ("https://github.com/unisonweb/unison/issues/" <>) . P.shown
+
+showIssueUrl :: (Applicative f) => Word -> f (P.Pretty P.ColorText)
+showIssueUrl = pure . issueUrl
+
+githubTitleForIssue :: Word -> IO (Either GH.Error Text)
+githubTitleForIssue =
+  fmap (fmap GH.issueTitle) . GH.github' GH.issueR "unisonweb" "unison" . GH.IssueNumber . fromIntegral
+
+-- | Look up the issue in the unisonweb/unison repo, and include the title in the message.
+fetchIssueFromGitHub :: Word -> IO Pretty
+fetchIssueFromGitHub i =
+  either (const $ issueUrl i) (\title -> P.wrap $ P.text title <> " " <> issueUrl i) <$> githubTitleForIssue i
+
 notifyUser ::
   -- | The directory being watched for .u files. If a `FilePath` isn’t provided, it uses a constant string. This is
   --   useful in contexts like transcripts, where we need the output to be consistent, and not vary because of a temp
   --   directory.
   Maybe FilePath ->
+  -- | How to present any GitHub issues associated with an error. For example, `showIssueUrl` or `fetchIssueFromGitHub`.
+  (Word -> IO (P.Pretty P.ColorText)) ->
   Output ->
   IO Pretty
-notifyUser dir = \case
+notifyUser dir issueFn = \case
   SaveTermNameConflict name ->
     pure
       . P.warnCallout
@@ -591,7 +610,7 @@ notifyUser dir = \case
             <> " with the codebase, or the term was deleted just now "
             <> " by someone else. Trying your command again might fix it."
       ]
-  EvaluationFailure err -> pure err
+  EvaluationFailure ctx err -> ctx <$> prettyError issueFn err
   SearchTermsNotFound hqs | null hqs -> pure mempty
   SearchTermsNotFound hqs ->
     pure $

--- a/unison-cli/src/Unison/LSP.hs
+++ b/unison-cli/src/Unison/LSP.hs
@@ -30,7 +30,6 @@ import Network.Simple.TCP qualified as TCP
 import System.Environment (lookupEnv)
 import Unison.Codebase
 import Unison.Codebase.ProjectPath qualified as PP
-import Unison.Codebase.Runtime (Runtime)
 import Unison.LSP.CancelRequest (cancelRequestHandler)
 import Unison.LSP.CodeAction (codeActionHandler)
 import Unison.LSP.CodeLens (codeLensHandler)
@@ -51,6 +50,7 @@ import Unison.LSP.Util.Signal (Signal)
 import Unison.LSP.VFS qualified as VFS
 import Unison.Parser.Ann
 import Unison.Prelude
+import Unison.Runtime (Runtime)
 import Unison.Symbol
 import UnliftIO
 import UnliftIO.Foreign (Errno (..), eADDRINUSE)

--- a/unison-cli/src/Unison/LSP/Types.hs
+++ b/unison-cli/src/Unison/LSP/Types.hs
@@ -26,7 +26,6 @@ import Language.LSP.Server qualified as LSP
 import Language.LSP.VFS
 import Unison.Codebase
 import Unison.Codebase.ProjectPath qualified as PP
-import Unison.Codebase.Runtime (Runtime)
 import Unison.Debug qualified as Debug
 import Unison.LSP.Orphans ()
 import Unison.LabeledDependency (LabeledDependency)
@@ -38,6 +37,7 @@ import Unison.Prelude
 import Unison.PrettyPrintEnvDecl (PrettyPrintEnvDecl)
 import Unison.Referent (Referent)
 import Unison.Result (Note)
+import Unison.Runtime (Runtime)
 import Unison.Server.Backend qualified as Backend
 import Unison.Server.NameSearch (NameSearch)
 import Unison.Sqlite qualified as Sqlite

--- a/unison-cli/src/Unison/MCP.hs
+++ b/unison-cli/src/Unison/MCP.hs
@@ -6,7 +6,6 @@ import Network.MCP.Types
 import Text.RawString.QQ (r)
 import Unison.Auth.HTTPClient qualified as AuthN
 import Unison.Codebase (Codebase)
-import Unison.Codebase.Runtime (Runtime)
 import Unison.MCP.Prompts (prompts)
 import Unison.MCP.StaticResources (staticResources)
 import Unison.MCP.Tools (tools)
@@ -14,19 +13,31 @@ import Unison.MCP.Types
 import Unison.MCP.Wrapper qualified as MCPWrapper
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
+import Unison.Runtime (Runtime)
 import Unison.Symbol (Symbol)
 
 serverDescription :: Text
 serverDescription =
   [r|
-        This server provides tools for interacting with Unison Code locally, such as typechecking or reading documentation, as well as tools for searching Unison Share, which is a platform for sharing Unison projects and libraries.
+        This server provides tools for interacting with Unison Code locally, such as typechecking or reading
+        documentation, as well as tools for searching Unison Share, which is a platform for sharing Unison projects and
+        libraries.
 
-        It also provides some mechanisms for editing and updating local Unison projects, such as installing libraries from Unison Share.
+        It also provides some mechanisms for editing and updating local Unison projects, such as installing libraries
+        from Unison Share.
 
-        Before doing any work in unison please read the file://unison-guide resource for information on how to write unison.
+        Before doing any work in unison please read the file://unison-guide resource for information on how to write
+        Unison.
     |]
 
-initServer :: Codebase IO Symbol Ann -> Runtime Symbol -> Runtime Symbol -> Maybe FilePath -> Text -> AuthN.AuthenticatedHttpClient -> IO MCP.Server
+initServer ::
+  Codebase IO Symbol Ann ->
+  Runtime Symbol ->
+  Runtime Symbol ->
+  Maybe FilePath ->
+  Text ->
+  AuthN.AuthenticatedHttpClient ->
+  IO MCP.Server
 initServer codebase runtime sbRuntime workDir ucmVersion authenticatedHTTPClient = do
   let env =
         Env
@@ -43,7 +54,14 @@ initServer codebase runtime sbRuntime workDir ucmVersion authenticatedHTTPClient
   runMCP env $ MCPWrapper.mkServer serverInfo serverDescription staticResources tools prompts
 
 -- | Run the MCP server until we hit EOF.
-runOnStdIO :: Codebase IO Symbol Ann -> Runtime Symbol -> Runtime Symbol -> FilePath -> Text -> AuthN.AuthenticatedHttpClient -> IO ()
+runOnStdIO ::
+  Codebase IO Symbol Ann ->
+  Runtime Symbol ->
+  Runtime Symbol ->
+  FilePath ->
+  Text ->
+  AuthN.AuthenticatedHttpClient ->
+  IO ()
 runOnStdIO codebase runtime sbRuntime workDir ucmVersion authenticatedHTTPClient = do
   server <- initServer codebase runtime sbRuntime (Just workDir) ucmVersion authenticatedHTTPClient
   -- Start the server with StdIO transport

--- a/unison-cli/src/Unison/MCP/Cli.hs
+++ b/unison-cli/src/Unison/MCP/Cli.hs
@@ -83,7 +83,7 @@ cliToMCP projCtx cli = do
   outputVar <- newTVarIO Seq.empty
   sourceCodeUpdatesVar <- newTVarIO Seq.empty
   let notify output = do
-        pretty <- Output.notifyUser workDir output
+        pretty <- Output.notifyUser workDir Output.fetchIssueFromGitHub output
         atomically $ modifyTVar outputVar (<> Seq.singleton pretty)
   let notifyNumbered output = do
         let (pretty, nargs) = Output.notifyNumbered output

--- a/unison-cli/src/Unison/MCP/Types.hs
+++ b/unison-cli/src/Unison/MCP/Types.hs
@@ -32,12 +32,12 @@ import Data.Text qualified as Text
 import Unison.Auth.HTTPClient (AuthenticatedHttpClient)
 import Unison.Codebase (Codebase)
 import Unison.Codebase.Editor.UCMVersion (UCMVersion)
-import Unison.Codebase.Runtime (Runtime)
 import Unison.Core.Project (ProjectBranchName (UnsafeProjectBranchName), ProjectName (UnsafeProjectName))
 import Unison.MCP.Wrapper (HasInputSchema (..))
 import Unison.Name (Name)
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
+import Unison.Runtime (Runtime)
 import Unison.Symbol (Symbol)
 import Unison.Syntax.Name qualified as Name
 

--- a/unison-cli/src/Unison/Main.hs
+++ b/unison-cli/src/Unison/Main.hs
@@ -40,20 +40,12 @@ import Ki qualified
 import Network.HTTP.Client qualified as HTTP
 import Network.HTTP.Client.TLS qualified as HTTP
 import Stats (recordRtsStats)
-import System.Directory
-  ( canonicalizePath,
-    getCurrentDirectory,
-    removeDirectoryRecursive,
-  )
+import System.Directory (canonicalizePath, getCurrentDirectory, removeDirectoryRecursive)
 import System.Environment (getProgName, withArgs)
 import System.Exit (ExitCode (..))
 import System.Exit qualified as Exit
 import System.Exit qualified as System
-import System.FilePath
-  ( replaceExtension,
-    takeExtension,
-    (</>),
-  )
+import System.FilePath (replaceExtension, takeExtension, (</>))
 import System.IO (stderr)
 import System.IO.CodePage (withCP65001)
 import System.IO.Temp qualified as Temp
@@ -74,7 +66,6 @@ import Unison.Codebase.Init qualified as CodebaseInit
 import Unison.Codebase.Init.OpenCodebaseError (OpenCodebaseError (..))
 import Unison.Codebase.Path qualified as Path
 import Unison.Codebase.ProjectPath qualified as PP
-import Unison.Codebase.Runtime qualified as Rt
 import Unison.Codebase.Runtime.Profile (ProfileSpec (..))
 import Unison.Codebase.SqliteCodebase qualified as SC
 import Unison.Codebase.Transcript.Parser qualified as Transcript
@@ -82,6 +73,7 @@ import Unison.Codebase.Transcript.Runner qualified as Transcript
 import Unison.Codebase.Verbosity qualified as Verbosity
 import Unison.CommandLine.Helpers (plural')
 import Unison.CommandLine.Main qualified as CommandLine
+import Unison.CommandLine.OutputMessages (fetchIssueFromGitHub)
 import Unison.CommandLine.Types qualified as CommandLine
 import Unison.CommandLine.Welcome (CodebaseInitStatus (..))
 import Unison.CommandLine.Welcome qualified as Welcome
@@ -94,7 +86,6 @@ import Unison.Parser.Ann (Ann)
 import Unison.Prelude
 import Unison.PrettyTerminal qualified as PT
 import Unison.Project (defaultBranchName)
-import Unison.Runtime.Exception (prettyRuntimeExnSansCtx)
 import Unison.Runtime.Interface qualified as RTI
 import Unison.Server.Backend qualified as Backend
 import Unison.Server.CodebaseServer qualified as Server
@@ -178,7 +169,7 @@ main version = do
           getCodebaseOrExit mCodePathOption SC.DoLock (SC.MigrateAutomatically SC.Backup SC.Vacuum) \(_, _, theCodebase) -> do
             RTI.withRuntime False RTI.OneOff (Version.gitDescribeWithDate version) \runtime -> do
               withArgs args (execute theCodebase runtime mainName) >>= \case
-                Left err -> exitError err
+                Left err -> exitError =<< RTI.prettyError fetchIssueFromGitHub err
                 Right () -> pure ()
         Run (RunFromFile file mainName) args
           | not (isDotU file) -> exitError "Files must have a .u extension."
@@ -242,7 +233,7 @@ main version = do
           BL.readFile file >>= \bs ->
             try (evaluate $ RTI.decodeStandalone bs) >>= \case
               Left re -> do
-                exnMessage <- prettyRuntimeExnSansCtx re
+                exnMessage <- RTI.prettyRuntimeExn fetchIssueFromGitHub re
                 exitError . P.lines $
                   [ P.wrap . P.text $
                       "I was unable to parse this file as a compiled\
@@ -262,7 +253,7 @@ main version = do
                 | not vmatch -> mismatchMsg
                 | otherwise ->
                     withArgs args (RTI.runStandalone False sto combIx) >>= \case
-                      Left err -> exitError err
+                      Left err -> exitError =<< RTI.prettyError fetchIssueFromGitHub err
                       Right () -> pure ()
                 where
                   vmatch = v == Version.gitDescribeWithDate version
@@ -600,8 +591,8 @@ runTranscripts version verbosity renderUsageInfo codebaseSetup mCodePathOption a
 launch ::
   Version ->
   FilePath ->
-  Rt.Runtime Symbol ->
-  Rt.Runtime Symbol ->
+  RTI.Runtime Symbol ->
+  RTI.Runtime Symbol ->
   Codebase.Codebase IO Symbol Ann ->
   [Either Input.Event Input.Input] ->
   AuthN.AuthenticatedHttpClient ->

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -236,6 +236,7 @@ library
     , frontmatter
     , fsnotify
     , generic-lens
+    , github
     , haskeline
     , hs-mcp
     , http-client >=0.7.6

--- a/unison-runtime/package.yaml
+++ b/unison-runtime/package.yaml
@@ -68,7 +68,6 @@ library:
     - directory
     - exceptions
     - filepath
-    - github
     - hashable
     - iproute
     - lens

--- a/unison-runtime/src/Unison/Codebase/Execute.hs
+++ b/unison-runtime/src/Unison/Codebase/Execute.hs
@@ -24,7 +24,6 @@ import Unison.Codebase.MainTerm qualified as MainTerm
 import Unison.Codebase.Path qualified as Path
 import Unison.Codebase.ProjectPath (ProjectPathG (..))
 import Unison.Codebase.ProjectPath qualified as PP
-import Unison.Codebase.Runtime (Runtime)
 import Unison.Codebase.Runtime qualified as Runtime
 import Unison.Codebase.Runtime.Profile (ProfileSpec (NoProf))
 import Unison.Codebase.Type (Codebase (..))
@@ -33,33 +32,36 @@ import Unison.Parser.Ann (Ann)
 import Unison.Parser.Ann qualified as Parser
 import Unison.Prelude
 import Unison.PrettyPrintEnv qualified as PPE
+import Unison.Runtime (Error (UnstructuredError), Runtime)
 import Unison.Runtime.IOSource qualified as IOSource
 import Unison.Symbol (Symbol)
 import Unison.Syntax.HashQualified qualified as HQ (toText)
-import Unison.Util.Pretty qualified as P
 
-execute ::
-  Codebase.Codebase IO Symbol Ann ->
-  Runtime Symbol ->
-  PP.ProjectPathNames ->
-  IO (Either Runtime.Error ())
+execute :: Codebase.Codebase IO Symbol Ann -> Runtime Symbol -> PP.ProjectPathNames -> IO (Either Error ())
 execute codebase runtime mainPath =
   (`finally` Runtime.terminate runtime) . runExceptT $ do
     (project, branch) <- ExceptT $ (Codebase.runTransactionWithRollback codebase) \rollback -> do
-      project <- Q.loadProjectByName mainPath.project `whenNothingM` rollback (Left . P.text $ ("Project not found: " <> into @Text mainPath.project))
-      branch <- Q.loadProjectBranchByName project.projectId mainPath.branch `whenNothingM` rollback (Left . P.text $ ("Branch not found: " <> into @Text mainPath.branch))
+      project <-
+        Q.loadProjectByName mainPath.project
+          `whenNothingM` rollback (Left . UnstructuredError $ "Project not found: " <> into @Text mainPath.project)
+      branch <-
+        Q.loadProjectBranchByName project.projectId mainPath.branch
+          `whenNothingM` rollback (Left . UnstructuredError $ "Branch not found: " <> into @Text mainPath.branch)
       pure . Right $ (project, branch)
-    projectRootNames <- fmap (Branch.toNames . Branch.head) . liftIO $ Codebase.expectProjectBranchRoot codebase project.projectId branch.branchId
+    projectRootNames <-
+      fmap (Branch.toNames . Branch.head) . liftIO $
+        Codebase.expectProjectBranchRoot codebase project.projectId branch.branchId
     let loadTypeOfTerm = Codebase.getTypeOfTerm codebase
     let mainType = Runtime.mainType runtime
     mainName <- case Path.toName (mainPath ^. PP.path_) of
       Just n -> pure (HQ.NameOnly n)
-      Nothing -> throwError ("Path must lead to an executable term: " <> P.text (Path.toText (PP.path mainPath)))
+      Nothing ->
+        throwError . UnstructuredError $ "Path must lead to an executable term: " <> Path.toText (PP.path mainPath)
 
     mt <- liftIO $ Codebase.runTransaction codebase $ getMainTerm loadTypeOfTerm projectRootNames mainName mainType
     case mt of
-      MainTerm.NotFound s -> throwError ("Not found: " <> P.text (HQ.toText s))
-      MainTerm.BadType s _ -> throwError (P.text (HQ.toText s) <> " is not of type '{IO} ()")
+      MainTerm.NotFound s -> throwError . UnstructuredError $ "Not found: " <> HQ.toText s
+      MainTerm.BadType s _ -> throwError . UnstructuredError $ HQ.toText s <> " is not of type '{IO} ()"
       MainTerm.Success _ tm _ -> do
         let codeLookup = codebaseToCodeLookup codebase
             ppe = PPE.empty

--- a/unison-runtime/src/Unison/Runtime.hs
+++ b/unison-runtime/src/Unison/Runtime.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE PatternSynonyms #-}
+
+module Unison.Runtime
+  ( Runtime,
+    pattern Runtime,
+    terminate,
+    evaluate,
+    compileTo,
+    mainType,
+    ioTestTypes,
+    Error (..),
+  )
+where
+
+import Data.Text (Text)
+import Unison.Codebase.Runtime qualified as Rt
+import Unison.PrettyPrintEnv (PrettyPrintEnv)
+import Unison.Reference (Reference)
+import Unison.Runtime.Decompile (DecompError, DecompResult)
+import Unison.Runtime.Exception (RuntimeExn)
+import Unison.Runtime.InternalError (CompileExn)
+import Unison.Runtime.Stack (RuntimePanic, Val)
+import Unison.Symbol (Symbol)
+
+data Error
+  = -- | __TODO__: This constructor should go away, but there are still a few places that have unstructured errors.
+    UnstructuredError Text
+  | CompileExn CompileExn
+  | RuntimeExn (Maybe (PrettyPrintEnv, Reference -> Reference, Val -> DecompResult Symbol)) RuntimeExn
+  | RuntimePanic PrettyPrintEnv (Val -> DecompResult Symbol) RuntimePanic
+
+type Runtime = Rt.Runtime Error DecompError
+
+pattern Runtime {terminate, evaluate, compileTo, mainType, ioTestTypes} =
+  Rt.Runtime {terminate, evaluate, compileTo, mainType, ioTestTypes}

--- a/unison-runtime/src/Unison/Runtime/Decompile.hs
+++ b/unison-runtime/src/Unison/Runtime/Decompile.hs
@@ -8,7 +8,6 @@ module Unison.Runtime.Decompile
   ( decompile,
     DecompResult,
     DecompError (..),
-    renderDecompError,
   )
 where
 
@@ -18,7 +17,6 @@ import Data.Text qualified as DT
 import Numeric.Natural (Natural)
 import Unison.ABT (substs)
 import Unison.Builtin.Decls qualified as DD
-import Unison.Codebase.Runtime (Error)
 import Unison.ConstructorReference (GConstructorReference (..))
 import Unison.Prelude
 import Unison.Reference (Reference, pattern Builtin)
@@ -46,7 +44,6 @@ import Unison.Runtime.Stack
     pattern DataC,
     pattern PApV,
   )
-import Unison.Syntax.NamePrinter (prettyReference)
 import Unison.Term
   ( Term,
     app,
@@ -80,7 +77,6 @@ import Unison.Type
     typeLinkRef,
   )
 import Unison.Util.Bytes qualified as By
-import Unison.Util.Pretty (indentN, lines, lit, shown, syntaxToColor, wrap)
 import Unison.Util.Text qualified as Text
 import Unison.Var (Var)
 import Prelude hiding (lines)
@@ -108,54 +104,6 @@ data DecompError
   deriving (Eq, Ord)
 
 type DecompResult v = (Set DecompError, Term v ())
-
-prf :: Reference -> Error
-prf = syntaxToColor . prettyReference 10
-
-printUnboxedTypeTag :: UnboxedTypeTag -> Error
-printUnboxedTypeTag = shown
-
-renderDecompError :: DecompError -> Error
-renderDecompError (BadBool n) =
-  lines
-    [ wrap "A boolean value had an unexpected constructor tag:",
-      indentN 2 . lit . fromString $ show n
-    ]
-renderDecompError (BadUnboxed tt) =
-  lines
-    [ wrap "An apparent numeric type had an unrecognized packed tag:",
-      indentN 2 $ printUnboxedTypeTag tt
-    ]
-renderDecompError (BadForeign rf) =
-  lines
-    [ wrap "A foreign value with no decompiled representation was encountered:",
-      indentN 2 $ prf rf
-    ]
-renderDecompError (BadData rf) =
-  lines
-    [ wrap
-        "A data type with no decompiled representation was encountered:",
-      indentN 2 $ prf rf
-    ]
-renderDecompError (BadPAp rf) =
-  lines
-    [ wrap "A partial function application could not be decompiled: ",
-      indentN 2 $ prf rf
-    ]
-renderDecompError (UnkComb rf) =
-  lines
-    [ wrap "A reference to an unknown function was encountered: ",
-      indentN 2 $ prf rf
-    ]
-renderDecompError (UnkLocal rf n) =
-  lines
-    [ "A reference to an unknown portion to a function was encountered: ",
-      indentN 2 $ "function: " <> prf rf,
-      indentN 2 $ "section: " <> lit (fromString $ show n)
-    ]
-renderDecompError Cont = "A continuation value was encountered"
-renderDecompError Exn = "An exception value was encountered"
-renderDecompError Aff = "An affine info value was encountered"
 
 decompile ::
   forall v.

--- a/unison-runtime/src/Unison/Runtime/Exception.hs
+++ b/unison-runtime/src/Unison/Runtime/Exception.hs
@@ -1,35 +1,15 @@
 module Unison.Runtime.Exception
-  ( module InternalError,
-    RuntimeExn (BU, PE),
-    bugMsg,
+  ( RuntimeExn (BU, PE),
     die,
     exn,
-    listErrors,
-    tabulateErrors,
-    peStr,
-    prettyPanic,
-    prettyRuntimeExn,
-    prettyRuntimeExnSansCtx,
   )
 where
 
 import Control.Exception (throw, throwIO)
-import Data.Text (isPrefixOf)
 import GHC.Stack (CallStack, callStack)
-import Unison.Builtin.Decls qualified as RF
-import Unison.Codebase.Runtime (Error)
 import Unison.Prelude
-import Unison.PrettyPrintEnv (PrettyPrintEnv)
-import Unison.PrettyPrintEnv qualified as PPE
 import Unison.Reference (Reference)
-import Unison.Referent qualified as RF (pattern Ref)
-import Unison.Runtime.Decompile (DecompError, DecompResult, decompile, renderDecompError)
-import Unison.Runtime.InternalError as InternalError
-import Unison.Runtime.Stack (RuntimePanic (Panic), Val)
-import Unison.Symbol (Symbol)
-import Unison.Syntax.NamePrinter (prettyHashQualified)
-import Unison.Syntax.TermPrinter (pretty)
-import Unison.Term qualified as Tm
+import Unison.Runtime.Stack (Val)
 import Unison.Util.Pretty as P
 
 data RuntimeExn
@@ -43,148 +23,7 @@ data RuntimeExn
       Text
       -- | Unison value
       Val
-
-prettyRuntimeExn' ::
-  (Applicative f) =>
-  (Word -> f (Pretty P.ColorText)) ->
-  PrettyPrintEnv ->
-  (Reference -> Reference) ->
-  (Val -> DecompResult Symbol) ->
-  RuntimeExn ->
-  f (Pretty P.ColorText)
-prettyRuntimeExn' issueFn ppe backmap decom = \case
-  PE _ issues err -> do
-    issueMessages <- traverse issueFn issues
-    pure $
-      P.fatalCallout . P.lines $
-        [ P.wrap "Sorry – I’ve encountered a Unison runtime error.",
-          "",
-          P.indentN 2 err,
-          ""
-        ]
-          <> if null issues
-            then [P.wrap "Please report it at https://github.com/unisonweb/unison/issues/new/choose."]
-            else
-              [ P.wrap "Please check if one of these known issues matches your situation:",
-                "",
-                P.bulleted issueMessages,
-                "",
-                P.wrap "If not, please open a new one: https://github.com/unisonweb/unison/issues/new/choose"
-              ]
-  BU tr0 nm c -> pure . bugMsg ppe tr nm $ decom c
-    where
-      tr = first backmap <$> tr0
-
-prettyRuntimeExn ::
-  PrettyPrintEnv -> (Reference -> Reference) -> (Val -> DecompResult Symbol) -> RuntimeExn -> IO (Pretty P.ColorText)
-prettyRuntimeExn =
-  prettyRuntimeExn' \i ->
-    either (const $ issueUrl i) (\title -> P.wrap $ P.text title <> " " <> issueUrl i) <$> githubTitleForIssue i
-
-prettyPanic :: PrettyPrintEnv -> (Val -> DecompResult Symbol) -> RuntimePanic -> Pretty P.ColorText
-prettyPanic ppe decom (Panic msg mval) =
-  P.callout panicIcon . P.linesNonEmpty $
-    [ P.wrap "The program halted with a runtime panic:",
-      "",
-      P.string msg
-    ]
-      ++ maybe [] (render . decom) mval
-  where
-    panicIcon = "💥🤯💥"
-    render (errs, tm) =
-      ["", P.indentN 2 $ pretty ppe tm, tabulateErrors errs]
-
-bugMsg ::
-  PrettyPrintEnv ->
-  [(Reference, Int)] ->
-  Text ->
-  (Set DecompError, Tm.Term Symbol ()) ->
-  Pretty ColorText
-bugMsg ppe tr name (errs, tm)
-  | name == "blank expression" =
-      P.callout icon . P.linesNonEmpty $
-        [ P.wrap $ "I encountered a" <> P.red (P.text name) <> "with the following name/message:",
-          "",
-          P.indentN 2 $ pretty ppe tm,
-          tabulateErrors errs,
-          stackTrace ppe tr
-        ]
-  | "pattern match failure" `isPrefixOf` name =
-      P.callout icon . P.linesNonEmpty $
-        [ P.wrap $ "I've encountered a" <> P.red (P.text name) <> "while scrutinizing:",
-          "",
-          P.indentN 2 $ pretty ppe tm,
-          "",
-          P.wrap "This happens when calling a function that doesn't handle all possible inputs",
-          tabulateErrors errs,
-          stackTrace ppe tr
-        ]
-  | name == "builtin.raise" =
-      P.callout icon . P.linesNonEmpty $
-        [ P.wrap ("The program halted with an unhandled exception:"),
-          "",
-          P.indentN 2 $ pretty ppe tm,
-          tabulateErrors errs,
-          stackTrace ppe tr
-        ]
-  | name == "builtin.bug",
-    RF.TupleTerm' [Tm.Text' msg, x] <- tm,
-    "pattern match failure" `isPrefixOf` msg =
-      P.callout icon . P.linesNonEmpty $
-        [ P.wrap $ "I've encountered a" <> P.red (P.text msg) <> "while scrutinizing:",
-          "",
-          P.indentN 2 $ pretty ppe x,
-          "",
-          P.wrap "This happens when calling a function that doesn't handle all possible inputs",
-          tabulateErrors errs,
-          stackTrace ppe tr
-        ]
-  | otherwise =
-      P.callout icon . P.linesNonEmpty $
-        [ P.wrap $ "I've encountered a call to" <> P.red (P.text name) <> "with the following value:",
-          "",
-          P.indentN 2 $ pretty ppe tm,
-          tabulateErrors errs,
-          stackTrace ppe tr
-        ]
-
-stackTrace :: PrettyPrintEnv -> [(Reference, Int)] -> Pretty ColorText
-stackTrace _ [] = mempty
-stackTrace ppe tr = "\nStack trace:\n" <> P.indentN 2 (P.lines $ f <$> tr)
-  where
-    f (rf, n) = name <> count
-      where
-        count
-          | n > 1 = " (" <> fromString (show n) <> " copies)"
-          | otherwise = ""
-        name =
-          syntaxToColor
-            . prettyHashQualified
-            . PPE.termName ppe
-            . RF.Ref
-            $ rf
-
-icon :: Pretty ColorText
-icon = "💔💥"
-
-listErrors :: Set DecompError -> [Error]
-listErrors = fmap (P.indentN 2 . renderDecompError) . toList
-
-tabulateErrors :: Set DecompError -> Error
-tabulateErrors errs | null errs = mempty
-tabulateErrors errs =
-  P.indentN 2 . P.lines $
-    ""
-      : P.wrap "The following errors occured while decompiling:"
-      : (listErrors errs)
-
-prettyRuntimeExnSansCtx :: RuntimeExn -> IO (Pretty P.ColorText)
-prettyRuntimeExnSansCtx = prettyRuntimeExn mempty id (decompile pure \_ _ -> Nothing)
-
--- | __TODO__: With GHC 9.10, this implementation can be moved to `displayException` on the `Exception` instance, and
---             this instance can be derived again (see haskell/core-libraries-committee#198).
-instance Show RuntimeExn where
-  show = P.toPlain 0 . runIdentity . prettyRuntimeExn' (pure . issueUrl) mempty id (decompile pure \_ _ -> Nothing)
+  deriving (Show)
 
 instance Exception RuntimeExn
 

--- a/unison-runtime/src/Unison/Runtime/Interface.hs
+++ b/unison-runtime/src/Unison/Runtime/Interface.hs
@@ -19,11 +19,18 @@ module Unison.Runtime.Interface
       ),
     decodeStandalone,
     RuntimeHost (..),
-    Runtime (..),
+    Runtime,
+    terminate,
 
     -- * Exported for tests
     getStoredCache,
     putStoredCache,
+
+    -- * error serialization (these should live in unison-cli, but they still have some call sites here)
+    prettyError,
+    prettyRuntimeExn,
+    renderDecompError,
+    tabulateErrors,
   )
 where
 
@@ -41,15 +48,9 @@ import Data.Foldable
 import Data.IORef
 import Data.List qualified as L
 import Data.Map.Strict qualified as Map
-import Data.Set as Set
-  ( filter,
-    fromList,
-    map,
-    notMember,
-    singleton,
-    (\\),
-  )
+import Data.Set as Set (filter, fromList, map, notMember, singleton, (\\))
 import Data.Set qualified as Set
+import Data.Text (isPrefixOf)
 import Data.Text as Text (unpack)
 import Data.Void (absurd)
 import System.FilePath
@@ -57,19 +58,8 @@ import Unison.ABT qualified as ABT
 import Unison.Builtin.Decls qualified as RF
 import Unison.Codebase.CodeLookup (CodeLookup (..))
 import Unison.Codebase.MainTerm (builtinIOTestTypes, builtinMain)
-import Unison.Codebase.Runtime
-  ( CompileOpts (..),
-    Error,
-    Response (..),
-    Runtime (..),
-  )
-import Unison.Codebase.Runtime.Profile
-  ( Profile (..),
-    ProfileSpec (..),
-    foldedProfile,
-    fullProfile,
-    miniProfile,
-  )
+import Unison.Codebase.Runtime (CompileOpts (..), Response (..))
+import Unison.Codebase.Runtime.Profile (Profile (..), ProfileSpec (..), foldedProfile, fullProfile, miniProfile)
 import Unison.ConstructorReference (ConstructorReference, GConstructorReference (..))
 import Unison.ConstructorReference qualified as RF
 import Unison.DataDeclaration (Decl, declFields, declTypeDependencies)
@@ -82,27 +72,17 @@ import Unison.PrettyPrintEnv qualified as PPE
 import Unison.Reference (Reference)
 import Unison.Reference qualified as RF
 import Unison.Referent qualified as RF (pattern Ref)
+import Unison.Runtime
 import Unison.Runtime.ANF as ANF
 import Unison.Runtime.ANF.Optimize as ANF
 import Unison.Runtime.ANF.Rehash as ANF (rehashGroups)
-import Unison.Runtime.ANF.Serialize as ANF
-  ( getGroupCurrent,
-    getOptInfos,
-    putGroup,
-    putOptInfos,
-  )
+import Unison.Runtime.ANF.Serialize as ANF (getGroupCurrent, getOptInfos, putGroup, putOptInfos)
 import Unison.Runtime.Builtin
-import Unison.Runtime.Decompile
-import Unison.Runtime.Exception
-  ( die,
-    listErrors,
-    prettyCompileExn,
-    prettyPanic,
-    prettyRuntimeExn,
-    prettyRuntimeExnSansCtx,
-    tabulateErrors,
-  )
+import Unison.Runtime.Decompile (DecompError, DecompResult, decompile)
+import Unison.Runtime.Decompile qualified as Decomp
+import Unison.Runtime.Exception (RuntimeExn (BU, PE), die)
 import Unison.Runtime.Foreign.Function (functionUnreplacements)
+import Unison.Runtime.InternalError (CompileExn (CE))
 import Unison.Runtime.MCode
   ( Args (..),
     CombIx (..),
@@ -143,6 +123,7 @@ import Unison.Runtime.Stack
 import Unison.Runtime.TypeTags qualified as TT
 import Unison.Symbol (Symbol)
 import Unison.Syntax.HashQualified qualified as HQ (toText)
+import Unison.Syntax.NamePrinter (prettyHashQualified, prettyReference)
 import Unison.Syntax.TermPrinter
 import Unison.Term qualified as Tm
 import Unison.Type qualified as Type
@@ -522,9 +503,9 @@ interpEvalDirect ::
   CodeLookup Symbol IO () ->
   PrettyPrintEnv ->
   Term Symbol ->
-  IO (Either Error (Response, Term Symbol))
+  IO (Either Error (Response DecompError, Term Symbol))
 interpEvalDirect activeThreads cleanupThreads ctxVar prof cl ppe tm =
-  catchInternalErrors $ do
+  catchErrors $ do
     ctx <- readIORef ctxVar
     (tyrs, tmrs) <- collectDeps cl tm
     (ctx, _) <- loadDeps cl ppe ctx tyrs tmrs
@@ -542,7 +523,7 @@ profileEval ::
   PrettyPrintEnv ->
   Maybe String ->
   Term Symbol ->
-  IO (Either Error (Response, Term Symbol))
+  IO (Either Error (Response DecompError, Term Symbol))
 profileEval actThr cleanThr ctxVar cl ppe mout tm = do
   prof <- spawnProfiler
   result <-
@@ -582,12 +563,11 @@ interpEval ::
   PrettyPrintEnv ->
   ProfileSpec ->
   Term Symbol ->
-  IO (Either Error (Response, Term Symbol))
+  IO (Either Error (Response DecompError, Term Symbol))
 interpEval actThr cleanThr ctxVar cl ppe = \case
   NoProf -> interpEvalDirect actThr cleanThr ctxVar Nothing cl ppe
   MiniProf -> profileEval actThr cleanThr ctxVar cl ppe Nothing
-  FullProf file ->
-    profileEval actThr cleanThr ctxVar cl ppe $ Just file
+  FullProf file -> profileEval actThr cleanThr ctxVar cl ppe $ Just file
 
 interpCompile ::
   Text ->
@@ -779,20 +759,21 @@ evalInContext ::
   Maybe ProfileComm ->
   ActiveThreads ->
   Word64 ->
-  IO (Either Error (Response, Term Symbol))
+  IO (Either Error (Response DecompError, Term Symbol))
 evalInContext ppe ctx prof activeThreads w = do
   r <- newIORef (boxedVal BlackHole)
   crs <- readTVarIO (combRefs $ ccache ctx)
   let hook = watchHook r
       decom = decompileCtx crs ctx
-      mkResponse errs = case listErrors errs of
-        [] -> EmptyResponse
-        es -> DecompErrs es
+      mkResponse errs =
+        if Set.null errs
+          then EmptyResponse
+          else DecompErrs $ toList errs
       finish = fmap (first mkResponse . decom)
 
       prettyError e =
-        prettyRuntimeExn ppe (backmapRef ctx) decom <$> fromException e
-          <|> pure . prettyPanic ppe decom <$> fromException e
+        RuntimeExn (pure (ppe, backmapRef ctx, decom)) <$> fromException e
+          <|> RuntimePanic ppe decom <$> fromException e
 
       debugText fancy val = case decom val of
         (errs, dv)
@@ -805,47 +786,34 @@ evalInContext ppe ctx prof activeThreads w = do
                 (debugTextFormat fancy $ pretty ppe dv)
 
   result <-
-    bitraverse id (const $ readIORef r) <=< tryJust prettyError $
-      ( maybe
-          (apply0 (Just hook) (ccache ctx) {tracer = debugText} activeThreads w)
-          (\pc -> apply0 (Just hook) (ccache ctx) {tracer = debugText, profiler = pc} activeThreads w)
-          prof
-      )
+    traverse (const $ readIORef r) <=< tryJust prettyError $
+      maybe
+        (apply0 (Just hook) (ccache ctx) {tracer = debugText} activeThreads w)
+        (\pc -> apply0 (Just hook) (ccache ctx) {tracer = debugText, profiler = pc} activeThreads w)
+        prof
+
   pure $ finish result
 
 executeMainComb ::
   CombIx ->
   CCache () ->
-  IO (Either (Pretty ColorText) ())
+  IO (Either Error ())
 executeMainComb init cc = do
   rSection <- resolveSection cc $ Ins (Pack RF.unitRef TT.unitTag ZArgs) $ Call True init init (VArg1 0)
-  result <-
-    UnliftIO.try . eval0 cc Nothing $ rSection
-  case result of
-    Left err -> Left <$> formatErr err
-    Right () -> pure (Right ())
+  result <- UnliftIO.try $ eval0 cc Nothing rSection
+  bitraverse contextualizeErr pure result
   where
-    formatErr re = do
+    contextualizeErr re = do
       crs <- readTVarIO (combRefs cc)
       let ctx = cacheContext cc
           decom =
-            decompile
-              (intermedToBase ctx)
-              ( backReferenceTm
-                  crs
-                  (floatRemap ctx)
-                  (intermedRemap ctx)
-                  (decompTm ctx)
-              )
-      prettyRuntimeExn mempty id decom re
+            decompile (intermedToBase ctx) . backReferenceTm crs (floatRemap ctx) (intermedRemap ctx) $
+              decompTm ctx
+      pure $ RuntimeExn (pure (mempty, id, decom)) re
 
-catchInternalErrors ::
-  IO (Either Error a) ->
-  IO (Either Error a)
-catchInternalErrors sub = sub `UnliftIO.catch` hCE `UnliftIO.catch` hRE
-  where
-    hCE = fmap Left . prettyCompileExn
-    hRE = fmap Left . prettyRuntimeExnSansCtx
+catchErrors :: IO (Either Error a) -> IO (Either Error a)
+catchErrors sub =
+  sub `UnliftIO.catch` (pure . Left . CompileExn) `UnliftIO.catch` (pure . Left . RuntimeExn Nothing)
 
 decodeStandalone ::
   BL.ByteString ->
@@ -896,14 +864,11 @@ withRuntime sandboxed runtimeHost version action =
 
 tryM :: IO () -> IO (Maybe Error)
 tryM =
-  flip UnliftIO.catch hRE
-    . flip UnliftIO.catch hCE
+  flip UnliftIO.catch (pure . pure . RuntimeExn Nothing)
+    . flip UnliftIO.catch (pure . pure . CompileExn)
     . fmap (const Nothing)
-  where
-    hCE = fmap Just . prettyCompileExn
-    hRE = fmap Just . prettyRuntimeExnSansCtx
 
-runStandalone :: Bool -> StoredCache -> CombIx -> IO (Either (Pretty ColorText) ())
+runStandalone :: Bool -> StoredCache -> CombIx -> IO (Either Error ())
 runStandalone sandboxed sc init =
   restoreCache sandboxed sc >>= executeMainComb init
 
@@ -1103,3 +1068,185 @@ standalone cc init =
           <*> readTVarIO (sandbox cc)
       Nothing ->
         die [] $ "standalone: unknown combinator: " ++ show init
+
+renderDecompError :: DecompError -> Pretty P.ColorText
+renderDecompError = \case
+  Decomp.BadBool n ->
+    P.lines
+      [ P.wrap "A boolean value had an unexpected constructor tag:",
+        P.indentN 2 . P.lit . fromString $ show n
+      ]
+  Decomp.BadUnboxed tt ->
+    P.lines
+      [ P.wrap "An apparent numeric type had an unrecognized packed tag:",
+        P.indentN 2 $ printUnboxedTypeTag tt
+      ]
+  Decomp.BadForeign rf ->
+    P.lines
+      [ P.wrap "A foreign value with no decompiled representation was encountered:",
+        P.indentN 2 $ prf rf
+      ]
+  Decomp.BadData rf ->
+    P.lines
+      [ P.wrap "A data type with no decompiled representation was encountered:",
+        P.indentN 2 $ prf rf
+      ]
+  Decomp.BadPAp rf ->
+    P.lines
+      [ P.wrap "A partial function application could not be decompiled: ",
+        P.indentN 2 $ prf rf
+      ]
+  Decomp.UnkComb rf ->
+    P.lines
+      [ P.wrap "A reference to an unknown function was encountered: ",
+        P.indentN 2 $ prf rf
+      ]
+  Decomp.UnkLocal rf n ->
+    P.lines
+      [ "A reference to an unknown portion to a function was encountered: ",
+        P.indentN 2 $ "function: " <> prf rf,
+        P.indentN 2 $ "section: " <> P.lit (fromString $ show n)
+      ]
+  Decomp.Cont -> "A continuation value was encountered"
+  Decomp.Exn -> "An exception value was encountered"
+  Decomp.Aff -> "An affine info value was encountered"
+  where
+    prf = P.syntaxToColor . prettyReference 10
+    printUnboxedTypeTag = P.shown
+
+tabulateErrors :: Set DecompError -> Pretty P.ColorText
+tabulateErrors errs | null errs = mempty
+tabulateErrors errs =
+  P.indentN 2 . P.lines $
+    ""
+      : P.wrap "The following errors occured while decompiling:"
+      : (P.indentN 2 . renderDecompError <$> toList errs)
+
+formatIssues :: (Applicative f) => (Word -> f (Pretty P.ColorText)) -> [Word] -> f (Pretty P.ColorText)
+formatIssues issueFn issues = do
+  issueMessages <- traverse issueFn issues
+  pure $
+    P.lines $
+      if null issues
+        then [P.wrap "Please report it at https://github.com/unisonweb/unison/issues/new/choose."]
+        else
+          [ P.wrap "Please check if one of these known issues matches your situation:",
+            "",
+            P.bulleted issueMessages,
+            "",
+            P.wrap "If not, please open a new one: https://github.com/unisonweb/unison/issues/new/choose"
+          ]
+
+prettyRuntimeExn' ::
+  (Applicative f) =>
+  PrettyPrintEnv ->
+  (Reference -> Reference) ->
+  (Val -> DecompResult Symbol) ->
+  (Word -> f (Pretty P.ColorText)) ->
+  RuntimeExn ->
+  f (Pretty P.ColorText)
+prettyRuntimeExn' ppe backmap decom issueFn = \case
+  PE _ issues err -> do
+    issueMessage <- formatIssues issueFn issues
+    pure $
+      P.fatalCallout . P.lines $
+        [ P.wrap "Sorry – I’ve encountered a Unison runtime error.",
+          "",
+          P.indentN 2 err,
+          "",
+          issueMessage
+        ]
+  BU tr0 nm c -> pure . P.callout "💔💥" . P.linesNonEmpty . bugMsg ppe tr nm $ decom c
+    where
+      tr = first backmap <$> tr0
+  where
+    bugMsg ppe tr name (errs, tm)
+      | name == "blank expression" =
+          [ P.wrap $ "I encountered a" <> P.red (P.text name) <> "with the following name/message:",
+            "",
+            P.indentN 2 $ pretty ppe tm,
+            tabulateErrors errs,
+            stackTrace ppe tr
+          ]
+      | "pattern match failure" `isPrefixOf` name =
+          [ P.wrap $ "I've encountered a" <> P.red (P.text name) <> "while scrutinizing:",
+            "",
+            P.indentN 2 $ pretty ppe tm,
+            "",
+            P.wrap "This happens when calling a function that doesn't handle all possible inputs",
+            tabulateErrors errs,
+            stackTrace ppe tr
+          ]
+      | name == "builtin.raise" =
+          [ P.wrap "The program halted with an unhandled exception:",
+            "",
+            P.indentN 2 $ pretty ppe tm,
+            tabulateErrors errs,
+            stackTrace ppe tr
+          ]
+      | name == "builtin.bug",
+        RF.TupleTerm' [Tm.Text' msg, x] <- tm,
+        "pattern match failure" `isPrefixOf` msg =
+          [ P.wrap $ "I've encountered a" <> P.red (P.text msg) <> "while scrutinizing:",
+            "",
+            P.indentN 2 $ pretty ppe x,
+            "",
+            P.wrap "This happens when calling a function that doesn't handle all possible inputs",
+            tabulateErrors errs,
+            stackTrace ppe tr
+          ]
+      | otherwise =
+          [ P.wrap $ "I've encountered a call to" <> P.red (P.text name) <> "with the following value:",
+            "",
+            P.indentN 2 $ pretty ppe tm,
+            tabulateErrors errs,
+            stackTrace ppe tr
+          ]
+      where
+        stackTrace _ [] = mempty
+        stackTrace ppe tr = "\nStack trace:\n" <> P.indentN 2 (P.lines $ f <$> tr)
+          where
+            f (rf, n) = name <> count
+              where
+                count
+                  | n > 1 = " (" <> P.shown n <> " copies)"
+                  | otherwise = ""
+                name = P.syntaxToColor . prettyHashQualified . PPE.termName ppe $ RF.Ref rf
+
+prettyRuntimeExn :: (Applicative f) => (Word -> f (Pretty P.ColorText)) -> RuntimeExn -> f (Pretty P.ColorText)
+prettyRuntimeExn = prettyRuntimeExn' mempty id (decompile pure \_ _ -> Nothing)
+
+-- |
+--
+--  __NB__: The only reason this is in the unison-runtime package is because it’s used in the tests. Otherwise it should move to unison-cli.
+prettyError ::
+  (Applicative f) =>
+  -- | A function for displaying unisonweb/unison issue numbers (for example,
+  --   `Unison.CommandLine.OutputMessages.showIssueUrl`).
+  (Word -> f (Pretty P.ColorText)) ->
+  Error ->
+  f (Pretty P.ColorText)
+prettyError issueFn = \case
+  UnstructuredError text -> pure $ P.text text
+  CompileExn (CE _ issues err) -> do
+    issueMessage <- formatIssues issueFn issues
+    pure $
+      P.fatalCallout . P.lines $
+        [ P.wrap "Sorry – I've encountered a bug in the Unison runtime.",
+          "",
+          P.indentN 2 $ P.string err,
+          "",
+          issueMessage
+        ]
+  RuntimeExn ctx re ->
+    maybe prettyRuntimeExn (\(ppe, backmapRef, decom) -> prettyRuntimeExn' ppe backmapRef decom) ctx issueFn re
+  RuntimePanic ppe decom (Panic msg mval) ->
+    pure . P.callout panicIcon . P.linesNonEmpty $
+      [ P.wrap "The program halted with a runtime panic:",
+        "",
+        P.string msg
+      ]
+        ++ maybe [] (render . decom) mval
+    where
+      panicIcon = "💥🤯💥"
+      render (errs, tm) = ["", P.indentN 2 $ pretty ppe tm, tabulateErrors errs]

--- a/unison-runtime/src/Unison/Runtime/InternalError.hs
+++ b/unison-runtime/src/Unison/Runtime/InternalError.hs
@@ -4,61 +4,16 @@
 --   cause an import cycle.
 module Unison.Runtime.InternalError
   ( CompileExn (CE),
-    githubTitleForIssue,
     internalBug,
-    issueUrl,
-    prettyCompileExn,
   )
 where
 
 import Control.Exception (throw)
 import GHC.Stack (CallStack, callStack)
-import GitHub qualified as GH
 import Unison.Prelude
-import Unison.Util.Pretty as Pretty
 
 data CompileExn = CE CallStack [Word] String
-
-issueUrl :: Word -> Pretty Pretty.ColorText
-issueUrl = Pretty.string . ("https://github.com/unisonweb/unison/issues/" <>) . show
-
-githubTitleForIssue :: Word -> IO (Either GH.Error Text)
-githubTitleForIssue =
-  fmap (fmap GH.issueTitle) . GH.github' GH.issueR "unisonweb" "unison" . GH.IssueNumber . fromIntegral
-
-prettyCompileExn' ::
-  (Applicative f) => (Word -> f (Pretty Pretty.ColorText)) -> CompileExn -> f (Pretty Pretty.ColorText)
-prettyCompileExn' issueFn (CE _ issues err) = do
-  issueMessages <- traverse issueFn issues
-  pure $
-    Pretty.fatalCallout . Pretty.lines $
-      [ Pretty.wrap "Sorry – I've encountered a bug in the Unison runtime.",
-        "",
-        Pretty.indentN 2 $ Pretty.string err,
-        ""
-      ]
-        <> if null issues
-          then [Pretty.wrap "Please report it at https://github.com/unisonweb/unison/issues/new/choose."]
-          else
-            [ Pretty.wrap "Please check if one of these known issues matches your situation:",
-              "",
-              Pretty.bulleted issueMessages,
-              "",
-              Pretty.wrap "If not, please open a new one: https://github.com/unisonweb/unison/issues/new/choose"
-            ]
-
-prettyCompileExn :: CompileExn -> IO (Pretty Pretty.ColorText)
-prettyCompileExn =
-  prettyCompileExn'
-    ( \i -> do
-        mtitle <- githubTitleForIssue i
-        pure $ either (const $ issueUrl i) (\title -> Pretty.wrap $ Pretty.text title <> " " <> issueUrl i) mtitle
-    )
-
--- | __TODO__: With GHC 9.10, this implementation can be moved to `displayException` on the `Exception` instance, and
---             this instance can be derived again (see haskell/core-libraries-committee#198).
-instance Show CompileExn where
-  show = Pretty.toPlain 0 . runIdentity . prettyCompileExn' (pure . issueUrl)
+  deriving (Show)
 
 instance Exception CompileExn
 

--- a/unison-runtime/src/Unison/Runtime/Machine.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine.hs
@@ -73,7 +73,7 @@ import Unison.Runtime.ANF.Serialize (serializeCode, deserializeCode)
 #endif
 import Unison.Runtime.Array as PA
 import Unison.Runtime.Builtin hiding (unitValue)
-import Unison.Runtime.Exception (RuntimeExn (BU, PE), die, peStr, prettyRuntimeExnSansCtx)
+import Unison.Runtime.Exception (RuntimeExn (BU, PE), die, peStr)
 import Unison.Runtime.Foreign
 import Unison.Runtime.Foreign.Function
   ( decodeVal,
@@ -496,21 +496,18 @@ encodeExn stk exc = do
       stk <- bumpn stk 3
       pokeTag stk 0
       bpokeOff stk 1 $ Foreign (Wrap Rf.typeLinkRef link)
-      pokeOffBi stk 2 =<< msg
+      pokeOffBi stk 2 msg
       stk <$ pokeOff stk 3 extra
       where
-        disp :: (Exception e) => e -> IO Util.Text.Text
-        disp = pure . Util.Text.pack . show
+        disp :: (Exception e) => e -> Util.Text.Text
+        disp = Util.Text.pack . show
         (link, msg, extra)
           | Just (ioe :: IOException) <- fromException exn =
               (Rf.ioFailureRef, disp ioe, unitValue)
-          | Just re <- fromException exn =
-              ( Rf.runtimeFailureRef,
-                Util.Text.pack . P.toPlain 0 <$> prettyRuntimeExnSansCtx re,
-                case re of
-                  PE _ _ _ -> unitValue
-                  BU _ _ val -> val
-              )
+          | Just re <- fromException exn = case re of
+              PE _stk _issues msg ->
+                (Rf.runtimeFailureRef, Util.Text.pack $ P.toPlain 0 msg, unitValue)
+              BU _ tx val -> (Rf.runtimeFailureRef, Util.Text.fromText tx, val)
           | Just (ae :: ArithException) <- fromException exn =
               (Rf.arithmeticFailureRef, disp ae, unitValue)
           | Just (nae :: NestedAtomically) <- fromException exn =
@@ -523,7 +520,7 @@ encodeExn stk exc = do
               (Rf.threadKilledFailureRef, disp ie, unitValue)
           | Just (Panic msg v) <- fromException exn,
             msg <- Util.Text.pack $ "panic: " ++ msg =
-              (Rf.miscFailureRef, pure msg, fromMaybe unitValue v)
+              (Rf.miscFailureRef, msg, fromMaybe unitValue v)
           | otherwise = (Rf.miscFailureRef, disp exn, unitValue)
 
 -- | Evaluate a section

--- a/unison-runtime/src/Unison/Runtime/Machine.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine.hs
@@ -73,7 +73,7 @@ import Unison.Runtime.ANF.Serialize (serializeCode, deserializeCode)
 #endif
 import Unison.Runtime.Array as PA
 import Unison.Runtime.Builtin hiding (unitValue)
-import Unison.Runtime.Exception (RuntimeExn (BU, PE), die, peStr)
+import Unison.Runtime.Exception (RuntimeExn (BU, PE), die, exn)
 import Unison.Runtime.Foreign
 import Unison.Runtime.Foreign.Function
   ( decodeVal,
@@ -372,7 +372,7 @@ exec env henv !_activeThreads !stk !k _ (Prim1 op i) = do
 exec _ _ !_activeThreads !stk !k cix (Prim2 THRO i j) = do
   name <- peekOffBi @Util.Text.Text stk i
   x <- peekOff stk j
-  () <- throwIO (BU (traceK r k) (Util.Text.toText name) x)
+  () <- throwIO $ BU (traceK r k) (Util.Text.toText name) x
   error "throwIO should never return"
   where
     r = combRef cix
@@ -665,7 +665,7 @@ fakeCix :: CombIx
 fakeCix = CIx exceptionRef maxBound maxBound
 
 unhandledAbilityRequest :: (HasCallStack) => IO a
-unhandledAbilityRequest = error . displayException $ peStr [2922, 5400] "eval: unhandled ability request"
+unhandledAbilityRequest = exn [2922, 5400] "eval: unhandled ability request"
 
 forkEval ::
   (RuntimeProfiler prof) =>

--- a/unison-runtime/src/Unison/Runtime/Machine/Types.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine/Types.hs
@@ -37,6 +37,7 @@ import Unison.Runtime.ANF.Optimize (OptInfos)
 import Unison.Runtime.Builtin
 import Unison.Runtime.Exception qualified as Exception
 import Unison.Runtime.Foreign (Failure (..))
+import Unison.Runtime.InternalError (CompileExn (CE))
 import Unison.Runtime.MCode
 import Unison.Runtime.Profiling
 import Unison.Runtime.Referenced
@@ -317,7 +318,7 @@ codeValidate cc tml = do
       rns = RN (refLookup "ty" rty) (refLookup "tm" rtm) (const Nothing)
       combinate (n, (r, g)) = evaluate $ emitCombs rns r n g
   (Nothing <$ traverse_ combinate (zip [ftm ..] tml))
-    `catch` \(Exception.CE cs _issues perr) ->
+    `catch` \(CE cs _issues perr) ->
       let msg = UText.pack perr
           extra = UText.pack $ show cs
        in pure . Just $ Failure ioFailureRef msg extra

--- a/unison-runtime/src/Unison/Runtime/Machine/Types.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine/Types.hs
@@ -43,7 +43,6 @@ import Unison.Runtime.Referenced
 import Unison.Runtime.Stack
 import Unison.Symbol
 import Unison.Util.EnumContainers as EC
-import Unison.Util.Pretty qualified as Pretty
 import Unison.Util.Text as UText
 
 -- | A ref storing every currently active thread.
@@ -318,7 +317,7 @@ codeValidate cc tml = do
       rns = RN (refLookup "ty" rty) (refLookup "tm" rtm) (const Nothing)
       combinate (n, (r, g)) = evaluate $ emitCombs rns r n g
   (Nothing <$ traverse_ combinate (zip [ftm ..] tml))
-    `catch` \ce@(Exception.CE cs _ _) -> do
-      msg <- fmap (UText.pack . Pretty.toPlain 0) $ Exception.prettyCompileExn ce
-      let extra = UText.pack $ show cs
-      pure . Just $ Failure ioFailureRef msg extra
+    `catch` \(Exception.CE cs _issues perr) ->
+      let msg = UText.pack perr
+          extra = UText.pack $ show cs
+       in pure . Just $ Failure ioFailureRef msg extra

--- a/unison-runtime/tests/Unison/Test/UnisonSources.hs
+++ b/unison-runtime/tests/Unison/Test/UnisonSources.hs
@@ -9,7 +9,7 @@ import System.Directory (doesFileExist)
 import System.FilePath (joinPath, replaceExtension, splitPath)
 import System.FilePath.Find (always, extension, find, (==?))
 import Unison.Builtin qualified as Builtin
-import Unison.Codebase.Runtime (Runtime, evaluateWatches)
+import Unison.Codebase.Runtime (evaluateWatches)
 import Unison.Codebase.Runtime.Profile (ProfileSpec (NoProf))
 import Unison.Names qualified as Names
 import Unison.Parser.Ann (Ann)
@@ -28,7 +28,7 @@ import Unison.Test.Common qualified as Common
 import Unison.UnisonFile qualified as UF
 import Unison.UnisonFile.Names qualified as UF
 import Unison.Util.Monoid (intercalateMap)
-import Unison.Util.Pretty (toPlain)
+import Unison.Util.Pretty qualified as Pretty
 
 type Note = Result.Note Symbol Ann
 
@@ -77,7 +77,7 @@ shouldPassLater = find always (extension ==? ".uu") shouldPassPath
 shouldFailLater :: IO [FilePath]
 shouldFailLater = find always (extension ==? ".uu") shouldFailPath
 
-go :: Runtime Symbol -> IO [FilePath] -> (EitherResult -> Test TFile) -> Test ()
+go :: RTI.Runtime Symbol -> IO [FilePath] -> (EitherResult -> Test TFile) -> Test ()
 go rt files how = do
   files' <- liftIO files
   tests (makePassingTest rt how <$> files')
@@ -103,8 +103,7 @@ decodeResult source (Result notes (Just (Left uf))) =
 decodeResult _source (Result _notes (Just (Right uf))) =
   Right uf
 
-makePassingTest ::
-  Runtime Symbol -> (EitherResult -> Test TFile) -> FilePath -> Test ()
+makePassingTest :: RTI.Runtime Symbol -> (EitherResult -> Test TFile) -> FilePath -> Test ()
 makePassingTest rt how filepath = scope (shortName filepath) $ do
   uf <- typecheckingTest how filepath
   resultTest rt uf filepath
@@ -117,33 +116,26 @@ typecheckingTest how filepath = scope "typecheck" $ do
   source <- io $ unpack <$> readUtf8 filepath
   how . decodeResult source $ parseAndSynthesizeAsFile [] (shortName filepath) source
 
-resultTest ::
-  Runtime Symbol -> TFile -> FilePath -> Test ()
+resultTest :: RTI.Runtime Symbol -> TFile -> FilePath -> Test ()
 resultTest rt uf filepath = do
   let valueFile = replaceExtension filepath "ur"
   rFileExists <- io $ doesFileExist valueFile
   if rFileExists
     then scope "result" $ do
       values <- io $ unpack <$> readUtf8 valueFile
-      let term = runIdentity (Parsers.parseTerm values parsingEnv)
-      let report e = throwIO (userError $ toPlain 10000 e)
+      let report = throwIO . userError . Pretty.toPlain 0 <=< RTI.prettyError (pure . Pretty.shown)
       (bindings, _, watches) <-
-        io $
-          either report pure
-            =<< evaluateWatches
-              Builtin.codeLookup
-              PPE.empty
-              NoProf
-              (const $ pure Nothing)
-              rt
-              uf
-      case term of
-        Right tm -> do
-          -- compare the watch expression from the .u with the expr in .ur
-          let watchResult = head (view _5 <$> Map.elems watches)
-              tm' = Term.letRec' False (bindings <&> \(sym, tm) -> (sym, (), tm)) watchResult
-          -- note . show $ tm'
-          -- note . show $ Term.amap (const ()) tm
-          expectEqual tm' (Term.amap (const ()) tm)
-        Left e -> crash $ PrintError.renderParseErrorAsANSI 80 values e
+        io $ either report pure =<< evaluateWatches Builtin.codeLookup PPE.empty NoProf (const $ pure Nothing) rt uf
+      either
+        (crash . PrintError.renderParseErrorAsANSI 80 values)
+        ( \tm -> do
+            -- compare the watch expression from the .u with the expr in .ur
+            let watchResult = head (view _5 <$> Map.elems watches)
+                tm' = Term.letRec' False (bindings <&> \(sym, tm) -> (sym, (), tm)) watchResult
+            -- note . show $ tm'
+            -- note . show $ Term.amap (const ()) tm
+            expectEqual tm' (Term.amap (const ()) tm)
+        )
+        . runIdentity
+        $ Parsers.parseTerm values parsingEnv
     else pure ()

--- a/unison-runtime/unison-runtime.cabal
+++ b/unison-runtime/unison-runtime.cabal
@@ -40,6 +40,7 @@ flag stackchecks
 library
   exposed-modules:
       Unison.Codebase.Execute
+      Unison.Runtime
       Unison.Runtime.ANF
       Unison.Runtime.ANF.Optimize
       Unison.Runtime.ANF.Rehash
@@ -130,7 +131,6 @@ library
     , directory
     , exceptions
     , filepath
-    , github
     , hashable
     , inspection-testing
     , iproute

--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -150,6 +150,8 @@ import Unison.Reference (Reference, TermReference, TypeReference)
 import Unison.Reference qualified as Reference
 import Unison.Referent (Referent)
 import Unison.Referent qualified as Referent
+import Unison.Runtime (Runtime)
+import Unison.Runtime.Decompile (DecompError)
 import Unison.Runtime.IOSource qualified as DD
 import Unison.Server.Doc qualified as Doc
 import Unison.Server.Doc.AsHtml qualified as DocHtml
@@ -785,12 +787,12 @@ mkTermDefinition codebase termPPED width r docs tm = do
 
 -- | Evaluate the doc at the given reference and return its evaluated-but-not-rendered form.
 evalDocRef ::
-  Rt.Runtime Symbol ->
+  Runtime Symbol ->
   Codebase IO Symbol Ann ->
   TermReference ->
   -- Evaluation always produces a doc, (it just might have error messages in it).
   -- We still return the errors for logging and debugging.
-  IO (Doc.EvaluatedDoc Symbol, [Rt.Error])
+  IO (Doc.EvaluatedDoc Symbol, [DecompError])
 evalDocRef rt codebase r = do
   let tm = Term.ref () r
   errsVar <- UnliftIO.newTVarIO []
@@ -862,9 +864,9 @@ renderDocRefs ::
   PPED.PrettyPrintEnvDecl ->
   Width ->
   Codebase IO Symbol Ann ->
-  Rt.Runtime Symbol ->
+  Runtime Symbol ->
   t TermReference ->
-  IO (t (HashQualifiedName, UnisonHash, Doc.Doc, [Rt.Error]))
+  IO (t (HashQualifiedName, UnisonHash, Doc.Doc, [DecompError]))
 renderDocRefs pped width codebase rt docRefs = do
   eDocs <- for docRefs \ref -> (ref,) <$> (evalDocRef rt codebase ref)
   for eDocs \(ref, (eDoc, docEvalErrs)) -> do
@@ -874,13 +876,13 @@ renderDocRefs pped width codebase rt docRefs = do
     pure (name, hash, renderedDoc, docEvalErrs)
 
 docsInBranchToHtmlFiles ::
-  Rt.Runtime Symbol ->
+  Runtime Symbol ->
   Codebase IO Symbol Ann ->
   Branch IO ->
   FilePath ->
-  -- Returns any doc evaluation errors which may have occurred.
-  -- Note that all docs will still be rendered even if there are errors.
-  IO [Rt.Error]
+  -- | Returns any doc evaluation errors which may have occurred.
+  --   Note that all docs will still be rendered even if there are errors.
+  IO [DecompError]
 docsInBranchToHtmlFiles runtime codebase currentBranch directory = do
   let allTerms = (R.toList . Branch.deepTerms . Branch.head) currentBranch
   -- ignores docs inside lib namespace, recursively

--- a/unison-share-api/src/Unison/Server/CodebaseServer.hs
+++ b/unison-share-api/src/Unison/Server/CodebaseServer.hs
@@ -92,7 +92,6 @@ import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Branch qualified as Branch
 import Unison.Codebase.Branch.Names qualified as Branch
 import Unison.Codebase.Path qualified as Path
-import Unison.Codebase.Runtime qualified as Rt
 import Unison.HashQualified
 import Unison.HashQualified qualified as HQ
 import Unison.Name as Name (Name, segments)
@@ -102,6 +101,7 @@ import Unison.PrettyPrintEnv.Names qualified as PPE
 import Unison.PrettyPrintEnvDecl (PrettyPrintEnvDecl)
 import Unison.PrettyPrintEnvDecl qualified as PPED
 import Unison.Project (ProjectAndBranch (..), ProjectBranchName, ProjectName)
+import Unison.Runtime (Runtime)
 import Unison.Server.Backend (Backend, BackendEnv, runBackend)
 import Unison.Server.Backend qualified as Backend
 import Unison.Server.Backend.DefinitionDiff qualified as DefinitionDiff
@@ -394,7 +394,7 @@ appAPI = Proxy
 
 app ::
   BackendEnv ->
-  Rt.Runtime Symbol ->
+  Runtime Symbol ->
   Codebase IO Symbol Ann ->
   FilePath ->
   Strict.ByteString ->
@@ -457,7 +457,7 @@ startServer ::
   Bool ->
   BackendEnv ->
   CodebaseServerOpts ->
-  Rt.Runtime Symbol ->
+  Runtime Symbol ->
   Codebase IO Symbol Ann ->
   MCPServer ->
   (Maybe BaseUrl -> IO a) ->
@@ -566,7 +566,7 @@ corsPolicy allowCorsHost =
 
 server ::
   BackendEnv ->
-  Rt.Runtime Symbol ->
+  Runtime Symbol ->
   Codebase IO Symbol Ann ->
   FilePath ->
   Strict.ByteString ->
@@ -582,7 +582,7 @@ server backendEnv rt codebase uiPath expectedToken mcpServer =
         :<|> serveUnisonAndDocs backendEnv rt codebase
         :<|> mcpServer
 
-serveUnisonAndDocs :: BackendEnv -> Rt.Runtime Symbol -> Codebase IO Symbol Ann -> Server UnisonAndDocsAPI
+serveUnisonAndDocs :: BackendEnv -> Runtime Symbol -> Codebase IO Symbol Ann -> Server UnisonAndDocsAPI
 serveUnisonAndDocs env rt codebase = serveUnisonLocal env codebase rt :<|> serveOpenAPI :<|> Tagged serveDocs
 
 serveDocs :: Application
@@ -599,7 +599,7 @@ hoistWithAuth api expectedToken server token = hoistServer @api @Handler @Handle
 
 serveProjectsCodebaseServerAPI ::
   Codebase IO Symbol Ann ->
-  Rt.Runtime Symbol ->
+  Runtime Symbol ->
   ProjectName ->
   ProjectBranchName ->
   ServerT CodebaseServerAPI (Backend IO)
@@ -646,7 +646,7 @@ resolveProjectRootHash :: Codebase IO v a -> ProjectAndBranch ProjectName Projec
 resolveProjectRootHash codebase projectAndBranchName = do
   resolveProjectRoot codebase projectAndBranchName <&> Causal.causalHash
 
-serveProjectDiffTermsEndpoint :: Codebase IO Symbol Ann -> Rt.Runtime Symbol -> ProjectName -> ProjectBranchName -> ProjectBranchName -> Name -> Name -> Backend IO TermDiffResponse
+serveProjectDiffTermsEndpoint :: Codebase IO Symbol Ann -> Runtime Symbol -> ProjectName -> ProjectBranchName -> ProjectBranchName -> Name -> Name -> Backend IO TermDiffResponse
 serveProjectDiffTermsEndpoint codebase rt projectName oldBranchRef newBranchRef oldTerm newTerm = do
   (oldPPED, oldNameSearch) <- contextForProjectBranch codebase projectName oldBranchRef
   (newPPED, newNameSearch) <- contextForProjectBranch codebase projectName newBranchRef
@@ -675,7 +675,7 @@ contextForProjectBranch codebase projectName branchName = do
   let nameSearch = Names.makeNameSearch hashLength names
   pure (pped, nameSearch)
 
-serveProjectDiffTypesEndpoint :: Codebase IO Symbol Ann -> Rt.Runtime Symbol -> ProjectName -> ProjectBranchName -> ProjectBranchName -> Name -> Name -> Backend IO TypeDiffResponse
+serveProjectDiffTypesEndpoint :: Codebase IO Symbol Ann -> Runtime Symbol -> ProjectName -> ProjectBranchName -> ProjectBranchName -> Name -> Name -> Backend IO TypeDiffResponse
 serveProjectDiffTypesEndpoint codebase rt projectName oldBranchRef newBranchRef oldType newType = do
   (oldPPED, oldNameSearch) <- contextForProjectBranch codebase projectName oldBranchRef
   (newPPED, newNameSearch) <- contextForProjectBranch codebase projectName newBranchRef
@@ -694,7 +694,7 @@ serveProjectDiffTypesEndpoint codebase rt projectName oldBranchRef newBranchRef 
   where
     width = Pretty.Width 80
 
-serveProjectsAPI :: Codebase IO Symbol Ann -> Rt.Runtime Symbol -> ServerT ProjectsAPI (Backend IO)
+serveProjectsAPI :: Codebase IO Symbol Ann -> Runtime Symbol -> ServerT ProjectsAPI (Backend IO)
 serveProjectsAPI codebase rt =
   projectListingEndpoint codebase
     :<|> ( \projectName ->
@@ -709,7 +709,7 @@ serveProjectsAPI codebase rt =
 serveUnisonLocal ::
   BackendEnv ->
   Codebase IO Symbol Ann ->
-  Rt.Runtime Symbol ->
+  Runtime Symbol ->
   Server UnisonLocalAPI
 serveUnisonLocal env codebase rt =
   hoistServer (Proxy @UnisonLocalAPI) (backendHandler env) $

--- a/unison-share-api/src/Unison/Server/Local/Definitions.hs
+++ b/unison-share-api/src/Unison/Server/Local/Definitions.hs
@@ -17,7 +17,6 @@ import Unison.Codebase (Codebase)
 import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Editor.DisplayObject (DisplayObject)
 import Unison.Codebase.Path qualified as Path
-import Unison.Codebase.Runtime qualified as Rt
 import Unison.DataDeclaration qualified as DD
 import Unison.HashQualified qualified as HQ
 import Unison.HashQualifiedPrime qualified as HQ'
@@ -30,6 +29,7 @@ import Unison.PrettyPrintEnv qualified as PPE
 import Unison.PrettyPrintEnvDecl qualified as PPED
 import Unison.Reference qualified as Reference
 import Unison.Referent qualified as Referent
+import Unison.Runtime (Runtime)
 import Unison.Server.Backend
 import Unison.Server.Backend qualified as Backend
 import Unison.Server.Doc qualified as Doc
@@ -59,7 +59,7 @@ prettyDefinitionsForHQName ::
   -- | Whether to suffixify bindings in the rendered syntax
   Suffixify ->
   -- | Runtime used to evaluate docs. This should be sandboxed if run on the server.
-  Rt.Runtime Symbol ->
+  Runtime Symbol ->
   Codebase IO Symbol Ann ->
   -- | The name, hash, or both, of the definition to display.
   HQ.HashQualified Name ->
@@ -129,7 +129,7 @@ termDefinitionByName ::
   PPED.PrettyPrintEnvDecl ->
   NameSearch Sqlite.Transaction ->
   Width ->
-  Rt.Runtime Symbol ->
+  Runtime Symbol ->
   Name ->
   Backend IO (Maybe TermDefinition)
 termDefinitionByName codebase pped nameSearch width rt name = runMaybeT $ do
@@ -158,7 +158,7 @@ typeDefinitionByName ::
   PPED.PrettyPrintEnvDecl ->
   NameSearch Sqlite.Transaction ->
   Width ->
-  Rt.Runtime Symbol ->
+  Runtime Symbol ->
   Name ->
   Backend IO (Maybe TypeDefinition)
 typeDefinitionByName codebase pped nameSearch width rt name = runMaybeT $ do

--- a/unison-share-api/src/Unison/Server/Local/Endpoints/GetDefinitions.hs
+++ b/unison-share-api/src/Unison/Server/Local/Endpoints/GetDefinitions.hs
@@ -22,7 +22,6 @@ import U.Codebase.HashTags (CausalHash)
 import Unison.Codebase (Codebase)
 import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Path qualified as Path
-import Unison.Codebase.Runtime qualified as Rt
 import Unison.Codebase.ShortCausalHash
   ( ShortCausalHash,
   )
@@ -30,6 +29,7 @@ import Unison.HashQualified qualified as HQ
 import Unison.Name (Name)
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
+import Unison.Runtime (Runtime)
 import Unison.Server.Backend qualified as Backend
 import Unison.Server.Local.Definitions qualified as Local
 import Unison.Server.Types
@@ -107,7 +107,7 @@ instance ToSample DefinitionDisplayResults where
   toSamples _ = noSamples
 
 serveDefinitions ::
-  Rt.Runtime Symbol ->
+  Runtime Symbol ->
   Codebase IO Symbol Ann ->
   Either ShortCausalHash CausalHash ->
   Maybe Path.Path ->

--- a/unison-share-api/src/Unison/Server/Local/Endpoints/NamespaceDetails.hs
+++ b/unison-share-api/src/Unison/Server/Local/Endpoints/NamespaceDetails.hs
@@ -13,11 +13,11 @@ import U.Codebase.HashTags (CausalHash)
 import Unison.Codebase (Codebase)
 import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Path qualified as Path
-import Unison.Codebase.Runtime qualified as Rt
 import Unison.Codebase.ShortCausalHash (ShortCausalHash)
 import Unison.NameSegment.Internal (NameSegment (NameSegment))
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
+import Unison.Runtime (Runtime)
 import Unison.Server.Backend
 import Unison.Server.Backend qualified as Backend
 import Unison.Server.Doc qualified as Doc
@@ -42,7 +42,7 @@ instance ToCapture (Capture "namespace" Text) where
       "The fully qualified name of a namespace. The leading `.` is optional."
 
 namespaceDetails ::
-  Rt.Runtime Symbol ->
+  Runtime Symbol ->
   Codebase IO Symbol Ann ->
   Path.Path ->
   Either ShortCausalHash CausalHash ->

--- a/unison-src/builtin-tests/interpreter-tests.output.md
+++ b/unison-src/builtin-tests/interpreter-tests.output.md
@@ -13,7 +13,7 @@ Before merging the PR on Github, we'll merge your branch on Share and restore `r
 ```
 
 ``` ucm :hide
-> clone @unison/runtime-tests/releases/0.0.4 runtime-tests/selected
+> clone @unison/runtime-tests/releases/0.0.3 runtime-tests/selected
 ```
 
 ``` ucm

--- a/unison-src/builtin-tests/interpreter-tests.sh
+++ b/unison-src/builtin-tests/interpreter-tests.sh
@@ -8,7 +8,7 @@ else
   ucm="$1"
 fi
 
-runtime_tests_version="@unison/runtime-tests/releases/0.0.4"
+runtime_tests_version="@unison/runtime-tests/releases/0.0.3"
 
 codebase=${XDG_CACHE_HOME:-"$HOME/.cache"}/unisonlanguage/runtime-tests.unison
 

--- a/unison-src/transcripts-using-base/failure-tests.output.md
+++ b/unison-src/transcripts-using-base/failure-tests.output.md
@@ -59,10 +59,7 @@ test2 = do
 
   The program halted with an unhandled exception:
 
-    Failure
-      (typeLink RuntimeFailure)
-      "💔💥\n\nI've encountered a call to builtin.bug with the following value:\n\n  \"whoa\"\n\nStack trace:\n  #00b3gl0n7k"
-      (Any "whoa")
+    Failure (typeLink RuntimeFailure) "builtin.bug" (Any "whoa")
 
   Stack trace:
     ##raise

--- a/unison-src/transcripts/idempotent/fix-4463.md
+++ b/unison-src/transcripts/idempotent/fix-4463.md
@@ -45,9 +45,7 @@ scratch/main> run main
   situation:
 
   * https://github.com/unisonweb/unison/issues/3625
-  * `renameTo: duplicate rename` pattern matching bug prevents
-    ability to add/update functions
-    https://github.com/unisonweb/unison/issues/4463
+  * https://github.com/unisonweb/unison/issues/4463
 
   If not, please open a new one:
   https://github.com/unisonweb/unison/issues/new/choose

--- a/unison-src/transcripts/idempotent/name-test-sandbox-violators.md
+++ b/unison-src/transcripts/idempotent/name-test-sandbox-violators.md
@@ -87,16 +87,16 @@ bar.test =
 
 
 
-  Error while evaluating test `bar.test`
+  Error while evaluating test `bar.test`:
 
-  💔💥
-
-  I've encountered a call to builtin.bug with the following
-  value:
-
-    "pure code can't perform I/O"
-
-  Stack trace:
-    #1k885m4e7g
-    #tnbpslc0n3
+    💔💥
+    
+    I've encountered a call to builtin.bug with the following
+    value:
+    
+      "pure code can't perform I/O"
+    
+    Stack trace:
+      #1k885m4e7g
+      #tnbpslc0n3
 ```


### PR DESCRIPTION
## Overview

This preserves structured errors (`CompileExn`, `DecompError`, `RuntimeExn`, and `RuntimePanic`) until much closer to `main`, allowing rendering decisions to be made with more information. For example, pulling issue titles from GitHub is no longer done when running transcripts (to avoid network-induced nondeterminism, reflected in fix-4463.md).

## Implementation notes

A new type, `Unison.Runtime.Error`, wraps `CompileExn`, `RuntimeExn`, and `RuntimePanic`, because they travel together.

`Unison.Codebase.Runtime.Error` is gone. It was the result of serializing various error types, and is now represented by either `Unison.Runtime.Error` or `DecompError`, depending on the site.

Error serialization has been moved to `Unison.Runtime.Interface`. Ideally, it would be moved out of unison-runtime completely and into unison-cli, but it is still used in tests, debugging, etc.

`Unison.Codebase.Editor.Output.EvaluationFailure` now takes a `Unison.Runtime.Error` and a separate function to apply to the prettified result, rather than expecting the failure to be prettified already.

This also indents the output for `test` failures (as seen in name-test-sandbox-violators.md).

## Test coverage

This is covered by existing transcripts. Two of the test outputs change (as called out above), and the rest _not_ changing shows that this is mostly a refactor.

## Loose ends

This is based on #5868, so that should be merged first. Until it’s merged, this PR’s diff includes the changes from that PR, but that one is pretty small, so it shouldn’t block review.
