### PR TITLE
Add message when pulling to indicate from and to causal hashes.

### DIFF
--- a/unison-cli/src/Unison/Cli/DownloadUtils.hs
+++ b/unison-cli/src/Unison/Cli/DownloadUtils.hs
@@ -10,6 +10,7 @@ where
 
 import Control.Concurrent.STM (atomically)
 import Control.Concurrent.STM.TVar (modifyTVar', newTVarIO, readTVar, readTVarIO)
+import U.Codebase.Sqlite.Operations qualified as Ops
 import Data.List.NonEmpty (pattern (:|))
 import System.Console.Regions qualified as Console.Regions
 import System.IO.Unsafe (unsafePerformIO)
@@ -17,6 +18,7 @@ import U.Codebase.HashTags (CausalHash)
 import U.Codebase.Sqlite.Queries qualified as Queries
 import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
+import Unison.Cli.MonadUtils qualified as Cli
 import Unison.Cli.Share.Projects qualified as Share
 import Unison.Codebase.Editor.HandleInput.AuthLogin (ensureAuthenticatedWithCodeserver)
 import Unison.Codebase.Editor.Output qualified as Output
@@ -36,6 +38,7 @@ import Unison.Sync.Common qualified as Sync.Common
 import Unison.Sync.Types qualified as Share
 import Unison.SyncV2.Types qualified as SyncV2
 import UnliftIO.Environment qualified as UnliftIO
+import Unison.Codebase.ProjectPath (ProjectBranch(..))
 
 data SyncVersion = SyncV1 | SyncV2
   deriving (Eq, Show)
@@ -53,8 +56,11 @@ downloadProjectBranchFromShare ::
   (HasCallStack) =>
   Share.IncludeSquashedHead ->
   Share.RemoteProjectBranch ->
+  -- | Whether this download is part of a pull operation. If 'True', we will
+  --   show the from and to causal hashes.
+  Bool ->
   Cli (Either Output.ShareError CausalHash)
-downloadProjectBranchFromShare useSquashed branch =
+downloadProjectBranchFromShare useSquashed branch isPull =
   Cli.labelE \done -> do
     let remoteProjectBranchName = branch.branchName
     causalHashJwt <-
@@ -62,7 +68,8 @@ downloadProjectBranchFromShare useSquashed branch =
         (Share.IncludeSquashedHead, Nothing) -> done Output.ShareExpectedSquashedHead
         (Share.IncludeSquashedHead, Just squashedHead) -> pure squashedHead
         (Share.NoSquashedHead, _) -> pure branch.branchHead
-    exists <- Cli.runTransaction (Queries.causalExistsByHash32 (Share.hashJWTHash causalHashJwt))
+    let causalHash32 = Share.hashJWTHash causalHashJwt
+    exists <- Cli.runTransaction (Queries.causalExistsByHash32 causalHash32)
     when (not exists) do
       case syncVersion of
         SyncV1 -> do
@@ -78,6 +85,10 @@ downloadProjectBranchFromShare useSquashed branch =
         SyncV2 -> do
           let branchRef = SyncV2.BranchRef (into @Text (ProjectAndBranch branch.projectName remoteProjectBranchName))
           let shouldValidate = Codeserver.isCustomCodeserver Codeserver.defaultCodeserver
+          when isPull $ do
+            pb <- Cli.getCurrentProjectBranch
+            currentCausalHash <- Cli.runTransaction $ Ops.expectProjectBranchHead pb.projectId pb.branchId
+            Cli.respond $ Output.SyncingFromTo currentCausalHash (Sync.Common.hash32ToCausalHash causalHash32)
           result <- SyncV2.syncFromCodeserver shouldValidate Share.hardCodedBaseUrl branchRef causalHashJwt
           void result & onLeft \err0 -> do
             done case err0 of

--- a/unison-cli/src/Unison/Cli/DownloadUtils.hs
+++ b/unison-cli/src/Unison/Cli/DownloadUtils.hs
@@ -10,11 +10,11 @@ where
 
 import Control.Concurrent.STM (atomically)
 import Control.Concurrent.STM.TVar (modifyTVar', newTVarIO, readTVar, readTVarIO)
-import U.Codebase.Sqlite.Operations qualified as Ops
 import Data.List.NonEmpty (pattern (:|))
 import System.Console.Regions qualified as Console.Regions
 import System.IO.Unsafe (unsafePerformIO)
 import U.Codebase.HashTags (CausalHash)
+import U.Codebase.Sqlite.Operations qualified as Ops
 import U.Codebase.Sqlite.Queries qualified as Queries
 import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
@@ -25,6 +25,7 @@ import Unison.Codebase.Editor.Output qualified as Output
 import Unison.Codebase.Editor.RemoteRepo (ReadShareLooseCode, shareUserHandleToText)
 import Unison.Codebase.Editor.RemoteRepo qualified as RemoteRepo
 import Unison.Codebase.Path qualified as Path
+import Unison.Codebase.ProjectPath (ProjectBranch (..))
 import Unison.Core.Project (ProjectAndBranch (..))
 import Unison.NameSegment.Internal qualified as NameSegment
 import Unison.Prelude
@@ -38,7 +39,6 @@ import Unison.Sync.Common qualified as Sync.Common
 import Unison.Sync.Types qualified as Share
 import Unison.SyncV2.Types qualified as SyncV2
 import UnliftIO.Environment qualified as UnliftIO
-import Unison.Codebase.ProjectPath (ProjectBranch(..))
 
 data SyncVersion = SyncV1 | SyncV2
   deriving (Eq, Show)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/InstallLib.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/InstallLib.hs
@@ -65,7 +65,7 @@ handleInstallLib remind (ProjectAndBranch libdepProjectName unresolvedLibdepBran
   Cli.Env {codebase} <- ask
 
   causalHash <-
-    downloadProjectBranchFromShare Share.IncludeSquashedHead libdepProjectBranch
+    downloadProjectBranchFromShare Share.IncludeSquashedHead libdepProjectBranch False
       & onLeftM (Cli.returnEarly . Output.ShareError)
 
   remoteBranchObject <- liftIO (Codebase.expectBranchForHash codebase causalHash)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectClone.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectClone.hs
@@ -224,7 +224,7 @@ cloneInto localProjectBranch remoteProjectBranch = do
   let remoteProjectBranchNames = ProjectAndBranch remoteProjectName remoteBranchName
 
   branchHead <-
-    downloadProjectBranchFromShare Share.NoSquashedHead remoteProjectBranch
+    downloadProjectBranchFromShare Share.NoSquashedHead remoteProjectBranch False
       & onLeftM (Cli.returnEarly . Output.ShareError)
 
   localProjectAndBranch <-

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectCreate.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectCreate.hs
@@ -109,7 +109,7 @@ projectCreate tryDownloadingBase maybeProjectName = do
                 Share.GetProjectBranchResponseProjectNotFound -> done Nothing
                 Share.GetProjectBranchResponseSuccess branch -> pure branch
             _hash <-
-              downloadProjectBranchFromShare Share.NoSquashedHead baseLatestReleaseBranch
+              downloadProjectBranchFromShare Share.NoSquashedHead baseLatestReleaseBranch False
                 & onLeftM (Cli.returnEarly . Output.ShareError)
             Cli.Env {codebase} <- ask
             baseLatestReleaseBranchObject <-

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Pull.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Pull.hs
@@ -52,6 +52,7 @@ handlePull unresolvedSourceAndTarget pullMode = do
               Input.PullWithoutHistory -> Share.IncludeSquashedHead
           )
           remoteBranch
+          True
           & onLeftM (Cli.returnEarly . Output.ShareError)
 
   remoteBranchIsEmpty <-

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/SyncV2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/SyncV2.hs
@@ -92,5 +92,5 @@ createOrUpdateBranch description destBranch causalHash = do
       pp <- Cli.getCurrentProjectPath
       void $ Branch.createBranch description createFrom pp.project (pure destBranch.branch)
 
-handleSyncFromCodeserver :: ShareProjects.IncludeSquashedHead -> ShareProjects.RemoteProjectBranch -> Cli (Either Output.ShareError CausalHash)
+handleSyncFromCodeserver :: ShareProjects.IncludeSquashedHead -> ShareProjects.RemoteProjectBranch -> Bool -> Cli (Either Output.ShareError CausalHash)
 handleSyncFromCodeserver = downloadProjectBranchFromShare

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -451,6 +451,7 @@ data Output
   | UCMServerNotRunning
   | BranchSquashSuccess ({- source -} ProjectAndBranch Project ProjectBranch) ({- dest branch -} ProjectAndBranch Project ProjectBranch)
   | BranchUpdate'BranchChanged
+  | SyncingFromTo CausalHash CausalHash
 
 data MoreEntriesThanShown = MoreEntriesThanShown | AllEntriesShown
   deriving (Eq, Show)
@@ -692,6 +693,7 @@ isFailure o = case o of
   UCMServerNotRunning -> True
   BranchSquashSuccess {} -> False
   BranchUpdate'BranchChanged {} -> True
+  SyncingFromTo {} -> False
 
 isNumberedFailure :: NumberedOutput -> Bool
 isNumberedFailure = \case

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -2373,7 +2373,7 @@ notifyUser dir = \case
       P.wrap $
         "Updating branch from"
           <> P.green (prettySCH $ SCH.fromHash 10 fromCausalHash)
-          <> "->"
+          <> "to"
           <> P.group (P.green $ prettySCH $ SCH.fromHash 10 toCausalHash)
 
 prettyShareError :: ShareError -> Pretty

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -2368,6 +2368,13 @@ notifyUser dir = \case
   BranchUpdate'BranchChanged -> do
     pure $
       P.wrap "Another process updated the codebase while your command was running, so I didn't apply the update. Please run the command again."
+  SyncingFromTo fromCausalHash toCausalHash -> do
+    pure $
+      P.wrap $
+        "Updating branch from"
+          <> P.green (prettySCH $ SCH.fromHash 10 fromCausalHash)
+          <> "->"
+          <> P.group (P.green $ prettySCH $ SCH.fromHash 10 toCausalHash)
 
 prettyShareError :: ShareError -> Pretty
 prettyShareError =


### PR DESCRIPTION
## Overview

Adds a message indicating where we're pulling from/to, 
this will be helpful for cases where pulls are feeling really slow, I can investigate them more easily.
cc @pchiusano 

<img width="430" height="118" alt="image" src="https://github.com/user-attachments/assets/30393ac2-6659-42e2-995a-a284fff69d6a" />

## Implementation notes

When pulling on a branch, show the old and new causal hashes.

## Interesting/controversial decisions

Probably not the best that we need to do this at all, but  more visibility into what's happening isn't a bad thing, and it makes it easy for users to `reset #old` if they want to undo a pull.

## Test coverage

I tried it out
