### PR TITLE
Add Dependents/Dependencies API for UCM Desktop

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -1996,8 +1996,8 @@ getTransitiveDependentsWithinScope scope query = do
         WITH RECURSIVE
         dependents_index_in_scope AS (
           SELECT *
-          FROM dependents_index
-          WHERE (dependent_object_id, dependent_component_index) IN (
+          FROM dependents_index d
+          WHERE (d.dependent_object_id, d.dependent_component_index) IN (
             SELECT object_id, component_index
             FROM $scopeTableName
           )

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -1878,6 +1878,9 @@ getDirectDependenciesOfScope isBuiltinType scope = do
           SELECT object_id, component_index
           FROM $tempTableName
         )
+          AND
+            -- Filter out self-dependencies
+            ((d.dependency_object_id, d.dependency_component_index) IS DISTINCT FROM (d.dependent_object_id, d.dependent_component_index))
       |]
 
   -- Drop the temporary table
@@ -1930,6 +1933,9 @@ getDirectDependentsWithinScope scope query = do
             ON d.dependent_object_id = s.object_id
             AND d.dependent_component_index = s.component_index
           JOIN object o ON s.object_id = o.id
+          WHERE
+            -- Filter out self-dependents
+            ((d.dependency_object_id, d.dependency_component_index) IS DISTINCT FROM (d.dependent_object_id, d.dependent_component_index))
       |]
 
   -- Drop the temporary tables
@@ -1995,6 +2001,8 @@ getTransitiveDependentsWithinScope scope query = do
             SELECT object_id, component_index
             FROM $scopeTableName
           )
+          -- Ignore self-dependents
+          AND ((d.dependency_object_id, d.dependency_component_index) IS DISTINCT FROM (d.dependent_object_id, d.dependent_component_index))
         ),
         transitive_dependents (object_id, component_index, type_id) AS (
           SELECT d.dependent_object_id, d.dependent_component_index, o.type_id

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -158,8 +158,6 @@ import Unison.DataDeclaration qualified as DD
 import Unison.Hash (Hash)
 import Unison.Hashing.V2.Convert qualified as Hashing
 import Unison.LabeledDependency qualified as LD
-import Unison.Name (Name)
-import Unison.Name qualified as Name
 import Unison.Parser.Ann (Ann)
 import Unison.Parser.Ann qualified as Parser
 import Unison.Prelude

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -99,6 +99,7 @@ module Unison.Codebase
     -- * Dependents
     dependents,
     dependentsOfComponent,
+    dependentsWithinBranchScope,
 
     -- * Sync
 
@@ -124,6 +125,7 @@ module Unison.Codebase
 where
 
 import Control.Monad.Except (ExceptT)
+import Data.Bifoldable (Bifoldable (..))
 import Data.Map qualified as Map
 import Data.Set qualified as Set
 import Data.Text qualified as Text
@@ -139,6 +141,7 @@ import Unison.Builtin qualified as Builtin
 import Unison.Builtin.Terms qualified as Builtin
 import Unison.Codebase.Branch (Branch)
 import Unison.Codebase.Branch qualified as Branch
+import Unison.Codebase.Branch.Names qualified as Branch
 import Unison.Codebase.BuiltinAnnotation (BuiltinAnnotation (builtinAnnotation))
 import Unison.Codebase.Path
 import Unison.Codebase.Path qualified as Path
@@ -153,11 +156,16 @@ import Unison.Core.Project (ProjectAndBranch)
 import Unison.DataDeclaration (Decl)
 import Unison.DataDeclaration qualified as DD
 import Unison.Hash (Hash)
+import Unison.HashQualifiedPrime qualified as HQ'
 import Unison.Hashing.V2.Convert qualified as Hashing
 import Unison.LabeledDependency qualified as LD
+import Unison.Name (Name)
+import Unison.Name qualified as Name
 import Unison.Parser.Ann (Ann)
 import Unison.Parser.Ann qualified as Parser
 import Unison.Prelude
+import Unison.PrettyPrintEnv qualified as PPE
+import Unison.PrettyPrintEnv.Names qualified as PPE
 import Unison.Project (ProjectAndBranch (ProjectAndBranch), ProjectBranchName, ProjectName)
 import Unison.Reference (Reference, TermReference, TermReferenceId, TypeReference)
 import Unison.Reference qualified as Reference
@@ -165,6 +173,7 @@ import Unison.Referent qualified as Referent
 import Unison.ShortHash qualified as SH
 import Unison.Sqlite qualified as Sqlite
 import Unison.Symbol (Symbol)
+import Unison.Syntax.HashQualifiedPrime qualified as HQ'
 import Unison.Term (Term)
 import Unison.Term qualified as Term
 import Unison.Type (Type)
@@ -175,6 +184,7 @@ import Unison.UnisonFile qualified as UF
 import Unison.Util.Defns (Defns (..), DefnsF)
 import Unison.Util.Recursion (XNor (Both, Neither), cata)
 import Unison.Util.Relation qualified as Rel
+import Unison.Util.Set qualified as Set
 import Unison.Var (Var)
 import Unison.WatchKind qualified as WK
 
@@ -520,6 +530,38 @@ dependentsOfComponent h =
   Set.union (Builtin.builtinTypeDependentsOfComponent h)
     . Set.map Reference.DerivedId
     <$> SqliteCodebase.Operations.dependentsOfComponentImpl h
+
+-- | Find all dependents of any provided definitions which are within the provided branch.
+dependentsWithinBranchScope :: Branch.Branch0 m -> (DefnsF Set Referent.Referent Reference.TypeReference) -> Sqlite.Transaction (DefnsF [] (HQ'.HashQualified Name, HQ'.HashQualified Name) (HQ'.HashQualified Name, HQ'.HashQualified Name))
+dependentsWithinBranchScope branch0 refs = do
+  let namespaceWithoutLibdeps = Branch.deleteLibdeps branch0
+  let ppeWithoutLibdeps =
+        let names = Branch.toNames namespaceWithoutLibdeps
+         in PPE.makePPE (PPE.hqNamer 10 names) (PPE.suffixifyByHash names)
+  dependents <-
+    Operations.directDependentsWithinScope
+      ( Set.union
+          (Set.mapMaybe Reference.toId (Branch.deepTypeReferences namespaceWithoutLibdeps))
+          (Set.mapMaybe Referent.toTermReferenceId (Branch.deepReferents namespaceWithoutLibdeps))
+      )
+      (bifoldMap (Set.map Referent.toReference) id refs)
+
+  let dependentNames ::
+        DefnsF
+          []
+          (HQ'.HashQualified Name, HQ'.HashQualified Name)
+          (HQ'.HashQualified Name, HQ'.HashQualified Name)
+      dependentNames =
+        bimap
+          (f (Referent.fromTermReferenceId >>> PPE.termNames ppeWithoutLibdeps))
+          (f (Reference.fromId >>> PPE.typeNames ppeWithoutLibdeps))
+          dependents
+        where
+          f g =
+            Set.toList
+              >>> mapMaybe (g >>> listToMaybe)
+              >>> Name.sortByText (fst >>> HQ'.toText)
+  pure dependentNames
 
 -- | Get the set of terms-or-constructors that have the given type.
 termsOfType :: (Var v) => Codebase m v a -> Type v a -> Sqlite.Transaction (Set Referent.Referent)

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -526,7 +526,7 @@ dependentsOfComponent h =
     . Set.map Reference.DerivedId
     <$> SqliteCodebase.Operations.dependentsOfComponentImpl h
 
--- | Find all dependents of any provided definitions which are within the provided branch.
+-- | Find direct dependents of any provided definitions which are within the provided branch.
 --
 -- Note: You may wish to delete lib deps beforehand.
 dependentsWithinBranchScope :: Branch.Branch0 m -> (DefnsF Set Referent.Referent Reference.TypeReference) -> Sqlite.Transaction (DefnsF Set TermReferenceId Reference.TypeReferenceId)

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -141,7 +141,6 @@ import Unison.Builtin qualified as Builtin
 import Unison.Builtin.Terms qualified as Builtin
 import Unison.Codebase.Branch (Branch)
 import Unison.Codebase.Branch qualified as Branch
-import Unison.Codebase.Branch.Names qualified as Branch
 import Unison.Codebase.BuiltinAnnotation (BuiltinAnnotation (builtinAnnotation))
 import Unison.Codebase.Path
 import Unison.Codebase.Path qualified as Path
@@ -156,7 +155,6 @@ import Unison.Core.Project (ProjectAndBranch)
 import Unison.DataDeclaration (Decl)
 import Unison.DataDeclaration qualified as DD
 import Unison.Hash (Hash)
-import Unison.HashQualifiedPrime qualified as HQ'
 import Unison.Hashing.V2.Convert qualified as Hashing
 import Unison.LabeledDependency qualified as LD
 import Unison.Name (Name)
@@ -164,8 +162,6 @@ import Unison.Name qualified as Name
 import Unison.Parser.Ann (Ann)
 import Unison.Parser.Ann qualified as Parser
 import Unison.Prelude
-import Unison.PrettyPrintEnv qualified as PPE
-import Unison.PrettyPrintEnv.Names qualified as PPE
 import Unison.Project (ProjectAndBranch (ProjectAndBranch), ProjectBranchName, ProjectName)
 import Unison.Reference (Reference, TermReference, TermReferenceId, TypeReference)
 import Unison.Reference qualified as Reference
@@ -173,7 +169,6 @@ import Unison.Referent qualified as Referent
 import Unison.ShortHash qualified as SH
 import Unison.Sqlite qualified as Sqlite
 import Unison.Symbol (Symbol)
-import Unison.Syntax.HashQualifiedPrime qualified as HQ'
 import Unison.Term (Term)
 import Unison.Term qualified as Term
 import Unison.Type (Type)
@@ -532,36 +527,16 @@ dependentsOfComponent h =
     <$> SqliteCodebase.Operations.dependentsOfComponentImpl h
 
 -- | Find all dependents of any provided definitions which are within the provided branch.
-dependentsWithinBranchScope :: Branch.Branch0 m -> (DefnsF Set Referent.Referent Reference.TypeReference) -> Sqlite.Transaction (DefnsF [] (HQ'.HashQualified Name, HQ'.HashQualified Name) (HQ'.HashQualified Name, HQ'.HashQualified Name))
+--
+-- Note: You may wish to delete lib deps beforehand.
+dependentsWithinBranchScope :: Branch.Branch0 m -> (DefnsF Set Referent.Referent Reference.TypeReference) -> Sqlite.Transaction (DefnsF Set TermReferenceId Reference.TypeReferenceId)
 dependentsWithinBranchScope branch0 refs = do
-  let namespaceWithoutLibdeps = Branch.deleteLibdeps branch0
-  let ppeWithoutLibdeps =
-        let names = Branch.toNames namespaceWithoutLibdeps
-         in PPE.makePPE (PPE.hqNamer 10 names) (PPE.suffixifyByHash names)
-  dependents <-
-    Operations.directDependentsWithinScope
-      ( Set.union
-          (Set.mapMaybe Reference.toId (Branch.deepTypeReferences namespaceWithoutLibdeps))
-          (Set.mapMaybe Referent.toTermReferenceId (Branch.deepReferents namespaceWithoutLibdeps))
-      )
-      (bifoldMap (Set.map Referent.toReference) id refs)
-
-  let dependentNames ::
-        DefnsF
-          []
-          (HQ'.HashQualified Name, HQ'.HashQualified Name)
-          (HQ'.HashQualified Name, HQ'.HashQualified Name)
-      dependentNames =
-        bimap
-          (f (Referent.fromTermReferenceId >>> PPE.termNames ppeWithoutLibdeps))
-          (f (Reference.fromId >>> PPE.typeNames ppeWithoutLibdeps))
-          dependents
-        where
-          f g =
-            Set.toList
-              >>> mapMaybe (g >>> listToMaybe)
-              >>> Name.sortByText (fst >>> HQ'.toText)
-  pure dependentNames
+  Operations.directDependentsWithinScope
+    ( Set.union
+        (Set.mapMaybe Reference.toId (Branch.deepTypeReferences branch0))
+        (Set.mapMaybe Referent.toTermReferenceId (Branch.deepReferents branch0))
+    )
+    (bifoldMap (Set.map Referent.toReference) id refs)
 
 -- | Get the set of terms-or-constructors that have the given type.
 termsOfType :: (Var v) => Codebase m v a -> Type v a -> Sqlite.Transaction (Set Referent.Referent)

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -96,10 +96,11 @@ module Unison.Codebase
     SqliteCodebase.Operations.hashLength,
     SqliteCodebase.Operations.branchHashLength,
 
-    -- * Dependents
+    -- * Dependents/Dependencies
     dependents,
     dependentsOfComponent,
     dependentsWithinBranchScope,
+    directDependencies,
 
     -- * Sync
 
@@ -177,6 +178,7 @@ import Unison.Typechecker.TypeLookup (TypeLookup (TypeLookup))
 import Unison.Typechecker.TypeLookup qualified as TL
 import Unison.UnisonFile qualified as UF
 import Unison.Util.Defns (Defns (..), DefnsF)
+import Unison.Util.Defns qualified as Defns
 import Unison.Util.Recursion (XNor (Both, Neither), cata)
 import Unison.Util.Relation qualified as Rel
 import Unison.Util.Set qualified as Set
@@ -537,6 +539,24 @@ dependentsWithinBranchScope branch0 refs = do
         (Set.mapMaybe Referent.toTermReferenceId (Branch.deepReferents branch0))
     )
     (bifoldMap (Set.map Referent.toReference) id refs)
+
+directDependencies ::
+  (DefnsF Set Referent.Referent Reference.TypeReference) ->
+  Sqlite.Transaction (DefnsF Set TermReference TypeReference)
+directDependencies refs = do
+  Operations.directDependenciesOfScope
+    Builtin.isBuiltinType
+    ( let refToIds :: Reference -> Set Reference.Id
+          refToIds =
+            maybe Set.empty Set.singleton . Reference.toId
+       in bifoldMap
+            ( foldMap \case
+                Referent.Con ref _ -> Defns.fromTypes (refToIds (ref ^. ConstructorReference.reference_))
+                Referent.Ref ref -> Defns.fromTerms (refToIds ref)
+            )
+            (foldMap (refToIds >>> Defns.fromTypes))
+            refs
+    )
 
 -- | Get the set of terms-or-constructors that have the given type.
 termsOfType :: (Var v) => Codebase m v a -> Type v a -> Sqlite.Transaction (Set Referent.Referent)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Dependencies.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Dependencies.hs
@@ -6,16 +6,14 @@ where
 import Control.Arrow ((***))
 import Data.Bifoldable (bifoldMap, binull)
 import Data.Set qualified as Set
-import U.Codebase.Sqlite.Operations qualified as Operations
-import Unison.Builtin qualified as Builtin
 import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
 import Unison.Cli.MonadUtils qualified as Cli
 import Unison.Cli.NameResolutionUtils (resolveHQName)
+import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Branch.Names qualified as Branch
 import Unison.Codebase.Editor.Output
 import Unison.Codebase.Editor.StructuredArgument qualified as SA
-import Unison.ConstructorReference qualified as ConstructorReference
 import Unison.HashQualified qualified as HQ
 import Unison.HashQualifiedPrime qualified as HQ'
 import Unison.LabeledDependency qualified as LD
@@ -25,11 +23,9 @@ import Unison.Prelude
 import Unison.PrettyPrintEnv qualified as PPE
 import Unison.PrettyPrintEnv.Names qualified as PPE
 import Unison.Reference (Reference)
-import Unison.Reference qualified as Reference
 import Unison.Referent qualified as Referent
 import Unison.Syntax.HashQualifiedPrime qualified as HQ'
 import Unison.Util.Defns (Defns (..), DefnsF)
-import Unison.Util.Defns qualified as Defns
 
 handleDependencies :: HQ.HashQualified Name -> Cli ()
 handleDependencies hq = do
@@ -44,20 +40,7 @@ handleDependencies hq = do
          in PPE.makePPE (PPE.hqNamer 10 names) (PPE.suffixifyByHash names)
 
   dependencies <- do
-    Cli.runTransaction do
-      Operations.directDependenciesOfScope
-        Builtin.isBuiltinType
-        ( let refToIds :: Reference -> Set Reference.Id
-              refToIds =
-                maybe Set.empty Set.singleton . Reference.toId
-           in bifoldMap
-                ( foldMap \case
-                    Referent.Con ref _ -> Defns.fromTypes (refToIds (ref ^. ConstructorReference.reference_))
-                    Referent.Ref ref -> Defns.fromTerms (refToIds ref)
-                )
-                (foldMap (refToIds >>> Defns.fromTypes))
-                refs
-        )
+    Cli.runTransaction $ Codebase.directDependencies refs
 
   let dependencyNames ::
         DefnsF

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Dependents.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Dependents.hs
@@ -36,6 +36,19 @@ handleDependents hq = do
     Cli.returnEarly (LabeledReferenceNotFound hq)
 
   namespace <- Cli.getCurrentProjectRoot0
+  dependents <- Cli.runTransaction $ computeDependents namespace refs
+
+  -- Set numbered args
+  (dependentNames.types ++ dependentNames.terms)
+    & map (SA.HashQualified . HQ'.toHQ . fst)
+    & Cli.setNumberedArgs
+
+  let lds = bifoldMap (Set.map LD.referent) (Set.map LD.typeRef) refs
+  Cli.respond (ListDependents ppe lds dependentNames)
+
+
+computeDependentsWithinScope :: Branch0 m -> _ -> Transaction _
+computeDependentsWithinScope branch refs = do
   let ppe =
         let names = Branch.toNames namespace
          in PPE.makePPE (PPE.hqNamer 10 names) (PPE.suffixifyByHash names)
@@ -44,15 +57,12 @@ handleDependents hq = do
   let ppeWithoutLibdeps =
         let names = Branch.toNames namespaceWithoutLibdeps
          in PPE.makePPE (PPE.hqNamer 10 names) (PPE.suffixifyByHash names)
-
-  dependents <- do
-    Cli.runTransaction do
-      Operations.directDependentsWithinScope
-        ( Set.union
-            (Set.mapMaybe Reference.toId (Branch.deepTypeReferences namespaceWithoutLibdeps))
-            (Set.mapMaybe Referent.toTermReferenceId (Branch.deepReferents namespaceWithoutLibdeps))
-        )
-        (bifoldMap (Set.map Referent.toReference) id refs)
+  Operations.directDependentsWithinScope
+    ( Set.union
+        (Set.mapMaybe Reference.toId (Branch.deepTypeReferences namespaceWithoutLibdeps))
+        (Set.mapMaybe Referent.toTermReferenceId (Branch.deepReferents namespaceWithoutLibdeps))
+    )
+    (bifoldMap (Set.map Referent.toReference) id refs)
 
   let dependentNames ::
         DefnsF
@@ -69,11 +79,4 @@ handleDependents hq = do
             Set.toList
               >>> mapMaybe (g >>> listToMaybe)
               >>> Name.sortByText (fst >>> HQ'.toText)
-
-  -- Set numbered args
-  (dependentNames.types ++ dependentNames.terms)
-    & map (SA.HashQualified . HQ'.toHQ . fst)
-    & Cli.setNumberedArgs
-
-  let lds = bifoldMap (Set.map LD.referent) (Set.map LD.typeRef) refs
-  Cli.respond (ListDependents ppe lds dependentNames)
+  pure dependentNames

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Dependents.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Dependents.hs
@@ -5,12 +5,11 @@ where
 
 import Data.Bifoldable (bifoldMap, binull)
 import Data.Set qualified as Set
-import U.Codebase.Sqlite.Operations qualified as Operations
 import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
 import Unison.Cli.MonadUtils qualified as Cli
 import Unison.Cli.NameResolutionUtils (resolveHQName)
-import Unison.Codebase.Branch qualified as Branch
+import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Branch.Names qualified as Branch
 import Unison.Codebase.Editor.Output
 import Unison.Codebase.Editor.StructuredArgument qualified as SA
@@ -18,15 +17,9 @@ import Unison.HashQualified qualified as HQ
 import Unison.HashQualifiedPrime qualified as HQ'
 import Unison.LabeledDependency qualified as LD
 import Unison.Name (Name)
-import Unison.Name qualified as Name
 import Unison.Prelude
-import Unison.PrettyPrintEnv qualified as PPE
 import Unison.PrettyPrintEnv.Names qualified as PPE
-import Unison.Reference qualified as Reference
-import Unison.Referent qualified as Referent
-import Unison.Syntax.HashQualifiedPrime qualified as HQ' (toText)
-import Unison.Util.Defns (Defns (..), DefnsF)
-import Unison.Util.Set qualified as Set
+import Unison.Util.Defns (Defns (..))
 
 handleDependents :: HQ.HashQualified Name -> Cli ()
 handleDependents hq = do
@@ -36,7 +29,7 @@ handleDependents hq = do
     Cli.returnEarly (LabeledReferenceNotFound hq)
 
   namespace <- Cli.getCurrentProjectRoot0
-  dependents <- Cli.runTransaction $ computeDependents namespace refs
+  dependentNames <- Cli.runTransaction $ Codebase.dependentsWithinBranchScope namespace refs
 
   -- Set numbered args
   (dependentNames.types ++ dependentNames.terms)
@@ -44,39 +37,9 @@ handleDependents hq = do
     & Cli.setNumberedArgs
 
   let lds = bifoldMap (Set.map LD.referent) (Set.map LD.typeRef) refs
-  Cli.respond (ListDependents ppe lds dependentNames)
 
-
-computeDependentsWithinScope :: Branch0 m -> _ -> Transaction _
-computeDependentsWithinScope branch refs = do
   let ppe =
         let names = Branch.toNames namespace
          in PPE.makePPE (PPE.hqNamer 10 names) (PPE.suffixifyByHash names)
 
-  let namespaceWithoutLibdeps = Branch.deleteLibdeps namespace
-  let ppeWithoutLibdeps =
-        let names = Branch.toNames namespaceWithoutLibdeps
-         in PPE.makePPE (PPE.hqNamer 10 names) (PPE.suffixifyByHash names)
-  Operations.directDependentsWithinScope
-    ( Set.union
-        (Set.mapMaybe Reference.toId (Branch.deepTypeReferences namespaceWithoutLibdeps))
-        (Set.mapMaybe Referent.toTermReferenceId (Branch.deepReferents namespaceWithoutLibdeps))
-    )
-    (bifoldMap (Set.map Referent.toReference) id refs)
-
-  let dependentNames ::
-        DefnsF
-          []
-          (HQ'.HashQualified Name, HQ'.HashQualified Name)
-          (HQ'.HashQualified Name, HQ'.HashQualified Name)
-      dependentNames =
-        bimap
-          (f (Referent.fromTermReferenceId >>> PPE.termNames ppeWithoutLibdeps))
-          (f (Reference.fromId >>> PPE.typeNames ppeWithoutLibdeps))
-          dependents
-        where
-          f g =
-            Set.toList
-              >>> mapMaybe (g >>> listToMaybe)
-              >>> Name.sortByText (fst >>> HQ'.toText)
-  pure dependentNames
+  Cli.respond (ListDependents ppe lds dependentNames)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Dependents.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Dependents.hs
@@ -35,12 +35,12 @@ handleDependents hq = do
     Cli.returnEarly (LabeledReferenceNotFound hq)
 
   namespace <- Cli.getCurrentProjectRoot0
-  dependents <- Cli.runTransaction $ Codebase.dependentsWithinBranchScope namespace refs
-
   let namespaceWithoutLibdeps = Branch.deleteLibdeps namespace
   let ppeWithoutLibdeps =
         let names = Branch.toNames namespaceWithoutLibdeps
          in PPE.makePPE (PPE.hqNamer 10 names) (PPE.suffixifyByHash names)
+  dependents <- Cli.runTransaction $ Codebase.dependentsWithinBranchScope namespaceWithoutLibdeps refs
+
 
   let dependentNames ::
         DefnsF

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Dependents.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Dependents.hs
@@ -18,11 +18,13 @@ import Unison.HashQualified qualified as HQ
 import Unison.HashQualifiedPrime qualified as HQ'
 import Unison.LabeledDependency qualified as LD
 import Unison.Name (Name)
+import Unison.Name qualified as Name
 import Unison.Prelude
 import Unison.PrettyPrintEnv qualified as PPE
 import Unison.PrettyPrintEnv.Names qualified as PPE
 import Unison.Reference qualified as Reference
 import Unison.Referent qualified as Referent
+import Unison.Syntax.HashQualifiedPrime qualified as HQ'
 import Unison.Util.Defns (Defns (..), DefnsF)
 
 handleDependents :: HQ.HashQualified Name -> Cli ()
@@ -55,8 +57,6 @@ handleDependents hq = do
             Set.toList
               >>> mapMaybe (g >>> listToMaybe)
               >>> Name.sortByText (fst >>> HQ'.toText)
-  pure dependentNames
-
   -- Set numbered args
   (dependentNames.types ++ dependentNames.terms)
     & map (SA.HashQualified . HQ'.toHQ . fst)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Dependents.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Dependents.hs
@@ -41,7 +41,6 @@ handleDependents hq = do
          in PPE.makePPE (PPE.hqNamer 10 names) (PPE.suffixifyByHash names)
   dependents <- Cli.runTransaction $ Codebase.dependentsWithinBranchScope namespaceWithoutLibdeps refs
 
-
   let dependentNames ::
         DefnsF
           []

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Dependents.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Dependents.hs
@@ -10,6 +10,7 @@ import Unison.Cli.Monad qualified as Cli
 import Unison.Cli.MonadUtils qualified as Cli
 import Unison.Cli.NameResolutionUtils (resolveHQName)
 import Unison.Codebase qualified as Codebase
+import Unison.Codebase.Branch qualified as Branch
 import Unison.Codebase.Branch.Names qualified as Branch
 import Unison.Codebase.Editor.Output
 import Unison.Codebase.Editor.StructuredArgument qualified as SA
@@ -18,8 +19,11 @@ import Unison.HashQualifiedPrime qualified as HQ'
 import Unison.LabeledDependency qualified as LD
 import Unison.Name (Name)
 import Unison.Prelude
+import Unison.PrettyPrintEnv qualified as PPE
 import Unison.PrettyPrintEnv.Names qualified as PPE
-import Unison.Util.Defns (Defns (..))
+import Unison.Reference qualified as Reference
+import Unison.Referent qualified as Referent
+import Unison.Util.Defns (Defns (..), DefnsF)
 
 handleDependents :: HQ.HashQualified Name -> Cli ()
 handleDependents hq = do
@@ -29,7 +33,29 @@ handleDependents hq = do
     Cli.returnEarly (LabeledReferenceNotFound hq)
 
   namespace <- Cli.getCurrentProjectRoot0
-  dependentNames <- Cli.runTransaction $ Codebase.dependentsWithinBranchScope namespace refs
+  dependents <- Cli.runTransaction $ Codebase.dependentsWithinBranchScope namespace refs
+
+  let namespaceWithoutLibdeps = Branch.deleteLibdeps namespace
+  let ppeWithoutLibdeps =
+        let names = Branch.toNames namespaceWithoutLibdeps
+         in PPE.makePPE (PPE.hqNamer 10 names) (PPE.suffixifyByHash names)
+
+  let dependentNames ::
+        DefnsF
+          []
+          (HQ'.HashQualified Name, HQ'.HashQualified Name)
+          (HQ'.HashQualified Name, HQ'.HashQualified Name)
+      dependentNames =
+        bimap
+          (f (Referent.fromTermReferenceId >>> PPE.termNames ppeWithoutLibdeps))
+          (f (Reference.fromId >>> PPE.typeNames ppeWithoutLibdeps))
+          dependents
+        where
+          f g =
+            Set.toList
+              >>> mapMaybe (g >>> listToMaybe)
+              >>> Name.sortByText (fst >>> HQ'.toText)
+  pure dependentNames
 
   -- Set numbered args
   (dependentNames.types ++ dependentNames.terms)

--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -257,9 +257,9 @@ hoistBackend f (Backend m) =
   Backend (mapReaderT (mapExceptT f) m)
 
 loadReferentType ::
-  Codebase m Symbol Ann ->
+  Codebase m Symbol a ->
   Referent ->
-  Sqlite.Transaction (Maybe (Type Symbol Ann))
+  Sqlite.Transaction (Maybe (Type Symbol a))
 loadReferentType codebase = \case
   Referent.Ref r -> Codebase.getTypeOfTerm codebase r
   Referent.Con r _ -> getTypeOfConstructor r
@@ -1250,3 +1250,28 @@ resolveProjectRoot codebase projectAndBranchName@(ProjectAndBranch projectName b
 resolveProjectRootHash :: Codebase IO v a -> ProjectAndBranch ProjectName ProjectBranchName -> Backend IO CausalHash
 resolveProjectRootHash codebase projectAndBranchName = do
   resolveProjectRoot codebase projectAndBranchName <&> V2Causal.causalHash
+
+termSummaryForReferent :: Codebase IO Symbol Ann -> Referent -> Maybe Name -> PPED.PrettyPrintEnvDecl -> Backend IO TermSummary
+termSummaryForReferent codebase referent mayName ppe = do
+  let shortHash = Referent.toShortHash referent
+  let displayName = maybe (HQ.HashOnly shortHash) HQ.NameOnly mayName
+  let termReference = Referent.toReference referent
+  let v2Referent = Cv.referent1to2 referent
+
+  sig <- hoistBackend (Codebase.runTransaction codebase) do
+    sig <- lift (loadReferentType codebase referent)
+    pure sig
+  case sig of
+    Nothing ->
+      throwError (MissingSignatureForTerm termReference)
+    Just typeSig -> do
+      let formattedTermSig = formatSuffixedType ppe width typeSig
+      let summary = mkSummary termReference formattedTermSig
+      tag <- lift $ getTermTag codebase v2Referent sig
+      pure $ TermSummary displayName shortHash summary tag
+  where
+    width = defaultWidth
+    mkSummary reference termSig =
+      if Reference.isBuiltin reference
+        then BuiltinObject termSig
+        else UserObject termSig

--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -48,6 +48,7 @@ module Unison.Server.Backend
     termListEntry,
     Codebase.termReferentsByShortHash,
     termSummaryForReferent,
+    typeSummaryForReference,
     typeDeclHeader,
     typeEntryDisplayName,
     typeEntryHQName,
@@ -1252,7 +1253,13 @@ resolveProjectRootHash :: Codebase IO v a -> ProjectAndBranch ProjectName Projec
 resolveProjectRootHash codebase projectAndBranchName = do
   resolveProjectRoot codebase projectAndBranchName <&> V2Causal.causalHash
 
-termSummaryForReferent :: Codebase IO Symbol Ann -> Referent -> Maybe Name -> (Set LD.LabeledDependency -> Sqlite.Transaction PPED.PrettyPrintEnvDecl) -> Maybe Width -> Backend IO TermSummary
+termSummaryForReferent ::
+  Codebase IO Symbol Ann ->
+  Referent ->
+  Maybe Name ->
+  (Set LD.LabeledDependency -> Sqlite.Transaction PPED.PrettyPrintEnvDecl) ->
+  Maybe Width ->
+  Backend IO TermSummary
 termSummaryForReferent codebase referent mayName mkPPE mayWidth = do
   let shortHash = Referent.toShortHash referent
   let termReference = Referent.toReference referent
@@ -1278,3 +1285,29 @@ termSummaryForReferent codebase referent mayName mkPPE mayWidth = do
       if Reference.isBuiltin reference
         then BuiltinObject termSig
         else UserObject termSig
+
+typeSummaryForReference ::
+  Codebase IO Symbol Ann ->
+  Reference ->
+  Maybe Name ->
+  (Set LD.LabeledDependency -> Sqlite.Transaction PPED.PrettyPrintEnvDecl) ->
+  Maybe Width ->
+  Backend IO TypeSummary
+typeSummaryForReference codebase reference mayName mkPPED mayWidth = do
+  let shortHash = Reference.toShortHash reference
+  lift do
+    Codebase.runTransaction codebase do
+      pped <- mkPPED $ Set.singleton (LD.TypeReference reference)
+      let displayName = PPE.typeName (PPED.unsuffixifiedPPE pped) reference
+      tag <- getTypeTag codebase reference
+      displayDecl <- displayType codebase reference
+      let syntaxHeader = typeToSyntaxHeader width displayName displayDecl
+      pure $
+        TypeSummary
+          { displayName = (maybe displayName HQ.NameOnly mayName),
+            hash = shortHash,
+            summary = bimap mungeSyntaxText mungeSyntaxText syntaxHeader,
+            tag = tag
+          }
+  where
+    width = mayDefaultWidth mayWidth

--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -47,6 +47,7 @@ module Unison.Server.Backend
     termEntryLabeledDependencies,
     termListEntry,
     Codebase.termReferentsByShortHash,
+    termSummaryForReferent,
     typeDeclHeader,
     typeEntryDisplayName,
     typeEntryHQName,
@@ -257,9 +258,9 @@ hoistBackend f (Backend m) =
   Backend (mapReaderT (mapExceptT f) m)
 
 loadReferentType ::
-  Codebase m Symbol a ->
+  Codebase m Symbol Ann ->
   Referent ->
-  Sqlite.Transaction (Maybe (Type Symbol a))
+  Sqlite.Transaction (Maybe (Type Symbol Ann))
 loadReferentType codebase = \case
   Referent.Ref r -> Codebase.getTypeOfTerm codebase r
   Referent.Con r _ -> getTypeOfConstructor r
@@ -1251,10 +1252,9 @@ resolveProjectRootHash :: Codebase IO v a -> ProjectAndBranch ProjectName Projec
 resolveProjectRootHash codebase projectAndBranchName = do
   resolveProjectRoot codebase projectAndBranchName <&> V2Causal.causalHash
 
-termSummaryForReferent :: Codebase IO Symbol Ann -> Referent -> Maybe Name -> PPED.PrettyPrintEnvDecl -> Backend IO TermSummary
-termSummaryForReferent codebase referent mayName ppe = do
+termSummaryForReferent :: Codebase IO Symbol Ann -> Referent -> Maybe Name -> (Set LD.LabeledDependency -> Sqlite.Transaction PPED.PrettyPrintEnvDecl) -> Maybe Width -> Backend IO TermSummary
+termSummaryForReferent codebase referent mayName mkPPE mayWidth = do
   let shortHash = Referent.toShortHash referent
-  let displayName = maybe (HQ.HashOnly shortHash) HQ.NameOnly mayName
   let termReference = Referent.toReference referent
   let v2Referent = Cv.referent1to2 referent
 
@@ -1265,12 +1265,15 @@ termSummaryForReferent codebase referent mayName ppe = do
     Nothing ->
       throwError (MissingSignatureForTerm termReference)
     Just typeSig -> do
-      let formattedTermSig = formatSuffixedType ppe width typeSig
+      let deps = Type.labeledDependencies typeSig
+      pped <- lift . Codebase.runTransaction codebase $ mkPPE deps
+      let formattedTermSig = formatSuffixedType pped width typeSig
       let summary = mkSummary termReference formattedTermSig
       tag <- lift $ getTermTag codebase v2Referent sig
-      pure $ TermSummary displayName shortHash summary tag
+      let displayName = PPE.termName (PPED.unsuffixifiedPPE pped) referent
+      pure $ TermSummary (maybe displayName HQ.NameOnly mayName) shortHash summary tag
   where
-    width = defaultWidth
+    width = mayDefaultWidth mayWidth
     mkSummary reference termSig =
       if Reference.isBuiltin reference
         then BuiltinObject termSig

--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -58,6 +58,8 @@ module Unison.Server.Backend
     renderDocRefs,
     docsForDefinitionName,
     normaliseRootCausalHash,
+    resolveProjectRootHash,
+    resolveProjectRoot,
 
     -- * Unused, could remove?
     resolveRootBranchHash,
@@ -97,6 +99,7 @@ import System.Directory
 import System.FilePath
 import Text.FuzzyFind qualified as FZF
 import U.Codebase.Branch (NamespaceStats (..))
+import U.Codebase.Branch qualified as V2
 import U.Codebase.Branch qualified as V2Branch
 import U.Codebase.Causal qualified as V2Causal
 import U.Codebase.HashTags (BranchHash, CausalHash (..))
@@ -144,7 +147,7 @@ import Unison.PrettyPrintEnv qualified as PPE
 import Unison.PrettyPrintEnv.Names qualified as PPE
 import Unison.PrettyPrintEnv.Util qualified as PPE
 import Unison.PrettyPrintEnvDecl qualified as PPED
-import Unison.Project (ProjectBranchName, ProjectName)
+import Unison.Project (ProjectAndBranch (..), ProjectBranchName, ProjectName)
 import Unison.Reference (Reference, TermReference, TypeReference)
 import Unison.Reference qualified as Reference
 import Unison.Referent (Referent)
@@ -1236,3 +1239,14 @@ loadTypeDisplayObject c = \case
   Reference.DerivedId id ->
     maybe (MissingObject $ Reference.idToShortHash id) UserObject
       <$> Codebase.getTypeDeclaration c id
+
+resolveProjectRoot :: Codebase IO v a -> ProjectAndBranch ProjectName ProjectBranchName -> Backend IO (V2.CausalBranch Sqlite.Transaction)
+resolveProjectRoot codebase projectAndBranchName@(ProjectAndBranch projectName branchName) = do
+  mayCB <- liftIO . Codebase.runTransaction codebase $ Codebase.getShallowProjectRootByNames projectAndBranchName
+  case mayCB of
+    Nothing -> throwError (ProjectBranchNameNotFound projectName branchName)
+    Just cb -> pure cb
+
+resolveProjectRootHash :: Codebase IO v a -> ProjectAndBranch ProjectName ProjectBranchName -> Backend IO CausalHash
+resolveProjectRootHash codebase projectAndBranchName = do
+  resolveProjectRoot codebase projectAndBranchName <&> V2Causal.causalHash

--- a/unison-share-api/src/Unison/Server/CodebaseServer.hs
+++ b/unison-share-api/src/Unison/Server/CodebaseServer.hs
@@ -105,8 +105,8 @@ import Unison.Server.Backend.DefinitionDiff qualified as DefinitionDiff
 import Unison.Server.Errors (backendError)
 import Unison.Server.Local.Definitions qualified as Defn
 import Unison.Server.Local.Endpoints.DefinitionSummary (TermSummaryAPI, TypeSummaryAPI, serveTermSummary, serveTypeSummary)
+import Unison.Server.Local.Endpoints.Definitions (DefinitionsAPI, serveDefinitionsServer)
 import Unison.Server.Local.Endpoints.FuzzyFind (FuzzyFindAPI, serveFuzzyFind)
-import Unison.Server.Local.Endpoints.GetDefinitions (DefinitionsAPI, serveDefinitionsServer)
 import Unison.Server.Local.Endpoints.NamespaceDetails qualified as NamespaceDetails
 import Unison.Server.Local.Endpoints.NamespaceListing qualified as NamespaceListing
 import Unison.Server.Local.Endpoints.Projects (ListProjectBranchesEndpoint, ListProjectsEndpoint, projectBranchListingEndpoint, projectListingEndpoint)

--- a/unison-share-api/src/Unison/Server/CodebaseServer.hs
+++ b/unison-share-api/src/Unison/Server/CodebaseServer.hs
@@ -84,9 +84,6 @@ import System.Environment (getExecutablePath)
 import System.FilePath ((</>))
 import System.FilePath qualified as FilePath
 import System.IO.Error qualified as IOError
-import U.Codebase.Branch qualified as V2
-import U.Codebase.Causal qualified as Causal
-import U.Codebase.HashTags (CausalHash)
 import Unison.Codebase (Codebase)
 import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Branch qualified as Branch
@@ -109,7 +106,7 @@ import Unison.Server.Errors (backendError)
 import Unison.Server.Local.Definitions qualified as Defn
 import Unison.Server.Local.Endpoints.DefinitionSummary (TermSummaryAPI, TypeSummaryAPI, serveTermSummary, serveTypeSummary)
 import Unison.Server.Local.Endpoints.FuzzyFind (FuzzyFindAPI, serveFuzzyFind)
-import Unison.Server.Local.Endpoints.GetDefinitions (DefinitionsAPI, serveDefinitions)
+import Unison.Server.Local.Endpoints.GetDefinitions (DefinitionsAPI, serveDefinitionsServer)
 import Unison.Server.Local.Endpoints.NamespaceDetails qualified as NamespaceDetails
 import Unison.Server.Local.Endpoints.NamespaceListing qualified as NamespaceListing
 import Unison.Server.Local.Endpoints.Projects (ListProjectBranchesEndpoint, ListProjectsEndpoint, projectBranchListingEndpoint, projectListingEndpoint)
@@ -606,45 +603,32 @@ serveProjectsCodebaseServerAPI ::
 serveProjectsCodebaseServerAPI codebase rt projectName branchName = do
   namespaceListingEndpoint
     :<|> namespaceDetailsEndpoint
-    :<|> serveDefinitionsEndpoint
+    :<|> serveDefinitionsServer'
     :<|> serveFuzzyFindEndpoint
     :<|> serveTermSummaryEndpoint
     :<|> serveTypeSummaryEndpoint
   where
     projectAndBranchName = ProjectAndBranch projectName branchName
     namespaceListingEndpoint rel name = do
-      root <- resolveProjectRootHash codebase projectAndBranchName
+      root <- Backend.resolveProjectRootHash codebase projectAndBranchName
       setCacheControl <$> NamespaceListing.serve codebase (Right root) rel name
     namespaceDetailsEndpoint namespaceName renderWidth = do
-      root <- resolveProjectRootHash codebase projectAndBranchName
+      root <- Backend.resolveProjectRootHash codebase projectAndBranchName
       setCacheControl <$> NamespaceDetails.namespaceDetails rt codebase namespaceName (Right root) renderWidth
 
-    serveDefinitionsEndpoint relativePath rawHqns renderWidth suff = do
-      root <- resolveProjectRootHash codebase projectAndBranchName
-      setCacheControl <$> serveDefinitions rt codebase (Right root) relativePath rawHqns renderWidth suff
+    serveDefinitionsServer' = serveDefinitionsServer rt codebase projectAndBranchName
 
     serveFuzzyFindEndpoint relativePath limit renderWidth query = do
-      root <- resolveProjectRootHash codebase projectAndBranchName
+      root <- Backend.resolveProjectRootHash codebase projectAndBranchName
       setCacheControl <$> serveFuzzyFind codebase (Right root) relativePath limit renderWidth query
 
     serveTermSummaryEndpoint shortHash mayName relativeTo renderWidth = do
-      root <- resolveProjectRootHash codebase projectAndBranchName
+      root <- Backend.resolveProjectRootHash codebase projectAndBranchName
       setCacheControl <$> serveTermSummary codebase shortHash mayName (Right root) relativeTo renderWidth
 
     serveTypeSummaryEndpoint shortHash mayName relativeTo renderWidth = do
-      root <- resolveProjectRootHash codebase projectAndBranchName
+      root <- Backend.resolveProjectRootHash codebase projectAndBranchName
       setCacheControl <$> serveTypeSummary codebase shortHash mayName (Right root) relativeTo renderWidth
-
-resolveProjectRoot :: Codebase IO v a -> ProjectAndBranch ProjectName ProjectBranchName -> Backend IO (V2.CausalBranch Sqlite.Transaction)
-resolveProjectRoot codebase projectAndBranchName@(ProjectAndBranch projectName branchName) = do
-  mayCB <- liftIO . Codebase.runTransaction codebase $ Codebase.getShallowProjectRootByNames projectAndBranchName
-  case mayCB of
-    Nothing -> throwError (Backend.ProjectBranchNameNotFound projectName branchName)
-    Just cb -> pure cb
-
-resolveProjectRootHash :: Codebase IO v a -> ProjectAndBranch ProjectName ProjectBranchName -> Backend IO CausalHash
-resolveProjectRootHash codebase projectAndBranchName = do
-  resolveProjectRoot codebase projectAndBranchName <&> Causal.causalHash
 
 serveProjectDiffTermsEndpoint :: Codebase IO Symbol Ann -> Runtime Symbol -> ProjectName -> ProjectBranchName -> ProjectBranchName -> Name -> Name -> Backend IO TermDiffResponse
 serveProjectDiffTermsEndpoint codebase rt projectName oldBranchRef newBranchRef oldTerm newTerm = do
@@ -667,7 +651,7 @@ serveProjectDiffTermsEndpoint codebase rt projectName oldBranchRef newBranchRef 
 
 contextForProjectBranch :: Codebase IO v a -> ProjectName -> ProjectBranchName -> Backend IO (PrettyPrintEnvDecl, NameSearch Sqlite.Transaction)
 contextForProjectBranch codebase projectName branchName = do
-  projectRootHash <- resolveProjectRootHash codebase (ProjectAndBranch projectName branchName)
+  projectRootHash <- Backend.resolveProjectRootHash codebase (ProjectAndBranch projectName branchName)
   projectRootBranch <- liftIO $ Codebase.expectBranchForHash codebase projectRootHash
   hashLength <- liftIO $ Codebase.runTransaction codebase Codebase.hashLength
   let names = Branch.toNames (Branch.head projectRootBranch)

--- a/unison-share-api/src/Unison/Server/Local/Endpoints/DefinitionSummary.hs
+++ b/unison-share-api/src/Unison/Server/Local/Endpoints/DefinitionSummary.hs
@@ -22,7 +22,6 @@ import Servant (Capture, QueryParam, throwError, (:>))
 import Servant.Docs (ToSample (..), noSamples)
 import Servant.OpenApi ()
 import Servant (Capture, QueryParam, (:>))
-import U.Codebase.Causal qualified as V2Causal
 import U.Codebase.HashTags (CausalHash)
 import Unison.Codebase (Codebase)
 import Unison.Codebase qualified as Codebase
@@ -70,11 +69,10 @@ serveTermSummary ::
   Backend IO TermSummary
 serveTermSummary codebase referent mayName root relativeTo mayWidth = do
   let relativeToPath = fromMaybe mempty relativeTo
-  namesPerspective <- Backend.hoistBackend (Codebase.runTransaction codebase) do
-    root <- Backend.normaliseRootCausalHash root
-    namesPerspective <- lift $ Ops.namesPerspectiveForRootAndPath (V2Causal.valueHash root) (coerce $ Path.toList relativeToPath)
-    pure namesPerspective
-  let mkPPED deps = PPESqlite.ppedForReferences namesPerspective deps
+  root <- Backend.hoistBackend (Codebase.runTransaction codebase) do
+    Backend.normaliseRootCausalHash root
+  (_, ppe) <- Backend.namesAtPathFromRootBranchHash codebase root relativeToPath
+  let mkPPED _deps = pure ppe
   Backend.termSummaryForReferent codebase referent mayName mkPPED mayWidth
 
 type TypeSummaryAPI =

--- a/unison-share-api/src/Unison/Server/Local/Endpoints/DefinitionSummary.hs
+++ b/unison-share-api/src/Unison/Server/Local/Endpoints/DefinitionSummary.hs
@@ -21,14 +21,13 @@ import Control.Monad.Reader
 import Servant (Capture, QueryParam, throwError, (:>))
 import Servant.Docs (ToSample (..), noSamples)
 import Servant.OpenApi ()
+import Servant (Capture, QueryParam, (:>))
 import U.Codebase.Causal qualified as V2Causal
 import U.Codebase.HashTags (CausalHash)
 import Unison.Codebase (Codebase)
 import Unison.Codebase qualified as Codebase
-import Unison.Codebase.Editor.DisplayObject (DisplayObject (..))
 import Unison.Codebase.Path qualified as Path
 import Unison.Codebase.ShortCausalHash (ShortCausalHash)
-import Unison.Codebase.SqliteCodebase.Conversions qualified as Cv
 import Unison.HashQualified qualified as HQ
 import Unison.Name (Name)
 import Unison.Parser.Ann (Ann)
@@ -36,13 +35,12 @@ import Unison.Prelude
 import Unison.Reference (Reference)
 import Unison.Reference qualified as Reference
 import Unison.Referent (Referent)
-import Unison.Referent qualified as Referent
 import Unison.Server.Backend (Backend)
 import Unison.Server.Backend qualified as Backend
 import Unison.Server.Types
   ( APIGet,
-    TermSummary(..),
-    TypeSummary(..),
+    TermSummary (..),
+    TypeSummary (..),
     mayDefaultWidth,
   )
 import Unison.Symbol (Symbol)
@@ -71,33 +69,13 @@ serveTermSummary ::
   Maybe Width ->
   Backend IO TermSummary
 serveTermSummary codebase referent mayName root relativeTo mayWidth = do
-  let shortHash = Referent.toShortHash referent
-  let displayName = maybe (HQ.HashOnly shortHash) HQ.NameOnly mayName
   let relativeToPath = fromMaybe mempty relativeTo
-  let termReference = Referent.toReference referent
-  let v2Referent = Cv.referent1to2 referent
-
-  (root, sig) <-
-    Backend.hoistBackend (Codebase.runTransaction codebase) do
-      root <- Backend.normaliseRootCausalHash root
-      sig <- lift (Backend.loadReferentType codebase referent)
-      pure (root, sig)
-  case sig of
-    Nothing ->
-      throwError (Backend.MissingSignatureForTerm termReference)
-    Just typeSig -> do
-      (_localNames, ppe) <- Backend.namesAtPathFromRootBranchHash codebase root relativeToPath
-      let formattedTermSig = Backend.formatSuffixedType ppe width typeSig
-      let summary = mkSummary termReference formattedTermSig
-      tag <- lift $ Backend.getTermTag codebase v2Referent sig
-      pure $ TermSummary displayName shortHash summary tag
-  where
-    width = mayDefaultWidth mayWidth
-
-    mkSummary reference termSig =
-      if Reference.isBuiltin reference
-        then BuiltinObject termSig
-        else UserObject termSig
+  namesPerspective <- Backend.hoistBackend (Codebase.runTransaction codebase) do
+    root <- Backend.normaliseRootCausalHash root
+    namesPerspective <- lift $ Ops.namesPerspectiveForRootAndPath (V2Causal.valueHash root) (coerce $ Path.toList relativeToPath)
+    pure namesPerspective
+  let mkPPED deps = PPESqlite.ppedForReferences namesPerspective deps
+  Backend.termSummaryForReferent codebase referent mayName mkPPED mayWidth
 
 type TypeSummaryAPI =
   "definitions"

--- a/unison-share-api/src/Unison/Server/Local/Endpoints/DefinitionSummary.hs
+++ b/unison-share-api/src/Unison/Server/Local/Endpoints/DefinitionSummary.hs
@@ -18,10 +18,8 @@ module Unison.Server.Local.Endpoints.DefinitionSummary
 where
 
 import Control.Monad.Reader
-import Servant (Capture, QueryParam, throwError, (:>))
-import Servant.Docs (ToSample (..), noSamples)
-import Servant.OpenApi ()
 import Servant (Capture, QueryParam, (:>))
+import Servant.OpenApi ()
 import U.Codebase.HashTags (CausalHash)
 import Unison.Codebase (Codebase)
 import Unison.Codebase qualified as Codebase

--- a/unison-share-api/src/Unison/Server/Local/Endpoints/DefinitionSummary.hs
+++ b/unison-share-api/src/Unison/Server/Local/Endpoints/DefinitionSummary.hs
@@ -18,11 +18,10 @@ module Unison.Server.Local.Endpoints.DefinitionSummary
 where
 
 import Control.Monad.Reader
-import Data.Aeson
-import Data.OpenApi (ToSchema)
 import Servant (Capture, QueryParam, throwError, (:>))
 import Servant.Docs (ToSample (..), noSamples)
 import Servant.OpenApi ()
+import U.Codebase.Causal qualified as V2Causal
 import U.Codebase.HashTags (CausalHash)
 import Unison.Codebase (Codebase)
 import Unison.Codebase qualified as Codebase
@@ -40,14 +39,12 @@ import Unison.Referent (Referent)
 import Unison.Referent qualified as Referent
 import Unison.Server.Backend (Backend)
 import Unison.Server.Backend qualified as Backend
-import Unison.Server.Syntax (SyntaxText)
 import Unison.Server.Types
   ( APIGet,
-    TermTag (..),
-    TypeTag,
+    TermSummary(..),
+    TypeSummary(..),
     mayDefaultWidth,
   )
-import Unison.ShortHash qualified as SH
 import Unison.Symbol (Symbol)
 import Unison.Util.Pretty (Width)
 
@@ -64,28 +61,6 @@ type TermSummaryAPI =
     :> QueryParam "relativeTo" Path.Path
     :> QueryParam "renderWidth" Width
     :> APIGet TermSummary
-
-instance ToSample TermSummary where
-  toSamples _ = noSamples
-
-data TermSummary = TermSummary
-  { displayName :: HQ.HashQualified Name,
-    hash :: SH.ShortHash,
-    summary :: DisplayObject SyntaxText SyntaxText,
-    tag :: TermTag
-  }
-  deriving (Generic, Show)
-
-instance ToJSON TermSummary where
-  toJSON (TermSummary {..}) =
-    object
-      [ "displayName" .= displayName,
-        "hash" .= hash,
-        "summary" .= summary,
-        "tag" .= tag
-      ]
-
-deriving instance ToSchema TermSummary
 
 serveTermSummary ::
   Codebase IO Symbol Ann ->
@@ -137,28 +112,6 @@ type TypeSummaryAPI =
     :> QueryParam "relativeTo" Path.Path
     :> QueryParam "renderWidth" Width
     :> APIGet TypeSummary
-
-instance ToSample TypeSummary where
-  toSamples _ = noSamples
-
-data TypeSummary = TypeSummary
-  { displayName :: HQ.HashQualified Name,
-    hash :: SH.ShortHash,
-    summary :: DisplayObject SyntaxText SyntaxText,
-    tag :: TypeTag
-  }
-  deriving (Generic, Show)
-
-instance ToJSON TypeSummary where
-  toJSON (TypeSummary {..}) =
-    object
-      [ "displayName" .= displayName,
-        "hash" .= hash,
-        "summary" .= summary,
-        "tag" .= tag
-      ]
-
-deriving instance ToSchema TypeSummary
 
 serveTypeSummary ::
   Codebase IO Symbol Ann ->

--- a/unison-share-api/src/Unison/Server/Local/Endpoints/Definitions.hs
+++ b/unison-share-api/src/Unison/Server/Local/Endpoints/Definitions.hs
@@ -81,8 +81,7 @@ type GetDefinitionEndpoint =
     :> APIGet DefinitionDisplayResults
 
 type GetDefinitionDependentsEndpoint =
-  QueryParam "relativeTo" Path.Path
-    :> RequiredQueryParam "name" (HQ.HashQualified Name)
+  RequiredQueryParam "name" (HQ.HashQualified Name)
     :> QueryParam "renderWidth" Width
     :> APIGet DefinitionSearchResults
 
@@ -146,30 +145,31 @@ getDefinitionDependentsEndpoint ::
   Runtime Symbol ->
   Codebase IO Symbol Ann ->
   ProjectAndBranch ProjectName ProjectBranchName ->
-  Maybe Path.Path ->
   HQ.HashQualified Name ->
   Maybe Width ->
   Backend.Backend IO (APIHeaders DefinitionSearchResults)
-getDefinitionDependentsEndpoint _rt codebase projectAndBranch _relativePath hqn mayWidth = do
+getDefinitionDependentsEndpoint _rt codebase projectAndBranch hqn mayWidth = do
   hqLength <- liftIO $ Codebase.runTransaction codebase $ Codebase.hashLength
   rootCausal <- Backend.resolveProjectRoot codebase projectAndBranch
-  (dependents, names) <- Backend.hoistBackend (Codebase.runTransaction codebase) $ do
+  (dependents, namesWithoutLibdeps) <- Backend.hoistBackend (Codebase.runTransaction codebase) $ do
     rootBranch <- lift $ Codebase.expectBranchForHashTx codebase (Causal.causalHash rootCausal)
     let rootBranch0 = Branch.head rootBranch
-    let names = Branch.toNames $ rootBranch0
-    Debug.debugM Debug.Temp "getDefinitionDependentsEndpoint: names" names
-    let nameSearch = makeNameSearch hqLength names
-    Debug.debugM Debug.Temp "getDefinitionDependentsEndpoint: hqn" hqn
+    let rootBranch0WithoutLibdeps = Branch.deleteLibdeps rootBranch0
+    let namesWithoutLibdeps = Branch.toNames $ Branch.deleteLibdeps rootBranch0
+    let nameSearch = makeNameSearch hqLength namesWithoutLibdeps
     QueryResult {hits} <- lift $ Backend.hqNameQuery codebase nameSearch ExactName [hqn]
-    Debug.debugM Debug.Temp "getDefinitionDependentsEndpoint: hits" hits
+
+    Debug.debugM Debug.Temp "hits" hits
     let defs =
           hits & foldMap \case
             Tp TypeResult {reference} -> Defns {terms = Set.empty, types = (Set.singleton reference)}
             Tm TermResult {referent} -> Defns {terms = (Set.singleton referent), types = Set.empty}
 
-    dependents <- lift $ Codebase.dependentsWithinBranchScope rootBranch0 defs
-    pure (dependents, names)
-  let pped = PPED.makePPED (PPE.hqNamer 10 names) PPE.dontSuffixify
+    dependents <- lift $ Codebase.dependentsWithinBranchScope rootBranch0WithoutLibdeps defs
+    pure (dependents, namesWithoutLibdeps)
+  Debug.debugM Debug.Temp "dependents" dependents
+
+  let pped = PPED.makePPED (PPE.hqNamer 10 namesWithoutLibdeps) PPE.dontSuffixify
   definitionSearchResults <-
     dependents
       & bitraverse (wither (doTerm pped) . Set.toList) (wither (doType pped) . Set.toList)

--- a/unison-share-api/src/Unison/Server/Local/Endpoints/Definitions.hs
+++ b/unison-share-api/src/Unison/Server/Local/Endpoints/Definitions.hs
@@ -32,7 +32,6 @@ import Unison.Codebase.Branch qualified as Branch
 import Unison.Codebase.Branch.Names qualified as Branch
 import Unison.Codebase.Path qualified as Path
 import Unison.Codebase.ProjectPath
-import Unison.Debug qualified as Debug
 import Unison.HashQualified qualified as HQ
 import Unison.Name (Name)
 import Unison.NamesWithHistory (SearchType (..))
@@ -159,7 +158,6 @@ getDefinitionDependentsEndpoint _rt codebase projectAndBranch hqn mayWidth = do
     let nameSearch = makeNameSearch hqLength namesWithoutLibdeps
     QueryResult {hits} <- lift $ Backend.hqNameQuery codebase nameSearch ExactName [hqn]
 
-    Debug.debugM Debug.Temp "hits" hits
     let defs =
           hits & foldMap \case
             Tp TypeResult {reference} -> Defns {terms = Set.empty, types = (Set.singleton reference)}
@@ -167,7 +165,6 @@ getDefinitionDependentsEndpoint _rt codebase projectAndBranch hqn mayWidth = do
 
     dependents <- lift $ Codebase.dependentsWithinBranchScope rootBranch0WithoutLibdeps defs
     pure (dependents, namesWithoutLibdeps)
-  Debug.debugM Debug.Temp "dependents" dependents
 
   let pped = PPED.makePPED (PPE.hqNamer 10 namesWithoutLibdeps) PPE.dontSuffixify
   definitionSearchResults <-

--- a/unison-share-api/src/Unison/Server/Local/Endpoints/Definitions.hs
+++ b/unison-share-api/src/Unison/Server/Local/Endpoints/Definitions.hs
@@ -210,6 +210,69 @@ getDefinitionDependentsEndpoint _rt codebase projectAndBranch hqn mayWidth = do
               branchRef
             }
 
+getDefinitionDependenciesEndpoint ::
+  Runtime Symbol ->
+  Codebase IO Symbol Ann ->
+  ProjectAndBranch ProjectName ProjectBranchName ->
+  HQ.HashQualified Name ->
+  Maybe Width ->
+  Backend.Backend IO (APIHeaders DefinitionSearchResults)
+getDefinitionDependenciesEndpoint _rt codebase projectAndBranch hqn mayWidth = do
+  hqLength <- liftIO $ Codebase.runTransaction codebase $ Codebase.hashLength
+  rootCausal <- Backend.resolveProjectRoot codebase projectAndBranch
+  (dependencies, names) <- Backend.hoistBackend (Codebase.runTransaction codebase) $ do
+    rootBranch <- lift $ Codebase.expectBranchForHashTx codebase (Causal.causalHash rootCausal)
+    let rootBranch0 = Branch.head rootBranch
+    let names = Branch.toNames rootBranch0
+    let nameSearch = makeNameSearch hqLength names
+    QueryResult {hits} <- lift $ Backend.hqNameQuery codebase nameSearch ExactName [hqn]
+
+    let defs =
+          hits & foldMap \case
+            Tp TypeResult {reference} -> Defns {terms = Set.empty, types = (Set.singleton reference)}
+            Tm TermResult {referent} -> Defns {terms = (Set.singleton referent), types = Set.empty}
+
+    dependencies <- lift $ Codebase.directDependencies defs
+    pure (dependencies, names)
+
+  let pped = PPED.makePPED (PPE.hqNamer 10 names) PPE.dontSuffixify
+  definitionSearchResults <-
+    dependencies
+      & bitraverse (wither (doTerm pped) . Set.toList) (wither (doType pped) . Set.toList)
+  definitionSearchResults
+    & bifold
+    & DefinitionSearchResults
+    & setCacheControl
+    & pure
+  where
+    project = projectAndBranch.project
+    branchRef = projectAndBranch.branch
+    doTerm :: PPED.PrettyPrintEnvDecl -> Reference.TermReference -> Backend.Backend IO (Maybe DefinitionSearchResult)
+    doTerm pped reference = runMaybeT do
+      let referent = Referent.fromTermReference reference
+      fqn <- hoistMaybe $ HQ.toName $ PPE.termName (PPED.unsuffixifiedPPE pped) referent
+      summary <- lift $ Backend.termSummaryForReferent codebase referent Nothing (\_ -> pure pped) mayWidth
+      pure $
+        DefinitionSearchResult
+          { fqn,
+            summary = ToTTermSummary summary,
+            project,
+            branchRef
+          }
+
+    doType :: PPED.PrettyPrintEnvDecl -> Reference.TypeReference -> Backend.Backend IO (Maybe DefinitionSearchResult)
+    doType pped reference = do
+      runMaybeT do
+        fqn <- hoistMaybe $ HQ.toName $ PPE.typeName (PPED.unsuffixifiedPPE pped) reference
+        summary <- lift $ Backend.typeSummaryForReference codebase reference Nothing (\_ -> pure pped) mayWidth
+        pure $
+          DefinitionSearchResult
+            { fqn,
+              summary = ToTTypeSummary summary,
+              project,
+              branchRef
+            }
+
 getDefinitionsEndpoint ::
   Runtime Symbol ->
   Codebase IO Symbol Ann ->

--- a/unison-share-api/src/Unison/Server/Local/Endpoints/Definitions.hs
+++ b/unison-share-api/src/Unison/Server/Local/Endpoints/Definitions.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Unison.Server.Local.Endpoints.GetDefinitions where
+module Unison.Server.Local.Endpoints.Definitions where
 
 import Data.Bifoldable (Bifoldable (..))
 import Data.Bitraversable (Bitraversable (..))
@@ -29,8 +29,10 @@ import U.Codebase.Reference (TermReferenceId)
 import Unison.Codebase (Codebase)
 import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Branch qualified as Branch
+import Unison.Codebase.Branch.Names qualified as Branch
 import Unison.Codebase.Path qualified as Path
 import Unison.Codebase.ProjectPath
+import Unison.Debug qualified as Debug
 import Unison.HashQualified qualified as HQ
 import Unison.Name (Name)
 import Unison.NamesWithHistory (SearchType (..))
@@ -152,16 +154,20 @@ getDefinitionDependentsEndpoint _rt codebase projectAndBranch _relativePath hqn 
   hqLength <- liftIO $ Codebase.runTransaction codebase $ Codebase.hashLength
   rootCausal <- Backend.resolveProjectRoot codebase projectAndBranch
   (dependents, names) <- Backend.hoistBackend (Codebase.runTransaction codebase) $ do
-    names <- lift $ Codebase.namesAtPath (Causal.valueHash rootCausal) (Path.fromList [])
-    branch0 <- Branch.head <$> lift (Codebase.expectBranchForHashTx codebase (Causal.causalHash rootCausal))
+    rootBranch <- lift $ Codebase.expectBranchForHashTx codebase (Causal.causalHash rootCausal)
+    let rootBranch0 = Branch.head rootBranch
+    let names = Branch.toNames $ rootBranch0
+    Debug.debugM Debug.Temp "getDefinitionDependentsEndpoint: names" names
     let nameSearch = makeNameSearch hqLength names
+    Debug.debugM Debug.Temp "getDefinitionDependentsEndpoint: hqn" hqn
     QueryResult {hits} <- lift $ Backend.hqNameQuery codebase nameSearch ExactName [hqn]
+    Debug.debugM Debug.Temp "getDefinitionDependentsEndpoint: hits" hits
     let defs =
           hits & foldMap \case
             Tp TypeResult {reference} -> Defns {terms = Set.empty, types = (Set.singleton reference)}
             Tm TermResult {referent} -> Defns {terms = (Set.singleton referent), types = Set.empty}
 
-    dependents <- lift $ Codebase.dependentsWithinBranchScope branch0 defs
+    dependents <- lift $ Codebase.dependentsWithinBranchScope rootBranch0 defs
     pure (dependents, names)
   let pped = PPED.makePPED (PPE.hqNamer 10 names) PPE.dontSuffixify
   definitionSearchResults <-

--- a/unison-share-api/src/Unison/Server/Local/Endpoints/Definitions.hs
+++ b/unison-share-api/src/Unison/Server/Local/Endpoints/Definitions.hs
@@ -69,6 +69,7 @@ import Unison.Util.Pretty (Width)
 type DefinitionsAPI =
   ("getDefinition" :> GetDefinitionEndpoint)
     :<|> ("getDefinitionDependents" :> GetDefinitionDependentsEndpoint)
+    :<|> ("getDefinitionDependencies" :> GetDefinitionDependenciesEndpoint)
 
 -- More endpoints could go here in the future
 
@@ -80,6 +81,11 @@ type GetDefinitionEndpoint =
     :> APIGet DefinitionDisplayResults
 
 type GetDefinitionDependentsEndpoint =
+  RequiredQueryParam "name" (HQ.HashQualified Name)
+    :> QueryParam "renderWidth" Width
+    :> APIGet DefinitionSearchResults
+
+type GetDefinitionDependenciesEndpoint =
   RequiredQueryParam "name" (HQ.HashQualified Name)
     :> QueryParam "renderWidth" Width
     :> APIGet DefinitionSearchResults
@@ -236,3 +242,4 @@ serveDefinitionsServer ::
 serveDefinitionsServer rt codebase projectAndBranch = do
   getDefinitionsEndpoint rt codebase projectAndBranch
     :<|> getDefinitionDependentsEndpoint rt codebase projectAndBranch
+    :<|> getDefinitionDependenciesEndpoint rt codebase projectAndBranch

--- a/unison-share-api/src/Unison/Server/Local/Endpoints/GetDefinitions.hs
+++ b/unison-share-api/src/Unison/Server/Local/Endpoints/GetDefinitions.hs
@@ -6,7 +6,6 @@
 
 module Unison.Server.Local.Endpoints.GetDefinitions where
 
-import Data.Bifoldable (Bifoldable (..))
 import Data.Set qualified as Set
 import Servant
   ( QueryParam,

--- a/unison-share-api/src/Unison/Server/Local/Endpoints/GetDefinitions.hs
+++ b/unison-share-api/src/Unison/Server/Local/Endpoints/GetDefinitions.hs
@@ -9,6 +9,8 @@ module Unison.Server.Local.Endpoints.GetDefinitions where
 import Servant
   ( QueryParam,
     QueryParams,
+    ServerT,
+    (:<|>) (..),
     (:>),
   )
 import Servant.Docs
@@ -18,37 +20,51 @@ import Servant.Docs
     ToSample (..),
     noSamples,
   )
-import U.Codebase.HashTags (CausalHash)
+import U.Codebase.Causal qualified as Causal
 import Unison.Codebase (Codebase)
 import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Path qualified as Path
-import Unison.Codebase.ShortCausalHash
-  ( ShortCausalHash,
-  )
+import Unison.Codebase.ProjectPath
 import Unison.HashQualified qualified as HQ
 import Unison.Name (Name)
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
+import Unison.Project
 import Unison.Runtime (Runtime)
 import Unison.Server.Backend qualified as Backend
 import Unison.Server.Local.Definitions qualified as Local
 import Unison.Server.Types
   ( APIGet,
+    APIHeaders,
     DefinitionDisplayResults,
+    DefinitionSearchResults,
+    RequiredQueryParam,
     Suffixify (..),
     defaultWidth,
+    setCacheControl,
   )
 import Unison.Symbol (Symbol)
 import Unison.Util.Monoid (foldMapM)
 import Unison.Util.Pretty (Width)
 
 type DefinitionsAPI =
-  "getDefinition"
-    :> QueryParam "relativeTo" Path.Path
+  ("getDefinition" :> GetDefinitionEndpoint)
+    :<|> ("getDefinitionDependents" :> GetDefinitionDependentsEndpoint)
+
+-- More endpoints could go here in the future
+
+type GetDefinitionEndpoint =
+  QueryParam "relativeTo" Path.Path
     :> QueryParams "names" (HQ.HashQualified Name)
     :> QueryParam "renderWidth" Width
     :> QueryParam "suffixifyBindings" Suffixify
     :> APIGet DefinitionDisplayResults
+
+type GetDefinitionDependentsEndpoint =
+  QueryParam "relativeTo" Path.Path
+    :> RequiredQueryParam "name" (HQ.HashQualified Name)
+    :> QueryParam "renderWidth" Width
+    :> APIGet DefinitionSearchResults
 
 instance ToParam (QueryParam "renderWidth" Width) where
   toParam _ =
@@ -106,25 +122,50 @@ instance ToParam (QueryParams "names" (HQ.HashQualified Name)) where
 instance ToSample DefinitionDisplayResults where
   toSamples _ = noSamples
 
-serveDefinitions ::
+getDefinitionDependentsEndpoint ::
   Runtime Symbol ->
   Codebase IO Symbol Ann ->
-  Either ShortCausalHash CausalHash ->
+  ProjectAndBranch ProjectName ProjectBranchName ->
+  Maybe Path.Path ->
+  HQ.HashQualified Name ->
+  Maybe Width ->
+  Backend.Backend IO (APIHeaders DefinitionSearchResults)
+getDefinitionDependentsEndpoint _rt codebase projectAndBranch _relativePath _hqn _width = do
+  rootCausal <- Backend.resolveProjectRoot codebase projectAndBranch
+  _names <- Backend.hoistBackend (Codebase.runTransaction codebase) $ do
+    _names <- lift $ Codebase.namesAtPath (Causal.valueHash rootCausal) (Path.fromList [])
+    pure ()
+  pure $ setCacheControl undefined
+
+getDefinitionsEndpoint ::
+  Runtime Symbol ->
+  Codebase IO Symbol Ann ->
+  ProjectAndBranch ProjectName ProjectBranchName ->
   Maybe Path.Path ->
   [HQ.HashQualified Name] ->
   Maybe Width ->
   Maybe Suffixify ->
-  Backend.Backend IO DefinitionDisplayResults
-serveDefinitions rt codebase root relativePath hqns width suff =
-  do
-    rootCausalHash <- Backend.hoistBackend (Codebase.runTransaction codebase) . Backend.normaliseRootCausalHash $ root
+  Backend.Backend IO (APIHeaders DefinitionDisplayResults)
+getDefinitionsEndpoint rt codebase projectAndBranchName relativePath hqns width suff = do
+  root <- Backend.resolveProjectRoot codebase projectAndBranchName
+  r <-
     foldMapM
       ( Local.prettyDefinitionsForHQName
           (maybe Path.Root Path.Absolute relativePath)
-          rootCausalHash
+          root
           width
           (fromMaybe (Suffixify True) suff)
           rt
           codebase
       )
       hqns
+  pure $ setCacheControl r
+
+serveDefinitionsServer ::
+  Runtime Symbol ->
+  Codebase IO Symbol Ann ->
+  ProjectAndBranch ProjectName ProjectBranchName ->
+  ServerT DefinitionsAPI (Backend.Backend IO)
+serveDefinitionsServer rt codebase projectAndBranch = do
+  getDefinitionsEndpoint rt codebase projectAndBranch
+    :<|> getDefinitionDependentsEndpoint rt codebase projectAndBranch

--- a/unison-share-api/src/Unison/Server/Local/Endpoints/GetDefinitions.hs
+++ b/unison-share-api/src/Unison/Server/Local/Endpoints/GetDefinitions.hs
@@ -6,6 +6,8 @@
 
 module Unison.Server.Local.Endpoints.GetDefinitions where
 
+import Data.Bifoldable (Bifoldable (..))
+import Data.Set qualified as Set
 import Servant
   ( QueryParam,
     QueryParams,
@@ -23,16 +25,21 @@ import Servant.Docs
 import U.Codebase.Causal qualified as Causal
 import Unison.Codebase (Codebase)
 import Unison.Codebase qualified as Codebase
+import Unison.Codebase.Branch qualified as Branch
 import Unison.Codebase.Path qualified as Path
 import Unison.Codebase.ProjectPath
 import Unison.HashQualified qualified as HQ
 import Unison.Name (Name)
+import Unison.NamesWithHistory (SearchType (..))
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
 import Unison.Project
 import Unison.Runtime (Runtime)
 import Unison.Server.Backend qualified as Backend
 import Unison.Server.Local.Definitions qualified as Local
+import Unison.Server.NameSearch.FromNames (makeNameSearch)
+import Unison.Server.QueryResult (QueryResult (..))
+import Unison.Server.SearchResult (SearchResult (..), TermResult (..), TypeResult (..))
 import Unison.Server.Types
   ( APIGet,
     APIHeaders,
@@ -44,6 +51,7 @@ import Unison.Server.Types
     setCacheControl,
   )
 import Unison.Symbol (Symbol)
+import Unison.Util.Defns (Defns (..))
 import Unison.Util.Monoid (foldMapM)
 import Unison.Util.Pretty (Width)
 
@@ -130,10 +138,21 @@ getDefinitionDependentsEndpoint ::
   HQ.HashQualified Name ->
   Maybe Width ->
   Backend.Backend IO (APIHeaders DefinitionSearchResults)
-getDefinitionDependentsEndpoint _rt codebase projectAndBranch _relativePath _hqn _width = do
+getDefinitionDependentsEndpoint _rt codebase projectAndBranch _relativePath hqn _width = do
+  hqLength <- liftIO $ Codebase.runTransaction codebase $ Codebase.hashLength
   rootCausal <- Backend.resolveProjectRoot codebase projectAndBranch
-  _names <- Backend.hoistBackend (Codebase.runTransaction codebase) $ do
-    _names <- lift $ Codebase.namesAtPath (Causal.valueHash rootCausal) (Path.fromList [])
+  Backend.hoistBackend (Codebase.runTransaction codebase) $ do
+    names <- lift $ Codebase.namesAtPath (Causal.valueHash rootCausal) (Path.fromList [])
+    branch0 <- Branch.head <$> lift (Codebase.expectBranchForHashTx codebase (Causal.causalHash rootCausal))
+    let nameSearch = makeNameSearch hqLength names
+    QueryResult {hits} <- lift $ Backend.hqNameQuery codebase nameSearch ExactName [hqn]
+    let defs =
+          hits & foldMap \case
+            Tp TypeResult {reference} -> Defns {terms = Set.empty, types = (Set.singleton reference)}
+            Tm TermResult {referent} -> Defns {terms = (Set.singleton referent), types = Set.empty}
+
+    dependents <- lift $ Codebase.dependentsWithinBranchScope branch0 defs
+    dependents & bifoldMapM _ _
     pure ()
   pure $ setCacheControl undefined
 

--- a/unison-share-api/src/Unison/Server/Local/Endpoints/GetDefinitions.hs
+++ b/unison-share-api/src/Unison/Server/Local/Endpoints/GetDefinitions.hs
@@ -1,11 +1,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Unison.Server.Local.Endpoints.GetDefinitions where
 
+import Data.Bifoldable (Bifoldable (..))
+import Data.Bitraversable (Bitraversable (..))
 import Data.Set qualified as Set
 import Servant
   ( QueryParam,
@@ -22,6 +25,7 @@ import Servant.Docs
     noSamples,
   )
 import U.Codebase.Causal qualified as Causal
+import U.Codebase.Reference (TermReferenceId)
 import Unison.Codebase (Codebase)
 import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Branch qualified as Branch
@@ -32,7 +36,12 @@ import Unison.Name (Name)
 import Unison.NamesWithHistory (SearchType (..))
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
+import Unison.PrettyPrintEnv qualified as PPE
+import Unison.PrettyPrintEnv.Names qualified as PPE
+import Unison.PrettyPrintEnvDecl qualified as PPED
 import Unison.Project
+import Unison.Reference qualified as Reference
+import Unison.Referent qualified as Referent
 import Unison.Runtime (Runtime)
 import Unison.Server.Backend qualified as Backend
 import Unison.Server.Local.Definitions qualified as Local
@@ -43,9 +52,11 @@ import Unison.Server.Types
   ( APIGet,
     APIHeaders,
     DefinitionDisplayResults,
-    DefinitionSearchResults,
+    DefinitionSearchResult (..),
+    DefinitionSearchResults (..),
     RequiredQueryParam,
     Suffixify (..),
+    TermOrTypeSummary (..),
     defaultWidth,
     setCacheControl,
   )
@@ -137,10 +148,10 @@ getDefinitionDependentsEndpoint ::
   HQ.HashQualified Name ->
   Maybe Width ->
   Backend.Backend IO (APIHeaders DefinitionSearchResults)
-getDefinitionDependentsEndpoint _rt codebase projectAndBranch _relativePath hqn _width = do
+getDefinitionDependentsEndpoint _rt codebase projectAndBranch _relativePath hqn mayWidth = do
   hqLength <- liftIO $ Codebase.runTransaction codebase $ Codebase.hashLength
   rootCausal <- Backend.resolveProjectRoot codebase projectAndBranch
-  Backend.hoistBackend (Codebase.runTransaction codebase) $ do
+  (dependents, names) <- Backend.hoistBackend (Codebase.runTransaction codebase) $ do
     names <- lift $ Codebase.namesAtPath (Causal.valueHash rootCausal) (Path.fromList [])
     branch0 <- Branch.head <$> lift (Codebase.expectBranchForHashTx codebase (Causal.causalHash rootCausal))
     let nameSearch = makeNameSearch hqLength names
@@ -151,9 +162,44 @@ getDefinitionDependentsEndpoint _rt codebase projectAndBranch _relativePath hqn 
             Tm TermResult {referent} -> Defns {terms = (Set.singleton referent), types = Set.empty}
 
     dependents <- lift $ Codebase.dependentsWithinBranchScope branch0 defs
-    dependents & bifoldMapM _ _
-    pure ()
-  pure $ setCacheControl undefined
+    pure (dependents, names)
+  let pped = PPED.makePPED (PPE.hqNamer 10 names) PPE.dontSuffixify
+  definitionSearchResults <-
+    dependents
+      & bitraverse (wither (doTerm pped) . Set.toList) (wither (doType pped) . Set.toList)
+  definitionSearchResults
+    & bifold
+    & DefinitionSearchResults
+    & setCacheControl
+    & pure
+  where
+    project = projectAndBranch.project
+    branchRef = projectAndBranch.branch
+    doTerm :: PPED.PrettyPrintEnvDecl -> TermReferenceId -> Backend.Backend IO (Maybe DefinitionSearchResult)
+    doTerm pped refId = runMaybeT do
+      let referent = Referent.fromTermReferenceId refId
+      fqn <- hoistMaybe $ HQ.toName $ PPE.termName (PPED.unsuffixifiedPPE pped) referent
+      summary <- lift $ Backend.termSummaryForReferent codebase referent Nothing (\_ -> pure pped) mayWidth
+      pure $
+        DefinitionSearchResult
+          { fqn,
+            summary = ToTTermSummary summary,
+            project,
+            branchRef
+          }
+
+    doType pped refId = do
+      runMaybeT do
+        let reference = Reference.fromId refId
+        fqn <- hoistMaybe $ HQ.toName $ PPE.typeName (PPED.unsuffixifiedPPE pped) reference
+        summary <- lift $ Backend.typeSummaryForReference codebase reference Nothing (\_ -> pure pped) mayWidth
+        pure $
+          DefinitionSearchResult
+            { fqn,
+              summary = ToTTypeSummary summary,
+              project,
+              branchRef
+            }
 
 getDefinitionsEndpoint ::
   Runtime Symbol ->

--- a/unison-share-api/src/Unison/Server/Orphans.hs
+++ b/unison-share-api/src/Unison/Server/Orphans.hs
@@ -376,6 +376,14 @@ instance ToSchema Path.Path where
 instance ToSchema Path.Absolute where
   declareNamedSchema _ = declareNamedSchema (Proxy @Text)
 
+instance ToParam (QueryParam' opts "name" (HQ.HashQualified Name)) where
+  toParam _ =
+    DocQueryParam
+      "name"
+      []
+      "A name, hash, or hash-qualified name."
+      Normal
+
 instance ToJSON (HQ.HashQualified Name) where
   toJSON = Aeson.String . HQ.toTextWith Name.toText
 

--- a/unison-share-api/src/Unison/Server/Types.hs
+++ b/unison-share-api/src/Unison/Server/Types.hs
@@ -24,6 +24,7 @@ import Servant qualified
 import Servant.API
   ( Capture,
     FromHttpApiData (..),
+    ToHttpApiData (..),
     Get,
     Header,
     Headers,
@@ -49,6 +50,7 @@ import Unison.Project (ProjectAndBranch, ProjectName)
 import Unison.Server.Doc (Doc)
 import Unison.Server.Orphans ()
 import Unison.Server.Syntax qualified as Syntax
+import Unison.Server.Syntax (SyntaxText)
 import Unison.ShortHash (ShortHash)
 import Unison.Syntax.HashQualified qualified as HQ (parseText)
 import Unison.Syntax.Name qualified as Name
@@ -624,3 +626,210 @@ instance FromJSON TypeDiffResponse where
 
 -- | Servant utility for a query param that's required, providing a useful error message if it's missing.
 type RequiredQueryParam = Servant.QueryParam' '[Servant.Required, Servant.Strict]
+
+data DefinitionNameSearchResult = DefinitionNameSearchResult
+  { token :: Name,
+    tag :: TermOrTypeTag
+  }
+
+instance ToJSON DefinitionNameSearchResult where
+  toJSON DefinitionNameSearchResult {..} =
+    Aeson.object
+      [ "token" .= token,
+        "tag" .= tag
+      ]
+
+instance FromJSON DefinitionNameSearchResult where
+  parseJSON = Aeson.withObject "DefinitionNameSearchResult" $ \o -> do
+    token <- o Aeson..: "token"
+    tag <- o Aeson..: "tag"
+    pure DefinitionNameSearchResult {token, tag}
+
+newtype DefinitionSearchResults = DefinitionSearchResults
+  { results :: [DefinitionSearchResult]
+  }
+
+instance ToJSON DefinitionSearchResults where
+  toJSON DefinitionSearchResults {..} =
+    Aeson.object
+      [ "results" .= results
+      ]
+
+instance FromJSON DefinitionSearchResults where
+  parseJSON = Aeson.withObject "DefinitionSearchResults" $ \o -> do
+    results <- o Aeson..: "results"
+    pure DefinitionSearchResults {results}
+
+data DefinitionSearchResult = DefinitionSearchResult
+  { fqn :: Name,
+    summary :: TermOrTypeSummary,
+    project :: ProjectName,
+    branchRef :: ProjectBranchName
+  }
+
+instance ToJSON DefinitionSearchResult where
+  toJSON DefinitionSearchResult {..} =
+    Aeson.object
+      [ "fqn" Aeson..= fqn,
+        "projectRef" Aeson..= project,
+        "branchRef" Aeson..= branchRef,
+        "kind" Aeson..= kind,
+        "definition" Aeson..= definition
+      ]
+    where
+      (kind, definition) = case summary of
+        ToTTermSummary TermSummary {displayName, hash, summary, tag} ->
+          ( Aeson.String "term",
+            Aeson.object
+              [ "displayName" Aeson..= displayName,
+                "hash" Aeson..= hash,
+                "summary" Aeson..= summary,
+                "tag" Aeson..= tag
+              ]
+          )
+        ToTTypeSummary TypeSummary {displayName, hash, summary, tag} ->
+          ( Aeson.String "type",
+            Aeson.object
+              [ "displayName" Aeson..= displayName,
+                "hash" Aeson..= hash,
+                "summary" Aeson..= summary,
+                "tag" Aeson..= tag
+              ]
+          )
+
+instance FromJSON DefinitionSearchResult where
+  parseJSON = Aeson.withObject "DefinitionSearchResult" $ \o -> do
+    fqn <- o Aeson..: "fqn"
+    project <- o Aeson..: "projectRef"
+    branchRef <- o Aeson..: "branchRef"
+    kind <- o Aeson..: "kind"
+    definition <- o Aeson..: "definition"
+    summary <- case kind of
+      Aeson.String "term" -> do
+        definitionObj <- case definition of
+          Aeson.Object obj -> pure obj
+          _ -> fail "Expected object for term definition"
+        displayName <- definitionObj Aeson..: "displayName"
+        hash <- definitionObj Aeson..: "hash"
+        summaryText <- definitionObj Aeson..: "summary"
+        tag <- definitionObj Aeson..: "tag"
+        pure $ ToTTermSummary $ TermSummary {displayName, hash, summary = summaryText, tag}
+      Aeson.String "type" -> do
+        definitionObj <- case definition of
+          Aeson.Object obj -> pure obj
+          _ -> fail "Expected object for type definition"
+        displayName <- definitionObj Aeson..: "displayName"
+        hash <- definitionObj Aeson..: "hash"
+        summaryText <- definitionObj Aeson..: "summary"
+        tag <- definitionObj Aeson..: "tag"
+        pure $ ToTTypeSummary $ TypeSummary {displayName, hash, summary = summaryText, tag}
+      _ -> fail "Invalid definition kind"
+    pure DefinitionSearchResult {fqn, summary, project, branchRef}
+
+
+instance Docs.ToSample TermSummary where
+  toSamples _ = Docs.noSamples
+
+data TermSummary = TermSummary
+  { displayName :: HQ.HashQualified Name,
+    hash :: ShortHash,
+    summary :: DisplayObject SyntaxText SyntaxText,
+    tag :: TermTag
+  }
+  deriving (Generic, Show)
+
+instance ToJSON TermSummary where
+  toJSON (TermSummary {..}) =
+    object
+      [ "displayName" .= displayName,
+        "hash" .= hash,
+        "summary" .= summary,
+        "tag" .= tag
+      ]
+
+deriving instance ToSchema TermSummary
+
+
+instance Docs.ToSample TypeSummary where
+  toSamples _ = Docs.noSamples
+
+data TypeSummary = TypeSummary
+  { displayName :: HQ.HashQualified Name,
+    hash :: ShortHash,
+    summary :: DisplayObject SyntaxText SyntaxText,
+    tag :: TypeTag
+  }
+  deriving (Generic, Show)
+
+instance ToJSON TypeSummary where
+  toJSON (TypeSummary {..}) =
+    object
+      [ "displayName" .= displayName,
+        "hash" .= hash,
+        "summary" .= summary,
+        "tag" .= tag
+      ]
+
+deriving instance ToSchema TypeSummary
+
+data TermOrTypeSummary = ToTTermSummary TermSummary | ToTTypeSummary TypeSummary
+  deriving (Show)
+
+instance ToJSON TermOrTypeSummary where
+  toJSON (ToTTermSummary ts) = object ["kind" .= ("term" :: Text), "payload" .= ts]
+  toJSON (ToTTypeSummary ts) = object ["kind" .= ("type" :: Text), "payload" .= ts]
+
+instance FromJSON TermOrTypeSummary where
+  parseJSON = withObject "TermOrTypeSummary" $ \o -> do
+    kind :: Text <- o .: "kind"
+    case kind of
+      "term" -> do
+        ts <- o .: "payload"
+        ts & withObject "TermSummary" \o -> do
+          displayName <- o .: "displayName"
+          hash <- o .: "hash"
+          summary <- o .: "summary"
+          tag <- o .: "tag"
+          pure $ ToTTermSummary $ TermSummary {..}
+      "type" -> do
+        ts <- o .: "payload"
+        ts & withObject "TypeSummary" \o -> do
+          displayName <- o .: "displayName"
+          hash <- o .: "hash"
+          summary <- o .: "summary"
+          tag <- o .: "tag"
+          pure $ ToTTypeSummary $ TypeSummary {..}
+      _ -> fail $ "Invalid kind: " <> Text.unpack kind
+
+data TermOrTypeTag = ToTTermTag TermTag | ToTTypeTag TypeTag
+  deriving stock (Show, Eq, Ord)
+
+instance FromHttpApiData TermOrTypeTag where
+  parseQueryParam = \case
+    "doc" -> Right $ ToTTermTag Doc
+    "test" -> Right $ ToTTermTag Test
+    "plain" -> Right $ ToTTermTag Plain
+    "data-constructor" -> Right $ ToTTermTag $ Constructor Data
+    "ability-constructor" -> Right $ ToTTermTag $ Constructor Ability
+    "data" -> Right $ ToTTypeTag Data
+    "ability" -> Right $ ToTTypeTag Ability
+    _ -> Left "Invalid TermOrTypeTag"
+
+instance ToHttpApiData TermOrTypeTag where
+  toQueryParam = \case
+    ToTTermTag Doc -> "doc"
+    ToTTermTag Test -> "test"
+    ToTTermTag Plain -> "plain"
+    ToTTermTag (Constructor Data) -> "data-constructor"
+    ToTTermTag (Constructor Ability) -> "ability-constructor"
+    ToTTypeTag Data -> "data"
+    ToTTypeTag Ability -> "ability"
+
+instance ToJSON TermOrTypeTag where
+  toJSON = String . toQueryParam
+
+instance FromJSON TermOrTypeTag where
+  parseJSON = withText "TermOrTypeTag" $ \txt ->
+    case parseQueryParam txt of
+      Left err -> fail $ Text.unpack err
+      Right tag -> pure tag

--- a/unison-share-api/src/Unison/Server/Types.hs
+++ b/unison-share-api/src/Unison/Server/Types.hs
@@ -24,12 +24,12 @@ import Servant qualified
 import Servant.API
   ( Capture,
     FromHttpApiData (..),
-    ToHttpApiData (..),
     Get,
     Header,
     Headers,
     JSON,
     QueryParam,
+    ToHttpApiData (..),
     addHeader,
   )
 import Servant.Docs (DocCapture (..), DocQueryParam (..), ParamKind (..), ToParam)
@@ -49,8 +49,8 @@ import Unison.Prelude
 import Unison.Project (ProjectAndBranch, ProjectName)
 import Unison.Server.Doc (Doc)
 import Unison.Server.Orphans ()
-import Unison.Server.Syntax qualified as Syntax
 import Unison.Server.Syntax (SyntaxText)
+import Unison.Server.Syntax qualified as Syntax
 import Unison.ShortHash (ShortHash)
 import Unison.Syntax.HashQualified qualified as HQ (parseText)
 import Unison.Syntax.Name qualified as Name
@@ -648,6 +648,7 @@ instance FromJSON DefinitionNameSearchResult where
 newtype DefinitionSearchResults = DefinitionSearchResults
   { results :: [DefinitionSearchResult]
   }
+  deriving (Show, Eq, Generic)
 
 instance ToJSON DefinitionSearchResults where
   toJSON DefinitionSearchResults {..} =
@@ -660,12 +661,20 @@ instance FromJSON DefinitionSearchResults where
     results <- o Aeson..: "results"
     pure DefinitionSearchResults {results}
 
+instance Docs.ToSample DefinitionSearchResults where
+  toSamples _ = Docs.noSamples
+
+deriving anyclass instance ToSchema DefinitionSearchResults
+
 data DefinitionSearchResult = DefinitionSearchResult
   { fqn :: Name,
     summary :: TermOrTypeSummary,
     project :: ProjectName,
     branchRef :: ProjectBranchName
   }
+  deriving (Show, Eq, Generic)
+
+deriving instance ToSchema DefinitionSearchResult
 
 instance ToJSON DefinitionSearchResult where
   toJSON DefinitionSearchResult {..} =
@@ -726,7 +735,6 @@ instance FromJSON DefinitionSearchResult where
       _ -> fail "Invalid definition kind"
     pure DefinitionSearchResult {fqn, summary, project, branchRef}
 
-
 instance Docs.ToSample TermSummary where
   toSamples _ = Docs.noSamples
 
@@ -736,7 +744,7 @@ data TermSummary = TermSummary
     summary :: DisplayObject SyntaxText SyntaxText,
     tag :: TermTag
   }
-  deriving (Generic, Show)
+  deriving (Generic, Show, Eq, Ord)
 
 instance ToJSON TermSummary where
   toJSON (TermSummary {..}) =
@@ -749,7 +757,6 @@ instance ToJSON TermSummary where
 
 deriving instance ToSchema TermSummary
 
-
 instance Docs.ToSample TypeSummary where
   toSamples _ = Docs.noSamples
 
@@ -759,7 +766,7 @@ data TypeSummary = TypeSummary
     summary :: DisplayObject SyntaxText SyntaxText,
     tag :: TypeTag
   }
-  deriving (Generic, Show)
+  deriving (Generic, Show, Eq, Ord)
 
 instance ToJSON TypeSummary where
   toJSON (TypeSummary {..}) =
@@ -773,7 +780,9 @@ instance ToJSON TypeSummary where
 deriving instance ToSchema TypeSummary
 
 data TermOrTypeSummary = ToTTermSummary TermSummary | ToTTypeSummary TypeSummary
-  deriving (Show)
+  deriving (Show, Eq, Ord, Generic)
+
+deriving instance ToSchema TermOrTypeSummary
 
 instance ToJSON TermOrTypeSummary where
   toJSON (ToTTermSummary ts) = object ["kind" .= ("term" :: Text), "payload" .= ts]

--- a/unison-share-api/unison-share-api.cabal
+++ b/unison-share-api/unison-share-api.cabal
@@ -28,9 +28,9 @@ library
       Unison.Server.Local
       Unison.Server.Local.Definitions
       Unison.Server.Local.Endpoints.Current
+      Unison.Server.Local.Endpoints.Definitions
       Unison.Server.Local.Endpoints.DefinitionSummary
       Unison.Server.Local.Endpoints.FuzzyFind
-      Unison.Server.Local.Endpoints.GetDefinitions
       Unison.Server.Local.Endpoints.NamespaceDetails
       Unison.Server.Local.Endpoints.NamespaceListing
       Unison.Server.Local.Endpoints.Projects

--- a/unison-src/transcripts/idempotent/addupdatemessages.md
+++ b/unison-src/transcripts/idempotent/addupdatemessages.md
@@ -96,10 +96,6 @@ Expected: `x` is now `3` and `X` has constructor `Three`. UCM tells you the old 
   Okay, I'm searching the branch for code that needs to be
   updated...
 
-  That's done. Now I'm making sure everything typechecks...
-
-  Everything typechecks, so I'm saving the results...
-
   Done.
 ```
 

--- a/unison-src/transcripts/idempotent/api-dependencies.md
+++ b/unison-src/transcripts/idempotent/api-dependencies.md
@@ -1,0 +1,343 @@
+``` ucm :hide
+scratch/main> builtins.merge
+```
+
+``` unison :hide
+type MyType = A | B
+
+type AnotherType = C | D
+
+myVal = A
+
+myNum = 1
+
+mySum = myNum + 2
+
+myCase = match myVal with
+  A -> myNum
+  B -> 2
+```
+
+``` ucm :hide
+scratch/main> update
+```
+
+``` api
+GET /api/projects/scratch/branches/main/getDefinitionDependencies?name=MyType
+RESPONSE:
+  {
+      "results": []
+  }
+
+```
+
+``` api
+GET /api/projects/scratch/branches/main/getDefinitionDependencies?name=myVal
+RESPONSE:
+  {
+      "results": [
+          {
+              "branchRef": "main",
+              "definition": {
+                  "displayName": "MyType",
+                  "hash": "#0qbc2dfom7m4pputtdojo849g2mp5kkr00kvsvjktb07tcmo1jql53bg73bqiib35vja4a7059rcet0raf7jsh4d8vg5582ibinpqj8",
+                  "summary": {
+                      "contents": [
+                          {
+                              "annotation": {
+                                  "tag": "DataTypeKeyword"
+                              },
+                              "segment": "type"
+                          },
+                          {
+                              "annotation": null,
+                              "segment": " "
+                          },
+                          {
+                              "annotation": {
+                                  "contents": "MyType",
+                                  "tag": "HashQualifier"
+                              },
+                              "segment": "MyType"
+                          }
+                      ],
+                      "tag": "UserObject"
+                  },
+                  "tag": "Data"
+              },
+              "fqn": "MyType",
+              "kind": "type",
+              "projectRef": "scratch"
+          }
+      ]
+  }
+
+```
+
+``` api
+GET /api/projects/scratch/branches/main/getDefinitionDependencies?name=myNum
+RESPONSE:
+  {
+      "results": [
+          {
+              "branchRef": "main",
+              "definition": {
+                  "displayName": "builtin.Nat",
+                  "hash": "##Nat",
+                  "summary": {
+                      "contents": [
+                          {
+                              "annotation": null,
+                              "segment": "builtin.Nat"
+                          }
+                      ],
+                      "tag": "BuiltinObject"
+                  },
+                  "tag": "Data"
+              },
+              "fqn": "builtin.Nat",
+              "kind": "type",
+              "projectRef": "scratch"
+          }
+      ]
+  }
+
+```
+
+``` api
+GET /api/projects/scratch/branches/main/getDefinitionDependencies?name=mySum
+RESPONSE:
+  {
+      "results": [
+          {
+              "branchRef": "main",
+              "definition": {
+                  "displayName": "builtin.Nat.+",
+                  "hash": "##Nat.+",
+                  "summary": {
+                      "contents": [
+                          {
+                              "annotation": {
+                                  "contents": "##Nat",
+                                  "tag": "TypeReference"
+                              },
+                              "segment": "builtin.Nat"
+                          },
+                          {
+                              "annotation": null,
+                              "segment": " "
+                          },
+                          {
+                              "annotation": {
+                                  "tag": "TypeOperator"
+                              },
+                              "segment": "->"
+                          },
+                          {
+                              "annotation": null,
+                              "segment": " "
+                          },
+                          {
+                              "annotation": {
+                                  "contents": "##Nat",
+                                  "tag": "TypeReference"
+                              },
+                              "segment": "builtin.Nat"
+                          },
+                          {
+                              "annotation": null,
+                              "segment": " "
+                          },
+                          {
+                              "annotation": {
+                                  "tag": "TypeOperator"
+                              },
+                              "segment": "->"
+                          },
+                          {
+                              "annotation": null,
+                              "segment": " "
+                          },
+                          {
+                              "annotation": {
+                                  "contents": "##Nat",
+                                  "tag": "TypeReference"
+                              },
+                              "segment": "builtin.Nat"
+                          }
+                      ],
+                      "tag": "BuiltinObject"
+                  },
+                  "tag": "Plain"
+              },
+              "fqn": "builtin.Nat.+",
+              "kind": "term",
+              "projectRef": "scratch"
+          },
+          {
+              "branchRef": "main",
+              "definition": {
+                  "displayName": "myNum",
+                  "hash": "#gjmq673r1vrurfotlnirv7vutdhm6sa3s02em5g22kk606mv6duvv8be402dv79312i4a0onepq5bo7citsodvq2g720nttj0ee9p0g",
+                  "summary": {
+                      "contents": [
+                          {
+                              "annotation": {
+                                  "contents": "##Nat",
+                                  "tag": "TypeReference"
+                              },
+                              "segment": "builtin.Nat"
+                          }
+                      ],
+                      "tag": "UserObject"
+                  },
+                  "tag": "Plain"
+              },
+              "fqn": "myNum",
+              "kind": "term",
+              "projectRef": "scratch"
+          },
+          {
+              "branchRef": "main",
+              "definition": {
+                  "displayName": "builtin.Nat",
+                  "hash": "##Nat",
+                  "summary": {
+                      "contents": [
+                          {
+                              "annotation": null,
+                              "segment": "builtin.Nat"
+                          }
+                      ],
+                      "tag": "BuiltinObject"
+                  },
+                  "tag": "Data"
+              },
+              "fqn": "builtin.Nat",
+              "kind": "type",
+              "projectRef": "scratch"
+          }
+      ]
+  }
+
+```
+
+Can also get dependencies by a hash-only:
+
+``` api
+GET /api/projects/scratch/branches/main/getDefinitionDependencies?name=@soiu5q8htcd
+RESPONSE:
+  {
+      "results": [
+          {
+              "branchRef": "main",
+              "definition": {
+                  "displayName": "builtin.Nat.+",
+                  "hash": "##Nat.+",
+                  "summary": {
+                      "contents": [
+                          {
+                              "annotation": {
+                                  "contents": "##Nat",
+                                  "tag": "TypeReference"
+                              },
+                              "segment": "builtin.Nat"
+                          },
+                          {
+                              "annotation": null,
+                              "segment": " "
+                          },
+                          {
+                              "annotation": {
+                                  "tag": "TypeOperator"
+                              },
+                              "segment": "->"
+                          },
+                          {
+                              "annotation": null,
+                              "segment": " "
+                          },
+                          {
+                              "annotation": {
+                                  "contents": "##Nat",
+                                  "tag": "TypeReference"
+                              },
+                              "segment": "builtin.Nat"
+                          },
+                          {
+                              "annotation": null,
+                              "segment": " "
+                          },
+                          {
+                              "annotation": {
+                                  "tag": "TypeOperator"
+                              },
+                              "segment": "->"
+                          },
+                          {
+                              "annotation": null,
+                              "segment": " "
+                          },
+                          {
+                              "annotation": {
+                                  "contents": "##Nat",
+                                  "tag": "TypeReference"
+                              },
+                              "segment": "builtin.Nat"
+                          }
+                      ],
+                      "tag": "BuiltinObject"
+                  },
+                  "tag": "Plain"
+              },
+              "fqn": "builtin.Nat.+",
+              "kind": "term",
+              "projectRef": "scratch"
+          },
+          {
+              "branchRef": "main",
+              "definition": {
+                  "displayName": "myNum",
+                  "hash": "#gjmq673r1vrurfotlnirv7vutdhm6sa3s02em5g22kk606mv6duvv8be402dv79312i4a0onepq5bo7citsodvq2g720nttj0ee9p0g",
+                  "summary": {
+                      "contents": [
+                          {
+                              "annotation": {
+                                  "contents": "##Nat",
+                                  "tag": "TypeReference"
+                              },
+                              "segment": "builtin.Nat"
+                          }
+                      ],
+                      "tag": "UserObject"
+                  },
+                  "tag": "Plain"
+              },
+              "fqn": "myNum",
+              "kind": "term",
+              "projectRef": "scratch"
+          },
+          {
+              "branchRef": "main",
+              "definition": {
+                  "displayName": "builtin.Nat",
+                  "hash": "##Nat",
+                  "summary": {
+                      "contents": [
+                          {
+                              "annotation": null,
+                              "segment": "builtin.Nat"
+                          }
+                      ],
+                      "tag": "BuiltinObject"
+                  },
+                  "tag": "Data"
+              },
+              "fqn": "builtin.Nat",
+              "kind": "type",
+              "projectRef": "scratch"
+          }
+      ]
+  }
+
+```

--- a/unison-src/transcripts/idempotent/api-dependents.md
+++ b/unison-src/transcripts/idempotent/api-dependents.md
@@ -167,11 +167,71 @@ RESPONSE:
 
 ```
 
+Has no dependents:
+
 ``` api
 GET /api/projects/scratch/branches/main/getDefinitionDependents?name=mySum
 RESPONSE:
   {
       "results": []
+  }
+
+```
+
+Can also get dependents by a hash-only:
+
+``` api
+GET /api/projects/scratch/branches/main/getDefinitionDependents?name=@0qbc2dfom7
+RESPONSE:
+  {
+      "results": [
+          {
+              "branchRef": "main",
+              "definition": {
+                  "displayName": "myVal",
+                  "hash": "#88n7vpiqu9qhuj8v444iq3h7v93qvi7kei7dmmjojg3kc52v1aisg435t9bfedqakhk5fv8hu15daf379c7ovrfci9q627s6e3r7h1g",
+                  "summary": {
+                      "contents": [
+                          {
+                              "annotation": {
+                                  "contents": "#0qbc2dfom7m4pputtdojo849g2mp5kkr00kvsvjktb07tcmo1jql53bg73bqiib35vja4a7059rcet0raf7jsh4d8vg5582ibinpqj8",
+                                  "tag": "TypeReference"
+                              },
+                              "segment": "MyType"
+                          }
+                      ],
+                      "tag": "UserObject"
+                  },
+                  "tag": "Plain"
+              },
+              "fqn": "myVal",
+              "kind": "term",
+              "projectRef": "scratch"
+          },
+          {
+              "branchRef": "main",
+              "definition": {
+                  "displayName": "myCase",
+                  "hash": "#le6cur61p625qb7qfsaq836ln4l20u3ecngthot7io4p762ijb5t5hiv0c59eab9b8lktjp8l0j70r53ci43s89hjjik6hfsvkbjv28",
+                  "summary": {
+                      "contents": [
+                          {
+                              "annotation": {
+                                  "contents": "##Nat",
+                                  "tag": "TypeReference"
+                              },
+                              "segment": "builtin.Nat"
+                          }
+                      ],
+                      "tag": "UserObject"
+                  },
+                  "tag": "Plain"
+              },
+              "fqn": "myCase",
+              "kind": "term",
+              "projectRef": "scratch"
+          }
+      ]
   }
 
 ```

--- a/unison-src/transcripts/idempotent/api-dependents.md
+++ b/unison-src/transcripts/idempotent/api-dependents.md
@@ -72,39 +72,6 @@ RESPONSE:
               "fqn": "myCase",
               "kind": "term",
               "projectRef": "scratch"
-          },
-          {
-              "branchRef": "main",
-              "definition": {
-                  "displayName": "MyType",
-                  "hash": "#0qbc2dfom7m4pputtdojo849g2mp5kkr00kvsvjktb07tcmo1jql53bg73bqiib35vja4a7059rcet0raf7jsh4d8vg5582ibinpqj8",
-                  "summary": {
-                      "contents": [
-                          {
-                              "annotation": {
-                                  "tag": "DataTypeKeyword"
-                              },
-                              "segment": "type"
-                          },
-                          {
-                              "annotation": null,
-                              "segment": " "
-                          },
-                          {
-                              "annotation": {
-                                  "contents": "MyType",
-                                  "tag": "HashQualifier"
-                              },
-                              "segment": "MyType"
-                          }
-                      ],
-                      "tag": "UserObject"
-                  },
-                  "tag": "Data"
-              },
-              "fqn": "MyType",
-              "kind": "type",
-              "projectRef": "scratch"
           }
       ]
   }

--- a/unison-src/transcripts/idempotent/api-dependents.md
+++ b/unison-src/transcripts/idempotent/api-dependents.md
@@ -2,7 +2,7 @@
 scratch/main> builtins.merge
 ```
 
-```unison
+``` unison :hide
 type MyType = A | B
 
 type AnotherType = C | D
@@ -13,21 +13,198 @@ myNum = 1
 
 mySum = myNum + 2
 
-myCase = cases
+myCase = match myVal with
   A -> myNum
   B -> 2
 ```
 
+``` ucm :hide
+scratch/main> update
+```
 
-```api
+``` api
 GET /api/projects/scratch/branches/main/getDefinitionDependents?name=MyType
+RESPONSE:
+  {
+      "results": [
+          {
+              "branchRef": "main",
+              "definition": {
+                  "displayName": "myVal",
+                  "hash": "#88n7vpiqu9qhuj8v444iq3h7v93qvi7kei7dmmjojg3kc52v1aisg435t9bfedqakhk5fv8hu15daf379c7ovrfci9q627s6e3r7h1g",
+                  "summary": {
+                      "contents": [
+                          {
+                              "annotation": {
+                                  "contents": "#0qbc2dfom7m4pputtdojo849g2mp5kkr00kvsvjktb07tcmo1jql53bg73bqiib35vja4a7059rcet0raf7jsh4d8vg5582ibinpqj8",
+                                  "tag": "TypeReference"
+                              },
+                              "segment": "MyType"
+                          }
+                      ],
+                      "tag": "UserObject"
+                  },
+                  "tag": "Plain"
+              },
+              "fqn": "myVal",
+              "kind": "term",
+              "projectRef": "scratch"
+          },
+          {
+              "branchRef": "main",
+              "definition": {
+                  "displayName": "myCase",
+                  "hash": "#le6cur61p625qb7qfsaq836ln4l20u3ecngthot7io4p762ijb5t5hiv0c59eab9b8lktjp8l0j70r53ci43s89hjjik6hfsvkbjv28",
+                  "summary": {
+                      "contents": [
+                          {
+                              "annotation": {
+                                  "contents": "##Nat",
+                                  "tag": "TypeReference"
+                              },
+                              "segment": "builtin.Nat"
+                          }
+                      ],
+                      "tag": "UserObject"
+                  },
+                  "tag": "Plain"
+              },
+              "fqn": "myCase",
+              "kind": "term",
+              "projectRef": "scratch"
+          },
+          {
+              "branchRef": "main",
+              "definition": {
+                  "displayName": "MyType",
+                  "hash": "#0qbc2dfom7m4pputtdojo849g2mp5kkr00kvsvjktb07tcmo1jql53bg73bqiib35vja4a7059rcet0raf7jsh4d8vg5582ibinpqj8",
+                  "summary": {
+                      "contents": [
+                          {
+                              "annotation": {
+                                  "tag": "DataTypeKeyword"
+                              },
+                              "segment": "type"
+                          },
+                          {
+                              "annotation": null,
+                              "segment": " "
+                          },
+                          {
+                              "annotation": {
+                                  "contents": "MyType",
+                                  "tag": "HashQualifier"
+                              },
+                              "segment": "MyType"
+                          }
+                      ],
+                      "tag": "UserObject"
+                  },
+                  "tag": "Data"
+              },
+              "fqn": "MyType",
+              "kind": "type",
+              "projectRef": "scratch"
+          }
+      ]
+  }
+
 ```
 
-```api
+``` api
 GET /api/projects/scratch/branches/main/getDefinitionDependents?name=myVal
+RESPONSE:
+  {
+      "results": [
+          {
+              "branchRef": "main",
+              "definition": {
+                  "displayName": "myCase",
+                  "hash": "#le6cur61p625qb7qfsaq836ln4l20u3ecngthot7io4p762ijb5t5hiv0c59eab9b8lktjp8l0j70r53ci43s89hjjik6hfsvkbjv28",
+                  "summary": {
+                      "contents": [
+                          {
+                              "annotation": {
+                                  "contents": "##Nat",
+                                  "tag": "TypeReference"
+                              },
+                              "segment": "builtin.Nat"
+                          }
+                      ],
+                      "tag": "UserObject"
+                  },
+                  "tag": "Plain"
+              },
+              "fqn": "myCase",
+              "kind": "term",
+              "projectRef": "scratch"
+          }
+      ]
+  }
+
 ```
 
-```api
+``` api
 GET /api/projects/scratch/branches/main/getDefinitionDependents?name=myNum
+RESPONSE:
+  {
+      "results": [
+          {
+              "branchRef": "main",
+              "definition": {
+                  "displayName": "myCase",
+                  "hash": "#le6cur61p625qb7qfsaq836ln4l20u3ecngthot7io4p762ijb5t5hiv0c59eab9b8lktjp8l0j70r53ci43s89hjjik6hfsvkbjv28",
+                  "summary": {
+                      "contents": [
+                          {
+                              "annotation": {
+                                  "contents": "##Nat",
+                                  "tag": "TypeReference"
+                              },
+                              "segment": "builtin.Nat"
+                          }
+                      ],
+                      "tag": "UserObject"
+                  },
+                  "tag": "Plain"
+              },
+              "fqn": "myCase",
+              "kind": "term",
+              "projectRef": "scratch"
+          },
+          {
+              "branchRef": "main",
+              "definition": {
+                  "displayName": "mySum",
+                  "hash": "#soiu5q8htcd38lhb0b434b8u1rlpq32v00cububck5so1ugs6avg5hjq99mvdm882c6mrcr8utq7v2hv7vm9sm6vk26jl6oscpt0okg",
+                  "summary": {
+                      "contents": [
+                          {
+                              "annotation": {
+                                  "contents": "##Nat",
+                                  "tag": "TypeReference"
+                              },
+                              "segment": "builtin.Nat"
+                          }
+                      ],
+                      "tag": "UserObject"
+                  },
+                  "tag": "Plain"
+              },
+              "fqn": "mySum",
+              "kind": "term",
+              "projectRef": "scratch"
+          }
+      ]
+  }
+
 ```
 
+``` api
+GET /api/projects/scratch/branches/main/getDefinitionDependents?name=mySum
+RESPONSE:
+  {
+      "results": []
+  }
+
+```

--- a/unison-src/transcripts/idempotent/api-dependents.md
+++ b/unison-src/transcripts/idempotent/api-dependents.md
@@ -1,0 +1,33 @@
+```ucm
+scratch/main> builtins.merge
+```
+
+```unison
+type MyType = A | B
+
+type AnotherType = C | D
+
+myVal = A
+
+myNum = 1
+
+mySum = myNum + 2
+
+myCase = cases
+  A -> myNum
+  B -> 2
+```
+
+
+```api
+GET /api/projects/scratch/branches/main/getDefinitionDependents?name=MyType
+```
+
+```api
+GET /api/projects/scratch/branches/main/getDefinitionDependents?name=myVal
+```
+
+```api
+GET /api/projects/scratch/branches/main/getDefinitionDependents?name=myNum
+```
+

--- a/unison-src/transcripts/idempotent/api-dependents.md
+++ b/unison-src/transcripts/idempotent/api-dependents.md
@@ -1,4 +1,4 @@
-```ucm
+``` ucm :hide
 scratch/main> builtins.merge
 ```
 

--- a/unison-src/transcripts/idempotent/api-summaries.md
+++ b/unison-src/transcripts/idempotent/api-summaries.md
@@ -59,7 +59,7 @@ RESPONSE:
 GET /api/projects/scratch/branches/main/definitions/terms/by-hash/@qkhkl0n238s1eqibd1ecb8605sqj1m4hpoaag177cu572otqlaf1u28c8suuuqgljdtthsjtr07rv04np05o6oa27ml9105k7uas0t8/summary
 RESPONSE:
   {
-      "displayName": "#qkhkl0n238s1eqibd1ecb8605sqj1m4hpoaag177cu572otqlaf1u28c8suuuqgljdtthsjtr07rv04np05o6oa27ml9105k7uas0t8",
+      "displayName": "nat",
       "hash": "#qkhkl0n238s1eqibd1ecb8605sqj1m4hpoaag177cu572otqlaf1u28c8suuuqgljdtthsjtr07rv04np05o6oa27ml9105k7uas0t8",
       "summary": {
           "contents": [

--- a/unison-src/transcripts/idempotent/dependents-dependencies-debugfile.md
+++ b/unison-src/transcripts/idempotent/dependents-dependencies-debugfile.md
@@ -75,9 +75,8 @@ But wait, there's more.  I can check the dependencies and dependents of a defini
     Types:
 
     1. builtin.Int
-    2. outside.B
 
-  Tip: Try `view 2` to see the source of any numbered item in
+  Tip: Try `view 1` to see the source of any numbered item in
        the above list.
 
 > dependencies d

--- a/unison-src/transcripts/idempotent/dependents-dependencies.md
+++ b/unison-src/transcripts/idempotent/dependents-dependencies.md
@@ -1,0 +1,156 @@
+# Test dependents and dependencies
+
+``` ucm :hide
+scratch/main> builtins.merge
+```
+
+``` unison :hide
+type MyType = A | B
+
+type AnotherType = C | D
+
+myVal = A
+
+myNum = 1
+
+mySum = myNum + 2
+
+myCase = match myVal with
+  A -> myNum
+  B -> 2
+```
+
+``` ucm :hide
+scratch/main> update
+```
+
+## Dependents
+
+``` ucm
+scratch/main> dependents MyType
+
+  Dependents of: type MyType
+
+    Terms:
+
+    1. myCase
+    2. myVal
+
+  Tip: Try `view 2` to see the source of any numbered item in
+       the above list.
+
+scratch/main> dependents AnotherType
+
+  type AnotherType has no dependents.
+
+scratch/main> dependents myNum
+
+  Dependents of: myNum
+
+    Terms:
+
+    1. myCase
+    2. mySum
+
+  Tip: Try `view 2` to see the source of any numbered item in
+       the above list.
+
+scratch/main> dependents myVal
+
+  Dependents of: myVal
+
+    Terms:
+
+    1. myCase
+
+  Tip: Try `view 1` to see the source of any numbered item in
+       the above list.
+
+scratch/main> dependents A
+
+  Dependents of: A
+
+    Terms:
+
+    1. myCase
+    2. myVal
+
+  Tip: Try `view 2` to see the source of any numbered item in
+       the above list.
+
+-- For better or worse, we don't have constructor-level granularity yet, so myVal shows here.
+scratch/main> dependents B
+
+  Dependents of: B
+
+    Terms:
+
+    1. myCase
+    2. myVal
+
+  Tip: Try `view 2` to see the source of any numbered item in
+       the above list.
+```
+
+## Dependencies
+
+``` ucm
+scratch/main> dependencies myCase
+
+  Dependencies of: myCase
+
+    Types:
+
+    1. builtin.Nat
+    2. MyType
+
+    Terms:
+
+    3. myNum
+    4. myVal
+
+  Tip: Try `view 4` to see the source of any numbered item in
+       the above list.
+
+scratch/main> dependencies mySum
+
+  Dependencies of: mySum
+
+    Types:
+
+    1. builtin.Nat
+
+    Terms:
+
+    2. builtin.Nat.+
+    3. myNum
+
+  Tip: Try `view 3` to see the source of any numbered item in
+       the above list.
+
+scratch/main> dependencies myNum
+
+  Dependencies of: myNum
+
+    Types:
+
+    1. builtin.Nat
+
+  Tip: Try `view 1` to see the source of any numbered item in
+       the above list.
+
+scratch/main> dependencies myVal
+
+  Dependencies of: myVal
+
+    Types:
+
+    1. MyType
+
+  Tip: Try `view 1` to see the source of any numbered item in
+       the above list.
+
+scratch/main> dependencies MyType
+
+  type MyType has no dependencies.
+```

--- a/unison-src/transcripts/idempotent/dependents-dependencies.md
+++ b/unison-src/transcripts/idempotent/dependents-dependencies.md
@@ -79,6 +79,7 @@ scratch/main> dependents A
        the above list.
 
 -- For better or worse, we don't have constructor-level granularity yet, so myVal shows here.
+
 scratch/main> dependents B
 
   Dependents of: B


### PR DESCRIPTION
## Overview

Adds `/api/projects/<project>/branches/<branch>/getDefinitionDependen(ts|cies)?name=<fqn>` which lists the dependents/dependencies of a term in the same format as Share (includes the type signature, name, hash, kind, and tag).

## Implementation notes

* Splits up the current `dependents` and `dependencies`  implementations into core logic, which I moved into the Codebase module, and the CLI stuff which stayed behind so I can use bits of it outside of the Cli monad (we should probably depend less on Cli or split it up for commands going forwards, since more commands will be converted to APIs.
* Changes dependents and dependencies queries to avoid self-references in results.

See transcript for api format.

Note: @hojberg  this doesn't support the `relativeTo` query param at the moment, the name must be the fqn and it returns all dependents within the scope of the project. Let me know if that needs to change.

## Test coverage

See transcripts