### PR TITLE
Add a few new aliases

### DIFF
--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -1624,7 +1624,7 @@ libInstallInputPattern :: InputPattern
 libInstallInputPattern =
   InputPattern
     { patternName = "lib.install",
-      aliases = ["install.lib"],
+      aliases = ["install.lib", "install"],
       visibility = I.Visible,
       params = Parameters [("library name", remoteProjectBranchOrReleaseArg)] $ Optional [] Nothing,
       help =
@@ -3430,8 +3430,8 @@ releaseDraft =
 upgrade :: InputPattern
 upgrade =
   InputPattern
-    { patternName = "upgrade",
-      aliases = [],
+    { patternName = "lib.upgrade",
+      aliases = ["upgrade", "upgrade.lib"],
       visibility = I.Visible,
       params =
         Parameters [("dependency to upgrade", dependencyArg), ("dependency to upgrade to", dependencyArg)] $

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -3431,7 +3431,7 @@ upgrade :: InputPattern
 upgrade =
   InputPattern
     { patternName = "lib.upgrade",
-      aliases = ["upgrade", "upgrade.lib"],
+      aliases = ["upgrade.lib", "upgrade"],
       visibility = I.Visible,
       params =
         Parameters [("dependency to upgrade", dependencyArg), ("dependency to upgrade to", dependencyArg)] $

--- a/unison-src/transcripts/idempotent/help.md
+++ b/unison-src/transcripts/idempotent/help.md
@@ -503,7 +503,7 @@
   `io.test.all`  runs unit tests for the current branch that use
                  IO
 
-  lib.install (or install.lib)
+  lib.install (or install.lib, install)
   The `lib.install` command installs a dependency into the `lib`
   namespace.
 
@@ -572,6 +572,10 @@
                                                            directory
                                                            at
                                                            `lib.myproject_dev`
+
+  lib.upgrade (or upgrade.lib, upgrade)
+  `upgrade old new` upgrades library dependency `lib.old` to
+  `lib.new`, and, if successful, deletes `lib.old`.
 
   list (or ls, dir)
   `list`       lists definitions and namespaces in the current
@@ -963,10 +967,6 @@
   accordingly. If the process can't be completed automatically,
   the dependents will be added back to the scratch file for your
   review.
-
-  upgrade
-  `upgrade old new` upgrades library dependency `lib.old` to
-  `lib.new`, and, if successful, deletes `lib.old`.
 
   version
   Print the version of unison you're running


### PR DESCRIPTION
## Overview

Just added a few aliases that seemed to be missing:

* `upgrade.lib` and `lib.upgrade` to match `lib.install` and `install.lib`
* `install` (by request from #stew)

I also changed `upgrade`'s primary command to `lib.upgrade` just so we're being consistent in our primary command names.
