### PR TITLE
make $MERGED absolute

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Merge2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Merge2.hs
@@ -24,10 +24,11 @@ import Data.Semialign (zipWith)
 import Data.Set qualified as Set
 import Data.Text qualified as Text
 import Data.Text.IO qualified as Text
-import System.Directory (canonicalizePath, getTemporaryDirectory, removeFile)
+import System.Directory (canonicalizePath, getCurrentDirectory, getTemporaryDirectory, removeFile)
 import System.Environment (lookupEnv)
 import System.FilePath ((</>))
 import System.IO.Temp qualified as Temporary
+import System.OsPath qualified
 import System.Process qualified as Process
 import Text.ANSI qualified as Text
 import Text.Builder qualified
@@ -418,7 +419,16 @@ doMerge info = do
                             alice = aliceFilenameSlug <> ".u",
                             bob = bobFilenameSlug <> ".u"
                           }
-                let mergedFilename = Text.Builder.run (aliceFilenameSlug <> "-" <> bobFilenameSlug <> "-merged.u")
+                mergedFilename <- do
+                  cwd <- liftIO getCurrentDirectory
+                  pure $
+                    Text.Builder.run $
+                      Text.Builder.string cwd
+                        <> Text.Builder.char (System.OsPath.toChar System.OsPath.pathSeparator)
+                        <> aliceFilenameSlug
+                        <> "-"
+                        <> bobFilenameSlug
+                        <> "-merged.u"
                 let mergetool =
                       mergetool0
                         & Text.pack


### PR DESCRIPTION
## Overview

This PR makes UCM invoke the mergetool with an absolute path to `$MERGED`.

## Test coverage

I tested this manually