### PR TITLE
Fix the return type of Integer.signum

### DIFF
--- a/unison-runtime/src/Unison/Runtime/Foreign/Function.hs
+++ b/unison-runtime/src/Unison/Runtime/Foreign/Function.hs
@@ -1123,7 +1123,7 @@ foreignCallHelper = \case
   Integer_ge -> mkForeign $ \(l :: Integer, r :: Integer) -> pure $ encodeVal (l >= r)
   Integer_neg -> mkForeign $ \(n :: Integer) -> pure $ encodeVal (-n)
   Integer_abs -> mkForeign $ \(n :: Integer) -> pure $ encodeVal (abs n)
-  Integer_signum -> mkForeign $ \(n :: Integer) -> pure $ encodeVal (signum n)
+  Integer_signum -> mkForeign $ \(n :: Integer) -> pure $ encodeVal (fromIntegral (signum n) :: Int)
   Integer_toFloat -> mkForeign $ \(n :: Integer) -> pure $ encodeVal (fromIntegral n :: Double)
   Natural_unsafeFromText -> mkForeign $ \(txt :: Text) -> case readMaybe (unpack txt) of
     Just n -> pure $ encodeVal (n :: Natural)

--- a/unison-src/transcripts/idempotent/builtins.md
+++ b/unison-src/transcripts/idempotent/builtins.md
@@ -252,7 +252,8 @@ test> Integer.tests.arithmetic =
         Integer.eq (Integer.fromInt +1000) (Integer.fromInt +1000),
         not (Integer.eq (Integer.fromInt +1000) (Integer.fromInt +999)),
         eq (Integer.abs (Integer.fromInt +1000)) (Integer.fromInt +1000),
-        eq (Integer.abs (Integer.fromInt -1000)) (Integer.fromInt +1000)
+        eq (Integer.abs (Integer.fromInt -1000)) (Integer.fromInt +1000),
+        not (Int.eq (Integer.signum (Integer.fromInt +1)) (Integer.signum (Integer.fromInt -1)))
         ]
 
 test> Integer.tests.bitwise =


### PR DESCRIPTION
The advertized type of `Integer.signum` is `Integer -> Int`, but it was actually returning an `Integer`, leading to strange results. This fix converts that `Integer` to an `Int` before returning.