### PR TITLE
Handle kind-inference of unkown builtins more gracefully

### DIFF
--- a/parser-typechecker/src/Unison/KindInference.hs
+++ b/parser-typechecker/src/Unison/KindInference.hs
@@ -28,7 +28,7 @@ import Unison.Codebase.BuiltinAnnotation (BuiltinAnnotation)
 import Unison.DataDeclaration
 import Unison.KindInference.Generate (declComponentConstraints, termConstraints)
 import Unison.KindInference.Solve (KindError, defaultUnconstrainedVars, initialState, step, verify)
-import Unison.KindInference.Solve.Monad (Env (..), SolveState, run, runGen)
+import Unison.KindInference.Solve.Monad (Env (..), SolveState, runGen, runSolve)
 import Unison.Prelude
 import Unison.PrettyPrintEnv qualified as PrettyPrintEnv
 import Unison.Reference
@@ -44,7 +44,7 @@ kindCheckAnnotations ::
   Term.Term v loc ->
   Either (NonEmpty (KindError v loc)) ()
 kindCheckAnnotations ppe st t =
-  let (cs, st') = run env st (runGen $ termConstraints t)
+  let (cs, st') = runSolve env st (runGen $ termConstraints t)
       env = Env ppe
    in step env st' cs $> ()
 
@@ -66,7 +66,7 @@ inferDecls ppe declMap =
         [(Reference, Decl v loc)] ->
         Either (NonEmpty (KindError v loc)) (SolveState v loc)
       handleComponent s c =
-        let (cs, st) = run env s (runGen $ declComponentConstraints c)
+        let (cs, st) = runSolve env s (runGen $ declComponentConstraints c)
          in step env st cs
 
       handleComponents ::

--- a/parser-typechecker/src/Unison/KindInference.hs
+++ b/parser-typechecker/src/Unison/KindInference.hs
@@ -23,11 +23,12 @@ where
 import Data.Foldable (foldlM)
 import Data.Graph (flattenSCC, stronglyConnCompR)
 import Data.List.NonEmpty (NonEmpty (..))
+import Data.List.NonEmpty qualified as Nel
 import Data.Map.Strict qualified as Map
 import Unison.Codebase.BuiltinAnnotation (BuiltinAnnotation)
 import Unison.DataDeclaration
 import Unison.KindInference.Generate (declComponentConstraints, termConstraints)
-import Unison.KindInference.Solve (KindError, defaultUnconstrainedVars, initialState, step, verify)
+import Unison.KindInference.Solve (KindError (..), defaultUnconstrainedVars, initialState, step, verify)
 import Unison.KindInference.Solve.Monad (Env (..), SolveState, runGen, runSolve)
 import Unison.Prelude
 import Unison.PrettyPrintEnv qualified as PrettyPrintEnv
@@ -43,10 +44,10 @@ kindCheckAnnotations ::
   SolveState v loc ->
   Term.Term v loc ->
   Either (NonEmpty (KindError v loc)) ()
-kindCheckAnnotations ppe st t =
-  let (cs, st') = runSolve env st (runGen $ termConstraints t)
-      env = Env ppe
-   in step env st' cs $> ()
+kindCheckAnnotations ppe st t = do
+  let env = Env ppe
+  (cs, st') <- mapLeft (Nel.singleton . SolveError) $ runSolve env st (runGen $ termConstraints t)
+  step env st' cs $> ()
 
 -- | Infer the kinds of all decl vars
 inferDecls ::
@@ -65,9 +66,9 @@ inferDecls ppe declMap =
         SolveState v loc ->
         [(Reference, Decl v loc)] ->
         Either (NonEmpty (KindError v loc)) (SolveState v loc)
-      handleComponent s c =
-        let (cs, st) = runSolve env s (runGen $ declComponentConstraints c)
-         in step env st cs
+      handleComponent s c = do
+        (cs, st) <- mapLeft (Nel.singleton . SolveError) $ runSolve env s (runGen $ declComponentConstraints c)
+        step env st cs
 
       handleComponents ::
         [[(Reference, Decl v loc)]] ->

--- a/parser-typechecker/src/Unison/KindInference/Constraint/Pretty.hs
+++ b/parser-typechecker/src/Unison/KindInference/Constraint/Pretty.hs
@@ -82,7 +82,7 @@ prettyCyclicUVarKindWorker prec u nameMap visitingSet =
 -- | Pretty print the kind constraint on the given @UVar@.
 --
 -- __Precondition:__ The @ConstraintMap@ is acyclic.
-tryPrettyUVarKind :: (Var v) => PrettyPrintEnv -> ConstraintMap v loc -> UVar v loc -> Either SolveError (P.Pretty P.ColorText)
+tryPrettyUVarKind :: (Var v) => PrettyPrintEnv -> ConstraintMap v loc -> UVar v loc -> Either (SolveError loc) (P.Pretty P.ColorText)
 tryPrettyUVarKind ppe constraints uvar = ppRunner ppe constraints do
   prettyUVarKind' arrPrec uvar
 
@@ -106,7 +106,7 @@ tryPrettySolvedConstraint ::
   PrettyPrintEnv ->
   ConstraintMap v loc ->
   Solved.Constraint (UVar v loc) v loc ->
-  Either SolveError (P.Pretty P.ColorText)
+  Either (SolveError loc) (P.Pretty P.ColorText)
 tryPrettySolvedConstraint ppe constraints c =
   ppRunner ppe constraints (prettySolvedConstraint' arrPrec c)
 
@@ -137,7 +137,7 @@ prettySolvedConstraint' prec = \case
 -- constraint map, but no constraints are added. This runner just
 -- allows running pretty printers outside of the @Solve@ monad by
 -- discarding the resulting state.
-ppRunner :: (Var v) => PrettyPrintEnv -> ConstraintMap v loc -> (forall r. Solve v loc r -> Either SolveError r)
+ppRunner :: (Var v) => PrettyPrintEnv -> ConstraintMap v loc -> (forall r. Solve v loc r -> Either (SolveError loc) r)
 ppRunner ppe constraints =
   let st =
         SolveState
@@ -161,7 +161,7 @@ tryPrettyCyclicUVarKind ::
   -- | A function to style the cyclic @UVar@'s variable name
   (P.Pretty P.ColorText -> P.Pretty P.ColorText) ->
   -- | (the pretty @UVar@ variable, the generating equation)
-  Either SolveError (P.Pretty P.ColorText, P.Pretty P.ColorText)
+  Either (SolveError loc) (P.Pretty P.ColorText, P.Pretty P.ColorText)
 tryPrettyCyclicUVarKind ppe constraints uvar theUVarStyle = ppRunner ppe constraints do
   find uvar >>= \case
     Nothing -> explode
@@ -200,6 +200,6 @@ prettyCyclicUVarKind ppe constraints uvar theUVarStyle =
     Left solveErr -> (prettySolveError solveErr, prettySolveError solveErr)
     Right pp -> pp
 
-prettySolveError :: SolveError -> P.Pretty P.ColorText
+prettySolveError :: (SolveError loc) -> P.Pretty P.ColorText
 prettySolveError = \case
-  MissingBuiltin builtin -> "Encountered unknown builtin when kind-checking: " <> P.text builtin <> ", try upgrading ucm."
+  MissingBuiltin _loc builtin -> "Encountered unknown builtin when kind-checking: " <> P.shown builtin <> ", try upgrading ucm."

--- a/parser-typechecker/src/Unison/KindInference/Constraint/Pretty.hs
+++ b/parser-typechecker/src/Unison/KindInference/Constraint/Pretty.hs
@@ -202,4 +202,8 @@ prettyCyclicUVarKind ppe constraints uvar theUVarStyle =
 
 prettySolveError :: (SolveError loc) -> P.Pretty P.ColorText
 prettySolveError = \case
-  MissingBuiltin _loc builtin -> "Encountered unknown builtin when kind-checking: " <> P.shown builtin <> ", try upgrading ucm."
+  MissingBuiltin _loc builtin ->
+    P.lines
+      [ "Encountered unknown builtin when kind-checking: " <> P.shown builtin,
+        "✨ Hint: Upgrading to the latest ucm may resolve this issue."
+      ]

--- a/parser-typechecker/src/Unison/KindInference/Constraint/Pretty.hs
+++ b/parser-typechecker/src/Unison/KindInference/Constraint/Pretty.hs
@@ -17,7 +17,7 @@ import Unison.KindInference.Solve.Monad
     Solve (..),
     SolveState (..),
     find,
-    run,
+    runSolve,
   )
 import Unison.KindInference.UVar (UVar (..))
 import Unison.Prelude
@@ -123,7 +123,7 @@ ppRunner ppe constraints =
             typeMap = mempty
           }
       env = Env ppe
-   in \solve -> fst (run env st solve)
+   in \solve -> fst (runSolve env st solve)
 
 -- | A pretty printer for cyclic kind constraints on a
 -- @UVar@. Expresses the infinite kind by a generating equation.

--- a/parser-typechecker/src/Unison/KindInference/Constraint/Pretty.hs
+++ b/parser-typechecker/src/Unison/KindInference/Constraint/Pretty.hs
@@ -4,7 +4,10 @@
 module Unison.KindInference.Constraint.Pretty
   ( prettyUVarKind,
     prettySolvedConstraint,
+    tryPrettySolvedConstraint,
+    tryPrettyUVarKind,
     prettyCyclicUVarKind,
+    prettySolveError,
   )
 where
 
@@ -15,6 +18,7 @@ import Unison.KindInference.Solve.Monad
   ( ConstraintMap,
     Env (..),
     Solve (..),
+    SolveError (..),
     SolveState (..),
     find,
     runSolve,
@@ -78,15 +82,33 @@ prettyCyclicUVarKindWorker prec u nameMap visitingSet =
 -- | Pretty print the kind constraint on the given @UVar@.
 --
 -- __Precondition:__ The @ConstraintMap@ is acyclic.
-prettyUVarKind :: (Var v) => PrettyPrintEnv -> ConstraintMap v loc -> UVar v loc -> P.Pretty P.ColorText
-prettyUVarKind ppe constraints uvar = ppRunner ppe constraints do
+tryPrettyUVarKind :: (Var v) => PrettyPrintEnv -> ConstraintMap v loc -> UVar v loc -> Either SolveError (P.Pretty P.ColorText)
+tryPrettyUVarKind ppe constraints uvar = ppRunner ppe constraints do
   prettyUVarKind' arrPrec uvar
+
+prettyUVarKind :: (Var v) => PrettyPrintEnv -> ConstraintMap v loc -> UVar v loc -> P.Pretty P.ColorText
+prettyUVarKind ppe constraints uvar =
+  case tryPrettyUVarKind ppe constraints uvar of
+    Left solveErr -> prettySolveError solveErr
+    Right pp -> pp
 
 prettyUVarKind' :: (Var v) => Int -> UVar v loc -> Solve v loc (P.Pretty P.ColorText)
 prettyUVarKind' prec u =
   find u >>= \case
     Nothing -> pure (prettyUnknown prec)
     Just c -> prettySolvedConstraint' prec c
+
+-- | Pretty print a 'Solved.Constraint'
+--
+-- __Precondition:__ The @ConstraintMap@ is acyclic.
+tryPrettySolvedConstraint ::
+  (Var v) =>
+  PrettyPrintEnv ->
+  ConstraintMap v loc ->
+  Solved.Constraint (UVar v loc) v loc ->
+  Either SolveError (P.Pretty P.ColorText)
+tryPrettySolvedConstraint ppe constraints c =
+  ppRunner ppe constraints (prettySolvedConstraint' arrPrec c)
 
 -- | Pretty print a 'Solved.Constraint'
 --
@@ -98,7 +120,9 @@ prettySolvedConstraint ::
   Solved.Constraint (UVar v loc) v loc ->
   P.Pretty P.ColorText
 prettySolvedConstraint ppe constraints c =
-  ppRunner ppe constraints (prettySolvedConstraint' arrPrec c)
+  case tryPrettySolvedConstraint ppe constraints c of
+    Left solveErr -> prettySolveError solveErr
+    Right pp -> pp
 
 prettySolvedConstraint' :: (Var v) => Int -> Solved.Constraint (UVar v loc) v loc -> Solve v loc (P.Pretty P.ColorText)
 prettySolvedConstraint' prec = \case
@@ -113,7 +137,7 @@ prettySolvedConstraint' prec = \case
 -- constraint map, but no constraints are added. This runner just
 -- allows running pretty printers outside of the @Solve@ monad by
 -- discarding the resulting state.
-ppRunner :: (Var v) => PrettyPrintEnv -> ConstraintMap v loc -> (forall r. Solve v loc r -> r)
+ppRunner :: (Var v) => PrettyPrintEnv -> ConstraintMap v loc -> (forall r. Solve v loc r -> Either SolveError r)
 ppRunner ppe constraints =
   let st =
         SolveState
@@ -123,13 +147,13 @@ ppRunner ppe constraints =
             typeMap = mempty
           }
       env = Env ppe
-   in \solve -> fst (runSolve env st solve)
+   in \solve -> fst <$> (runSolve env st solve)
 
 -- | A pretty printer for cyclic kind constraints on a
 -- @UVar@. Expresses the infinite kind by a generating equation.
 --
 -- __Precondition:__ The @UVar@ has a cyclic constraint.
-prettyCyclicUVarKind ::
+tryPrettyCyclicUVarKind ::
   (Var v) =>
   PrettyPrintEnv ->
   ConstraintMap v loc ->
@@ -137,8 +161,8 @@ prettyCyclicUVarKind ::
   -- | A function to style the cyclic @UVar@'s variable name
   (P.Pretty P.ColorText -> P.Pretty P.ColorText) ->
   -- | (the pretty @UVar@ variable, the generating equation)
-  (P.Pretty P.ColorText, P.Pretty P.ColorText)
-prettyCyclicUVarKind ppe constraints uvar theUVarStyle = ppRunner ppe constraints do
+  Either SolveError (P.Pretty P.ColorText, P.Pretty P.ColorText)
+tryPrettyCyclicUVarKind ppe constraints uvar theUVarStyle = ppRunner ppe constraints do
   find uvar >>= \case
     Nothing -> explode
     Just c -> do
@@ -157,3 +181,25 @@ prettyCyclicUVarKind ppe constraints uvar theUVarStyle = ppRunner ppe constraint
         Just n -> pure (n, P.wrap (n <> "=" <> pp))
   where
     explode = error ("[prettyCyclicUVarKind] called with non-cyclic uvar: " <> show uvar)
+
+-- | A pretty printer for cyclic kind constraints on a
+-- @UVar@. Expresses the infinite kind by a generating equation.
+--
+-- __Precondition:__ The @UVar@ has a cyclic constraint.
+prettyCyclicUVarKind ::
+  (Var v) =>
+  PrettyPrintEnv ->
+  ConstraintMap v loc ->
+  UVar v loc ->
+  -- | A function to style the cyclic @UVar@'s variable name
+  (P.Pretty P.ColorText -> P.Pretty P.ColorText) ->
+  -- | (the pretty @UVar@ variable, the generating equation)
+  (P.Pretty P.ColorText, P.Pretty P.ColorText)
+prettyCyclicUVarKind ppe constraints uvar theUVarStyle =
+  case tryPrettyCyclicUVarKind ppe constraints uvar theUVarStyle of
+    Left solveErr -> (prettySolveError solveErr, prettySolveError solveErr)
+    Right pp -> pp
+
+prettySolveError :: SolveError -> P.Pretty P.ColorText
+prettySolveError = \case
+  MissingBuiltin builtin -> "Encountered unknown builtin when kind-checking: " <> P.text builtin <> ", try upgrading ucm."

--- a/parser-typechecker/src/Unison/KindInference/Error.hs
+++ b/parser-typechecker/src/Unison/KindInference/Error.hs
@@ -37,6 +37,7 @@ lspLoc = \case
   ArgumentMismatchArrow _ ConstraintConflict' {conflictedVar} _ -> varLoc conflictedVar
   EffectListMismatch ConstraintConflict' {conflictedVar} _ -> varLoc conflictedVar
   ConstraintConflict gen _ _ -> gen ^. Unsolved.loc
+  SolveError e -> mempty
   where
     varLoc var = ABT.annotation $ uvarType var
 

--- a/parser-typechecker/src/Unison/KindInference/Error.hs
+++ b/parser-typechecker/src/Unison/KindInference/Error.hs
@@ -15,8 +15,9 @@ import Unison.KindInference.Generate.Monad (GeneratedConstraint)
 import Unison.KindInference.Solve.Monad
   ( ConstraintMap,
     Solve (..),
-    SolveError,
+    SolveError (..),
   )
+import Unison.KindInference.Solve.Monad qualified as Solve
 import Unison.KindInference.UVar (UVar (..))
 import Unison.Prelude
 import Unison.Type (Type)
@@ -37,9 +38,11 @@ lspLoc = \case
   ArgumentMismatchArrow _ ConstraintConflict' {conflictedVar} _ -> varLoc conflictedVar
   EffectListMismatch ConstraintConflict' {conflictedVar} _ -> varLoc conflictedVar
   ConstraintConflict gen _ _ -> gen ^. Unsolved.loc
-  SolveError e -> mempty
+  SolveError err -> solveErrLoc err
   where
     varLoc var = ABT.annotation $ uvarType var
+    solveErrLoc = \case
+      Solve.MissingBuiltin loc _ -> loc
 
 -- | Errors that may arise during kind inference
 data KindError v loc
@@ -85,7 +88,7 @@ data KindError v loc
       (ConstraintConflict v loc)
       -- | in this context
       (ConstraintMap v loc)
-  | SolveError SolveError
+  | SolveError (SolveError loc)
 
 -- | Transform generic constraint conflicts into more specific error
 -- by examining its @ConstraintContext@.

--- a/parser-typechecker/src/Unison/KindInference/Error.hs
+++ b/parser-typechecker/src/Unison/KindInference/Error.hs
@@ -15,6 +15,7 @@ import Unison.KindInference.Generate.Monad (GeneratedConstraint)
 import Unison.KindInference.Solve.Monad
   ( ConstraintMap,
     Solve (..),
+    SolveError,
   )
 import Unison.KindInference.UVar (UVar (..))
 import Unison.Prelude
@@ -83,6 +84,7 @@ data KindError v loc
       (ConstraintConflict v loc)
       -- | in this context
       (ConstraintMap v loc)
+  | SolveError SolveError
 
 -- | Transform generic constraint conflicts into more specific error
 -- by examining its @ConstraintContext@.

--- a/parser-typechecker/src/Unison/KindInference/Error/Pretty.hs
+++ b/parser-typechecker/src/Unison/KindInference/Error/Pretty.hs
@@ -181,6 +181,7 @@ prettyKindError prettyType showSource color1 color2 env = \case
             [ (varLoc conflictedVar, color2)
             ]
      in theErrMsg
+  SolveError solveError -> prettySolveError solveError
   where
     varLoc var = ABT.annotation $ uvarType var
     prettyTyp = prettyType . uvarType

--- a/parser-typechecker/src/Unison/KindInference/Generate.hs
+++ b/parser-typechecker/src/Unison/KindInference/Generate.hs
@@ -8,6 +8,7 @@ module Unison.KindInference.Generate
   )
 where
 
+import Control.Monad.Except
 import Data.Foldable (foldlM)
 import Data.Set qualified as Set
 import U.Core.ABT qualified as ABT
@@ -21,10 +22,11 @@ import Unison.KindInference.Constraint.Context (ConstraintContext (..))
 import Unison.KindInference.Constraint.Provenance (Provenance (..))
 import Unison.KindInference.Constraint.Provenance qualified as Provenance
 import Unison.KindInference.Constraint.Unsolved (Constraint (..))
-import Unison.KindInference.Generate.Monad (Gen, GeneratedConstraint, freshVar, lookupType, pushType, scopedType)
+import Unison.KindInference.Generate.Monad (Gen, GenError (..), GeneratedConstraint, freshVar, lookupType, pushType, scopedType)
 import Unison.KindInference.UVar (UVar)
 import Unison.Prelude
 import Unison.Reference (Reference)
+import Unison.Reference qualified as Reference
 import Unison.Term qualified as Term
 import Unison.Type qualified as Type
 import Unison.Util.Recursion
@@ -94,7 +96,10 @@ typeConstraintTree resultVar term@ABT.Term {annotation, out} = do
         pure (foldr Constraint ct gcs)
       Type.Ref r ->
         lookupType (Type.ref annotation r) >>= \case
-          Nothing -> error ("[typeConstraintTree] Ref lookup failure: " <> show term)
+          Nothing ->
+            if Reference.isBuiltin r
+              then throwError $ MissingBuiltin annotation r
+              else error ("[typeConstraintTree] Ref lookup failure: " <> show term)
           Just x -> pure $ Constraint (Unify (Provenance ContextLookup annotation) resultVar x) (Node [])
       Type.Effect effTyp b -> do
         effKind <- freshVar effTyp

--- a/parser-typechecker/src/Unison/KindInference/Generate/Monad.hs
+++ b/parser-typechecker/src/Unison/KindInference/Generate/Monad.hs
@@ -25,6 +25,7 @@ import Unison.KindInference.Constraint.Provenance (Provenance)
 import Unison.KindInference.Constraint.Unsolved (Constraint (..))
 import Unison.KindInference.UVar (UVar (..))
 import Unison.Prelude
+import Unison.Reference (Reference)
 import Unison.Symbol
 import Unison.Type qualified as T
 import Unison.Var
@@ -40,22 +41,22 @@ data GenState v loc = GenState
   }
   deriving stock (Generic)
 
-data GenError = MissingBuiltin Text
+data GenError loc = MissingBuiltin loc Reference
   deriving stock (Show, Eq)
 
 newtype Gen v loc a = Gen
-  { unGen :: StateT (GenState v loc) (Except GenError) a
+  { unGen :: StateT (GenState v loc) (Except (GenError loc)) a
   }
   deriving newtype
     ( Functor,
       Applicative,
       Monad,
       MonadState (GenState v loc),
-      MonadError GenError
+      MonadError (GenError loc)
     )
 
 -- | @Gen@ monad runner
-run :: Gen v loc a -> GenState v loc -> Either GenError (a, GenState v loc)
+run :: Gen v loc a -> GenState v loc -> Either (GenError loc) (a, GenState v loc)
 run (Gen ma) st0 =
   runStateT ma st0
     & runExcept

--- a/parser-typechecker/src/Unison/KindInference/Generate/Monad.hs
+++ b/parser-typechecker/src/Unison/KindInference/Generate/Monad.hs
@@ -38,7 +38,7 @@ data GenState v loc = GenState
   deriving stock (Generic)
 
 newtype Gen v loc a = Gen
-  { unGen :: GenState v loc -> (a, GenState v loc)
+  { unGen :: State (GenState v loc) a
   }
   deriving
     ( Functor,
@@ -50,7 +50,7 @@ newtype Gen v loc a = Gen
 
 -- | @Gen@ monad runner
 run :: Gen v loc a -> GenState v loc -> (a, GenState v loc)
-run (Gen ma) st0 = ma st0
+run (Gen ma) st0 = runState ma st0
 
 -- | Create a unique @UVar@ associated with @typ@
 freshVar :: (Var v) => T.Type v loc -> Gen v loc (UVar v loc)

--- a/parser-typechecker/src/Unison/KindInference/Generate/Monad.hs
+++ b/parser-typechecker/src/Unison/KindInference/Generate/Monad.hs
@@ -41,6 +41,7 @@ data GenState v loc = GenState
   deriving stock (Generic)
 
 data GenError = MissingBuiltin Text
+  deriving stock (Show, Eq)
 
 newtype Gen v loc a = Gen
   { unGen :: StateT (GenState v loc) (Except GenError) a

--- a/parser-typechecker/src/Unison/KindInference/Generate/Monad.hs
+++ b/parser-typechecker/src/Unison/KindInference/Generate/Monad.hs
@@ -1,6 +1,7 @@
 module Unison.KindInference.Generate.Monad
   ( Gen (..),
     GenState (..),
+    GenError (..),
     GeneratedConstraint,
     run,
     freshVar,
@@ -11,6 +12,8 @@ module Unison.KindInference.Generate.Monad
   )
 where
 
+import Control.Monad.Error.Class
+import Control.Monad.Except
 import Control.Monad.State.Strict
 import Data.Functor.Compose
 import Data.List.NonEmpty (NonEmpty ((:|)))
@@ -37,20 +40,24 @@ data GenState v loc = GenState
   }
   deriving stock (Generic)
 
+data GenError = MissingBuiltin Text
+
 newtype Gen v loc a = Gen
-  { unGen :: State (GenState v loc) a
+  { unGen :: StateT (GenState v loc) (Except GenError) a
   }
-  deriving
+  deriving newtype
     ( Functor,
       Applicative,
       Monad,
-      MonadState (GenState v loc)
+      MonadState (GenState v loc),
+      MonadError GenError
     )
-    via State (GenState v loc)
 
 -- | @Gen@ monad runner
-run :: Gen v loc a -> GenState v loc -> (a, GenState v loc)
-run (Gen ma) st0 = runState ma st0
+run :: Gen v loc a -> GenState v loc -> Either GenError (a, GenState v loc)
+run (Gen ma) st0 =
+  runStateT ma st0
+    & runExcept
 
 -- | Create a unique @UVar@ associated with @typ@
 freshVar :: (Var v) => T.Type v loc -> Gen v loc (UVar v loc)

--- a/parser-typechecker/src/Unison/KindInference/Solve.hs
+++ b/parser-typechecker/src/Unison/KindInference/Solve.hs
@@ -33,8 +33,8 @@ import Unison.KindInference.Solve.Monad
     Solve (..),
     SolveState (..),
     emptyState,
-    run,
     runGen,
+    runSolve,
   )
 import Unison.KindInference.UVar (UVar (..))
 import Unison.PatternMatchCoverage.Pretty as P
@@ -83,7 +83,7 @@ step e st cs =
               Left e -> pure (Left e)
               Right _ -> do
                 Left <$> traverse improveError (e :| es)
-   in case unSolve action e st of
+   in case runSolve e st action of
         (res, finalState) -> case res of
           Left e -> Left e
           Right () -> Right finalState
@@ -317,7 +317,7 @@ verify st =
 
 initialState :: forall v loc. (BuiltinAnnotation loc, Show loc, Ord loc, Var v) => Env -> SolveState v loc
 initialState env =
-  let ((), finalState) = run env emptyState initializeState
+  let ((), finalState) = runSolve env emptyState initializeState
    in finalState
 
 initializeState :: forall v loc. (BuiltinAnnotation loc, Ord loc, Show loc, Var v) => Solve v loc ()

--- a/parser-typechecker/src/Unison/KindInference/Solve.hs
+++ b/parser-typechecker/src/Unison/KindInference/Solve.hs
@@ -16,6 +16,7 @@ import Control.Monad.Reader qualified as M
 import Control.Monad.State.Strict qualified as M
 import Control.Monad.Trans.Except
 import Data.List.NonEmpty (NonEmpty (..))
+import Data.List.NonEmpty qualified as Nel
 import Data.Set qualified as Set
 import Unison.Codebase.BuiltinAnnotation (BuiltinAnnotation)
 import Unison.Debug (DebugFlag (KindInference), shouldDebug)
@@ -83,8 +84,9 @@ step e st cs =
               Left e -> pure (Left e)
               Right _ -> do
                 Left <$> traverse improveError (e :| es)
-   in case runSolve e st action of
-        (res, finalState) -> case res of
+   in do
+        (res, finalState) <- mapLeft (Nel.singleton . SolveError) $ runSolve e st action
+        case res of
           Left e -> Left e
           Right () -> Right finalState
 
@@ -317,8 +319,9 @@ verify st =
 
 initialState :: forall v loc. (BuiltinAnnotation loc, Show loc, Ord loc, Var v) => Env -> SolveState v loc
 initialState env =
-  let ((), finalState) = runSolve env emptyState initializeState
-   in finalState
+  case runSolve env emptyState initializeState of
+    Left err -> error $ "initialState: unexpected error: " <> show err
+    Right ((), finalState) -> finalState
 
 initializeState :: forall v loc. (BuiltinAnnotation loc, Ord loc, Show loc, Var v) => Solve v loc ()
 initializeState = assertGen do

--- a/parser-typechecker/src/Unison/KindInference/Solve/Monad.hs
+++ b/parser-typechecker/src/Unison/KindInference/Solve/Monad.hs
@@ -30,6 +30,7 @@ import Unison.KindInference.UVar (UVar (..))
 import Unison.PatternMatchCoverage.UFMap qualified as U
 import Unison.Prelude
 import Unison.PrettyPrintEnv (PrettyPrintEnv)
+import Unison.Reference (Reference)
 import Unison.Symbol
 import Unison.Type qualified as T
 import Unison.Var
@@ -62,11 +63,11 @@ data Descriptor v loc = Descriptor
   { descriptorConstraint :: Maybe (Constraint (UVar v loc) v loc)
   }
 
-data SolveError
-  = MissingBuiltin Text
+data SolveError loc
+  = MissingBuiltin loc Reference
   deriving stock (Show, Eq)
 
-newtype Solve v loc a = Solve {unSolve :: M.ReaderT Env (M.StateT (SolveState v loc) (Except SolveError)) a}
+newtype Solve v loc a = Solve {unSolve :: M.ReaderT Env (M.StateT (SolveState v loc) (Except (SolveError loc))) a}
   deriving newtype
     ( Functor,
       Applicative,
@@ -81,9 +82,9 @@ liftGen :: Gen v loc a -> Solve v loc a
 liftGen (Gen action) = Solve $ do
   lift $ zoom genStateL $ M.mapStateT (withExcept genErrorToSolveError) $ action
   where
-    genErrorToSolveError :: Gen.GenError -> SolveError
+    genErrorToSolveError :: Gen.GenError loc -> (SolveError loc)
     genErrorToSolveError = \case
-      Gen.MissingBuiltin builtin -> MissingBuiltin builtin
+      Gen.MissingBuiltin ann builtin -> MissingBuiltin ann builtin
 
 -- | Helper for inteleaving constraint generation and solving
 genStateL :: Lens' (SolveState v loc) (Gen.GenState v loc)
@@ -123,7 +124,7 @@ addUnconstrainedVar uvar = do
   M.put st {constraints = constraints'}
 
 -- | Runner for the @Solve@ monad
-runSolve :: Env -> SolveState v loc -> Solve v loc a -> Either SolveError (a, SolveState v loc)
+runSolve :: Env -> SolveState v loc -> Solve v loc a -> Either (SolveError loc) (a, SolveState v loc)
 runSolve e st action =
   unSolve action
     & flip M.runReaderT e

--- a/parser-typechecker/src/Unison/KindInference/Solve/Monad.hs
+++ b/parser-typechecker/src/Unison/KindInference/Solve/Monad.hs
@@ -4,16 +4,18 @@ module Unison.KindInference.Solve.Monad
     SolveState (..),
     Descriptor (..),
     ConstraintMap,
+    liftGen,
     runSolve,
     emptyState,
     find,
-    genStateL,
     runGen,
     addUnconstrainedVar,
   )
 where
 
-import Control.Lens (Lens', (%%~))
+import Control.Lens (Lens')
+import Control.Lens.Zoom
+import Control.Monad.Except
 import Control.Monad.Fix (MonadFix (..))
 import Control.Monad.Reader qualified as M
 import Control.Monad.State.Strict qualified as M
@@ -59,8 +61,11 @@ data Descriptor v loc = Descriptor
   { descriptorConstraint :: Maybe (Constraint (UVar v loc) v loc)
   }
 
-newtype Solve v loc a = Solve {unSolve :: M.ReaderT Env (M.State (SolveState v loc)) a}
-  deriving
+data SolveError
+  = MissingBuiltin Text
+
+newtype Solve v loc a = Solve {unSolve :: M.ReaderT Env (M.StateT (SolveState v loc) (Except SolveError)) a}
+  deriving newtype
     ( Functor,
       Applicative,
       Monad,
@@ -68,7 +73,15 @@ newtype Solve v loc a = Solve {unSolve :: M.ReaderT Env (M.State (SolveState v l
       M.MonadReader Env,
       M.MonadState (SolveState v loc)
     )
-    via M.ReaderT Env (M.State (SolveState v loc))
+
+-- Run a Gen action in the Solve monad
+liftGen :: Gen v loc a -> Solve v loc a
+liftGen (Gen action) = Solve $ do
+  lift $ zoom genStateL $ M.mapStateT (withExcept genErrorToSolveError) $ action
+  where
+    genErrorToSolveError :: Gen.GenError -> SolveError
+    genErrorToSolveError = \case
+      Gen.MissingBuiltin builtin -> MissingBuiltin builtin
 
 -- | Helper for inteleaving constraint generation and solving
 genStateL :: Lens' (SolveState v loc) (Gen.GenState v loc)
@@ -89,13 +102,11 @@ genStateL f st =
 -- | Interleave constraint generation into constraint solving
 runGen :: (Var v) => Gen v loc a -> Solve v loc a
 runGen gena = do
-  st <- M.get
   let gena' = do
         res <- gena
         st <- M.get
         pure (res, Gen.newVars st)
-  let ((cs, vs), st') = st & genStateL %%~ Gen.run gena'
-  M.put st'
+  (cs, vs) <- zoom genStateL $ gena'
   traverse_ addUnconstrainedVar vs
   M.modify \st -> st {newUnifVars = vs ++ newUnifVars st}
   pure cs

--- a/parser-typechecker/src/Unison/KindInference/Solve/Monad.hs
+++ b/parser-typechecker/src/Unison/KindInference/Solve/Monad.hs
@@ -64,6 +64,7 @@ data Descriptor v loc = Descriptor
 
 data SolveError
   = MissingBuiltin Text
+  deriving stock (Show, Eq)
 
 newtype Solve v loc a = Solve {unSolve :: M.ReaderT Env (M.StateT (SolveState v loc) (Except SolveError)) a}
   deriving newtype

--- a/parser-typechecker/src/Unison/KindInference/Solve/Monad.hs
+++ b/parser-typechecker/src/Unison/KindInference/Solve/Monad.hs
@@ -4,7 +4,7 @@ module Unison.KindInference.Solve.Monad
     SolveState (..),
     Descriptor (..),
     ConstraintMap,
-    run,
+    runSolve,
     emptyState,
     find,
     genStateL,
@@ -17,7 +17,6 @@ import Control.Lens (Lens', (%%~))
 import Control.Monad.Fix (MonadFix (..))
 import Control.Monad.Reader qualified as M
 import Control.Monad.State.Strict qualified as M
-import Data.Functor.Identity
 import Data.List.NonEmpty (NonEmpty)
 import Data.Map.Strict qualified as M
 import Data.Set qualified as Set
@@ -60,7 +59,7 @@ data Descriptor v loc = Descriptor
   { descriptorConstraint :: Maybe (Constraint (UVar v loc) v loc)
   }
 
-newtype Solve v loc a = Solve {unSolve :: Env -> SolveState v loc -> (a, SolveState v loc)}
+newtype Solve v loc a = Solve {unSolve :: M.ReaderT Env (M.State (SolveState v loc)) a}
   deriving
     ( Functor,
       Applicative,
@@ -111,8 +110,11 @@ addUnconstrainedVar uvar = do
   M.put st {constraints = constraints'}
 
 -- | Runner for the @Solve@ monad
-run :: Env -> SolveState v loc -> Solve v loc a -> (a, SolveState v loc)
-run e st action = unSolve action e st
+runSolve :: Env -> SolveState v loc -> Solve v loc a -> (a, SolveState v loc)
+runSolve e st action =
+  unSolve action
+    & flip M.runReaderT e
+    & flip M.runState st
 
 -- | Initial solve state
 emptyState :: SolveState v loc

--- a/parser-typechecker/src/Unison/KindInference/Solve/Monad.hs
+++ b/parser-typechecker/src/Unison/KindInference/Solve/Monad.hs
@@ -2,6 +2,7 @@ module Unison.KindInference.Solve.Monad
   ( Solve (..),
     Env (..),
     SolveState (..),
+    SolveError (..),
     Descriptor (..),
     ConstraintMap,
     liftGen,
@@ -106,7 +107,7 @@ runGen gena = do
         res <- gena
         st <- M.get
         pure (res, Gen.newVars st)
-  (cs, vs) <- zoom genStateL $ gena'
+  (cs, vs) <- liftGen gena'
   traverse_ addUnconstrainedVar vs
   M.modify \st -> st {newUnifVars = vs ++ newUnifVars st}
   pure cs
@@ -121,11 +122,12 @@ addUnconstrainedVar uvar = do
   M.put st {constraints = constraints'}
 
 -- | Runner for the @Solve@ monad
-runSolve :: Env -> SolveState v loc -> Solve v loc a -> (a, SolveState v loc)
+runSolve :: Env -> SolveState v loc -> Solve v loc a -> Either SolveError (a, SolveState v loc)
 runSolve e st action =
   unSolve action
     & flip M.runReaderT e
-    & flip M.runState st
+    & flip M.runStateT st
+    & runExcept
 
 -- | Initial solve state
 emptyState :: SolveState v loc

--- a/unison-runtime/unison-runtime.cabal
+++ b/unison-runtime/unison-runtime.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -43,8 +43,8 @@ library
       Unison.Runtime
       Unison.Runtime.ANF
       Unison.Runtime.ANF.MurmurHash.Untyped
-      Unison.Runtime.ANF.POp
       Unison.Runtime.ANF.Optimize
+      Unison.Runtime.ANF.POp
       Unison.Runtime.ANF.Rehash
       Unison.Runtime.ANF.Serialize
       Unison.Runtime.ANF.Serialize.CodeV4


### PR DESCRIPTION
## Overview

Addresses, but doesn't fully solve: https://github.com/unisonweb/unison/issues/5896

Previously: 

```
Encountered exception:
[typeConstraintTree] Ref lookup failure: ReferenceBuiltin "Integer"
CallStack (from HasCallStack):
  error, called at src/Unison/KindInference/Generate.hs:97:22 in unison-parser-typechecker-0.0.0-BFjY27DYsGCCOy52yx0xpw:Unison.KindInference.Generate
```

Now:

```
  Loading changes detected in ~/dev/unison/scratch.u.


    Encountered unknown builtin when kind-checking: ReferenceBuiltin "Integer"
    ✨ Hint: Upgrading to the latest ucm may resolve this issue.
```

## Implementation notes

* Adds failure tracking via ExceptT to `Gen` and `Solve` monads so we can properly handle errors triggered there.
* For now, only actually track and handle errors looking up types for missing builtins.

## Test coverage

* TODO

## Loose ends

It would be nice to simply ignore definitions which trigger kind checking errors during TDNR; but with the way things are arranged it's quite tricky to separate things.

I think what's happening is we're somewhere collecting all possible matching names, then we infer kinds for all  decls and terms which we might possibly reference; before we even do the initial typecheck and before we get to TDNR proper.
I'm not familiar with how the kind checker works, so it may not be so easy as to just cull anything that fails checking, since there are inter-dependencies on kinds between things, e.g. if I cull a type I need to make sure I correctly cull everything which refer to the unification variables in that culled type since they now may never be solved;