### PR TITLE
Prevent uName from overwriting other syntax groups

### DIFF
--- a/editor-support/vim/syntax/unison.vim
+++ b/editor-support/vim/syntax/unison.vim
@@ -64,6 +64,7 @@ syn match uBoolean "\<\(true\|false\)\>"
 
 syn match uType "\<\C[A-Z][0-9A-Za-z_'!]*\>"
 syn match uName "\<\C[a-z_][0-9A-Za-z_'!]*\>" contains=ALL
+syn match uDef "^\C[A-Za-z_][0-9A-Za-z_'!]*:"
 
 " Comments
 syn match   uLineComment      "---*\([^-!#$%&\*\+./<=>\?@\\^|~].*\)\?$"
@@ -125,6 +126,7 @@ if version >= 508 || !exists("did_u_syntax_inits")
    HiLink       uLineComment                     Comment
    HiLink       uLink                            Type
    HiLink       uName                            Identifier
+   HiLink       uDef                             Typedef
    HiLink       uNumber                          Number
    HiLink       uOperator                        Operator
    HiLink       uPragma                          SpecialComment

--- a/editor-support/vim/syntax/unison.vim
+++ b/editor-support/vim/syntax/unison.vim
@@ -63,7 +63,7 @@ syn match uConditional		"\<\(if\|else\|then\)\>"
 syn match uBoolean "\<\(true\|false\)\>"
 
 syn match uType "\<\C[A-Z][0-9A-Za-z_'!]*\>"
-syn match uName "\<\C[a-z_][0-9A-Za-z_'!]*\>"
+syn match uName "\<\C[a-z_][0-9A-Za-z_'!]*\>" contains=ALL
 
 " Comments
 syn match   uLineComment      "---*\([^-!#$%&\*\+./<=>\?@\\^|~].*\)\?$"


### PR DESCRIPTION
Syntax highlighting in vim before:
<img width="658" height="218" alt="image" src="https://github.com/user-attachments/assets/07073996-c2b5-45b0-8c7e-41b41097fdbd" />

Syntax highlighting in vim after:
<img width="678" height="226" alt="image" src="https://github.com/user-attachments/assets/513557ba-351d-45fb-94f3-73449412ba9e" />

The problem was that `uName` group overwrited other groups, not allowing their highlights to be taken into effect.