### PR TITLE
Add `mv` and `rm` command aliases

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -92,3 +92,4 @@ The format for this list: name, GitHub handle
 * Brandon Barker (@bbarker)
 * Manish Bhasin (@xmbhasin)
 * Erik Schnetter (@eschnett)
+* Régis Kuckaertz (@regiskuckaertz)

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -1272,7 +1272,7 @@ renameTerm :: InputPattern
 renameTerm =
   InputPattern
     "move.term"
-    ["rename.term"]
+    ["rename.term", "mv.term"]
     I.Visible
     ( Parameters [("definition to move", exactDefinitionTermQueryArg), ("new location", newNameArg)] $
         Optional [] Nothing
@@ -1286,7 +1286,7 @@ moveAll :: InputPattern
 moveAll =
   InputPattern
     "move"
-    ["rename"]
+    ["rename", "mv"]
     I.Visible
     (Parameters [("definition to move", namespaceOrDefinitionArg), ("new location", newNameArg)] $ Optional [] Nothing)
     "`move foo bar` renames the term, type, and namespace foo to bar."
@@ -1298,7 +1298,7 @@ renameType :: InputPattern
 renameType =
   InputPattern
     "move.type"
-    ["rename.type"]
+    ["rename.type", "mv.type"]
     I.Visible
     (Parameters [("type to move", exactDefinitionTypeQueryArg), ("new location", newNameArg)] $ Optional [] Nothing)
     "`move.type foo bar` renames `foo` to `bar`."
@@ -1311,6 +1311,7 @@ deleteGen ::
   Maybe String -> ParameterType -> String -> ([HQ'.HashQualified (Path.Split Path')] -> DeleteTarget) -> InputPattern
 deleteGen suffix queryCompletionArg target mkTarget =
   let cmd = maybe "delete" ("delete." <>) suffix
+      alias = maybe "rm" ("rm." <>) suffix
       info =
         P.wrapColumn2
           [ ( P.sep
@@ -1334,7 +1335,7 @@ deleteGen suffix queryCompletionArg target mkTarget =
           ]
    in InputPattern
         cmd
-        []
+        [alias]
         I.Visible
         (Parameters [] $ OnePlus ("definition to delete", queryCompletionArg))
         info
@@ -1362,7 +1363,7 @@ deleteProject :: InputPattern
 deleteProject =
   InputPattern
     { patternName = "delete.project",
-      aliases = ["project.delete"],
+      aliases = ["project.delete", "rm.project"],
       visibility = I.Visible,
       params = Parameters [("project to delete", projectNameArg)] $ Optional [] Nothing,
       help =
@@ -1378,7 +1379,7 @@ deleteBranch :: InputPattern
 deleteBranch =
   InputPattern
     { patternName = "delete.branch",
-      aliases = ["branch.delete"],
+      aliases = ["branch.delete", "rm.branch"],
       visibility = I.Visible,
       params = Parameters [("branch to delete", projectBranchNameArg suggestionsConfig)] $ Optional [] Nothing,
       help =
@@ -1539,7 +1540,7 @@ deleteNamespace :: InputPattern
 deleteNamespace =
   InputPattern
     "delete.namespace"
-    []
+    ["rm.namespace"]
     I.Visible
     (Parameters [("namespace to delete", namespaceArg)] $ Optional [] Nothing)
     "`delete.namespace <foo>` deletes the namespace `foo`"
@@ -1549,7 +1550,7 @@ deleteNamespaceForce :: InputPattern
 deleteNamespaceForce =
   InputPattern
     "delete.namespace.force"
-    []
+    ["rm.namespace.force"]
     I.Visible
     (Parameters [("namespace to delete", namespaceArg)] $ Optional [] Nothing)
     ( "`delete.namespace.force <foo>` deletes the namespace `foo`,"
@@ -1567,7 +1568,7 @@ renameBranch :: InputPattern
 renameBranch =
   InputPattern
     "move.namespace"
-    ["rename.namespace"]
+    ["rename.namespace", "mv.namespace"]
     I.Visible
     (Parameters [("namespace to move", namespaceArg), ("new location", newNameArg)] $ Optional [] Nothing)
     "`move.namespace foo bar` renames the path `foo` to `bar`."

--- a/unison-runtime/unison-runtime.cabal
+++ b/unison-runtime/unison-runtime.cabal
@@ -43,8 +43,8 @@ library
       Unison.Runtime
       Unison.Runtime.ANF
       Unison.Runtime.ANF.MurmurHash.Untyped
-      Unison.Runtime.ANF.POp
       Unison.Runtime.ANF.Optimize
+      Unison.Runtime.ANF.POp
       Unison.Runtime.ANF.Rehash
       Unison.Runtime.ANF.Serialize
       Unison.Runtime.ANF.Serialize.CodeV4

--- a/unison-src/transcripts/idempotent/help.md
+++ b/unison-src/transcripts/idempotent/help.md
@@ -163,42 +163,42 @@
   debug.numberedArgs
   Dump the contents of the numbered args state.
 
-  delete
+  delete (or rm)
   `delete foo` removes the term or type name `foo` from the namespace.                
   `delete foo bar` removes the term or type name `foo` and `bar` from the namespace.  
 
-  delete.branch (or branch.delete)
+  delete.branch (or branch.delete, rm.branch)
   `delete.branch foo/bar`  deletes the branch `bar` in the
                            project `foo`
   `delete.branch /bar`     deletes the branch `bar` in the
                            current project
 
-  delete.namespace
+  delete.namespace (or rm.namespace)
   `delete.namespace <foo>` deletes the namespace `foo`
 
-  delete.namespace.force
+  delete.namespace.force (or rm.namespace.force)
   `delete.namespace.force <foo>` deletes the namespace `foo`,deletion will proceed even if other code depends on definitions in foo.
 
-  delete.project (or project.delete)
+  delete.project (or project.delete, rm.project)
   `delete.project foo`  deletes the local project `foo`
 
-  delete.term
+  delete.term (or rm.term)
   `delete.term foo` removes the term name `foo` from the namespace.                
   `delete.term foo bar` removes the term name `foo` and `bar` from the namespace.  
 
-  delete.term.verbose
+  delete.term.verbose (or rm.term.verbose)
   `delete.term.verbose foo` removes the term name `foo` from the namespace.                
   `delete.term.verbose foo bar` removes the term name `foo` and `bar` from the namespace.  
 
-  delete.type
+  delete.type (or rm.type)
   `delete.type foo` removes the type name `foo` from the namespace.                
   `delete.type foo bar` removes the type name `foo` and `bar` from the namespace.  
 
-  delete.type.verbose
+  delete.type.verbose (or rm.type.verbose)
   `delete.type.verbose foo` removes the type name `foo` from the namespace.                
   `delete.type.verbose foo bar` removes the type name `foo` and `bar` from the namespace.  
 
-  delete.verbose
+  delete.verbose (or rm.verbose)
   `delete.verbose foo` removes the term or type name `foo` from the namespace.                
   `delete.verbose foo bar` removes the term or type name `foo` and `bar` from the namespace.  
 
@@ -610,16 +610,16 @@
     * merge /merge-topic-into-main
     * delete.branch /merge-topic-into-main
 
-  move (or rename)
+  move (or rename, mv)
   `move foo bar` renames the term, type, and namespace foo to bar.
 
-  move.namespace (or rename.namespace)
+  move.namespace (or rename.namespace, mv.namespace)
   `move.namespace foo bar` renames the path `foo` to `bar`.
 
-  move.term (or rename.term)
+  move.term (or rename.term, mv.term)
   `move.term foo bar` renames `foo` to `bar`.
 
-  move.type (or rename.type)
+  move.type (or rename.type, mv.type)
   `move.type foo bar` renames `foo` to `bar`.
 
   names


### PR DESCRIPTION
Adds two aliases:

1. `mv`: is accepted everywhere `move` is, `mv.type`, `mv.namespace`, etc
3. `rm`: is accepted everywhere `delete` is

In my long experience writing Unison (2 days), tab completion has worked really well, with the exception of `move` and `delete`. I often type `mv` instead of `mo` and have had to backtrack, and I never think about `delete`.

<img width="692" height="108" alt="image" src="https://github.com/user-attachments/assets/c6c02576-3e15-4d3f-a1da-c79473e57ee0" />

<img width="692" height="179" alt="image" src="https://github.com/user-attachments/assets/0874b05d-3967-465d-bc88-81b2f8a2ab0e" />

