### PR TITLE
fix new project name rules

### DIFF
--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -200,7 +200,7 @@ main dir welcome ppIds initialInputs runtime sbRuntime codebase serverBaseUrl uc
                   <> P.wrap
                     ( "Please"
                         <> IP.makeExample IP.projectRenameInputPattern []
-                        <> "them using only ASCII letters, numbers, and hyphens, of length 2-40 characters."
+                        <> "them using only ASCII letters, numbers, hyphens, and underscores. (You also can't use the name 'code' or 'p')."
                     )
             ]
 

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -9,6 +9,7 @@ import Control.Lens ((?~))
 import Control.Lens.Lens
 import Crypto.Random qualified as Random
 import Data.IORef
+import Data.List qualified as List
 import Data.List.NonEmpty qualified as NEL
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Text qualified as Text
@@ -190,19 +191,22 @@ main dir welcome ppIds initialInputs runtime sbRuntime codebase serverBaseUrl uc
         pure case invalidProjectNames of
           [] -> []
           _ ->
-            [ Right . CreateMessage . P.warnCallout $
-                P.wrap "We're updating UCM's project naming rules, and these names won’t be supported much longer:"
-                  <> P.newline
-                  <> P.newline
-                  <> P.group (P.commas (map P.prettyProjectName invalidProjectNames))
-                  <> P.newline
-                  <> P.newline
-                  <> P.wrap
-                    ( "Please"
-                        <> IP.makeExample IP.projectRenameInputPattern []
-                        <> "them using only ASCII letters, numbers, hyphens, and underscores. (You also can't use the name 'code' or 'p')."
-                    )
-            ]
+            let isReservedName (into @Text -> name) = name == "code" || name == "p"
+                hasReservedName = isJust (List.find isReservedName invalidProjectNames)
+             in [ Right . CreateMessage . P.warnCallout $
+                    P.wrap "We're updating UCM's project naming rules, and these names won’t be supported much longer:"
+                      <> P.newline
+                      <> P.newline
+                      <> P.group (P.commas (map P.prettyProjectName invalidProjectNames))
+                      <> P.newline
+                      <> P.newline
+                      <> P.wrap
+                        ( "Please"
+                            <> IP.makeExample IP.projectRenameInputPattern []
+                            <> "them using only ASCII letters, numbers, hyphens, and underscores."
+                            <> (if hasReservedName then "(You also can't use the names 'code' or 'p'.)" else mempty)
+                        )
+                ]
 
       let initialState = Cli.loopState0 ppIds
       initialInputsRef <- newIORef $ Welcome.run welcome ++ initialInputs ++ invalidProjectNamesInputs

--- a/unison-core/src/Unison/Project.hs
+++ b/unison-core/src/Unison/Project.hs
@@ -92,7 +92,7 @@ newProjectNameParser = do
   where
     projectSlugParser :: Megaparsec.Parsec Void Text Text.Builder
     projectSlugParser = do
-      name <- Megaparsec.takeWhile1P Nothing \c -> Char.isAscii c || Char.isDigit c || c == '-' || c == '_'
+      name <- Megaparsec.takeWhile1P Nothing \c -> Char.isAsciiLower c || Char.isAsciiUpper c || Char.isDigit c || c == '-' || c == '_'
       when (name == "p" || name == "code") do
         fail ("Project cannot be named 'code' or 'p'")
       pure (Text.Builder.text name)

--- a/unison-core/src/Unison/Project.hs
+++ b/unison-core/src/Unison/Project.hs
@@ -35,7 +35,6 @@ where
 
 import Data.Char qualified as Char
 import Data.Kind (Type)
-import Data.Monoid qualified as Monoid
 import Data.Text qualified as Text
 import Data.Text.Read qualified as Text (decimal)
 import Data.These (These (..))
@@ -91,37 +90,12 @@ newProjectNameParser = do
   hasTrailingSlash <- isJust <$> optional (Megaparsec.char '/')
   pure (UnsafeProjectName (Text.Builder.run (userSlug <> projectSlug)), hasTrailingSlash)
   where
-    -- Github project regular expression: ^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){1,39}$
-    --
-    -- In English: a-z or 0-9, followed by 1-39 repetitions of a-z or 0-9 or hyphen, with the restriction that any
-    -- hyphen must be followed by a-z or 0-9
-    --
-    -- We implement that here, but with parser combinators: a-z or 0-9, followed by 1 or more chunks of [optional
-    -- hyphen followed by 1 or more a-z or 0-9], checking length at the end
     projectSlugParser :: Megaparsec.Parsec Void Text Text.Builder
     projectSlugParser = do
-      firstChar <- Megaparsec.satisfy isAsciiLowerOrDigit
-      chunks <- some ((,) <$> optional (Megaparsec.char '-') <*> Megaparsec.takeWhile1P Nothing isAsciiLowerOrDigit)
-      when (chunksLength chunks > 39) (fail "Project name must be 2-40 characters long.")
-      pure $
-        Text.Builder.char firstChar
-          <> foldMap
-            ( \(maybeHyphen, chunk) ->
-                maybe (mempty @Text.Builder) Text.Builder.char maybeHyphen <> Text.Builder.text chunk
-            )
-            chunks
-      where
-        isAsciiLowerOrDigit :: Char -> Bool
-        isAsciiLowerOrDigit c =
-          Char.isAsciiLower c || Char.isDigit c
-
-        chunksLength :: [(Maybe Char, Text)] -> Int
-        chunksLength =
-          Monoid.getSum . foldMap (Monoid.Sum . chunkLength)
-
-        chunkLength :: (Maybe Char, Text) -> Int
-        chunkLength (maybeHyphen, chunk) =
-          (if isJust maybeHyphen then 1 else 0) + Text.length chunk
+      name <- Megaparsec.takeWhile1P Nothing \c -> Char.isAscii c || Char.isDigit c || c == '-' || c == '_'
+      when (name == "p" || name == "code") do
+        fail ("Project cannot be named 'code' or 'p'")
+      pure (Text.Builder.text name)
 
 isValidNewProjectName :: ProjectName -> Bool
 isValidNewProjectName (UnsafeProjectName projectName) =


### PR DESCRIPTION
## Overview

New project name rules: 1+ characters in the set {ascii letter, digit, `-`, `_`}. Can't be `p` or `code`.