### PR TITLE
Fix `use` insertion when `do` block starts with destructuring bind

### DIFF
--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -1340,8 +1340,9 @@ suffixCounterType n used = \case
 
 printAnnotate :: (HasCallStack, Var v, Ord v) => PrettyPrintEnv -> Term2 v at ap v a -> Term3 v PrintAnnotation
 printAnnotate n tm =
-  fmap snd (go (reannotateUp (suffixCounterTerm n usedTermNames usedTypeNames) tm))
+  fmap snd (go annotated)
   where
+    annotated = reannotateUp (suffixCounterTerm n usedTermNames usedTypeNames) tm
     -- See `countHQ` to see how these are used to make sure that
     -- a `use` clause doesn't introduce shadowing of a local variable
     usedTermNames =
@@ -1351,6 +1352,23 @@ printAnnotate n tm =
     varToName = toList . Name.parseText . Var.name . Var.reset
     go :: (Ord v) => Term2 v at ap v b -> Term2 v () () v b
     go = extraMap' id (const ()) (const ())
+    isLiteral :: Term2 v at ap v a -> Bool
+    isLiteral (Bytes' _) = True
+    isLiteral _ = False
+    reannotateUp g t = case ABT.out t of
+      ABT.Var v -> ABT.annotatedVar (annotation t, g t) v
+      ABT.Cycle body ->
+        let body' = reannotateUp g body
+        in ABT.cycle' (annotation t, snd (annotation body')) body'
+      ABT.Abs v body ->
+        let body' = reannotateUp g body
+        in ABT.abs' (annotation t, snd (annotation body')) v body'
+      ABT.Tm body ->
+        -- literals like 0xsaaff don't contribute to the annotations
+        -- even though they desugar to function calls
+        let body' = reannotateUp g <$> body
+            ann = if isLiteral t then mempty else g t <> foldMap (snd . annotation) body'
+        in ABT.tm' (annotation t, ann) body'
 
 countTypeUsages :: (Var v, Ord v) => PrettyPrintEnv -> Set Name -> Type v a -> PrintAnnotation
 countTypeUsages n usedTy t = snd $ annotation $ reannotateUp (suffixCounterType n usedTy) t
@@ -1889,10 +1907,10 @@ unLamsMatch' t = case unLamsUntilDelay' t of
           rhsVars = ABT.freeVars rhs
        in Set.union guardVars rhsVars
 
-pattern Bytes' :: [Word64] -> Term3 v PrintAnnotation
+pattern Bytes' :: [Word64] -> Term2 v at ap v a
 pattern Bytes' bs <- (toBytes -> Just bs)
 
-toBytes :: Term3 v PrintAnnotation -> Maybe [Word64]
+toBytes :: Term2 v at ap v a -> Maybe [Word64]
 toBytes (App' (Builtin' "Bytes.fromList") (List' bs)) =
   toList <$> traverse go bs
   where

--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -317,24 +317,23 @@ pretty0
                         <> fmt S.ControlKeyword "with"
                           `hangHandler` ph
                     ]
-          Delay' x
-            | Match' _ _ <- x -> do
-                px <- pretty0 (ac Annotation Block im doc) x
-                let hang = if isSoftHangable x then PP.softHang else PP.hang
-                pure . paren (p > Control) $
-                  fmt S.ControlKeyword "do" `hang` px
-            | otherwise -> do
-                let (im0', uses0) = calcImports im x
-                let allowUses = isLet x || (p == Bottom)
-                let im' = if allowUses then im0' else im
-                let uses = if allowUses then uses0 else []
-                let soft = isSoftHangable x && null uses && p < Annotation
-                let hang = if soft then PP.softHang else PP.hang
-                px <- pretty0 (ac Annotation Block im' doc) x
-                -- this makes sure we get proper indentation if `px` spills onto
-                -- multiple lines, since `do` introduces layout block
-                let indent = PP.Width (if soft then 2 else 0) + (if soft && p < Application then 1 else 0)
-                pure . paren (p > Control) $
+          Delay' x@(Match' scrutinee cs) | not (isDestructuringBind scrutinee cs) -> do
+            px <- pretty0 (ac Annotation Block im doc) x
+            let hang = if isSoftHangable x then PP.softHang else PP.hang
+            pure . paren (p > Control) $
+              fmt S.ControlKeyword "do" `hang` px
+          Delay' x -> do 
+            let (im0', uses0) = calcImports im x
+            let allowUses = isLet x || (p == Bottom)
+            let im' = if allowUses then im0' else im
+            let uses = if allowUses then uses0 else []
+            let soft = isSoftHangable x && null uses && p < Annotation
+            let hang = if soft then PP.softHang else PP.hang
+            px <- pretty0 (ac Annotation Block im' doc) x
+            -- this makes sure we get proper indentation if `px` spills onto
+            -- multiple lines, since `do` introduces layout block
+            let indent = PP.Width (if soft then 2 else 0) + (if soft && p < Application then 1 else 0)
+            pure . paren (p > Control) $
                   fmt S.ControlKeyword "do" `hang` PP.lines (uses <> [PP.indentNAfterNewline indent px])
           List' xs -> do
             let listLink p = fmt (S.TypeReference Type.listRef) p
@@ -1628,9 +1627,10 @@ isSoftHangable (LamsNamedMatch' [] _) = True
 isSoftHangable (Match' scrute cases) = not (isDestructuringBind scrute cases)
 isSoftHangable _ = False
 
-isLet :: Term2 vt at ap v a -> Bool
+isLet :: (Ord v) => Term2 vt at ap v a -> Bool
 isLet (Let1Named' {}) = True
 isLet (LetRecNamed' {}) = True
+isLet (Match' scrutinee cs) = isDestructuringBind scrutinee cs
 isLet _ = False
 
 -- Matches with a single case, no variable shadowing, and where the pattern

--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -317,14 +317,17 @@ pretty0
                         <> fmt S.ControlKeyword "with"
                           `hangHandler` ph
                     ]
-          Delay' x@(Match' scrutinee cs) | not (isDestructuringBind scrutinee cs) -> do
-            px <- pretty0 (ac Annotation Block im doc) x
-            let hang = if isSoftHangable x then PP.softHang else PP.hang
-            pure . paren (p > Control) $
-              fmt S.ControlKeyword "do" `hang` px
+          Delay' x@(Match' scrutinee cs) 
+            | not (isDestructuringBind scrutinee cs) -> do
+              px <- pretty0 (ac Annotation Block im doc) x
+              let hang = if isSoftHangable x then PP.softHang else PP.hang
+              pure . paren (p > Control) $
+                fmt S.ControlKeyword "do" `hang` px
           Delay' x -> do
             let (im0', uses0) = calcImports im x
-            let allowUses = isLet x || (p == Bottom)
+            let allowUses = isLet x || (p == Bottom) || isDestructure x
+                  where isDestructure (Match' scrutinee cs) = isDestructuringBind scrutinee cs 
+                        isDestructure _ = False
             let im' = if allowUses then im0' else im
             let uses = if allowUses then uses0 else []
             let soft = isSoftHangable x && null uses && p < Annotation
@@ -1615,6 +1618,7 @@ immediateChildBlockTerms = \case
     --   x =
     --    use Nat +
     --    1 + 1
+    doLet2 (_, LamsNamedMatch' _ _) = []
     doLet2 (v, LamsNamedOpt' _ body) = [body | not (Var.isAction v), isLet body]
     doLet2 t = error (show t) []
 
@@ -1630,7 +1634,6 @@ isSoftHangable _ = False
 isLet :: (Ord v) => Term2 vt at ap v a -> Bool
 isLet (Let1Named' {}) = True
 isLet (LetRecNamed' {}) = True
-isLet (Match' scrutinee cs) = isDestructuringBind scrutinee cs
 isLet _ = False
 
 -- Matches with a single case, no variable shadowing, and where the pattern

--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -1619,7 +1619,6 @@ immediateChildBlockTerms = \case
     --   x =
     --    use Nat +
     --    1 + 1
-    doLet2 (_, LamsNamedMatch' _ _) = []
     doLet2 (v, LamsNamedOpt' _ body) = [body | not (Var.isAction v), isLet body]
     doLet2 t = error (show t) []
 
@@ -1632,7 +1631,7 @@ isSoftHangable (LamsNamedMatch' [] _) = True
 isSoftHangable (Match' scrute cases) = not (isDestructuringBind scrute cases)
 isSoftHangable _ = False
 
-isLet :: (Ord v) => Term2 vt at ap v a -> Bool
+isLet :: Term2 vt at ap v a -> Bool
 isLet (Let1Named' {}) = True
 isLet (LetRecNamed' {}) = True
 isLet _ = False

--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -322,7 +322,7 @@ pretty0
             let hang = if isSoftHangable x then PP.softHang else PP.hang
             pure . paren (p > Control) $
               fmt S.ControlKeyword "do" `hang` px
-          Delay' x -> do 
+          Delay' x -> do
             let (im0', uses0) = calcImports im x
             let allowUses = isLet x || (p == Bottom)
             let im' = if allowUses then im0' else im
@@ -334,7 +334,7 @@ pretty0
             -- multiple lines, since `do` introduces layout block
             let indent = PP.Width (if soft then 2 else 0) + (if soft && p < Application then 1 else 0)
             pure . paren (p > Control) $
-                  fmt S.ControlKeyword "do" `hang` PP.lines (uses <> [PP.indentNAfterNewline indent px])
+              fmt S.ControlKeyword "do" `hang` PP.lines (uses <> [PP.indentNAfterNewline indent px])
           List' xs -> do
             let listLink p = fmt (S.TypeReference Type.listRef) p
             let comma = listLink ", " `PP.orElse` ("\n" <> listLink ", ")

--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -1359,16 +1359,16 @@ printAnnotate n tm =
       ABT.Var v -> ABT.annotatedVar (annotation t, g t) v
       ABT.Cycle body ->
         let body' = reannotateUp g body
-        in ABT.cycle' (annotation t, snd (annotation body')) body'
+         in ABT.cycle' (annotation t, snd (annotation body')) body'
       ABT.Abs v body ->
         let body' = reannotateUp g body
-        in ABT.abs' (annotation t, snd (annotation body')) v body'
+         in ABT.abs' (annotation t, snd (annotation body')) v body'
       ABT.Tm body ->
         -- literals like 0xsaaff don't contribute to the annotations
         -- even though they desugar to function calls
         let body' = reannotateUp g <$> body
             ann = if isLiteral t then mempty else g t <> foldMap (snd . annotation) body'
-        in ABT.tm' (annotation t, ann) body'
+         in ABT.tm' (annotation t, ann) body'
 
 countTypeUsages :: (Var v, Ord v) => PrettyPrintEnv -> Set Name -> Type v a -> PrintAnnotation
 countTypeUsages n usedTy t = snd $ annotation $ reannotateUp (suffixCounterType n usedTy) t

--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -317,17 +317,18 @@ pretty0
                         <> fmt S.ControlKeyword "with"
                           `hangHandler` ph
                     ]
-          Delay' x@(Match' scrutinee cs) 
+          Delay' x@(Match' scrutinee cs)
             | not (isDestructuringBind scrutinee cs) -> do
-              px <- pretty0 (ac Annotation Block im doc) x
-              let hang = if isSoftHangable x then PP.softHang else PP.hang
-              pure . paren (p > Control) $
-                fmt S.ControlKeyword "do" `hang` px
+                px <- pretty0 (ac Annotation Block im doc) x
+                let hang = if isSoftHangable x then PP.softHang else PP.hang
+                pure . paren (p > Control) $
+                  fmt S.ControlKeyword "do" `hang` px
           Delay' x -> do
             let (im0', uses0) = calcImports im x
             let allowUses = isLet x || (p == Bottom) || isDestructure x
-                  where isDestructure (Match' scrutinee cs) = isDestructuringBind scrutinee cs 
-                        isDestructure _ = False
+                  where
+                    isDestructure (Match' scrutinee cs) = isDestructuringBind scrutinee cs
+                    isDestructure _ = False
             let im' = if allowUses then im0' else im
             let uses = if allowUses then uses0 else []
             let soft = isSoftHangable x && null uses && p < Annotation

--- a/unison-src/transcripts-round-trip/main.output.md
+++ b/unison-src/transcripts-round-trip/main.output.md
@@ -817,8 +817,9 @@ UUID.random = do UUUID 0 (0, 0)
 
 UUID.randomUUIDBytes : 'Bytes
 UUID.randomUUIDBytes = do
+  use Bytes ++
   (UUUID a (b, _)) = random()
-  encodeNat64be a Bytes.++ encodeNat64be b
+  encodeNat64be a ++ encodeNat64be b
 
 (|>) : a -> (a ->{e} b) ->{e} b
 a |> f = f a

--- a/unison-src/transcripts/idempotent/fix-do-destructure.md
+++ b/unison-src/transcripts/idempotent/fix-do-destructure.md
@@ -11,12 +11,38 @@ example = do
   use foo ++
   (x, y) = ("hi", "there")
   x ++ y ++ "z" ++ "a" ++ "b" ++ "c"
+
+example2 =
+  use foo ++
+  (x, y) = ("hi", "there")
+  x ++ y ++ "z" ++ "a" ++ "b" ++ "c"
+
+blah : [a] -> Text 
+blah =
+  use foo ++
+  go = cases
+    (a1, a2) ->
+      cases
+        [] -> "finished" 
+        x +: xs -> "hi" ++ "bye" ++ "yay" ++ "nay"
+  go ([], [])
+
+blah2 : [a] -> Text 
+blah2 =
+  use foo ++
+  go a1 a2 = cases
+        [] -> "finished" 
+        x +: xs -> "hi" ++ "bye" ++ "yay" ++ "nay"
+  go [] []
 ```
 
 ``` ucm :added-by-ucm
   Loading changes detected in scratch.u.
 
+  + blah       : [a] -> Text
+  + blah2      : [a] -> Text
   + example    : 'Text
+  + example2   : Text
   + (foo.++)   : a -> b -> Text
   + (zoink.++) : a -> b -> ()
 
@@ -31,10 +57,34 @@ example = do
 
   Done.
 
-> view example
+> view example example2 blah blah2
+
+  blah : [a] -> Text
+  blah =
+    use foo ++
+    go = cases
+      (a1, a2) ->
+        cases
+          []      -> "finished"
+          x +: xs -> "hi" ++ "bye" ++ "yay" ++ "nay"
+    go ([], [])
+
+  blah2 : [a] -> Text
+  blah2 =
+    use foo ++
+    go a1 a2 = cases
+      []      -> "finished"
+      x +: xs -> "hi" ++ "bye" ++ "yay" ++ "nay"
+    go [] []
 
   example : 'Text
   example = do
+    use foo ++
+    (x, y) = ("hi", "there")
+    x ++ y ++ "z" ++ "a" ++ "b" ++ "c"
+
+  example2 : Text
+  example2 =
     use foo ++
     (x, y) = ("hi", "there")
     x ++ y ++ "z" ++ "a" ++ "b" ++ "c"

--- a/unison-src/transcripts/idempotent/fix-do-destructure.md
+++ b/unison-src/transcripts/idempotent/fix-do-destructure.md
@@ -1,0 +1,41 @@
+``` ucm :hide
+> builtins.merge
+```
+
+``` unison
+a zoink.++ b = ()
+
+a foo.++ b = "abracadabra"
+
+example = do 
+  use foo ++
+  (x, y) = ("hi", "there")
+  x ++ y ++ "z" ++ "a" ++ "b" ++ "c"
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  + example    : 'Text
+  + (foo.++)   : a -> b -> Text
+  + (zoink.++) : a -> b -> ()
+
+  Run `update` to apply these changes to your codebase.
+```
+
+``` ucm
+> add
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+
+> view example
+
+  example : 'Text
+  example = do
+    use foo ++
+    (x, y) = ("hi", "there")
+    x ++ y ++ "z" ++ "a" ++ "b" ++ "c"
+```

--- a/unison-src/transcripts/pretty-print-libraries.output.md
+++ b/unison-src/transcripts/pretty-print-libraries.output.md
@@ -4623,7 +4623,6 @@ abilities.Random.splits.bytes = Random.splits Bytes.size Bytes.splitAt
 
 abilities.Random.splits.bytes.doc : Doc
 abilities.Random.splits.bytes.doc =
-  use fromList impl
   {{
   `` splits.bytes chunkCount bytes `` splits `bytes` into `chunkCount` chunks
   of uniformly-distributed size.
@@ -6289,7 +6288,6 @@ bug.impossible.doc = {{ Handler for exceptions that shouldn't happen. }}
 Bytes.++.doc : Doc
 Bytes.++.doc =
   use Bytes ++
-  use fromList impl
   {{
   Append two {type Bytes} values.
   
@@ -6317,7 +6315,6 @@ Bytes.at.doc : Doc
 Bytes.at.doc =
   use Bytes at
   use Optional flatten
-  use fromList impl
   {{
   Returns the byte at the given index in the {type Bytes} value, as a
   {type Nat}.
@@ -6488,7 +6485,6 @@ Bytes.constantTimeEqual b1 b2 =
 
 Bytes.constantTimeEqual.doc : Doc
 Bytes.constantTimeEqual.doc =
-  use fromList impl
   {{
   Like {===} but examines every byte of both inputs even if an earlier byte
   doesn't match. Used to avoid timing attacks when (say) verifying an {hmac}.
@@ -6514,7 +6510,6 @@ test> Bytes.constantTimeEqual.tests = test.verify do
 
 Bytes.decodeNat16be.doc : Doc
 Bytes.decodeNat16be.doc =
-  use fromList impl
   {{
   Decodes a {type Nat} from the first two bytes of a {type Bytes} value in
   big-endian order. Returns a pair containing the decoded {type Nat} and the
@@ -6553,7 +6548,6 @@ Bytes.decodeNat16be.doc =
 
 Bytes.decodeNat16le.doc : Doc
 Bytes.decodeNat16le.doc =
-  use fromList impl
   {{
   Decodes a {type Nat} from the first two bytes of a {type Bytes} value in
   little-endian order. Returns a pair containing the decoded {type Nat} and the
@@ -6602,7 +6596,6 @@ Bytes.decodeNat16sbe n bs =
 
 Bytes.decodeNat16sbe.doc : Doc
 Bytes.decodeNat16sbe.doc =
-  use fromList impl
   {{
   Decodes **at most** a given number of 16-bit unsigned integers in big-endian
   order from the given {type Bytes} and returns them as a list of {type Nat}
@@ -6627,7 +6620,6 @@ Bytes.decodeNat16sbe.doc =
 
 Bytes.decodeNat32be.doc : Doc
 Bytes.decodeNat32be.doc =
-  use fromList impl
   {{
   Decodes a {type Nat} from the first four bytes of a {type Bytes} value in
   big-endian order. Returns a pair containing the decoded {type Nat} and the
@@ -6666,7 +6658,6 @@ Bytes.decodeNat32be.doc =
 
 Bytes.decodeNat32le.doc : Doc
 Bytes.decodeNat32le.doc =
-  use fromList impl
   {{
   Decodes a {type Nat} from the first four bytes of a {type Bytes} value in
   little-endian order. Returns a pair containing the decoded {type Nat} and the
@@ -6715,7 +6706,6 @@ Bytes.decodeNat32sbe n bs =
 
 Bytes.decodeNat32sbe.doc : Doc
 Bytes.decodeNat32sbe.doc =
-  use fromList impl
   {{
   Decodes **at most** a given number of 32-bit unsigned integers in big-endian
   order from the given {type Bytes} and returns them as a list of {type Nat}
@@ -6740,7 +6730,6 @@ Bytes.decodeNat32sbe.doc =
 
 Bytes.decodeNat64be.doc : Doc
 Bytes.decodeNat64be.doc =
-  use fromList impl
   {{
   Decodes a {type Nat} from the first eight bytes of a {type Bytes} value in
   big-endian order. Returns a pair containing the decoded {type Nat} and the
@@ -6779,7 +6768,6 @@ Bytes.decodeNat64be.doc =
 
 Bytes.decodeNat64le.doc : Doc
 Bytes.decodeNat64le.doc =
-  use fromList impl
   {{
   Decodes a {type Nat} from the first eight bytes of a {type Bytes} value in
   little-endian order. Returns a pair containing the decoded {type Nat} and the
@@ -6828,7 +6816,6 @@ Bytes.decodeNat64sbe n bs =
 
 Bytes.decodeNat64sbe.doc : Doc
 Bytes.decodeNat64sbe.doc =
-  use fromList impl
   {{
   Decodes **at most** a given number of 64-bit unsigned integers in big-endian
   order from the given {type Bytes} and returns them as a list of {type Nat}
@@ -6853,7 +6840,6 @@ Bytes.doc : Doc
 Bytes.doc =
   use Bytes ++
   use Text toUtf8
-  use fromList impl
   {{
   {type Bytes} is a type of in-memory data represented as strings of bytes.
   
@@ -7080,7 +7066,6 @@ Bytes.doc =
 Bytes.drop.doc : Doc
 Bytes.drop.doc =
   use Bytes drop
-  use fromList impl
   {{
   `` drop n b `` returns the {type Bytes} `b` with the first `n` bytes removed.
   
@@ -7605,7 +7590,6 @@ Bytes.fromList.doc =
 
 Bytes.gzip.compress.doc : Doc
 Bytes.gzip.compress.doc =
-  use fromList impl
   use gzip compress
   {{
   Compresses a {type Bytes} value using the
@@ -7693,7 +7677,6 @@ Bytes.isEmpty bs =
 Bytes.isEmpty.doc : Doc
 Bytes.isEmpty.doc =
   use Bytes isEmpty
-  use fromList impl
   {{
   Returns `` true `` if the {type Bytes} is empty.
   
@@ -7725,7 +7708,6 @@ Bytes.shiftLeft n bs =
 Bytes.shiftLeft.doc : Doc
 Bytes.shiftLeft.doc =
   use Bytes shiftLeft
-  use fromList impl
   {{
   `` shiftLeft n bs `` shifts all the {type Bytes} `bs` left by `n` bits, where
   `n` is at most ``8``. Passing `n` larger than `` 8 `` will have the same
@@ -7759,7 +7741,6 @@ Bytes.shiftRight n bs =
 Bytes.shiftRight.doc : Doc
 Bytes.shiftRight.doc =
   use Bytes shiftRight
-  use fromList impl
   {{
   `` shiftRight n bs `` shifts all the {type Bytes} `bs` right by `n` bits,
   where `n` is at most ``8``. Passing `n` larger than `` 8 `` will have the
@@ -7785,7 +7766,6 @@ Bytes.shiftRight.doc =
 Bytes.size.doc : Doc
 Bytes.size.doc =
   use Bytes size
-  use fromList impl
   {{
   Returns the number of bytes in the given {type Bytes}.
   
@@ -7806,7 +7786,6 @@ Bytes.splitAt index bytes = (Bytes.take index bytes, Bytes.drop index bytes)
 Bytes.splitAt.doc : Doc
 Bytes.splitAt.doc =
   use Bytes splitAt
-  use fromList impl
   {{
   `` splitAt index bytes `` splits the provided bytes into two pieces at the
   given index. The length of the first piece will be the given index, and the
@@ -7845,7 +7824,6 @@ Bytes.splitAt.doc =
 
 test> Bytes.splitAt.tests = 
   test.verify do
-    use fromList impl
     (index, expected) =
       each
         [ (1, (0xsc0, 0xsdecafe))
@@ -7860,7 +7838,6 @@ test> Bytes.splitAt.tests =
 Bytes.take.doc : Doc
 Bytes.take.doc =
   use Bytes take
-  use fromList impl
   {{
   `` take n b `` returns the first `n` bytes of `b`.
   
@@ -7886,7 +7863,6 @@ Bytes.take.doc =
 Bytes.toBase16.doc : Doc
 Bytes.toBase16.doc =
   use Bytes toBase16
-  use fromList impl
   {{
   Transforms {type Bytes} to their hexadecimal representation in the ASCII
   character set. See also {toBase16.text} if you'd like to convert directly to
@@ -7903,7 +7879,6 @@ Bytes.toBase16.doc =
 
 Bytes.toBase32.doc : Doc
 Bytes.toBase32.doc =
-  use fromList impl
   {{
   Transforms {type Bytes} to their representation in the
   [RFC 4648 base32 alphabet](https://en.wikipedia.org/wiki/Base32#RFC_4648_Base32_alphabet).
@@ -7972,7 +7947,6 @@ Bytes.toBase32Hex.text.doc =
 
 Bytes.toBase64.doc : Doc
 Bytes.toBase64.doc =
-  use fromList impl
   {{
   Transforms {type Bytes} to their representation in the
   [RFC 4648 base64 alphabet](https://en.wikipedia.org/wiki/Base64).
@@ -8051,7 +8025,6 @@ Bytes.toNat64sbe bs =
 
 Bytes.toNat64sbe.doc : Doc
 Bytes.toNat64sbe.doc =
-  use fromList impl
   {{
   Decodes a list of {type Nat}s in
   [big-endian](https://en.wikipedia.org/wiki/Endianness) order from
@@ -8099,7 +8072,6 @@ Bytes.truncateLeft n =
 
 Bytes.truncateLeft.doc : Doc
 Bytes.truncateLeft.doc =
-  use fromList impl
   {{
   `` truncateLeft n bs `` truncates the {type Bytes} `bs` to `n` bits, counting
   from the left.
@@ -8143,7 +8115,6 @@ Bytes.truncateRight n bs =
 
 Bytes.truncateRight.doc : Doc
 Bytes.truncateRight.doc =
-  use fromList impl
   {{
   `` truncateRight n bs `` truncates the {type Bytes} `bs` to `n` bits,
   counting from the right.
@@ -10150,7 +10121,6 @@ crypto.Ed25519.sign = cases
 
 crypto.Ed25519.sign.doc : Doc
 crypto.Ed25519.sign.doc =
-  use fromList impl
   {{
   Signs a message with an Ed25519 key pair and returns the signature.
   
@@ -10198,7 +10168,6 @@ crypto.Ed25519.verify.doc =
   use Ed25519.PublicKey PublicKey
   use Ed25519.Signature Signature
   use Text toUtf8
-  use fromList impl
   {{
   Verifies an Ed25519 signature on a message.
   
@@ -10422,7 +10391,6 @@ crypto.HashAlgorithm.Sha3_512.doc =
 
 crypto.hashBytes.doc : Doc
 crypto.hashBytes.doc =
-  use fromList impl
   {{
   `` hashBytes algo bs `` hashes bytes using
   {{ docExample 1 do algo -> (algo : HashAlgorithm) }}.
@@ -10662,7 +10630,6 @@ crypto.Rsa.sign.doc =
   use Rsa.PrivateKey PrivateKey
   use Rsa.PublicKey PublicKey
   use Text toUtf8
-  use fromList impl
   {{
   Signs a message with an RSA private key and returns the signature.
   
@@ -10707,7 +10674,6 @@ crypto.Rsa.sign.doc =
 
 test> crypto.Rsa.sign.test = 
   test.verify do
-    use fromList impl
     actual = 
       catch do
         private =
@@ -10746,7 +10712,6 @@ crypto.Rsa.verify.doc =
   use Rsa.PrivateKey PrivateKey
   use Rsa.PublicKey PublicKey
   use Text toUtf8
-  use fromList impl
   {{
   Verifies an RSA signature on a message.
   
@@ -10793,7 +10758,6 @@ crypto.Rsa.verify.doc =
 test> crypto.Rsa.verify.test = 
   test.verify do
     use Text toUtf8
-    use fromList impl
     result = 
       catch do
         private =
@@ -13337,7 +13301,6 @@ data.ByteArray.++.doc =
 data.ByteArray.append.doc : Doc
 data.ByteArray.append.doc =
   use ByteArray fromBytes
-  use fromList impl
   {{
   Constructs a new {type data.ByteArray} with the contents of both the given
   {type data.ByteArray}s, in order.
@@ -14052,7 +14015,6 @@ data.ByteArray.Raw.read8.doc : Doc
 data.ByteArray.Raw.read8.doc =
   use Raw fromBytes
   use data.ByteArray.Raw read8
-  use fromList impl
   {{
   Reads an 8-bit unsigned integer from the given raw byte array at the given
   index, returning it as a {type Nat}. Throws an {type ArrayFailure}
@@ -55969,7 +55931,6 @@ IO.concurrent.STM.TMap.contains b m = isSome (TMap.lookup b m)
 IO.concurrent.STM.TMap.contains.doc : Doc
 IO.concurrent.STM.TMap.contains.doc =
   use TMap contains insert
-  use fromList impl
   {{
   `` contains key t `` returns `` true `` if the key is found and `` false ``
   otherwise.
@@ -56015,7 +55976,6 @@ IO.concurrent.STM.TMap.delete b tm =
 IO.concurrent.STM.TMap.delete.doc : Doc
 IO.concurrent.STM.TMap.delete.doc =
   use TMap delete
-  use fromList impl
   {{
   `` delete key tm `` deletes a key from `tm`.
   
@@ -56032,7 +55992,6 @@ IO.concurrent.STM.TMap.delete.doc =
 IO.concurrent.STM.TMap.doc : Doc
 IO.concurrent.STM.TMap.doc =
   use TMap empty insert lookup
-  use fromList impl
   {{
   A transactional, very low contention concurrent mutable map, keyed by
   {type Bytes}. If there are many concurrent writes, this will generally be
@@ -56332,7 +56291,6 @@ IO.concurrent.STM.TMap.insert b a m = insert.impl 0 b a m
 IO.concurrent.STM.TMap.insert.doc : Doc
 IO.concurrent.STM.TMap.insert.doc =
   use TMap insert
-  use fromList impl
   {{
   `` insert key v t `` inserts an entry in the map, replacing any existing
   entry that may exist for `key`.
@@ -56380,7 +56338,6 @@ IO.concurrent.STM.TMap.lookup b m =
 IO.concurrent.STM.TMap.lookup.doc : Doc
 IO.concurrent.STM.TMap.lookup.doc =
   use TMap lookup
-  use fromList impl
   {{
   `` lookup key t `` returns {Some} if the key is found and {None} otherwise.
   
@@ -60291,7 +60248,6 @@ IO.net.URI.Path.doc =
 IO.net.URI.Path.encode : Path -> Bytes
 IO.net.URI.Path.encode p =
   use Bytes ++
-  use fromList impl
   foldDelimited (++) encode.segment 0xs2f 0xs2f Bytes.empty (segments p)
 
 IO.net.URI.Path.encode.char : Char -> Text
@@ -66648,7 +66604,6 @@ Nat.fromBytesBigEndian bs = match decodeNat64be bs with
 
 Nat.fromBytesBigEndian.doc : Doc
 Nat.fromBytesBigEndian.doc =
-  use fromList impl
   {{
   Reads a {type Nat} from a {type Bytes}, assuming most significant bytes come
   first.
@@ -66681,7 +66636,6 @@ Nat.fromBytesLittleEndian bs = match decodeNat64le bs with
 
 Nat.fromBytesLittleEndian.doc : Doc
 Nat.fromBytesLittleEndian.doc =
-  use fromList impl
   {{
   Reads a {type Nat} from a {type Bytes}, assuming least significant bytes come
   first.
@@ -67892,7 +67846,6 @@ Nat.toBytesBigEndian.doc =
   }}
 
 test> Nat.toBytesBigEndian.test.ex1 =
-  use fromList impl
   check
     (toBytesBigEndian 255 === 0xs00000000000000ff
       && toBytesBigEndian 65305 === 0xs000000000000ff19
@@ -67929,7 +67882,6 @@ Nat.toBytesLittleEndian.doc =
   }}
 
 test> Nat.toBytesLittleEndian.test.ex1 =
-  use fromList impl
   check
     (toBytesLittleEndian 255 === 0xsff00000000000000
       && toBytesLittleEndian 65305 === 0xs19ff000000000000
@@ -83306,7 +83258,6 @@ Body.decodeBody req getHeaders attach =
 Body.decodeChunkedBody : Boolean ->{Decode} (Body, Headers)
 Body.decodeChunkedBody expectTrailers =
   use Decode failWith label until utf8
-  use fromList impl
   decodeChunkSize : '{Decode} Nat
   decodeChunkSize =
     do
@@ -84888,7 +84839,6 @@ HttpRequest.encodeNoBody : proxy.ProxyPresence -> HttpRequest -> Bytes
 HttpRequest.encodeNoBody proxyPresence req =
   use Bytes ++
   use Headers orElse
-  use fromList impl
   (HttpRequest method version uri headers body) = req
   headers' =
     orElse (forURI uri) (standard.contentLength body) |> orElse headers
@@ -85484,7 +85434,6 @@ test> HttpResponse.encodeChunked.tests.withTrailers =
 HttpResponse.encodeNoBody : HttpResponse -> Bytes
 HttpResponse.encodeNoBody = cases
   HttpResponse (Status code reason) version headers body ->
-    use fromList impl
     headers' =
       if Headers.contains "Content-Length" headers then headers
       else Headers.union headers (standard.contentLength body)
@@ -85674,7 +85623,6 @@ LICENSE.doc = License.toDoc LICENSE
 
 message.encodeChunkedBody : '{g, Stream Bytes} Headers ->{g, Stream Bytes} ()
 message.encodeChunkedBody =
-  use fromList impl
   emitChunk : Bytes ->{Stream Bytes} ()
   emitChunk chunk =
     use Bytes ++
@@ -87107,7 +87055,6 @@ websockets.Frame.decoder.maskOrUnmask key payload =
     |> (bs -> unsafeRun! do Bytes.fromList bs)
 
 test> websockets.Frame.decoder.tests.fragmentedContinuation =
-  use fromList impl
   check
     ((toEither do runDecode decoder 0xs80026c6f)
       === Right (Continuation true 0xs6c6f))
@@ -87118,13 +87065,11 @@ test> websockets.Frame.decoder.tests.fragmentedTextUnmasked =
       === Right (Text false "Hel"))
 
 test> websockets.Frame.decoder.tests.ping =
-  use fromList impl
   check
     ((toEither do runDecode decoder 0xs890548656c6c6f)
       === Right (Ping 0xs48656c6c6f))
 
 test> websockets.Frame.decoder.tests.pong =
-  use fromList impl
   check
     ((toEither do runDecode decoder 0xs8a0548656c6c6f)
       === Right (Pong 0xs48656c6c6f))
@@ -87188,7 +87133,6 @@ test> websockets.Frame.encoder.tests.pong =
   check (encoder None (Pong (Text.toUtf8 "Hello")) === 0xs8a0548656c6c6f)
 
 test> websockets.Frame.encoder.tests.singleTextMasked =
-  use fromList impl
   check
     (encoder (Some 0xs37fa213d) (Text true "Hello")
       === 0xs818537fa213d7f9f4d5158)

--- a/unison-src/transcripts/pretty-print-libraries.output.md
+++ b/unison-src/transcripts/pretty-print-libraries.output.md
@@ -7845,6 +7845,7 @@ Bytes.splitAt.doc =
 
 test> Bytes.splitAt.tests = 
   test.verify do
+    use fromList impl
     (index, expected) =
       each
         [ (1, (0xsc0, 0xsdecafe))
@@ -10808,10 +10809,10 @@ test> crypto.Rsa.verify.test =
 data.Array.append : data.Array a -> data.Array a -> data.Array a
 data.Array.append arr1 arr2 = unsafeRun! do
   Scope.run do
-    (Arr off1 len1 raw1) = arr1
-    (Arr off2 len2 raw2) = arr2
     use Nat +
     use data.Array.Raw copyTo!
+    (Arr off1 len1 raw1) = arr1
+    (Arr off2 len2 raw2) = arr2
     m = Scope.Raw.array (len1 + len2)
     copyTo! m 0 raw1 off1 len1
     copyTo! m len1 raw2 off2 len2
@@ -10931,8 +10932,8 @@ data.Array.at!.doc =
 data.Array.cons : a -> data.Array a -> data.Array a
 data.Array.cons x arr = unsafeRun! do
   Scope.run do
-    (Arr off len raw) = arr
     use Nat +
+    (Arr off len raw) = arr
     m = Scope.Raw.array (len + 1)
     data.Array.Raw.copyTo! m 1 raw off len
     Raw.write m 0 x
@@ -11164,8 +11165,8 @@ test> data.Array.firstIndexOf.tests.finds = test.verify do
 data.Array.foldLeft : (a ->{g} b ->{h} a) -> a -> data.Array b ->{g, h} a
 data.Array.foldLeft f acc arr = unsafeRun! do
   Scope.run do
-    (Arr off len raw) = arr
     use Nat + >=
+    (Arr off len raw) = arr
     go n acc =
       if n >= len then acc
       else
@@ -11206,8 +11207,8 @@ data.Array.foldLeft.doc =
 data.Array.foldRight : (a ->{g} b ->{h} b) -> b -> data.Array a ->{g, h} b
 data.Array.foldRight f acc arr = unsafeRun! do
   Scope.run do
-    (Arr off len raw) = arr
     use Nat + - ==
+    (Arr off len raw) = arr
     go n acc =
       if n == 0 then acc
       else
@@ -11638,8 +11639,8 @@ data.Array.slice.doc =
 data.Array.snoc : data.Array a -> a -> data.Array a
 data.Array.snoc arr x = unsafeRun! do
   Scope.run do
-    (Arr off len raw) = arr
     use Nat +
+    (Arr off len raw) = arr
     m = Scope.Raw.array (len + 1)
     data.Array.Raw.copyTo! m 0 raw off len
     Raw.write m len x
@@ -86945,16 +86946,16 @@ test> tests.testHttpResponseRoundTrip = verifyAndIgnore do
   ensureEqual nc (fromBytes false bs3)
 
 test> tests.testParseRequest = verifyAndIgnore do
-  (HttpRequest m v u h b) = HttpRequest.fromStream do emit exampleRequest
   use test ensureEqual
+  (HttpRequest m v u h b) = HttpRequest.fromStream do emit exampleRequest
   ensureEqual 2262 (Bytes.size (Body.toBytes b))
   ensureEqual 11 (data.Map.size (Headers.toMap h))
 
 test> tests.testParseResponse = 
   verifyAndIgnore do
+    use test ensureEqual
     (HttpResponse s v h b) =
       HttpResponse.fromStream false do emit exampleResponse
-    use test ensureEqual
     ensureEqual 2262 (Bytes.size (Body.toBytes b))
     ensureEqual 11 (data.Map.size (Headers.toMap h))
 


### PR DESCRIPTION
Previously, the pretty-printer would fail to insert a `use` clause at the start of a `do` block, if that `do` block began with a destructuring bind. This could sometimes lead to some terrible rendering with chains of operators all showing up with qualified names. 

Here's a minimal example. There are two things called `++`, a `zoink.++` and `foo.++`. Thus, the code must disambiguate with a `use` clause:

```
a zoink.++ b = ()

a foo.++ b = "abracadabra"

example = do 
  use foo ++
  (x, y) = ("hi", "there")
  x ++ y ++ "z" ++ "a" ++ "b" ++ "c"
```

The `use` clause wasn't being used when viewing `example` because the `do` block starts with a `Match`, which isn't typically considered a candidate spot for `use` insertion. But actually, if the `match` happens to be a destructuring bind, putting a `use` clause there is fine.

Here's before and after - 

**Before:**

<img width="1192" height="230" alt="CleanShot 2025-10-01 at 16 10 25@2x" src="https://github.com/user-attachments/assets/cb8b1315-6537-46c1-92d4-b1281de5b715" />

**After:**

<img width="834" height="282" alt="CleanShot 2025-10-01 at 16 10 48@2x" src="https://github.com/user-attachments/assets/37da8ead-69ba-4fbb-a472-457e1d206bfa" />

## Testing

I added a transcript test and it passes all the existing transcript tests.

## Misc

I fixed what ended up being an unrelated bug with `Bytes` literals causing imports of `Bytes.fromList.impl`.