### PR TITLE
Correct `Semi`s when reordering stanzas

### DIFF
--- a/unison-src/transcripts/idempotent/debug-definitions.md
+++ b/unison-src/transcripts/idempotent/debug-definitions.md
@@ -67,7 +67,7 @@ ability Ask a where
   Constructor #0 of the following type:
   EffectDeclaration
       { toDataDecl = DataDeclaration
-          { modifier = Unique "a1ns7cunv2dvjmum0q8jbc54g6811cbh"
+          { modifier = Unique "oe3grapnkl7hmodmhgpat73j697ltvnk"
           , annotation = External
           , bound =
               [ User "a" ]
@@ -80,7 +80,7 @@ ability Ask a where
                           (
                               {
                                   [ ReferenceDerived
-                                      ( Id "d8m1kmiscgfrl5n9ruvq1432lntfntl7nnao45qlk2uqhparm0uq2im0kbspu6u6kv65hd0i5oljq9m4b78peh5ekpma7gkihtsmfh0" 0 )
+                                      ( Id "tl3k480g06phii2dv4mmmsg0bimdounfml8p5om9vdsuhph96344lr1o845fucikf1me2akuqaslnibc26mkhcmiuvmk821k7ghnnjo" 0 )
                                       ( Var User "a" )
                                   ]
                               } Var User "a"
@@ -128,7 +128,7 @@ ability Ask a where
 
   EffectDeclaration
       { toDataDecl = DataDeclaration
-          { modifier = Unique "a1ns7cunv2dvjmum0q8jbc54g6811cbh"
+          { modifier = Unique "oe3grapnkl7hmodmhgpat73j697ltvnk"
           , annotation = External
           , bound =
               [ User "a" ]
@@ -141,7 +141,7 @@ ability Ask a where
                           (
                               {
                                   [ ReferenceDerived
-                                      ( Id "d8m1kmiscgfrl5n9ruvq1432lntfntl7nnao45qlk2uqhparm0uq2im0kbspu6u6kv65hd0i5oljq9m4b78peh5ekpma7gkihtsmfh0" 0 )
+                                      ( Id "tl3k480g06phii2dv4mmmsg0bimdounfml8p5om9vdsuhph96344lr1o845fucikf1me2akuqaslnibc26mkhcmiuvmk821k7ghnnjo" 0 )
                                       ( Var User "a" )
                                   ]
                               } Var User "a"

--- a/unison-src/transcripts/idempotent/fix-686.md
+++ b/unison-src/transcripts/idempotent/fix-686.md
@@ -1,0 +1,77 @@
+`use` statements at the end of a file get reordered to the top, but doing so requires careful handling of virtual semis.
+
+``` unison :bug
+a = ()
+use .base
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I got confused here:
+
+      1 | a = ()
+
+
+  I was surprised to find a = here.
+  I was expecting one of these instead:
+
+  * ability
+  * bang
+  * binding
+  * do
+  * false
+  * force
+  * handle
+  * if
+  * lambda
+  * let
+  * newline or semicolon
+  * quote
+  * termLink
+  * true
+  * tuple
+  * type
+  * typeLink
+```
+
+The same issues occur when a `use` statement gets reordered from the bottom of any block.
+
+``` unison :bug
+a = let
+  x = 3
+  x
+  use .base
+
+b = 3
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I got confused here:
+
+      2 |   x = 3
+
+
+  I was surprised to find a = here.
+  I was expecting one of these instead:
+
+  * bang
+  * binding
+  * do
+  * end of input
+  * false
+  * force
+  * handle
+  * if
+  * lambda
+  * let
+  * newline or semicolon
+  * pattern
+  * quote
+  * termLink
+  * true
+  * tuple
+  * typeLink
+```

--- a/unison-src/transcripts/idempotent/fix-686.md
+++ b/unison-src/transcripts/idempotent/fix-686.md
@@ -1,6 +1,6 @@
 `use` statements at the end of a file get reordered to the top, but doing so requires careful handling of virtual semis.
 
-``` unison :bug
+``` unison
 a = ()
 use .base
 ```
@@ -8,36 +8,14 @@ use .base
 ``` ucm :added-by-ucm
   Loading changes detected in scratch.u.
 
-  I got confused here:
+  + a : ()
 
-      1 | a = ()
-
-
-  I was surprised to find a = here.
-  I was expecting one of these instead:
-
-  * ability
-  * bang
-  * binding
-  * do
-  * false
-  * force
-  * handle
-  * if
-  * lambda
-  * let
-  * newline or semicolon
-  * quote
-  * termLink
-  * true
-  * tuple
-  * type
-  * typeLink
+  Run `update` to apply these changes to your codebase.
 ```
 
 The same issues occur when a `use` statement gets reordered from the bottom of any block.
 
-``` unison :bug
+``` unison
 a = let
   x = 3
   x
@@ -49,29 +27,8 @@ b = 3
 ``` ucm :added-by-ucm
   Loading changes detected in scratch.u.
 
-  I got confused here:
+  + a : ##Nat
+  + b : ##Nat
 
-      2 |   x = 3
-
-
-  I was surprised to find a = here.
-  I was expecting one of these instead:
-
-  * bang
-  * binding
-  * do
-  * end of input
-  * false
-  * force
-  * handle
-  * if
-  * lambda
-  * let
-  * newline or semicolon
-  * pattern
-  * quote
-  * termLink
-  * true
-  * tuple
-  * typeLink
+  Run `update` to apply these changes to your codebase.
 ```

--- a/unison-src/transcripts/idempotent/move-all.md
+++ b/unison-src/transcripts/idempotent/move-all.md
@@ -89,7 +89,7 @@ scratch/main> history Bar
   Note: The most recent namespace hash is immediately below this
         message.
 
-  ⊙ 1. #hk3a3lsc2e
+  ⊙ 1. #3cghtnopgc
 
     + Adds / updates:
     
@@ -99,7 +99,7 @@ scratch/main> history Bar
     
       T.T
 
-  □ 2. #vqc50q3b3v (start of history)
+  □ 2. #b9cgp80aad (start of history)
 ```
 
 ## Happy Path - Just term

--- a/unison-src/transcripts/idempotent/move-namespace.md
+++ b/unison-src/transcripts/idempotent/move-namespace.md
@@ -181,7 +181,7 @@ scratch/happy> history b
   Note: The most recent namespace hash is immediately below this
         message.
 
-  ⊙ 1. #ugqniosnp0
+  ⊙ 1. #oai4e4tpah
 
     + Adds / updates:
     
@@ -191,7 +191,7 @@ scratch/happy> history b
     
       T.T
 
-  □ 2. #a7r726o5ut (start of history)
+  □ 2. #i573phkaer (start of history)
 ```
 
 ## Namespace history

--- a/unison-syntax/src/Unison/Syntax/Lexer/Unison.hs
+++ b/unison-syntax/src/Unison/Syntax/Lexer/Unison.hs
@@ -891,15 +891,18 @@ reorder = foldr fixup [] . sortWith f
       Reserved "namespace" -> 1
       Reserved "use" -> 2
       _ -> 4 :: Int
-    -- after reordering can end up with trailing semicolon at the end of
-    -- a block, which we remove with this pass
-    fixup stanza [] = case Lens.unsnoc stanza of
-      Nothing -> []
-      -- remove any trailing `Semi` from the last non-empty stanza
-      Just (init, Leaf (Token (Semi _) _ _)) -> [init]
-      -- don’t touch other stanzas
-      Just (_, _) -> [stanza]
-    fixup stanza tail = stanza : tail
+    -- after reordering can end up with semicolons in the wrong place, which we correct with this pass
+    fixup stanza tail = case Lens.unsnoc stanza of
+      -- drop empty stanzas
+      Nothing -> tail
+      Just (init, last) -> (: tail) case (last, tail) of
+        -- remove any trailing `Semi` from the last stanza
+        (Leaf (Token (Semi _) _ _), []) -> init
+        -- leave other stanzas alone
+        (Leaf (Token (Semi _) _ _), _) -> stanza
+        (_, []) -> stanza
+        -- add a trailing `Semi` to non-final stanzas without one
+        (_, _) -> Lens.snoc stanza . Leaf . pure $ Semi True
 
 -- | This turns the lexeme stream into a tree, reordering some lexeme subsequences.
 preParse :: [Token Lexeme] -> BlockTree (Token Lexeme)


### PR DESCRIPTION
## Overview

We pull types, ablities, and `use` to the beginning of files and
definitions. But if they occur at the end of a block, they don’t have a
trailing `Semi`. Reordering in that case would create an invalid stanza.

This ensures we add trailing `Semi`s to any stanza not at the end of a
block.

Fixes #686.

## Implementation notes

This drops some empty stanzas that weren’t dropped before, which accounts for the changed hashes in some other tests.

## Test coverage

Adds a new transcript with two known failure cases.