### PR TITLE
add cancel command

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/ProjectBranch.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/ProjectBranch.hs
@@ -16,6 +16,7 @@ data ProjectBranch = ProjectBranch
     branchId :: !ProjectBranchId,
     name :: !ProjectBranchName,
     parentBranchId :: !(Maybe ProjectBranchId),
+    isMerge :: !Bool,
     isUpdate :: !Bool,
     isUpgrade :: !Bool
   }

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -3004,6 +3004,7 @@ loadProjectBranchSql projectId branchId =
       project_branch.branch_id,
       project_branch.name,
       project_branch_parent.parent_branch_id,
+      EXISTS (SELECT 1 FROM merge_branch WHERE project_id = :projectId AND branch_id = :branchId),
       EXISTS (SELECT 1 FROM update_branch WHERE project_id = :projectId AND branch_id = :branchId),
       EXISTS (SELECT 1 FROM upgrade_branch WHERE project_id = :projectId AND branch_id = :branchId)
     FROM
@@ -3016,10 +3017,10 @@ loadProjectBranchSql projectId branchId =
   |]
 
 mungeLoadProjectBranchResult ::
-  (ProjectId, ProjectBranchId, ProjectBranchName, Maybe ProjectBranchId, Bool, Bool) ->
+  (ProjectId, ProjectBranchId, ProjectBranchName, Maybe ProjectBranchId, Bool, Bool, Bool) ->
   ProjectBranch
-mungeLoadProjectBranchResult (projectId, branchId, name, parentBranchId, isUpdate, isUpgrade) =
-  ProjectBranch {projectId, branchId, name, parentBranchId, isUpdate, isUpgrade}
+mungeLoadProjectBranchResult (projectId, branchId, name, parentBranchId, isMerge, isUpdate, isUpgrade) =
+  ProjectBranch {projectId, branchId, name, parentBranchId, isMerge, isUpdate, isUpgrade}
 
 loadProjectBranchByName :: ProjectId -> ProjectBranchName -> Transaction (Maybe ProjectBranch)
 loadProjectBranchByName projectId name = do
@@ -3044,6 +3045,7 @@ loadProjectBranchByName projectId name = do
 
 loadProjectBranchByProjectBranchRow :: ProjectBranchRow -> Transaction ProjectBranch
 loadProjectBranchByProjectBranchRow branch = do
+  isMerge <- projectBranchIsMergeBranch branch.projectId branch.branchId
   isUpdate <- projectBranchIsUpdateBranch branch.projectId branch.branchId
   isUpgrade <- projectBranchIsUpgradeBranch branch.projectId branch.branchId
   pure
@@ -3052,6 +3054,7 @@ loadProjectBranchByProjectBranchRow branch = do
         branchId = branch.branchId,
         name = branch.name,
         parentBranchId = branch.parentBranchId,
+        isMerge,
         isUpdate,
         isUpgrade
       }
@@ -3673,6 +3676,20 @@ loadProjectBranchParent projectId projectBranchId =
       FROM project_branch_parent
       WHERE project_id = :projectId
         AND branch_id = :projectBranchId
+    |]
+
+-- | Get whether or not a project branch is a "merge branch". Returns false if the branch either isn't a merge branch
+-- (likely) or doesn't exist at all (weird).
+projectBranchIsMergeBranch :: ProjectId -> ProjectBranchId -> Transaction Bool
+projectBranchIsMergeBranch projectId branchId =
+  queryOneCol
+    [sql|
+      SELECT EXISTS (
+        SELECT 1
+        FROM merge_branch
+        WHERE project_id = :projectId
+          AND branch_id = :branchId
+      )
     |]
 
 loadMergeBranchParents ::

--- a/unison-cli/src/Unison/Cli/ProjectUtils.hs
+++ b/unison-cli/src/Unison/Cli/ProjectUtils.hs
@@ -212,8 +212,7 @@ resolveProjectBranchInProject :: Project -> ProjectAndBranch (Maybe ProjectName)
 resolveProjectBranchInProject defaultProj (ProjectAndBranch mayProjectName mayBranchName) = do
   let branchName = fromMaybe defaultBranchName mayBranchName
   let projectName = fromMaybe (defaultProj ^. #name) mayProjectName
-  projectAndBranch <- expectProjectAndBranchByTheseNames (These projectName branchName)
-  pure projectAndBranch
+  expectProjectAndBranchByTheseNames (These projectName branchName)
 
 getProjectByName :: ProjectName -> Cli (Maybe Sqlite.Project)
 getProjectByName projectName = do

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -50,6 +50,7 @@ import Unison.Codebase.Editor.HandleInput.Branch (handleBranch)
 import Unison.Codebase.Editor.HandleInput.BranchRename (handleBranchRename)
 import Unison.Codebase.Editor.HandleInput.BranchSquash (handleBranchSquash)
 import Unison.Codebase.Editor.HandleInput.Branches (handleBranches)
+import Unison.Codebase.Editor.HandleInput.Cancel (handleCancel)
 import Unison.Codebase.Editor.HandleInput.CommitMerge (handleCommitMerge)
 import Unison.Codebase.Editor.HandleInput.DebugDefinition qualified as DebugDefinition
 import Unison.Codebase.Editor.HandleInput.DebugFoldRanges qualified as DebugFoldRanges
@@ -758,6 +759,7 @@ loop e = do
         LibInstallLocalI src destLibName -> handleInstallLocalLib src destLibName
         DebugSynhashTermI name -> handleDebugSynhashTerm name
         EditDependentsI name -> handleEditDependents name
+        CancelI -> handleCancel
 
 inputDescription :: Input -> Cli Text
 inputDescription input =
@@ -939,6 +941,7 @@ inputDescription input =
     UpgradeCommitI {} -> wat
     UpgradeI {} -> wat
     VersionI -> wat
+    CancelI -> wat
   where
     p' :: Path' -> Cli Text
     p' = fmap (into @Text) . Cli.resolvePath'

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Cancel.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Cancel.hs
@@ -1,0 +1,23 @@
+module Unison.Codebase.Editor.HandleInput.Cancel
+  ( handleCancel,
+  )
+where
+
+import U.Codebase.Sqlite.ProjectBranch (ProjectBranch (..))
+import Unison.Cli.Monad (Cli)
+import Unison.Cli.Monad qualified as Cli
+import Unison.Cli.MonadUtils qualified as Cli
+import Unison.Codebase.Editor.HandleInput.DeleteBranch (handleDeleteBranch2)
+import Unison.Codebase.Editor.Output qualified as Output
+import Unison.Codebase.ProjectPath (ProjectPathG (..))
+import Unison.Prelude
+import Unison.Project (ProjectAndBranch (..))
+
+handleCancel :: Cli ()
+handleCancel = do
+  current <- Cli.getCurrentProjectPath
+
+  when (not (current.branch.isUpdate || current.branch.isUpgrade || current.branch.isMerge)) do
+    Cli.returnEarly (Output.Literal "There's no merge, update, or upgrade in progress.")
+
+  handleDeleteBranch2 (ProjectAndBranch current.project current.branch)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/DeleteBranch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/DeleteBranch.hs
@@ -1,6 +1,7 @@
 -- | @delete.branch@ input handler
 module Unison.Codebase.Editor.HandleInput.DeleteBranch
   ( handleDeleteBranch,
+    handleDeleteBranch2,
     doDeleteProjectBranch,
   )
 where
@@ -18,7 +19,6 @@ import Unison.Cli.Monad qualified as Cli
 import Unison.Cli.MonadUtils qualified as Cli
 import Unison.Cli.ProjectUtils qualified as ProjectUtils
 import Unison.Codebase qualified as Codebase
-import Unison.Codebase.Editor.HandleInput.ProjectCreate
 import Unison.Codebase.ProjectPath (ProjectPathG (..))
 import Unison.Codebase.SqliteCodebase.Operations qualified as Ops
 import Unison.Core.Project (ProjectBranchName (..), ProjectName (..))
@@ -32,9 +32,15 @@ import Unison.Sqlite qualified as Sqlite
 -- Its children branches, if any, are reparented to their grandparent, if any. You may delete the only branch in a
 -- project.
 handleDeleteBranch :: ProjectAndBranch (Maybe ProjectName) ProjectBranchName -> Cli ()
-handleDeleteBranch projectAndBranchNamesToDelete = do
-  ProjectPath currentProject currentBranch _ <- Cli.getCurrentProjectPath
-  projectAndBranchToDelete@(ProjectAndBranch projectOfBranchToDelete branchToDelete) <- ProjectUtils.resolveProjectBranchInProject currentProject (projectAndBranchNamesToDelete & #branch %~ Just)
+handleDeleteBranch namesToDelete = do
+  current <- Cli.getCurrentProjectPath
+  toDelete <- ProjectUtils.resolveProjectBranchInProject current.project (namesToDelete & #branch %~ Just)
+  handleDeleteBranch2 toDelete
+
+-- | Like 'handleDeleteBranch2', but for when the branch name to delete is already resolved to a branch.
+handleDeleteBranch2 :: ProjectAndBranch Project ProjectBranch -> Cli ()
+handleDeleteBranch2 toDelete = do
+  current <- Cli.getCurrentProjectPath
 
   -- If the user is on the branch that they're deleting, we have to cd somewhere; try these in order:
   --
@@ -42,21 +48,25 @@ handleDeleteBranch projectAndBranchNamesToDelete = do
   --   2. cd to "main", if it exists
   --   3. Any other branch in the codebase
   --   4. Create a new branch in the current project
-  when (branchToDelete ^. #branchId == currentBranch ^. #branchId) do
-    mayNextLocation <-
-      Cli.runTransaction . runMaybeT $
-        asum
-          [ parentBranch (branchToDelete ^. #projectId) (branchToDelete ^. #parentBranchId),
-            findMainBranchInProjectExcept (currentProject ^. #projectId) (branchToDelete ^. #branchId),
-            -- Any branch in the codebase except the one we're deleting
-            findAnyBranchInProjectExcept (branchToDelete ^. #projectId) (branchToDelete ^. #branchId),
-            findAnyBranchInCodebaseExcept (branchToDelete ^. #projectId) (branchToDelete ^. #branchId),
-            createNewBranchInProjectExcept projectOfBranchToDelete.name branchToDelete.name
-          ]
+  when (toDelete.branch.branchId == current.branch.branchId) do
+    nextLocation <-
+      Cli.runTransaction do
+        maybeNextLocation <-
+          runMaybeT $
+            asum
+              [ parentBranch toDelete.branch.projectId toDelete.branch.parentBranchId,
+                findMainBranchInProjectExcept current.project.projectId toDelete.branch.branchId,
+                -- Any branch in the codebase except the one we're deleting
+                findAnyBranchInProjectExcept toDelete.branch.projectId toDelete.branch.branchId,
+                findAnyBranchInCodebaseExcept toDelete.branch.projectId toDelete.branch.branchId
+              ]
+        case maybeNextLocation of
+          Just nextLocation -> pure nextLocation
+          Nothing -> createNewBranchInProjectExcept toDelete.project.name toDelete.branch.name
 
-    nextLoc <- mayNextLocation `whenNothing` projectCreate False Nothing
-    Cli.switchProject nextLoc
-  doDeleteProjectBranch projectAndBranchToDelete
+    Cli.switchProject nextLocation
+
+  doDeleteProjectBranch toDelete
   where
     parentBranch :: ProjectId -> Maybe ProjectBranchId -> MaybeT Sqlite.Transaction (ProjectAndBranch ProjectId ProjectBranchId)
     parentBranch projectId mayParentBranchId = do
@@ -66,8 +76,8 @@ handleDeleteBranch projectAndBranchNamesToDelete = do
     findMainBranchInProjectExcept :: ProjectId -> ProjectBranchId -> MaybeT Sqlite.Transaction (ProjectAndBranch ProjectId ProjectBranchId)
     findMainBranchInProjectExcept projectId exceptBranchId = do
       branch <- MaybeT $ Queries.loadProjectBranchByName projectId defaultBranchName
-      guard (branch ^. #branchId /= exceptBranchId)
-      pure (ProjectAndBranch projectId (branch ^. #branchId))
+      guard (branch.branchId /= exceptBranchId)
+      pure (ProjectAndBranch projectId branch.branchId)
 
     findAnyBranchInProjectExcept :: ProjectId -> ProjectBranchId -> MaybeT Sqlite.Transaction (ProjectAndBranch ProjectId ProjectBranchId)
     findAnyBranchInProjectExcept projectId exceptBranchId = do
@@ -79,15 +89,16 @@ handleDeleteBranch projectAndBranchNamesToDelete = do
       (_, pbIds) <- MaybeT . fmap (List.find (\(_, ids) -> ids /= ProjectAndBranch exceptProjectId exceptBranchId)) $ Queries.loadAllProjectBranchNamePairs
       pure pbIds
 
-    createNewBranchInProjectExcept :: ProjectName -> ProjectBranchName -> MaybeT Sqlite.Transaction (ProjectAndBranch ProjectId ProjectBranchId)
-    createNewBranchInProjectExcept projectName (UnsafeProjectBranchName "main") = lift $ do
-      (_, emptyCausalHashId) <- Codebase.emptyCausalHash
-      Ops.insertProjectAndBranch projectName (UnsafeProjectBranchName "main2") emptyCausalHashId
-        <&> \(proj, branch) -> ProjectAndBranch proj.projectId branch.branchId
-    createNewBranchInProjectExcept projectName _ = lift $ do
-      (_, emptyCausalHashId) <- Codebase.emptyCausalHash
-      Ops.insertProjectAndBranch projectName (UnsafeProjectBranchName "main") emptyCausalHashId
-        <&> \(proj, branch) -> ProjectAndBranch proj.projectId branch.branchId
+    createNewBranchInProjectExcept :: ProjectName -> ProjectBranchName -> Sqlite.Transaction (ProjectAndBranch ProjectId ProjectBranchId)
+    createNewBranchInProjectExcept projectName = \case
+      UnsafeProjectBranchName "main" -> do
+        (_, emptyCausalHashId) <- Codebase.emptyCausalHash
+        Ops.insertProjectAndBranch projectName (UnsafeProjectBranchName "main2") emptyCausalHashId
+          <&> \(proj, branch) -> ProjectAndBranch proj.projectId branch.branchId
+      _ -> do
+        (_, emptyCausalHashId) <- Codebase.emptyCausalHash
+        Ops.insertProjectAndBranch projectName (UnsafeProjectBranchName "main") emptyCausalHashId
+          <&> \(proj, branch) -> ProjectAndBranch proj.projectId branch.branchId
 
 -- | Delete a project branch and record an entry in the reflog.
 doDeleteProjectBranch :: (HasCallStack) => ProjectAndBranch Sqlite.Project Sqlite.ProjectBranch -> Cli ()

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Merge2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Merge2.hs
@@ -354,7 +354,7 @@ doMerge info = do
         typecheckedFile <-
           mergeblob.typecheckedFile & onNothing do
             env <- ask
-            (_temporaryBranchId, temporaryBranchName) <-
+            _ <-
               HandleInput.Branch.createBranch
                 info.description
                 ( let sourceStuff =
@@ -402,7 +402,7 @@ doMerge info = do
                     (Text.pack scratchFilePath)
                     (Text.pack $ Pretty.toPlain 80 mergeblob.unparsedFile)
                     True
-                done (Output.MergeFailure scratchFilePath mergeSourceAndTarget temporaryBranchName)
+                done (Output.MergeFailure scratchFilePath mergeSourceAndTarget)
               Just mergetool0 -> do
                 let aliceFilenameSlug = projectBranchNameToValidProjectBranchNameText mergeSourceAndTarget.alice.branch
                 let bobFilenameSlug = mangleMergeSource mergeSourceAndTarget.bob
@@ -453,7 +453,7 @@ doMerge info = do
                       True
                     let createProcess = (Process.shell (Text.unpack mergetool)) {Process.delegate_ctlc = True}
                     Process.withCreateProcess createProcess \_ _ _ -> Process.waitForProcess
-                done (Output.MergeFailureWithMergetool mergeSourceAndTarget temporaryBranchName mergetool exitCode)
+                done (Output.MergeFailureWithMergetool mergeSourceAndTarget mergetool exitCode)
 
         Cli.runTransaction (Codebase.addDefsToCodebase env.codebase typecheckedFile)
         Cli.updateProjectBranchRoot_

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Upgrade.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Upgrade.hs
@@ -197,7 +197,7 @@ handleUpgrade oldName newName = do
       uniqueTypeGuidsByName <-
         Cli.runTransaction (makeUniqueTypeGuids (BiMultimap.range unconflictedView.defns.types))
 
-      (_temporaryBranchId, temporaryBranchName) <-
+      _ <-
         HandleInput.Branch.createBranch
           textualDescriptionOfUpgrade
           ( CreateFrom'Upgrade
@@ -219,7 +219,7 @@ handleUpgrade oldName newName = do
           Just (file, _) -> file
       #latestFile ?= (scratchFilePath, True)
       liftIO $ env.writeSource (Text.pack scratchFilePath) (Text.pack $ Pretty.toPlain 80 prettyUnisonFile) True
-      Cli.returnEarly (Output.UpgradeFailure pp.branch.name temporaryBranchName scratchFilePath oldName newName)
+      Cli.returnEarly (Output.UpgradeFailure pp.branch.name scratchFilePath oldName newName)
 
   branchUpdates <-
     Cli.runTransactionWithRollback \abort -> do

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -243,6 +243,7 @@ data Input
   | DebugSynhashTermI !Name
   | EditDependentsI !(HQ.HashQualified Name)
   | BranchSquashI (ProjectAndBranch (Maybe ProjectName) ProjectBranchName) (ProjectAndBranch (Maybe ProjectName) ProjectBranchName)
+  | CancelI
   deriving (Eq, Show)
 
 -- | The source of a `branch` command: what to make the new branch from.

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -424,10 +424,10 @@ data Output
   | ProjectHasNoReleases ProjectName
   | UpdateTypecheckingFailure
   | UpdateTypecheckingFailure2 !FilePath !ProjectBranchName !ProjectBranchName
-  | UpgradeFailure !ProjectBranchName !ProjectBranchName !FilePath !NameSegment !NameSegment
+  | UpgradeFailure !ProjectBranchName !FilePath !NameSegment !NameSegment
   | UpgradeSuccess !NameSegment !NameSegment !(Maybe NameSegment)
-  | MergeFailure !FilePath !MergeSourceAndTarget !ProjectBranchName
-  | MergeFailureWithMergetool !MergeSourceAndTarget !ProjectBranchName !Text !ExitCode
+  | MergeFailure !FilePath !MergeSourceAndTarget
+  | MergeFailureWithMergetool !MergeSourceAndTarget !Text !ExitCode
   | MergeSuccess !MergeSourceAndTarget
   | MergeSuccessFastForward !MergeSourceAndTarget
   | MergeConflictedAliases !MergeSourceOrTarget !(Defn (Name, Name) (Name, Name))

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -11,6 +11,7 @@ module Unison.CommandLine.InputPatterns
     branchInputPattern,
     branchRenameInputPattern,
     branchesInputPattern,
+    cancelInputPattern,
     cd,
     clear,
     clone,
@@ -1519,6 +1520,17 @@ cd =
       [Left ".."] -> Right Input.UpI
       [p] -> Input.SwitchBranchI <$> handlePath'Arg p
       args -> wrongArgsLength "exactly one argument" args
+
+cancelInputPattern :: InputPattern
+cancelInputPattern =
+  InputPattern
+    { patternName = "cancel",
+      aliases = [],
+      visibility = I.Visible,
+      params = noParams,
+      help = P.wrapColumn2 [(makeExample' cancelInputPattern, "cancels the in-progress merge, update, or upgrade.")],
+      parse = \_ -> pure Input.CancelI
+    }
 
 back :: InputPattern
 back =
@@ -3514,6 +3526,7 @@ validInputs =
       branchInputPattern,
       branchRenameInputPattern,
       branchesInputPattern,
+      cancelInputPattern,
       cd,
       clear,
       clone,

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -2020,7 +2020,7 @@ notifyUser dir issueFn = \case
               <> "it will be merged back into"
               <> P.group (prettyProjectBranchName baseBranch <> ".")
           )
-  UpgradeFailure main temp path old new ->
+  UpgradeFailure main path old new ->
     pure $
       P.lines
         [ P.wrap $
@@ -2040,7 +2040,7 @@ notifyUser dir issueFn = \case
               <> prettyProjectBranchName main
               <> "and delete the temporary branch. Or, if you decide to cancel the upgrade instead, you can run",
           "",
-          P.indentN 2 (IP.makeExampleNoBackticks IP.deleteBranch [prettySlashProjectBranchName temp]),
+          P.indentN 2 (IP.makeExampleNoBackticks IP.cancelInputPattern []),
           "",
           P.wrap $
             "to delete the temporary branch and switch back to"
@@ -2066,7 +2066,7 @@ notifyUser dir issueFn = \case
                   <> prettyNew
                   <> "to"
                   <> P.group (prettyLib final <> ".")
-  MergeFailure path aliceAndBob temp ->
+  MergeFailure path aliceAndBob ->
     pure $
       P.lines $
         [ P.wrap $
@@ -2086,13 +2086,13 @@ notifyUser dir issueFn = \case
               <> prettyProjectBranchName aliceAndBob.alice.branch
               <> "and delete the temporary branch. Or, if you decide to cancel the merge instead, you can run",
           "",
-          P.indentN 2 (IP.makeExampleNoBackticks IP.deleteBranch [prettySlashProjectBranchName temp]),
+          P.indentN 2 (IP.makeExampleNoBackticks IP.cancelInputPattern []),
           "",
           P.wrap $
             "to delete the temporary branch and switch back to"
               <> P.group (prettyProjectBranchName aliceAndBob.alice.branch <> ".")
         ]
-  MergeFailureWithMergetool aliceAndBob temp mergetool exitCode ->
+  MergeFailureWithMergetool aliceAndBob mergetool exitCode ->
     case exitCode of
       ExitSuccess ->
         pure $
@@ -2115,7 +2115,7 @@ notifyUser dir issueFn = \case
                   <> prettyProjectBranchName aliceAndBob.alice.branch
                   <> "and delete the temporary branch. Or, if you decide to cancel the merge instead, you can run",
               "",
-              P.indentN 2 (IP.makeExampleNoBackticks IP.deleteBranch [prettySlashProjectBranchName temp]),
+              P.indentN 2 (IP.makeExampleNoBackticks IP.cancelInputPattern []),
               "",
               P.wrap $
                 "to delete the temporary branch and switch back to"

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -52,6 +52,7 @@ library
       Unison.Codebase.Editor.HandleInput.Branches
       Unison.Codebase.Editor.HandleInput.BranchRename
       Unison.Codebase.Editor.HandleInput.BranchSquash
+      Unison.Codebase.Editor.HandleInput.Cancel
       Unison.Codebase.Editor.HandleInput.CommitMerge
       Unison.Codebase.Editor.HandleInput.DebugDefinition
       Unison.Codebase.Editor.HandleInput.DebugFoldRanges

--- a/unison-src/transcripts/idempotent/cancel.md
+++ b/unison-src/transcripts/idempotent/cancel.md
@@ -1,0 +1,299 @@
+# The `cancel` command.
+
+## `cancel` cancels an in-progress update.
+
+``` ucm :hide
+scratch/main> builtins.mergeio lib.builtin
+```
+
+``` unison
+foo = 17
+bar = foo + foo
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  + bar : Nat
+  + foo : Nat
+
+  Run `update` to apply these changes to your codebase.
+```
+
+``` ucm
+scratch/main> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+```
+
+``` unison
+foo = +17
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  ~ foo : Int
+
+  ~ (modified)
+
+  Run `update` to apply these changes to your codebase.
+```
+
+``` ucm :error
+scratch/main> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Some definitions don't typecheck with your changes. I've
+  update the file scratch.u with the definitions that need
+  fixing. Once the file is compiling, try `update` again.
+
+  I've also switched you to a new branch update-main for this
+  work. On `update`, it will be merged back into main.
+```
+
+``` unison :added-by-ucm scratch.u
+foo = +17
+
+-- The definitions below no longer typecheck with the changes above.
+-- Please fix the errors and try `update` again.
+
+bar : Nat
+bar =
+  use Nat +
+  foo + foo
+
+```
+
+``` ucm
+scratch/update-main> cancel
+
+scratch/main> branches
+
+       Branch   Remote branch
+  1.   main     
+```
+
+``` ucm :hide
+scratch/main> project.delete scratch
+```
+
+## `cancel` cancels an in-progress upgrade.
+
+``` ucm :hide
+scratch/main> builtins.mergeio lib.builtin
+```
+
+``` unison
+lib.old.foo = 17
+lib.new.foo = +17
+bar = old.foo + old.foo
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  + bar         : Nat
+  + lib.new.foo : Int
+  + lib.old.foo : Nat
+
+  Run `update` to apply these changes to your codebase.
+```
+
+``` ucm
+scratch/main> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+```
+
+``` ucm :error
+scratch/main> upgrade old new
+
+  I couldn't automatically upgrade old to new. However, I've
+  added the definitions that need attention to the top of
+  scratch.u.
+
+  When you're done, you can run
+
+    update
+
+  to merge your changes back into main and delete the temporary
+  branch. Or, if you decide to cancel the upgrade instead, you
+  can run
+
+    cancel
+
+  to delete the temporary branch and switch back to main.
+```
+
+``` unison :added-by-ucm scratch.u
+-- The definitions below no longer typecheck after upgrading.
+-- Please fix the errors, then run `update`.
+
+bar : Nat
+bar =
+  use Nat +
+  foo + foo
+
+```
+
+``` ucm
+scratch/upgrade-old-to-new> cancel
+
+scratch/main> branches
+
+       Branch   Remote branch
+  1.   main     
+```
+
+``` ucm :hide
+scratch/main> project.delete scratch
+```
+
+## `cancel` cancels an in-progress merge.
+
+``` ucm :hide
+scratch/main> builtins.mergeio lib.builtin
+```
+
+``` ucm
+scratch/main> branch alice
+
+  Done. I've created the alice branch based off of main.
+
+  Tip: To merge your work back into the main branch, first
+       `switch /main` then `merge /alice`.
+```
+
+``` unison
+foo = 17
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  + foo : Nat
+
+  Run `update` to apply these changes to your codebase.
+```
+
+``` ucm
+scratch/alice> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+
+scratch/alice> switch /main
+
+scratch/main> branch bob
+
+  Done. I've created the bob branch based off of main.
+
+  Tip: To merge your work back into the main branch, first
+       `switch /main` then `merge /bob`.
+```
+
+``` unison
+foo = 18
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  + foo : Nat
+
+  Run `update` to apply these changes to your codebase.
+```
+
+``` ucm
+scratch/bob> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+
+scratch/bob> switch /alice
+```
+
+``` ucm :error
+scratch/alice> merge /bob
+
+  Loading namespaces...
+
+  Computing diff...
+
+  Loading definitions...
+
+  Computing merge...
+
+  I couldn't automatically merge scratch/bob into scratch/alice.
+  However, I've added the definitions that need attention to the
+  top of scratch.u.
+
+  When you're done, you can run
+
+    merge.commit
+
+  to merge your changes back into alice and delete the temporary
+  branch. Or, if you decide to cancel the merge instead, you can
+  run
+
+    cancel
+
+  to delete the temporary branch and switch back to alice.
+```
+
+``` unison :added-by-ucm scratch.u
+-- scratch/alice
+foo : Nat
+foo = 17
+
+-- scratch/bob
+foo : Nat
+foo = 18
+
+```
+
+``` ucm
+scratch/merge-bob-into-alice> cancel
+
+scratch/alice> branches
+
+       Branch   Remote branch
+  1.   alice    
+  2.   bob      
+  3.   main     
+```
+
+``` ucm :hide
+scratch/main> project.delete scratch
+```
+
+## `cancel` doesn't do anything when run on a non-update, non-upgrade, non-merge branch.
+
+``` ucm :hide
+scratch/main> builtins.mergeio lib.builtin
+```
+
+``` ucm
+scratch/main> cancel
+
+  There's no merge, update, or upgrade in progress.
+```
+
+``` ucm :hide
+scratch/main> project.delete scratch
+```

--- a/unison-src/transcripts/idempotent/fix-5612.md
+++ b/unison-src/transcripts/idempotent/fix-5612.md
@@ -133,7 +133,7 @@ scratch/main> merge /topic
   branch. Or, if you decide to cancel the merge instead, you can
   run
 
-    delete.branch /merge-topic-into-main
+    cancel
 
   to delete the temporary branch and switch back to main.
 ```
@@ -297,7 +297,7 @@ scratch/main> merge /topic
   branch. Or, if you decide to cancel the merge instead, you can
   run
 
-    delete.branch /merge-topic-into-main
+    cancel
 
   to delete the temporary branch and switch back to main.
 ```

--- a/unison-src/transcripts/idempotent/fix4482.md
+++ b/unison-src/transcripts/idempotent/fix4482.md
@@ -44,7 +44,7 @@ mybar = bar + bar
   branch. Or, if you decide to cancel the upgrade instead, you
   can run
 
-    delete.branch /upgrade-foo0-to-foo1
+    cancel
 
   to delete the temporary branch and switch back to main.
 ```

--- a/unison-src/transcripts/idempotent/help.md
+++ b/unison-src/transcripts/idempotent/help.md
@@ -51,6 +51,9 @@
   `branches`      lists all branches in the current project
   `branches foo`  lists all branches in the project `foo`
 
+  cancel
+  `cancel`  cancels the in-progress merge, update, or upgrade.
+
   clear
   `clear`  Clears the screen.
 

--- a/unison-src/transcripts/idempotent/merge.md
+++ b/unison-src/transcripts/idempotent/merge.md
@@ -834,7 +834,7 @@ scratch/alice> merge /bob
   branch. Or, if you decide to cancel the merge instead, you can
   run
 
-    delete.branch /merge-bob-into-alice
+    cancel
 
   to delete the temporary branch and switch back to alice.
 ```
@@ -921,7 +921,7 @@ scratch/alice> merge /bob
   branch. Or, if you decide to cancel the merge instead, you can
   run
 
-    delete.branch /merge-bob-into-alice
+    cancel
 
   to delete the temporary branch and switch back to alice.
 ```
@@ -1019,7 +1019,7 @@ scratch/alice> merge /bob
   branch. Or, if you decide to cancel the merge instead, you can
   run
 
-    delete.branch /merge-bob-into-alice
+    cancel
 
   to delete the temporary branch and switch back to alice.
 ```
@@ -1122,7 +1122,7 @@ scratch/alice> merge /bob
   branch. Or, if you decide to cancel the merge instead, you can
   run
 
-    delete.branch /merge-bob-into-alice
+    cancel
 
   to delete the temporary branch and switch back to alice.
 ```
@@ -1203,7 +1203,7 @@ scratch/alice> merge /bob
   branch. Or, if you decide to cancel the merge instead, you can
   run
 
-    delete.branch /merge-bob-into-alice
+    cancel
 
   to delete the temporary branch and switch back to alice.
 ```
@@ -1284,7 +1284,7 @@ scratch/alice> merge bob
   branch. Or, if you decide to cancel the merge instead, you can
   run
 
-    delete.branch /merge-bob-into-alice
+    cancel
 
   to delete the temporary branch and switch back to alice.
 ```
@@ -1361,7 +1361,7 @@ scratch/alice> merge bob
   branch. Or, if you decide to cancel the merge instead, you can
   run
 
-    delete.branch /merge-bob-into-alice
+    cancel
 
   to delete the temporary branch and switch back to alice.
 ```
@@ -1455,7 +1455,7 @@ scratch/alice> merge bob
   branch. Or, if you decide to cancel the merge instead, you can
   run
 
-    delete.branch /merge-bob-into-alice
+    cancel
 
   to delete the temporary branch and switch back to alice.
 ```
@@ -1583,7 +1583,7 @@ scratch/alice> merge bob
   branch. Or, if you decide to cancel the merge instead, you can
   run
 
-    delete.branch /merge-bob-into-alice
+    cancel
 
   to delete the temporary branch and switch back to alice.
 ```
@@ -1673,7 +1673,7 @@ scratch/alice> merge bob
   branch. Or, if you decide to cancel the merge instead, you can
   run
 
-    delete.branch /merge-bob-into-alice
+    cancel
 
   to delete the temporary branch and switch back to alice.
 ```
@@ -1773,7 +1773,7 @@ scratch/alice> merge /bob
   branch. Or, if you decide to cancel the merge instead, you can
   run
 
-    delete.branch /merge-bob-into-alice
+    cancel
 
   to delete the temporary branch and switch back to alice.
 ```
@@ -2807,7 +2807,7 @@ scratch/alice> merge /bob
   branch. Or, if you decide to cancel the merge instead, you can
   run
 
-    delete.branch /merge-bob-into-alice
+    cancel
 
   to delete the temporary branch and switch back to alice.
 ```
@@ -3192,7 +3192,7 @@ scratch/alice> merge /bob
   branch. Or, if you decide to cancel the merge instead, you can
   run
 
-    delete.branch /merge-bob-into-alice
+    cancel
 
   to delete the temporary branch and switch back to alice.
 ```
@@ -3373,7 +3373,7 @@ scratch/main> merge /topic
   branch. Or, if you decide to cancel the merge instead, you can
   run
 
-    delete.branch /merge-topic-into-main
+    cancel
 
   to delete the temporary branch and switch back to main.
 ```
@@ -3455,7 +3455,7 @@ scratch/topic> merge /main
   branch. Or, if you decide to cancel the merge instead, you can
   run
 
-    delete.branch /merge-main-into-topic
+    cancel
 
   to delete the temporary branch and switch back to topic.
 ```
@@ -3536,7 +3536,7 @@ scratch/topic> merge /topic2
   branch. Or, if you decide to cancel the merge instead, you can
   run
 
-    delete.branch /merge-topic2-into-topic
+    cancel
 
   to delete the temporary branch and switch back to topic.
 ```
@@ -3716,7 +3716,7 @@ scratch/alice> merge /bob
   branch. Or, if you decide to cancel the merge instead, you can
   run
 
-    delete.branch /merge-bob-into-alice
+    cancel
 
   to delete the temporary branch and switch back to alice.
 ```

--- a/unison-src/transcripts/idempotent/upgrade.md
+++ b/unison-src/transcripts/idempotent/upgrade.md
@@ -119,7 +119,7 @@ proj/main> upgrade old new
   branch. Or, if you decide to cancel the upgrade instead, you
   can run
 
-    delete.branch /upgrade-old-to-new
+    cancel
 
   to delete the temporary branch and switch back to main.
 ```
@@ -229,7 +229,7 @@ proj/main> upgrade old new
   branch. Or, if you decide to cancel the upgrade instead, you
   can run
 
-    delete.branch /upgrade-old-to-new
+    cancel
 
   to delete the temporary branch and switch back to main.
 ```
@@ -398,7 +398,7 @@ myproject/main> upgrade old new
   branch. Or, if you decide to cancel the upgrade instead, you
   can run
 
-    delete.branch /upgrade-old-to-new
+    cancel
 
   to delete the temporary branch and switch back to main.
 ```


### PR DESCRIPTION
## Overview

This PR adds a `cancel` command, which is shorthand for `delete.branch <the current branch name>`, and only works on merge/update/upgrade branches.