### PR TITLE
Implement side-by-side diffs

### DIFF
--- a/unison-share-api/package.yaml
+++ b/unison-share-api/package.yaml
@@ -38,6 +38,7 @@ library:
     - servant-docs
     - servant-openapi3
     - servant-server
+    - split
     - text
     - transformers
     - unison-codebase

--- a/unison-share-api/package.yaml
+++ b/unison-share-api/package.yaml
@@ -80,11 +80,13 @@ tests:
       - unison-share-api
       - base
       - bytestring
+      - raw-strings-qq
       - serialise
       - text
       - unison-hash
       - unison-prelude
       - unison-codebase-sqlite
+      - unison-pretty-printer
       - vector
 
     main: Main.hs

--- a/unison-share-api/src/Unison/Server/Backend/DefinitionDiff.hs
+++ b/unison-share-api/src/Unison/Server/Backend/DefinitionDiff.hs
@@ -2,6 +2,8 @@
 module Unison.Server.Backend.DefinitionDiff
   ( diffDisplayObjects,
     linewiseDiff,
+    Paired(..),
+    Changed(..),
   )
 where
 
@@ -11,7 +13,6 @@ import Data.Function
 import Data.List qualified as List
 import Data.List.Extra qualified as List
 import Data.List.Split qualified as Split
-import Data.Text qualified as Text
 import Unison.Codebase.Editor.DisplayObject (DisplayObject (..))
 import Unison.Prelude
 import Unison.Server.Syntax (SyntaxText)
@@ -168,7 +169,6 @@ linewiseDiff diffEq left right =
                       Right (Left a) -> (a, mempty)
                       Right (Right b) -> (mempty, b)
              in diffChangeChunk diffEq lefts rights
-        & traceShowId
 
 -- Diff data can be one-sided or have a counter-part on the other side of the diff.
 -- We can use this to represent things like name-changes for the same hash, or hash-changes for the same name.
@@ -237,61 +237,3 @@ pairLines left right =
    in ( paired,
         fmap swapPair <$> paired
       )
-
-testDiff :: Text -> Text -> Text
-testDiff l r =
-  let left = embed l
-      right = embed r
-      (ldiff, rdiff) = linewiseDiff (==) left right
-   in align (testRender ldiff) (testRender rdiff)
-  where
-
-embed :: Text -> [Segment ()]
-embed txt =
-  txt
-    & Text.lines
-    & fmap (List.intersperse (Segment " " Nothing) . fmap ((\w -> Segment w Nothing) . Text.unpack) . Text.words)
-    & List.intercalate [Segment "\n" Nothing]
-
-testRender :: [Changed [Paired (Segment a)]] -> Text
-testRender diffs =
-  let renderSegment :: Segment a -> Text
-      renderSegment (Segment {segment}) = Text.pack segment
-      renderPaired :: Paired (Segment a) -> Text
-      renderPaired (OneSided s) = "{" <> renderSegment s <> "}"
-      renderPaired (Paired s1 _) = renderSegment s1
-      renderChanged :: Changed [Paired (Segment a)] -> Text
-      renderChanged Spacer = "////"
-      renderChanged (Unchanged segs) = Text.concat (renderPaired <$> segs)
-      renderChanged (Changed segs) = "*" <> Text.concat (renderPaired <$> segs)
-   in Text.unlines $ fmap renderChanged diffs
-
-align :: Text -> Text -> Text
-align left right = Text.unlines $ zipWith formatRow leftLines rightLines
-  where
-    leftLines = Text.lines left
-    rightLines = Text.lines right
-
-    -- Find the maximum length in the left column
-    maxLeftWidth = maximum $ map Text.length leftLines
-
-    -- Pad the left text and combine with right text
-    formatRow l r = Text.justifyLeft (maxLeftWidth + 2) ' ' l <> r
-
-simpleLeft :: Text
-simpleLeft = "one word\ntwo words\nthree words"
-
-simpleRight :: Text
-simpleRight = "one word\ndifferent words\nthree words"
-
-complexLeft :: Text
-complexLeft = "one word\ntwo words\nthree words"
-
-complexRight :: Text
-complexRight = "one word\nmulti-line\ndifference\nshould add spacers\nthree words"
-
-apples :: Text
-apples = "same\napples\nsame\napples and then some"
-
-oranges :: Text
-oranges = "same\noranges\nsame\noranges and then some"

--- a/unison-share-api/src/Unison/Server/Backend/DefinitionDiff.hs
+++ b/unison-share-api/src/Unison/Server/Backend/DefinitionDiff.hs
@@ -2,8 +2,8 @@
 module Unison.Server.Backend.DefinitionDiff
   ( diffDisplayObjects,
     linewiseDiff,
-    Paired(..),
-    Changed(..),
+    Paired (..),
+    Changed (..),
   )
 where
 
@@ -17,24 +17,24 @@ import Unison.Codebase.Editor.DisplayObject (DisplayObject (..))
 import Unison.Prelude
 import Unison.Server.Syntax (SyntaxText)
 import Unison.Server.Syntax qualified as Syntax
-import Unison.Server.Types (DisplayObjectDiff (..), SemanticSyntaxDiff (..))
+import Unison.Server.Types (Changed (..), DisplayObjectDiff (..), LinewiseDiff (..), Paired (..), SemanticSyntaxDiff (..), swapPair)
 import Unison.Util.AnnotatedText (AnnotatedText (..), Segment (..))
 import Unison.Util.AnnotatedText qualified as AT
 import Unison.Util.List qualified as ListUtil
 
 diffDisplayObjects :: (HasCallStack) => DisplayObject SyntaxText SyntaxText -> DisplayObject SyntaxText SyntaxText -> DisplayObjectDiff
 diffDisplayObjects from to = case (from, to) of
-  (BuiltinObject fromST, BuiltinObject toST) -> DisplayObjectDiff (BuiltinObject (diffSyntaxText fromST toST))
+  (BuiltinObject fromST, BuiltinObject toST) -> DisplayObjectDiff (BuiltinObject (semanticLinewiseDiff fromST toST))
   (MissingObject fromSH, MissingObject toSH)
     | fromSH == toSH -> DisplayObjectDiff (MissingObject fromSH)
     | otherwise -> MismatchedDisplayObjects (MissingObject fromSH) (MissingObject toSH)
-  (UserObject fromST, UserObject toST) -> DisplayObjectDiff (UserObject (diffSyntaxText fromST toST))
+  (UserObject fromST, UserObject toST) -> DisplayObjectDiff (UserObject (semanticLinewiseDiff fromST toST))
   (l, r) -> MismatchedDisplayObjects l r
 
-diffSyntaxText :: SyntaxText -> SyntaxText -> [SemanticSyntaxDiff Syntax.Element]
-diffSyntaxText (AnnotatedText fromST) (AnnotatedText toST) =
-  diffSegments syntaxElementDiffEq fromST toST
-    & expandSpecialCases specialCaseAnnotations
+-- diffSyntaxText :: SyntaxText -> SyntaxText -> [SemanticSyntaxDiff Syntax.Element]
+-- diffSyntaxText (AnnotatedText fromST) (AnnotatedText toST) =
+--   diffSegments syntaxElementDiffEq fromST toST
+--     & expandSpecialCases specialCaseAnnotations
 
 -- We special-case situations where the name of a definition changed but its hash didn't;
 -- and cases where the name didn't change but the hash did.
@@ -57,30 +57,6 @@ syntaxElementDiffEq (AT.Segment {segment = fromSegment, annotation = fromAnnotat
           Syntax.HashQualifier {} -> a == b
           _ -> False
 
-specialCaseAnnotations :: AT.Segment Syntax.Element -> AT.Segment Syntax.Element -> Either (AT.Segment Syntax.Element) [SemanticSyntaxDiff Syntax.Element]
-specialCaseAnnotations fromSegment toSegment
-  | fromSegment == toSegment = Left fromSegment
-  | AT.annotation fromSegment == AT.annotation toSegment = Right [SegmentChange (AT.segment fromSegment, AT.segment toSegment) (AT.annotation fromSegment)]
-  -- We only emit an annotation change if it's a change in just the hash of the element (optionally the KIND of hash reference can change too).
-  | AT.segment fromSegment == AT.segment toSegment,
-    Just _fromHash <- AT.annotation fromSegment >>= elementHash,
-    Just _toHash <- AT.annotation toSegment >>= elementHash =
-      Right [AnnotationChange (AT.segment fromSegment) (AT.annotation fromSegment, AT.annotation toSegment)]
-  | otherwise =
-      -- the annotation changed, but it's not a recognized hash change.
-      -- This can happen in certain special cases, e.g. a paren changed from being a syntax element into being part
-      -- of a unit.
-      -- We just emit both as old/new segments.
-      Right [Old [fromSegment], New [toSegment]]
-  where
-    elementHash :: Syntax.Element -> Maybe Syntax.UnisonHash
-    elementHash = \case
-      Syntax.TypeReference hash -> Just hash
-      Syntax.TermReference hash -> Just hash
-      Syntax.DataConstructorReference hash -> Just hash
-      Syntax.AbilityConstructorReference hash -> Just hash
-      _ -> Nothing
-
 diffSegments ::
   forall f a.
   (Foldable f) =>
@@ -94,32 +70,7 @@ diffSegments diffEq left right =
     (Foldable.toList left)
     (Foldable.toList right)
 
-expandSpecialCases ::
-  (Segment a -> Segment a -> Either (Segment a) [SemanticSyntaxDiff a]) ->
-  [Diff.Diff [AT.Segment a]] ->
-  [SemanticSyntaxDiff a]
-expandSpecialCases detectSpecialCase xs =
-  xs
-    & foldMap \case
-      Diff.First ys -> [Old ys]
-      Diff.Second ys -> [New ys]
-      Diff.Both from to ->
-        -- Each list should always be the same length.
-        zipWith detectSpecialCase from to
-          & (flip List.foldr [])
-            ( \next acc -> case (acc, next) of
-                (Both xs : rest, Left seg) -> Both (seg : xs) : rest
-                (_, Left seg) -> Both [seg] : acc
-                (_, Right diff) -> diff ++ acc
-            )
-
 data DiffOrSame = Different | Same
-  deriving (Eq, Ord, Show)
-
-data Changed a
-  = Changed a
-  | Unchanged a
-  | Spacer
   deriving (Eq, Ord, Show)
 
 -- | Compute a line-wise diff between two lists of segments.
@@ -138,7 +89,7 @@ linewiseDiff ::
   -- Returns a tuple of lists,
   -- Each list is the same length, when lines are present on both sides they're considered Equal.
   -- When lines are only present on one side, the other side has a Nothing in that position as padding.
-  ([Changed [Paired (Segment a)]], [Changed [Paired (Segment a)]])
+  LinewiseDiff (Paired (Segment a))
 linewiseDiff diffEq left right =
   let leftLines = Split.splitWhen ((== "\n") . AT.segment) . toList $ left
       rightLines = Split.splitWhen ((== "\n") . AT.segment) . toList $ right
@@ -169,17 +120,39 @@ linewiseDiff diffEq left right =
                       Right (Left a) -> (a, mempty)
                       Right (Right b) -> (mempty, b)
              in diffChangeChunk diffEq lefts rights
+        & \(lhsLines, rhsLines) ->
+          LinewiseDiff {lhsLines, rhsLines}
 
--- Diff data can be one-sided or have a counter-part on the other side of the diff.
--- We can use this to represent things like name-changes for the same hash, or hash-changes for the same name.
-data Paired a
-  = OneSided a
-  | Paired a a
-  deriving (Eq, Ord, Show)
-
-swapPair :: Paired a -> Paired a
-swapPair (OneSided a) = OneSided a
-swapPair (Paired a b) = Paired b a
+semanticLinewiseDiff :: SyntaxText -> SyntaxText -> LinewiseDiff (SemanticSyntaxDiff Syntax.Element)
+semanticLinewiseDiff (AnnotatedText lhs) (AnnotatedText rhs) =
+  linewiseDiff syntaxElementDiffEq lhs rhs
+    <&> specialCasePairs
+  where
+    specialCasePairs :: Paired (Segment Syntax.Element) -> SemanticSyntaxDiff Syntax.Element
+    specialCasePairs = \case
+      OneSided a -> OnlyThisSide a
+      Paired fromSegment toSegment
+        | fromSegment == toSegment -> Both fromSegment
+        | AT.annotation fromSegment == AT.annotation toSegment -> SegmentChange (AT.segment fromSegment, AT.segment toSegment) (AT.annotation fromSegment)
+        -- We only emit an annotation change if it's a change in just the hash of the element (optionally the KIND of hash reference can change too).
+        | AT.segment fromSegment == AT.segment toSegment,
+          Just _fromHash <- AT.annotation fromSegment >>= elementHash,
+          Just _toHash <- AT.annotation toSegment >>= elementHash ->
+            AnnotationChange (AT.segment fromSegment) (AT.annotation fromSegment, AT.annotation toSegment)
+        | otherwise ->
+            -- the annotation changed, but it's not a recognized hash change.
+            -- This can happen in certain special cases, e.g. a paren changed from being a syntax element into being part
+            -- of a unit.
+            -- We just emit both as old/new segments.
+            OnlyThisSide fromSegment
+        where
+          elementHash :: Syntax.Element -> Maybe Syntax.UnisonHash
+          elementHash = \case
+            Syntax.TypeReference hash -> Just hash
+            Syntax.TermReference hash -> Just hash
+            Syntax.DataConstructorReference hash -> Just hash
+            Syntax.AbilityConstructorReference hash -> Just hash
+            _ -> Nothing
 
 -- Takes the left and right sides of a diff which are part of the same contiguous chunk, then
 -- diffs them and returns padded left/right line diffs

--- a/unison-share-api/src/Unison/Server/Backend/DefinitionDiff.hs
+++ b/unison-share-api/src/Unison/Server/Backend/DefinitionDiff.hs
@@ -11,6 +11,7 @@ import Data.Function
 import Data.List qualified as List
 import Data.List.Extra qualified as List
 import Data.List.Split qualified as Split
+import Data.Text qualified as Text
 import Unison.Codebase.Editor.DisplayObject (DisplayObject (..))
 import Unison.Prelude
 import Unison.Server.Syntax (SyntaxText)
@@ -114,23 +115,29 @@ expandSpecialCases detectSpecialCase xs =
 data DiffOrSame = Different | Same
   deriving (Eq, Ord, Show)
 
+data Changed a
+  = Changed a
+  | Unchanged a
+  | Spacer
+  deriving (Eq, Ord, Show)
+
 -- | Compute a line-wise diff between two lists of segments.
 --
 -- >>> let s a = Segment a Nothing
--- >>> let left = [s "line1", s "\n", s "line2", s "\n", s "line3"]
+-- >>> let left = [s "line1", s "\n", s "line2", s "\n", s "line3", s "\n", s "line3"]
 -- >>> let right = [s "line1", s "\n", s "lineX", s "\n", s "line3"]
--- >>> linewiseDiff left right
--- ([Just [Segment {segment = "line1", annotation = Nothing}],Just [Segment {segment = "line2", annotation = Nothing}],Nothing,Just [Segment {segment = "line3", annotation = Nothing}]],[Just [Segment {segment = "line1", annotation = Nothing}],Nothing,Just [Segment {segment = "lineX", annotation = Nothing}],Just [Segment {segment = "line3", annotation = Nothing}]])
+-- >>> linewiseDiff (==) left right
+-- ([Unchanged [Paired (Segment {segment = "line1", annotation = Nothing}) (Segment {segment = "line1", annotation = Nothing})],Changed [OneSided (Segment {segment = "line2", annotation = Nothing})],Changed [OneSided (Segment {segment = "line3", annotation = Nothing})],Unchanged [Paired (Segment {segment = "line3", annotation = Nothing}) (Segment {segment = "line3", annotation = Nothing})]],[Unchanged [Paired (Segment {segment = "line1", annotation = Nothing}) (Segment {segment = "line1", annotation = Nothing})],Changed [OneSided (Segment {segment = "lineX", annotation = Nothing})],Spacer,Unchanged [Paired (Segment {segment = "line3", annotation = Nothing}) (Segment {segment = "line3", annotation = Nothing})]])
 linewiseDiff ::
   forall f a.
-  (Foldable f, Eq a) =>
+  (Foldable f, Eq a, Show a) =>
   (Segment a -> Segment a -> Bool) ->
   f (Segment a) ->
   f (Segment a) ->
   -- Returns a tuple of lists,
   -- Each list is the same length, when lines are present on both sides they're considered Equal.
   -- When lines are only present on one side, the other side has a Nothing in that position as padding.
-  ([Maybe [Paired (Segment a)]], [Maybe [Paired (Segment a)]])
+  ([Changed [Paired (Segment a)]], [Changed [Paired (Segment a)]])
 linewiseDiff diffEq left right =
   let leftLines = Split.splitWhen ((== "\n") . AT.segment) . toList $ left
       rightLines = Split.splitWhen ((== "\n") . AT.segment) . toList $ right
@@ -144,28 +151,31 @@ linewiseDiff diffEq left right =
                   Diff.First a -> (Different, Right $ Left a)
                   Diff.Second b -> (Different, Right $ Right b)
             )
-   in partitioned & foldMap \case
-        (Same, ds) ->
-          ds & foldMap \case
-            Left (a, b) -> do
-              let (l, r) = pairLines a b
-               in (Just <$> l, Just <$> r)
-            Right _ -> error "impossible"
-        (Different, ds) ->
-          -- When left and right are different, We do a subdiff on the chunk
-          let (lefts :: [[Segment a]], rights :: [[Segment a]]) =
-                ds
-                  & foldMap \case
-                    Left _ -> error "impossible"
-                    Right (Left a) -> (a, mempty)
-                    Right (Right b) -> (mempty, b)
-           in diffChangeChunk diffEq lefts rights
+   in partitioned
+        & foldMap \case
+          (Same, ds) ->
+            ds & foldMap \case
+              Left (a, b) -> do
+                let (l, r) = pairLines a b
+                 in (Unchanged <$> l, Unchanged <$> r)
+              Right _ -> error "impossible"
+          (Different, ds) ->
+            -- When left and right are different, We do a subdiff on the chunk
+            let (lefts :: [[Segment a]], rights :: [[Segment a]]) =
+                  ds
+                    & foldMap \case
+                      Left _ -> error "impossible"
+                      Right (Left a) -> (a, mempty)
+                      Right (Right b) -> (mempty, b)
+             in diffChangeChunk diffEq lefts rights
+        & traceShowId
 
 -- Diff data can be one-sided or have a counter-part on the other side of the diff.
 -- We can use this to represent things like name-changes for the same hash, or hash-changes for the same name.
 data Paired a
   = OneSided a
   | Paired a a
+  deriving (Eq, Ord, Show)
 
 swapPair :: Paired a -> Paired a
 swapPair (OneSided a) = OneSided a
@@ -181,7 +191,7 @@ diffChangeChunk ::
   [[Segment a]] ->
   -- Lists of lines, where each line is a list of segments.
   -- 'Nothing' lines are just padding
-  ([Maybe [Paired (Segment a)]], [Maybe [Paired (Segment a)]])
+  ([Changed [Paired (Segment a)]], [Changed [Paired (Segment a)]])
 diffChangeChunk diffEq leftLines rightLines =
   -- Represent newlines with 'Nothing' so we can do a flat diff.
   let flattenedL :: [Maybe (Segment a)]
@@ -190,26 +200,29 @@ diffChangeChunk diffEq leftLines rightLines =
       flattenedR = List.intercalate [Nothing] (fmap Just <$> rightLines)
       diff :: [Diff.PolyDiff [Maybe (Segment a)] [Maybe (Segment a)]]
       diff = diffSegments mayDiffEq flattenedL flattenedR
-      (leftResults :: [[Paired (Segment a)]], rightResults) =
+      (leftResults :: [Maybe (Paired (Segment a))], rightResults) =
         diff
           & foldMap \case
             Diff.First ys ->
-              let reLined = List.splitOn [Nothing] ys
-               in ((fmap) OneSided . catMaybes <$> reLined, mempty)
+              (fmap OneSided <$> ys, mempty)
             Diff.Second ys ->
-              let reLined = List.splitOn [Nothing] ys
-               in (mempty, (fmap) OneSided . catMaybes <$> reLined)
+              (mempty, fmap OneSided <$> ys)
             Diff.Both from to ->
-              let reLinedL = List.splitOn [Nothing] from
-                  reLinedR = List.splitOn [Nothing] to
-               in pairLines (catMaybes <$> reLinedL) (catMaybes <$> reLinedR)
+              let zipper = \cases
+                    Nothing Nothing -> Nothing
+                    (Just l) (Just r) -> Just (Paired l r)
+                    _ _ -> error "impossible"
+               in (zipWith zipper from to, zipWith zipper to from)
+
       -- Now only padding newlines are represented by Nothing.
-      padding = repeat Nothing
-      leftLength = length leftResults
-      rightLength = length rightResults
+      padding = repeat Spacer
+      relinedLeft = catMaybes <$> List.splitOn [Nothing] leftResults
+      relinedRight = catMaybes <$> List.splitOn [Nothing] rightResults
+      leftLength = length relinedLeft
+      rightLength = length relinedRight
       maxLines = max leftLength rightLength
-   in ( (Just <$> leftResults) <> take (maxLines - leftLength) padding,
-        take (maxLines - rightLength) padding <> (Just <$> rightResults)
+   in ( (Changed <$> relinedLeft) <> take (maxLines - leftLength) padding,
+        (Changed <$> relinedRight) <> take (maxLines - rightLength) padding
       )
   where
     mayDiffEq :: Maybe (Segment a) -> Maybe (Segment a) -> Bool
@@ -224,3 +237,61 @@ pairLines left right =
    in ( paired,
         fmap swapPair <$> paired
       )
+
+testDiff :: Text -> Text -> Text
+testDiff l r =
+  let left = embed l
+      right = embed r
+      (ldiff, rdiff) = linewiseDiff (==) left right
+   in align (testRender ldiff) (testRender rdiff)
+  where
+
+embed :: Text -> [Segment ()]
+embed txt =
+  txt
+    & Text.lines
+    & fmap (List.intersperse (Segment " " Nothing) . fmap ((\w -> Segment w Nothing) . Text.unpack) . Text.words)
+    & List.intercalate [Segment "\n" Nothing]
+
+testRender :: [Changed [Paired (Segment a)]] -> Text
+testRender diffs =
+  let renderSegment :: Segment a -> Text
+      renderSegment (Segment {segment}) = Text.pack segment
+      renderPaired :: Paired (Segment a) -> Text
+      renderPaired (OneSided s) = "{" <> renderSegment s <> "}"
+      renderPaired (Paired s1 _) = renderSegment s1
+      renderChanged :: Changed [Paired (Segment a)] -> Text
+      renderChanged Spacer = "////"
+      renderChanged (Unchanged segs) = Text.concat (renderPaired <$> segs)
+      renderChanged (Changed segs) = "*" <> Text.concat (renderPaired <$> segs)
+   in Text.unlines $ fmap renderChanged diffs
+
+align :: Text -> Text -> Text
+align left right = Text.unlines $ zipWith formatRow leftLines rightLines
+  where
+    leftLines = Text.lines left
+    rightLines = Text.lines right
+
+    -- Find the maximum length in the left column
+    maxLeftWidth = maximum $ map Text.length leftLines
+
+    -- Pad the left text and combine with right text
+    formatRow l r = Text.justifyLeft (maxLeftWidth + 2) ' ' l <> r
+
+simpleLeft :: Text
+simpleLeft = "one word\ntwo words\nthree words"
+
+simpleRight :: Text
+simpleRight = "one word\ndifferent words\nthree words"
+
+complexLeft :: Text
+complexLeft = "one word\ntwo words\nthree words"
+
+complexRight :: Text
+complexRight = "one word\nmulti-line\ndifference\nshould add spacers\nthree words"
+
+apples :: Text
+apples = "same\napples\nsame\napples and then some"
+
+oranges :: Text
+oranges = "same\noranges\nsame\noranges and then some"

--- a/unison-share-api/src/Unison/Server/Backend/DefinitionDiff.hs
+++ b/unison-share-api/src/Unison/Server/Backend/DefinitionDiff.hs
@@ -1,6 +1,7 @@
 -- | Utilities for displaying diffs between definitions.
 module Unison.Server.Backend.DefinitionDiff
   ( diffDisplayObjects,
+    linewiseDiff,
   )
 where
 
@@ -10,7 +11,6 @@ import Data.Function
 import Data.List qualified as List
 import Data.List.Extra qualified as List
 import Data.List.Split qualified as Split
-import Data.Text qualified as Text
 import Unison.Codebase.Editor.DisplayObject (DisplayObject (..))
 import Unison.Prelude
 import Unison.Server.Syntax (SyntaxText)
@@ -124,13 +124,14 @@ data DiffOrSame = Different | Same
 linewiseDiff ::
   forall f a.
   (Foldable f, Eq a) =>
+  (Segment a -> Segment a -> Bool) ->
   f (Segment a) ->
   f (Segment a) ->
   -- Returns a tuple of lists,
   -- Each list is the same length, when lines are present on both sides they're considered Equal.
   -- When lines are only present on one side, the other side has a Nothing in that position as padding.
-  ([Maybe [Segment a]], [Maybe [Segment a]])
-linewiseDiff left right =
+  ([Maybe [Paired (Segment a)]], [Maybe [Paired (Segment a)]])
+linewiseDiff diffEq left right =
   let leftLines = Split.splitWhen ((== "\n") . AT.segment) . toList $ left
       rightLines = Split.splitWhen ((== "\n") . AT.segment) . toList $ right
       groupedDiff = Diff.getGroupedDiff leftLines rightLines
@@ -146,22 +147,19 @@ linewiseDiff left right =
    in partitioned & foldMap \case
         (Same, ds) ->
           ds & foldMap \case
-            Left (a, b) -> (Just <$> a, Just <$> b)
+            Left (a, b) -> do
+              let (l, r) = pairLines a b
+               in (Just <$> l, Just <$> r)
             Right _ -> error "impossible"
         (Different, ds) ->
-          -- When left and right are different, We add padding to the end of the left and the beginning of the right
-          -- so that the diffs are visually separate, but then line up again when we get to the next matching section.
+          -- When left and right are different, We do a subdiff on the chunk
           let (lefts :: [[Segment a]], rights :: [[Segment a]]) =
                 ds
                   & foldMap \case
                     Left _ -> error "impossible"
                     Right (Left a) -> (a, mempty)
                     Right (Right b) -> (mempty, b)
-              leftLineCount = length lefts
-              rightLineCount = length rights
-           in ( (Just <$> lefts) <> replicate rightLineCount Nothing,
-                replicate leftLineCount Nothing <> (Just <$> rights)
-              )
+           in diffChangeChunk diffEq lefts rights
 
 -- Diff data can be one-sided or have a counter-part on the other side of the diff.
 -- We can use this to represent things like name-changes for the same hash, or hash-changes for the same name.
@@ -204,8 +202,7 @@ diffChangeChunk diffEq leftLines rightLines =
             Diff.Both from to ->
               let reLinedL = List.splitOn [Nothing] from
                   reLinedR = List.splitOn [Nothing] to
-                  zipped = zipWith (zipWith Paired) (catMaybes <$> reLinedL) (catMaybes <$> reLinedR)
-               in (zipped, fmap swapPair <$> zipped)
+               in pairLines (catMaybes <$> reLinedL) (catMaybes <$> reLinedR)
       -- Now only padding newlines are represented by Nothing.
       padding = repeat Nothing
       leftLength = length leftResults
@@ -220,3 +217,10 @@ diffChangeChunk diffEq leftLines rightLines =
       Nothing Nothing -> True
       (Just l) (Just r) -> diffEq l r
       _ _ -> False
+
+pairLines :: [[a]] -> [[a]] -> ([[Paired a]], [[Paired a]])
+pairLines left right =
+  let paired = zipWith (zipWith Paired) left right
+   in ( paired,
+        fmap swapPair <$> paired
+      )

--- a/unison-share-api/src/Unison/Server/Backend/DefinitionDiff.hs
+++ b/unison-share-api/src/Unison/Server/Backend/DefinitionDiff.hs
@@ -122,7 +122,16 @@ linewiseDiff diffEq left right =
              in diffChangeChunk diffEq lefts rights
         & \(lhsLines, rhsLines) ->
           LinewiseDiff {lhsLines, rhsLines}
+  where
+    pairLines :: forall x. [[x]] -> [[x]] -> ([[Paired x]], [[Paired x]])
+    pairLines left right =
+      let paired = zipWith (zipWith Paired) left right
+      in ( paired,
+            fmap swapPair <$> paired
+          )
 
+-- | Compute a semantic line-wise diff between two SyntaxText values, with special-casing
+-- to detect tokens whose name stayed the same but whose hash changed, or whose hash stayed the same but whose name changed.
 semanticLinewiseDiff :: SyntaxText -> SyntaxText -> LinewiseDiff (SemanticSyntaxDiff Syntax.Element)
 semanticLinewiseDiff (AnnotatedText lhs) (AnnotatedText rhs) =
   linewiseDiff syntaxElementDiffEq lhs rhs
@@ -154,7 +163,7 @@ semanticLinewiseDiff (AnnotatedText lhs) (AnnotatedText rhs) =
             Syntax.AbilityConstructorReference hash -> Just hash
             _ -> Nothing
 
--- Takes the left and right sides of a diff which are part of the same contiguous chunk, then
+-- | Takes the left and right sides of a diff which are part of the same contiguous chunk, then
 -- diffs them and returns padded left/right line diffs
 diffChangeChunk ::
   forall a.
@@ -203,10 +212,3 @@ diffChangeChunk diffEq leftLines rightLines =
       Nothing Nothing -> True
       (Just l) (Just r) -> diffEq l r
       _ _ -> False
-
-pairLines :: [[a]] -> [[a]] -> ([[Paired a]], [[Paired a]])
-pairLines left right =
-  let paired = zipWith (zipWith Paired) left right
-   in ( paired,
-        fmap swapPair <$> paired
-      )

--- a/unison-share-api/src/Unison/Server/Backend/DefinitionDiff.hs
+++ b/unison-share-api/src/Unison/Server/Backend/DefinitionDiff.hs
@@ -12,6 +12,7 @@ import Data.Foldable qualified as Foldable
 import Data.Function
 import Data.List qualified as List
 import Data.List.Extra qualified as List
+import Data.List.NonEmpty qualified as NEL
 import Data.List.Split qualified as Split
 import Unison.Codebase.Editor.DisplayObject (DisplayObject (..))
 import Unison.Prelude
@@ -21,6 +22,7 @@ import Unison.Server.Types (Changed (..), DisplayObjectDiff (..), LinewiseDiff (
 import Unison.Util.AnnotatedText (AnnotatedText (..), Segment (..))
 import Unison.Util.AnnotatedText qualified as AT
 import Unison.Util.List qualified as ListUtil
+import Unison.Util.Recursion qualified as Rec
 
 diffDisplayObjects :: (HasCallStack) => DisplayObject SyntaxText SyntaxText -> DisplayObject SyntaxText SyntaxText -> DisplayObjectDiff
 diffDisplayObjects from to = case (from, to) of
@@ -136,12 +138,14 @@ semanticLinewiseDiff :: SyntaxText -> SyntaxText -> LinewiseDiff (SemanticSyntax
 semanticLinewiseDiff (AnnotatedText lhs) (AnnotatedText rhs) =
   linewiseDiff syntaxElementDiffEq lhs rhs
     <&> specialCasePairs
+    & \(LinewiseDiff {lhsLines, rhsLines}) ->
+      LinewiseDiff {lhsLines = (fmap . fmap) aggregateChunks lhsLines, rhsLines = (fmap . fmap) aggregateChunks rhsLines}
   where
     specialCasePairs :: Paired (Segment Syntax.Element) -> SemanticSyntaxDiff Syntax.Element
     specialCasePairs = \case
-      OneSided a -> OnlyThisSide a
+      OneSided a -> OnlyThisSide (NEL.singleton a)
       Paired fromSegment toSegment
-        | fromSegment == toSegment -> Both fromSegment
+        | fromSegment == toSegment -> Both (NEL.singleton fromSegment)
         | AT.annotation fromSegment == AT.annotation toSegment -> SegmentChange (AT.segment fromSegment, AT.segment toSegment) (AT.annotation fromSegment)
         -- We only emit an annotation change if it's a change in just the hash of the element (optionally the KIND of hash reference can change too).
         | AT.segment fromSegment == AT.segment toSegment,
@@ -153,7 +157,7 @@ semanticLinewiseDiff (AnnotatedText lhs) (AnnotatedText rhs) =
             -- This can happen in certain special cases, e.g. a paren changed from being a syntax element into being part
             -- of a unit.
             -- We just emit both as old/new segments.
-            OnlyThisSide fromSegment
+            OnlyThisSide (NEL.singleton fromSegment)
         where
           elementHash :: Syntax.Element -> Maybe Syntax.UnisonHash
           elementHash = \case
@@ -162,6 +166,18 @@ semanticLinewiseDiff (AnnotatedText lhs) (AnnotatedText rhs) =
             Syntax.DataConstructorReference hash -> Just hash
             Syntax.AbilityConstructorReference hash -> Just hash
             _ -> Nothing
+
+    -- Collapse subsequent chunks of the same kind of diff into one chunk.
+    aggregateChunks :: [SemanticSyntaxDiff Syntax.Element] -> [SemanticSyntaxDiff Syntax.Element]
+    aggregateChunks =
+      Rec.cata \case
+        Rec.Neither -> []
+        Rec.Both x [] -> [x]
+        Rec.Both (OnlyThisSide xs) (OnlyThisSide ys : rest) ->
+          OnlyThisSide (xs <> ys) : rest
+        Rec.Both (Both xs) (Both ys : rest) ->
+          Both (xs <> ys) : rest
+        Rec.Both x xs -> x : xs
 
 -- | Takes the left and right sides of a diff which are part of the same contiguous chunk, then
 -- diffs them and returns padded left/right line diffs

--- a/unison-share-api/src/Unison/Server/Backend/DefinitionDiff.hs
+++ b/unison-share-api/src/Unison/Server/Backend/DefinitionDiff.hs
@@ -126,7 +126,7 @@ linewiseDiff diffEq left right =
     pairLines :: forall x. [[x]] -> [[x]] -> ([[Paired x]], [[Paired x]])
     pairLines left right =
       let paired = zipWith (zipWith Paired) left right
-      in ( paired,
+       in ( paired,
             fmap swapPair <$> paired
           )
 

--- a/unison-share-api/src/Unison/Server/Backend/DefinitionDiff.hs
+++ b/unison-share-api/src/Unison/Server/Backend/DefinitionDiff.hs
@@ -8,13 +8,17 @@ import Data.Algorithm.Diff qualified as Diff
 import Data.Foldable qualified as Foldable
 import Data.Function
 import Data.List qualified as List
+import Data.List.Extra qualified as List
+import Data.List.Split qualified as Split
+import Data.Text qualified as Text
 import Unison.Codebase.Editor.DisplayObject (DisplayObject (..))
 import Unison.Prelude
 import Unison.Server.Syntax (SyntaxText)
 import Unison.Server.Syntax qualified as Syntax
 import Unison.Server.Types (DisplayObjectDiff (..), SemanticSyntaxDiff (..))
-import Unison.Util.AnnotatedText (AnnotatedText (..))
+import Unison.Util.AnnotatedText (AnnotatedText (..), Segment (..))
 import Unison.Util.AnnotatedText qualified as AT
+import Unison.Util.List qualified as ListUtil
 
 diffDisplayObjects :: (HasCallStack) => DisplayObject SyntaxText SyntaxText -> DisplayObject SyntaxText SyntaxText -> DisplayObjectDiff
 diffDisplayObjects from to = case (from, to) of
@@ -25,70 +29,194 @@ diffDisplayObjects from to = case (from, to) of
   (UserObject fromST, UserObject toST) -> DisplayObjectDiff (UserObject (diffSyntaxText fromST toST))
   (l, r) -> MismatchedDisplayObjects l r
 
-diffSyntaxText :: SyntaxText -> SyntaxText -> [SemanticSyntaxDiff]
+diffSyntaxText :: SyntaxText -> SyntaxText -> [SemanticSyntaxDiff Syntax.Element]
 diffSyntaxText (AnnotatedText fromST) (AnnotatedText toST) =
+  diffSegments syntaxElementDiffEq fromST toST
+    & expandSpecialCases specialCaseAnnotations
+
+-- We special-case situations where the name of a definition changed but its hash didn't;
+-- and cases where the name didn't change but the hash did.
+--
+-- The diff algorithm only understands whether items are equal or not, so in order to add this special behavior we
+-- treat these special cases as equal, then we can detect and expand them in a post-processing step.
+syntaxElementDiffEq :: AT.Segment Syntax.Element -> AT.Segment Syntax.Element -> Bool
+syntaxElementDiffEq (AT.Segment {segment = fromSegment, annotation = fromAnnotation}) (AT.Segment {segment = toSegment, annotation = toAnnotation}) =
+  fromSegment == toSegment
+    || case (fromAnnotation, toAnnotation) of
+      (Nothing, _) -> False
+      (_, Nothing) -> False
+      (Just a, Just b) ->
+        case a of
+          -- The set of annotations we want to special-case
+          Syntax.TypeReference {} -> a == b
+          Syntax.TermReference {} -> a == b
+          Syntax.DataConstructorReference {} -> a == b
+          Syntax.AbilityConstructorReference {} -> a == b
+          Syntax.HashQualifier {} -> a == b
+          _ -> False
+
+specialCaseAnnotations :: AT.Segment Syntax.Element -> AT.Segment Syntax.Element -> Either (AT.Segment Syntax.Element) [SemanticSyntaxDiff Syntax.Element]
+specialCaseAnnotations fromSegment toSegment
+  | fromSegment == toSegment = Left fromSegment
+  | AT.annotation fromSegment == AT.annotation toSegment = Right [SegmentChange (AT.segment fromSegment, AT.segment toSegment) (AT.annotation fromSegment)]
+  -- We only emit an annotation change if it's a change in just the hash of the element (optionally the KIND of hash reference can change too).
+  | AT.segment fromSegment == AT.segment toSegment,
+    Just _fromHash <- AT.annotation fromSegment >>= elementHash,
+    Just _toHash <- AT.annotation toSegment >>= elementHash =
+      Right [AnnotationChange (AT.segment fromSegment) (AT.annotation fromSegment, AT.annotation toSegment)]
+  | otherwise =
+      -- the annotation changed, but it's not a recognized hash change.
+      -- This can happen in certain special cases, e.g. a paren changed from being a syntax element into being part
+      -- of a unit.
+      -- We just emit both as old/new segments.
+      Right [Old [fromSegment], New [toSegment]]
+  where
+    elementHash :: Syntax.Element -> Maybe Syntax.UnisonHash
+    elementHash = \case
+      Syntax.TypeReference hash -> Just hash
+      Syntax.TermReference hash -> Just hash
+      Syntax.DataConstructorReference hash -> Just hash
+      Syntax.AbilityConstructorReference hash -> Just hash
+      _ -> Nothing
+
+diffSegments ::
+  forall f a.
+  (Foldable f) =>
+  (a -> a -> Bool) ->
+  f a ->
+  f a ->
+  [Diff.PolyDiff [a] [a]]
+diffSegments diffEq left right =
   Diff.getGroupedDiffBy
     diffEq
-    (Foldable.toList @Seq fromST)
-    (Foldable.toList @Seq toST)
-    & expandSpecialCases
-  where
-    -- We special-case situations where the name of a definition changed but its hash didn't;
-    -- and cases where the name didn't change but the hash did.
-    --
-    -- The diff algorithm only understands whether items are equal or not, so in order to add this special behavior we
-    -- treat these special cases as equal, then we can detect and expand them in a post-processing step.
-    diffEq :: AT.Segment Syntax.Element -> AT.Segment Syntax.Element -> Bool
-    diffEq (AT.Segment {segment = fromSegment, annotation = fromAnnotation}) (AT.Segment {segment = toSegment, annotation = toAnnotation}) =
-      fromSegment == toSegment
-        || case (fromAnnotation, toAnnotation) of
-          (Nothing, _) -> False
-          (_, Nothing) -> False
-          (Just a, Just b) ->
-            case a of
-              -- The set of annotations we want to special-case
-              Syntax.TypeReference {} -> a == b
-              Syntax.TermReference {} -> a == b
-              Syntax.DataConstructorReference {} -> a == b
-              Syntax.AbilityConstructorReference {} -> a == b
-              Syntax.HashQualifier {} -> a == b
-              _ -> False
+    (Foldable.toList left)
+    (Foldable.toList right)
 
-    expandSpecialCases :: [Diff.Diff [AT.Segment (Syntax.Element)]] -> [SemanticSyntaxDiff]
-    expandSpecialCases xs =
-      xs
-        & foldMap \case
-          Diff.First ys -> [Old ys]
-          Diff.Second ys -> [New ys]
-          Diff.Both from to ->
-            -- Each list should always be the same length.
-            zipWith detectSpecialCase from to
-              & (flip List.foldr [])
-                ( \next acc -> case (acc, next) of
-                    (Both xs : rest, Left seg) -> Both (seg : xs) : rest
-                    (_, Left seg) -> Both [seg] : acc
-                    (_, Right diff) -> diff ++ acc
-                )
-    detectSpecialCase :: AT.Segment Syntax.Element -> AT.Segment Syntax.Element -> Either (AT.Segment Syntax.Element) [SemanticSyntaxDiff]
-    detectSpecialCase fromSegment toSegment
-      | fromSegment == toSegment = Left fromSegment
-      | AT.annotation fromSegment == AT.annotation toSegment = Right [SegmentChange (AT.segment fromSegment, AT.segment toSegment) (AT.annotation fromSegment)]
-      -- We only emit an annotation change if it's a change in just the hash of the element (optionally the KIND of hash reference can change too).
-      | AT.segment fromSegment == AT.segment toSegment,
-        Just _fromHash <- AT.annotation fromSegment >>= elementHash,
-        Just _toHash <- AT.annotation toSegment >>= elementHash =
-          Right [AnnotationChange (AT.segment fromSegment) (AT.annotation fromSegment, AT.annotation toSegment)]
-      | otherwise =
-          -- the annotation changed, but it's not a recognized hash change.
-          -- This can happen in certain special cases, e.g. a paren changed from being a syntax element into being part
-          -- of a unit.
-          -- We just emit both as old/new segments.
-          Right [Old [fromSegment], New [toSegment]]
-      where
-        elementHash :: Syntax.Element -> Maybe Syntax.UnisonHash
-        elementHash = \case
-          Syntax.TypeReference hash -> Just hash
-          Syntax.TermReference hash -> Just hash
-          Syntax.DataConstructorReference hash -> Just hash
-          Syntax.AbilityConstructorReference hash -> Just hash
-          _ -> Nothing
+expandSpecialCases ::
+  (Segment a -> Segment a -> Either (Segment a) [SemanticSyntaxDiff a]) ->
+  [Diff.Diff [AT.Segment a]] ->
+  [SemanticSyntaxDiff a]
+expandSpecialCases detectSpecialCase xs =
+  xs
+    & foldMap \case
+      Diff.First ys -> [Old ys]
+      Diff.Second ys -> [New ys]
+      Diff.Both from to ->
+        -- Each list should always be the same length.
+        zipWith detectSpecialCase from to
+          & (flip List.foldr [])
+            ( \next acc -> case (acc, next) of
+                (Both xs : rest, Left seg) -> Both (seg : xs) : rest
+                (_, Left seg) -> Both [seg] : acc
+                (_, Right diff) -> diff ++ acc
+            )
+
+data DiffOrSame = Different | Same
+  deriving (Eq, Ord, Show)
+
+-- | Compute a line-wise diff between two lists of segments.
+--
+-- >>> let s a = Segment a Nothing
+-- >>> let left = [s "line1", s "\n", s "line2", s "\n", s "line3"]
+-- >>> let right = [s "line1", s "\n", s "lineX", s "\n", s "line3"]
+-- >>> linewiseDiff left right
+-- ([Just [Segment {segment = "line1", annotation = Nothing}],Just [Segment {segment = "line2", annotation = Nothing}],Nothing,Just [Segment {segment = "line3", annotation = Nothing}]],[Just [Segment {segment = "line1", annotation = Nothing}],Nothing,Just [Segment {segment = "lineX", annotation = Nothing}],Just [Segment {segment = "line3", annotation = Nothing}]])
+linewiseDiff ::
+  forall f a.
+  (Foldable f, Eq a) =>
+  f (Segment a) ->
+  f (Segment a) ->
+  -- Returns a tuple of lists,
+  -- Each list is the same length, when lines are present on both sides they're considered Equal.
+  -- When lines are only present on one side, the other side has a Nothing in that position as padding.
+  ([Maybe [Segment a]], [Maybe [Segment a]])
+linewiseDiff left right =
+  let leftLines = Split.splitWhen ((== "\n") . AT.segment) . toList $ left
+      rightLines = Split.splitWhen ((== "\n") . AT.segment) . toList $ right
+      groupedDiff = Diff.getGroupedDiff leftLines rightLines
+      partitioned =
+        groupedDiff
+          & ListUtil.groupMap
+            ( \d ->
+                case d of
+                  Diff.Both a b -> (Same, Left (a, b))
+                  Diff.First a -> (Different, Right $ Left a)
+                  Diff.Second b -> (Different, Right $ Right b)
+            )
+   in partitioned & foldMap \case
+        (Same, ds) ->
+          ds & foldMap \case
+            Left (a, b) -> (Just <$> a, Just <$> b)
+            Right _ -> error "impossible"
+        (Different, ds) ->
+          -- When left and right are different, We add padding to the end of the left and the beginning of the right
+          -- so that the diffs are visually separate, but then line up again when we get to the next matching section.
+          let (lefts :: [[Segment a]], rights :: [[Segment a]]) =
+                ds
+                  & foldMap \case
+                    Left _ -> error "impossible"
+                    Right (Left a) -> (a, mempty)
+                    Right (Right b) -> (mempty, b)
+              leftLineCount = length lefts
+              rightLineCount = length rights
+           in ( (Just <$> lefts) <> replicate rightLineCount Nothing,
+                replicate leftLineCount Nothing <> (Just <$> rights)
+              )
+
+-- Diff data can be one-sided or have a counter-part on the other side of the diff.
+-- We can use this to represent things like name-changes for the same hash, or hash-changes for the same name.
+data Paired a
+  = OneSided a
+  | Paired a a
+
+swapPair :: Paired a -> Paired a
+swapPair (OneSided a) = OneSided a
+swapPair (Paired a b) = Paired b a
+
+-- Takes the left and right sides of a diff which are part of the same contiguous chunk, then
+-- diffs them and returns padded left/right line diffs
+diffChangeChunk ::
+  forall a.
+  (Eq a) =>
+  (Segment a -> Segment a -> Bool) ->
+  [[Segment a]] ->
+  [[Segment a]] ->
+  -- Lists of lines, where each line is a list of segments.
+  -- 'Nothing' lines are just padding
+  ([Maybe [Paired (Segment a)]], [Maybe [Paired (Segment a)]])
+diffChangeChunk diffEq leftLines rightLines =
+  -- Represent newlines with 'Nothing' so we can do a flat diff.
+  let flattenedL :: [Maybe (Segment a)]
+      flattenedL = List.intercalate [Nothing] (fmap Just <$> leftLines)
+      flattenedR :: [Maybe (Segment a)]
+      flattenedR = List.intercalate [Nothing] (fmap Just <$> rightLines)
+      diff :: [Diff.PolyDiff [Maybe (Segment a)] [Maybe (Segment a)]]
+      diff = diffSegments mayDiffEq flattenedL flattenedR
+      (leftResults :: [[Paired (Segment a)]], rightResults) =
+        diff
+          & foldMap \case
+            Diff.First ys ->
+              let reLined = List.splitOn [Nothing] ys
+               in ((fmap) OneSided . catMaybes <$> reLined, mempty)
+            Diff.Second ys ->
+              let reLined = List.splitOn [Nothing] ys
+               in (mempty, (fmap) OneSided . catMaybes <$> reLined)
+            Diff.Both from to ->
+              let reLinedL = List.splitOn [Nothing] from
+                  reLinedR = List.splitOn [Nothing] to
+                  zipped = zipWith (zipWith Paired) (catMaybes <$> reLinedL) (catMaybes <$> reLinedR)
+               in (zipped, fmap swapPair <$> zipped)
+      -- Now only padding newlines are represented by Nothing.
+      padding = repeat Nothing
+      leftLength = length leftResults
+      rightLength = length rightResults
+      maxLines = max leftLength rightLength
+   in ( (Just <$> leftResults) <> take (maxLines - leftLength) padding,
+        take (maxLines - rightLength) padding <> (Just <$> rightResults)
+      )
+  where
+    mayDiffEq :: Maybe (Segment a) -> Maybe (Segment a) -> Bool
+    mayDiffEq = \cases
+      Nothing Nothing -> True
+      (Just l) (Just r) -> diffEq l r
+      _ _ -> False

--- a/unison-share-api/src/Unison/Server/Types.hs
+++ b/unison-share-api/src/Unison/Server/Types.hs
@@ -289,9 +289,8 @@ data TypeTag = Ability | Data
 -- Includes special-cases for when the name in a definition has changed but the hash hasn't
 -- (rename/alias), and when the hash has changed but the name hasn't (update propagation).
 data SemanticSyntaxDiff a
-  = Old [Segment a]
-  | New [Segment a]
-  | Both [Segment a]
+  = OnlyThisSide (Segment a)
+  | Both (Segment a)
   | --  (fromSegment, toSegment) (shared annotation)
     SegmentChange (String, String) (Maybe a)
   | -- (shared segment) (fromAnnotation, toAnnotation)
@@ -302,14 +301,9 @@ deriving instance (ToSchema a) => ToSchema (SemanticSyntaxDiff a)
 
 instance (ToJSON a) => ToJSON (SemanticSyntaxDiff a) where
   toJSON = \case
-    Old segments ->
+    OnlyThisSide segments ->
       object
-        [ "diffTag" .= ("old" :: Text),
-          "elements" .= segments
-        ]
-    New segments ->
-      object
-        [ "diffTag" .= ("new" :: Text),
+        [ "diffTag" .= ("one-sided" :: Text),
           "elements" .= segments
         ]
     Both segments ->
@@ -336,8 +330,7 @@ instance (FromJSON a) => FromJSON (SemanticSyntaxDiff a) where
   parseJSON = Aeson.withObject "SemanticSyntaxDiff" \obj -> do
     diffTag :: Text <- obj .: "diffTag"
     case diffTag of
-      "old" -> Old <$> obj .: "elements"
-      "new" -> New <$> obj .: "elements"
+      "one-sided" -> OnlyThisSide <$> obj .: "elements"
       "both" -> Both <$> obj .: "elements"
       "segmentChange" -> do
         fromSegment <- obj .: "fromSegment"
@@ -351,13 +344,79 @@ instance (FromJSON a) => FromJSON (SemanticSyntaxDiff a) where
         pure $ AnnotationChange segment (fromAnnotation, toAnnotation)
       _ -> fail "Invalid diffTag"
 
+data Changed a
+  = Changed a
+  | Unchanged a
+  | Spacer
+  deriving (Eq, Ord, Show, Generic, Functor, Foldable, Traversable)
+
+instance (ToJSON a) => ToJSON (Changed a) where
+  toJSON = \case
+    Changed a ->
+      object
+        [ "kind" .= ("changed" :: Text),
+          "value" .= a
+        ]
+    Unchanged a ->
+      object
+        [ "kind" .= ("unchanged" :: Text),
+          "value" .= a
+        ]
+    Spacer ->
+      object
+        [ "kind" .= ("spacer" :: Text)
+        ]
+
+instance (FromJSON a) => FromJSON (Changed a) where
+  parseJSON = Aeson.withObject "Changed" \obj -> do
+    kind :: Text <- obj .: "kind"
+    case kind of
+      "changed" -> Changed <$> obj .: "value"
+      "unchanged" -> Unchanged <$> obj .: "value"
+      "spacer" -> pure Spacer
+      _ -> fail "Invalid kind"
+
+deriving instance (ToSchema a) => ToSchema (Changed a)
+
+data LinewiseDiff a = LinewiseDiff
+  { lhsLines :: [Changed [a]],
+    rhsLines :: [Changed [a]]
+  }
+  deriving stock (Eq, Show, Ord, Generic, Functor, Foldable, Traversable)
+
+deriving instance (ToSchema a) => ToSchema (LinewiseDiff a)
+
+instance (ToJSON a) => ToJSON (LinewiseDiff a) where
+  toJSON LinewiseDiff {..} =
+    object
+      [ "left" .= lhsLines,
+        "right" .= rhsLines
+      ]
+
+instance (FromJSON a) => FromJSON (LinewiseDiff a) where
+  parseJSON = Aeson.withObject "LinewiseDiff" \obj -> do
+    lhsLines <- obj .: "left"
+    rhsLines <- obj .: "right"
+    pure $ LinewiseDiff {..}
+
+-- Diff data can be one-sided or have a counter-part on the other side of the diff.
+-- We can use this to represent things like name-changes for the same hash, or hash-changes for the same name.
+data Paired a
+  = OneSided a
+  | Paired a a
+  deriving (Eq, Ord, Show)
+
+swapPair :: Paired a -> Paired a
+swapPair (OneSided a) = OneSided a
+swapPair (Paired a b) = Paired b a
+
 -- | A diff of the syntax of a term or type
 --
 -- It doesn't make sense to diff builtins with ABTs, so in that case we just provide the
 -- undiffed syntax.
 data DisplayObjectDiff
-  = DisplayObjectDiff (DisplayObject [SemanticSyntaxDiff Syntax.Element] [SemanticSyntaxDiff Syntax.Element])
-  | MismatchedDisplayObjects (DisplayObject Syntax.SyntaxText Syntax.SyntaxText) (DisplayObject Syntax.SyntaxText Syntax.SyntaxText)
+  = DisplayObjectDiff (DisplayObject (LinewiseDiff (SemanticSyntaxDiff Syntax.Element)) (LinewiseDiff (SemanticSyntaxDiff Syntax.Element)))
+  | MismatchedDisplayObjects (DisplayObject SyntaxText SyntaxText) (DisplayObject SyntaxText SyntaxText)
   deriving stock (Show, Eq, Ord, Generic)
 
 deriving instance ToSchema DisplayObjectDiff

--- a/unison-share-api/src/Unison/Server/Types.hs
+++ b/unison-share-api/src/Unison/Server/Types.hs
@@ -10,6 +10,7 @@ import Data.Aeson qualified as Aeson
 import Data.Bifoldable (Bifoldable (..))
 import Data.Bitraversable (Bitraversable (..))
 import Data.ByteString.Lazy qualified as LZ
+import Data.List.NonEmpty (NonEmpty)
 import Data.Map qualified as Map
 import Data.OpenApi
   ( OpenApiType (..),
@@ -289,8 +290,8 @@ data TypeTag = Ability | Data
 -- Includes special-cases for when the name in a definition has changed but the hash hasn't
 -- (rename/alias), and when the hash has changed but the name hasn't (update propagation).
 data SemanticSyntaxDiff a
-  = OnlyThisSide (Segment a)
-  | Both (Segment a)
+  = OnlyThisSide (NonEmpty (Segment a))
+  | Both (NonEmpty (Segment a))
   | --  (fromSegment, toSegment) (shared annotation)
     SegmentChange (String, String) (Maybe a)
   | -- (shared segment) (fromAnnotation, toAnnotation)

--- a/unison-share-api/src/Unison/Server/Types.hs
+++ b/unison-share-api/src/Unison/Server/Types.hs
@@ -303,7 +303,7 @@ instance (ToJSON a) => ToJSON (SemanticSyntaxDiff a) where
   toJSON = \case
     OnlyThisSide segments ->
       object
-        [ "diffTag" .= ("one-sided" :: Text),
+        [ "diffTag" .= ("oneSided" :: Text),
           "elements" .= segments
         ]
     Both segments ->

--- a/unison-share-api/src/Unison/Server/Types.hs
+++ b/unison-share-api/src/Unison/Server/Types.hs
@@ -54,6 +54,7 @@ import Unison.Server.Syntax qualified as Syntax
 import Unison.ShortHash (ShortHash)
 import Unison.Syntax.HashQualified qualified as HQ (parseText)
 import Unison.Syntax.Name qualified as Name
+import Unison.Util.AnnotatedText (Segment)
 import Unison.Util.Pretty (Width (..))
 
 type APIHeaders x =
@@ -287,19 +288,19 @@ data TypeTag = Ability | Data
 -- | A type for semantic diffing of definitions.
 -- Includes special-cases for when the name in a definition has changed but the hash hasn't
 -- (rename/alias), and when the hash has changed but the name hasn't (update propagation).
-data SemanticSyntaxDiff
-  = Old [Syntax.SyntaxSegment]
-  | New [Syntax.SyntaxSegment]
-  | Both [Syntax.SyntaxSegment]
+data SemanticSyntaxDiff a
+  = Old [Segment a]
+  | New [Segment a]
+  | Both [Segment a]
   | --  (fromSegment, toSegment) (shared annotation)
-    SegmentChange (String, String) (Maybe Syntax.Element)
+    SegmentChange (String, String) (Maybe a)
   | -- (shared segment) (fromAnnotation, toAnnotation)
-    AnnotationChange String (Maybe Syntax.Element, Maybe Syntax.Element)
+    AnnotationChange String (Maybe a, Maybe a)
   deriving (Eq, Show, Ord, Generic)
 
-deriving instance ToSchema SemanticSyntaxDiff
+deriving instance (ToSchema a) => ToSchema (SemanticSyntaxDiff a)
 
-instance ToJSON SemanticSyntaxDiff where
+instance (ToJSON a) => ToJSON (SemanticSyntaxDiff a) where
   toJSON = \case
     Old segments ->
       object
@@ -331,7 +332,7 @@ instance ToJSON SemanticSyntaxDiff where
           "toAnnotation" .= toAnnotation
         ]
 
-instance FromJSON SemanticSyntaxDiff where
+instance (FromJSON a) => FromJSON (SemanticSyntaxDiff a) where
   parseJSON = Aeson.withObject "SemanticSyntaxDiff" \obj -> do
     diffTag :: Text <- obj .: "diffTag"
     case diffTag of
@@ -355,7 +356,7 @@ instance FromJSON SemanticSyntaxDiff where
 -- It doesn't make sense to diff builtins with ABTs, so in that case we just provide the
 -- undiffed syntax.
 data DisplayObjectDiff
-  = DisplayObjectDiff (DisplayObject [SemanticSyntaxDiff] [SemanticSyntaxDiff])
+  = DisplayObjectDiff (DisplayObject [SemanticSyntaxDiff Syntax.Element] [SemanticSyntaxDiff Syntax.Element])
   | MismatchedDisplayObjects (DisplayObject Syntax.SyntaxText Syntax.SyntaxText) (DisplayObject Syntax.SyntaxText Syntax.SyntaxText)
   deriving stock (Show, Eq, Ord, Generic)
 

--- a/unison-share-api/tests/Main.hs
+++ b/unison-share-api/tests/Main.hs
@@ -5,11 +5,13 @@ import System.Environment (getArgs)
 import System.IO
 import System.IO.CodePage (withCP65001)
 import Unison.Test.Sync.Roundtrip qualified as SyncRoundtrip
+import Unison.Test.Server.Backend.DefinitionDiff qualified as DefinitionDiff
 
 test :: Test ()
 test =
   tests
     [ SyncRoundtrip.test
+    , DefinitionDiff.test
     ]
 
 main :: IO ()

--- a/unison-share-api/tests/Main.hs
+++ b/unison-share-api/tests/Main.hs
@@ -4,14 +4,14 @@ import EasyTest
 import System.Environment (getArgs)
 import System.IO
 import System.IO.CodePage (withCP65001)
-import Unison.Test.Sync.Roundtrip qualified as SyncRoundtrip
 import Unison.Test.Server.Backend.DefinitionDiff qualified as DefinitionDiff
+import Unison.Test.Sync.Roundtrip qualified as SyncRoundtrip
 
 test :: Test ()
 test =
   tests
-    [ SyncRoundtrip.test
-    , DefinitionDiff.test
+    [ SyncRoundtrip.test,
+      DefinitionDiff.test
     ]
 
 main :: IO ()

--- a/unison-share-api/tests/Unison/Test/Server/Backend/DefinitionDiff.hs
+++ b/unison-share-api/tests/Unison/Test/Server/Backend/DefinitionDiff.hs
@@ -11,6 +11,7 @@ import Text.RawString.QQ (r)
 import Unison.Prelude
 import Unison.Server.Backend.DefinitionDiff
 import Unison.Server.Orphans ()
+import Unison.Server.Types (LinewiseDiff(..))
 import Unison.Util.AnnotatedText (Segment (..))
 
 test :: EasyTest.Test ()
@@ -78,9 +79,8 @@ sidesAlwaysEqualLengths =
     (left, right) <- forAll $ genDiffs
     let leftSegments = textToSegment left
         rightSegments = textToSegment right
-        (lDiff, rDiff) = linewiseDiff (==) leftSegments rightSegments
-    traceShowM (lDiff, rDiff)
-    diff lDiff ((==) `on` length) rDiff
+        LinewiseDiff{lhsLines, rhsLines} = linewiseDiff (==) leftSegments rightSegments
+    diff lhsLines ((==) `on` length) rhsLines
 
 textToSegment :: Text -> [Segment ()]
 textToSegment txt =
@@ -216,8 +216,8 @@ testDiff :: Text -> Text -> Text
 testDiff l r =
   let left = textToSegment l
       right = textToSegment r
-      (ldiff, rdiff) = linewiseDiff (==) left right
-   in align (renderDiffText ldiff) (renderDiffText rdiff)
+      LinewiseDiff{lhsLines, rhsLines} = linewiseDiff (==) left right
+   in align (renderDiffText lhsLines) (renderDiffText rhsLines)
 
 align :: Text -> Text -> Text
 align left right = Text.unlines $ zipWith formatRow leftLines rightLines

--- a/unison-share-api/tests/Unison/Test/Server/Backend/DefinitionDiff.hs
+++ b/unison-share-api/tests/Unison/Test/Server/Backend/DefinitionDiff.hs
@@ -1,0 +1,246 @@
+module Unison.Test.Server.Backend.DefinitionDiff (test) where
+
+import Data.Function
+import Data.List qualified as List
+import Data.Text qualified as Text
+import EasyTest qualified as EasyTest
+import Hedgehog hiding (Test, test)
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Text.RawString.QQ (r)
+import Unison.Prelude
+import Unison.Server.Backend.DefinitionDiff
+import Unison.Server.Orphans ()
+import Unison.Util.AnnotatedText (Segment (..))
+
+test :: EasyTest.Test ()
+test =
+  void . EasyTest.scope "definitiondiffs" $ do
+    success <-
+      EasyTest.io
+        $ checkParallel
+        $ Group
+          "linewise-diffs"
+        $ [ ("sides-always-equal-lengths", sidesAlwaysEqualLengths)
+          ]
+          <> explicitTestCases
+    EasyTest.expect success
+
+genDiffs :: Gen (Text, Text)
+genDiffs = do
+  initial <- diffText
+  -- Choose a diffee that's either a few modifications of the initial text or a completely new random text
+  diffee <- Gen.choice [modifiedText initial, diffText]
+  pure (initial, diffee)
+  where
+    modifiedText txt = do
+      numModifications <- Gen.int (Range.linear 1 5)
+      result <- modifications txt numModifications
+      pure result
+
+    whitespace = Gen.element [" ", "\n"]
+    -- Get a random char, including '\n' explicitly improves the chance of newlines, which are especially important for diffs. Choice shrinks towards earlier elements
+    diffText = do
+      numWords <- Gen.int (Range.linear 10 30)
+      let wordsM = List.replicate numWords diffWord
+      Text.concat <$> (sequenceA $ List.intersperse whitespace wordsM)
+
+    diffWord = Gen.text (Range.linear 1 5) Gen.alpha
+    -- Get a random location in the text, preference for the beginning and end of the text, since those are
+    -- interesting.
+    genTextLoc txt = Gen.choice [pure (Text.length txt), pure 0, Gen.int (Range.linear 0 (Text.length txt))]
+    changeSomething txt = do
+      loc <- genTextLoc txt
+      let (before, after) = Text.splitAt loc txt
+      newTxt <- diffWord
+      dropAmt <- Gen.int (Range.linear 1 10)
+      pure $ before <> newTxt <> Text.drop dropAmt after
+    insertSomething txt = do
+      loc <- genTextLoc txt
+      let (before, after) = Text.splitAt loc txt
+      newTxt <- diffWord
+      pure $ before <> newTxt <> after
+    deleteSomething txt = do
+      loc <- genTextLoc txt
+      let (before, after) = Text.splitAt loc txt
+      dropAmt <- Gen.int (Range.linear 1 10)
+      pure $ before <> Text.drop dropAmt after
+    -- Apply n random modifications to the text
+    modifications txt 0 = pure txt
+    modifications txt n = do
+      updated <- Gen.choice [changeSomething txt, insertSomething txt, deleteSomething txt]
+      modifications updated (n - 1)
+
+-- Both sides of a line-wise diff should be padded to match lengths.
+sidesAlwaysEqualLengths :: Property
+sidesAlwaysEqualLengths =
+  property $ do
+    (left, right) <- forAll $ genDiffs
+    let leftSegments = textToSegment left
+        rightSegments = textToSegment right
+        (lDiff, rDiff) = linewiseDiff (==) leftSegments rightSegments
+    traceShowM (lDiff, rDiff)
+    diff lDiff ((==) `on` length) rDiff
+
+textToSegment :: Text -> [Segment ()]
+textToSegment txt =
+  txt
+    & Text.lines
+    & fmap
+      ( \t ->
+          t
+            & Text.splitOn " "
+            & fmap (Text.unpack)
+            & fmap \case
+              "" -> Nothing
+              w -> Just (Segment w Nothing)
+            & List.intersperse (Just $ (Segment " " Nothing))
+            & catMaybes
+      )
+    & List.intercalate [Segment "\n" Nothing]
+
+data TestCase = TestCase
+  { name :: PropertyName,
+    left :: Text,
+    right :: Text,
+    expected :: Text
+  }
+
+explicitTestCases :: [(PropertyName, Property)]
+explicitTestCases =
+  [ TestCase
+      { name = "simple-modification",
+        left =
+          [r|
+one word
+two words
+three words
+|],
+        right =
+          [r|
+one word
+different words
+three words
+|],
+        expected =
+          [r|
+one word     | one word
+*{two} words | *{different} words
+three words  | three words
+|]
+      },
+    TestCase
+      { name = "unrelated-strings",
+        left =
+          [r|
+Completely different string
+shouldn't
+have much in common
+|],
+        right =
+          [r|
+Lorem ipsum dolor sit amet
+consectetur adipisicing elit
+sed do eiusmod tempor incididunt
+ut labore et dolore magna aliqua
+Ut enim ad minim veniam
+|],
+        expected =
+          [r|
+*{Completely} {different} {string} | *{Lorem} {ipsum} {dolor}{ }{sit}{ }{amet}
+*{shouldn't}                       | *{consectetur}{ }{adipisicing}{ }{elit}
+*{have} {much} {in} {common}       | *{sed} {do} {eiusmod} {tempor}{ }{incididunt}
+////                               | *{ut}{ }{labore}{ }{et}{ }{dolore}{ }{magna}{ }{aliqua}
+////                               | *{Ut}{ }{enim}{ }{ad}{ }{minim}{ }{veniam}
+|]
+      },
+    TestCase
+      { name = "complex-diff",
+        left =
+          [r|
+unchangedDefinition = 1
+myDefinition : Nat -> Text -> Text
+myDefinition n txt =
+  -- Check for non-positive n
+  if n == 0 then txt
+  else Text.drop n txt
+|],
+        right =
+          [r|
+unchangedDefinition = 1
+myNewDefinition : Int -> Text -> Text
+myNewDefinition k input =
+  -- Check for non-positive n
+  if n <= 0
+    then txt
+  else
+    Text.take n input
+|],
+        expected =
+          [r|
+unchangedDefinition = 1                 | unchangedDefinition = 1
+*{myDefinition} : {Nat} -> Text -> Text | *{myNewDefinition} : {Int} -> Text -> Text
+*{myDefinition} {n} {txt} =             | *{myNewDefinition} {k} {input} =
+  -- Check for non-positive n           |   -- Check for non-positive n
+*  if n {==} 0 then txt                 | *  if n {<=} 0
+*  else {Text.drop} n {txt}             | * { }{ }{ }then txt
+////                                    | *  else
+////                                    | *  { }{ }{Text.take}{ }n {input}
+|]
+      }
+  ]
+    <&> \(TestCase {name, left, right, expected}) ->
+      ( name,
+        property $ do
+          let actual = (Text.strip (testDiff (Text.strip left) (Text.strip right)))
+          Hedgehog.footnote ("Actual:\n\n" <> Text.unpack actual <> "\n\nExpected:\n\n" <> Text.unpack (Text.strip expected))
+          actual === (Text.strip expected)
+      )
+
+-- | Renders a structured diff side as text, annotating changed lines with `*` and changed segments within changed lines by wrapping them with `{}`.
+-- Spacers are represented by `////`.
+renderDiffText :: [Changed [Paired (Segment a)]] -> Text
+renderDiffText diffs =
+  let renderSegment :: Segment a -> Text
+      renderSegment (Segment {segment}) = Text.pack segment
+      renderPaired :: Paired (Segment a) -> Text
+      renderPaired (OneSided s) = "{" <> renderSegment s <> "}"
+      renderPaired (Paired s1 _) = renderSegment s1
+      renderChanged :: Changed [Paired (Segment a)] -> Text
+      renderChanged Spacer = "////"
+      renderChanged (Unchanged segs) = Text.concat (renderPaired <$> segs)
+      renderChanged (Changed segs) = "*" <> Text.concat (renderPaired <$> segs)
+   in Text.unlines $ fmap renderChanged diffs
+
+testDiff :: Text -> Text -> Text
+testDiff l r =
+  let left = textToSegment l
+      right = textToSegment r
+      (ldiff, rdiff) = linewiseDiff (==) left right
+   in align (renderDiffText ldiff) (renderDiffText rdiff)
+
+align :: Text -> Text -> Text
+align left right = Text.unlines $ zipWith formatRow leftLines rightLines
+  where
+    leftLines = Text.lines left
+    rightLines = Text.lines right
+
+    -- Find the maximum length in the left column
+    maxLeftWidth = maximum $ map Text.length leftLines
+
+    -- Pad the left text and combine with right text
+    formatRow l r = Text.justifyLeft maxLeftWidth ' ' l <> " | " <> r
+
+-- Helpers for testing semantic diffs on plaintext
+
+-- simpleLeft :: Text
+-- simpleLeft = "one word\ntwo words\nthree words"
+
+-- simpleRight :: Text
+-- simpleRight = "one word\ndifferent words\nthree words"
+
+-- complexLeft :: Text
+-- complexLeft = "one word\ntwo words\nthree words"
+
+-- complexRight :: Text
+-- complexRight = "one word\nmulti-line\ndifference\nshould add spacers\nthree words"

--- a/unison-share-api/tests/Unison/Test/Server/Backend/DefinitionDiff.hs
+++ b/unison-share-api/tests/Unison/Test/Server/Backend/DefinitionDiff.hs
@@ -11,7 +11,7 @@ import Text.RawString.QQ (r)
 import Unison.Prelude
 import Unison.Server.Backend.DefinitionDiff
 import Unison.Server.Orphans ()
-import Unison.Server.Types (LinewiseDiff(..))
+import Unison.Server.Types (LinewiseDiff (..))
 import Unison.Util.AnnotatedText (Segment (..))
 
 test :: EasyTest.Test ()
@@ -79,7 +79,7 @@ sidesAlwaysEqualLengths =
     (left, right) <- forAll $ genDiffs
     let leftSegments = textToSegment left
         rightSegments = textToSegment right
-        LinewiseDiff{lhsLines, rhsLines} = linewiseDiff (==) leftSegments rightSegments
+        LinewiseDiff {lhsLines, rhsLines} = linewiseDiff (==) leftSegments rightSegments
     diff lhsLines ((==) `on` length) rhsLines
 
 textToSegment :: Text -> [Segment ()]
@@ -216,7 +216,7 @@ testDiff :: Text -> Text -> Text
 testDiff l r =
   let left = textToSegment l
       right = textToSegment r
-      LinewiseDiff{lhsLines, rhsLines} = linewiseDiff (==) left right
+      LinewiseDiff {lhsLines, rhsLines} = linewiseDiff (==) left right
    in align (renderDiffText lhsLines) (renderDiffText rhsLines)
 
 align :: Text -> Text -> Text

--- a/unison-share-api/unison-share-api.cabal
+++ b/unison-share-api/unison-share-api.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.38.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -117,6 +117,7 @@ library
     , servant-docs
     , servant-openapi3
     , servant-server
+    , split
     , text
     , transformers
     , unison-codebase

--- a/unison-share-api/unison-share-api.cabal
+++ b/unison-share-api/unison-share-api.cabal
@@ -152,6 +152,7 @@ test-suite unison-share-api-tests
   type: exitcode-stdio-1.0
   main-is: Main.hs
   other-modules:
+      Unison.Test.Server.Backend.DefinitionDiff
       Unison.Test.Sync.Gen
       Unison.Test.Sync.Roundtrip
   hs-source-dirs:
@@ -195,11 +196,13 @@ test-suite unison-share-api-tests
     , code-page
     , easytest
     , hedgehog
+    , raw-strings-qq
     , serialise
     , text
     , unison-codebase-sqlite
     , unison-hash
     , unison-prelude
+    , unison-pretty-printer
     , unison-share-api
     , vector
   default-language: Haskell2010

--- a/unison-src/transcripts/idempotent/definition-diff-api.md
+++ b/unison-src/transcripts/idempotent/definition-diff-api.md
@@ -134,39 +134,32 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "term",
-                                      "tag": "HashQualifier"
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "contents": "term",
+                                          "tag": "HashQualifier"
+                                      },
+                                      "segment": "term"
                                   },
-                                  "segment": "term"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "TypeAscriptionColon"
+                                  {
+                                      "annotation": {
+                                          "tag": "TypeAscriptionColon"
+                                      },
+                                      "segment": " :"
                                   },
-                                  "segment": " :"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "##Nat",
-                                      "tag": "TypeReference"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "Nat"
-                              }
+                                  {
+                                      "annotation": {
+                                          "contents": "##Nat",
+                                          "tag": "TypeReference"
+                                      },
+                                      "segment": "Nat"
+                                  }
+                              ]
                           }
                       ]
                   },
@@ -175,22 +168,21 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "term",
-                                      "tag": "HashQualifier"
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "contents": "term",
+                                          "tag": "HashQualifier"
+                                      },
+                                      "segment": "term"
                                   },
-                                  "segment": "term"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "BindingEquals"
-                                  },
-                                  "segment": " ="
-                              }
+                                  {
+                                      "annotation": {
+                                          "tag": "BindingEquals"
+                                      },
+                                      "segment": " ="
+                                  }
+                              ]
                           }
                       ]
                   },
@@ -199,44 +191,34 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "UseKeyword"
+                              "elements": [
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
                                   },
-                                  "segment": "use "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "UsePrefix"
+                                  {
+                                      "annotation": {
+                                          "tag": "UseKeyword"
+                                      },
+                                      "segment": "use "
                                   },
-                                  "segment": "Nat"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "UseSuffix"
+                                  {
+                                      "annotation": {
+                                          "tag": "UsePrefix"
+                                      },
+                                      "segment": "Nat"
                                   },
-                                  "segment": "+"
-                              }
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "UseSuffix"
+                                      },
+                                      "segment": "+"
+                                  }
+                              ]
                           }
                       ]
                   },
@@ -245,45 +227,40 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "_",
-                                      "tag": "HashQualifier"
+                              "elements": [
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
                                   },
-                                  "segment": "_"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "BindingEquals"
+                                  {
+                                      "annotation": {
+                                          "contents": "_",
+                                          "tag": "HashQualifier"
+                                      },
+                                      "segment": "_"
                                   },
-                                  "segment": " ="
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
+                                  {
+                                      "annotation": {
+                                          "tag": "BindingEquals"
+                                      },
+                                      "segment": " ="
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  }
+                              ]
                           },
                           {
                               "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "TextLiteral"
-                                  },
-                                  "segment": "\"Here's some text\""
-                              }
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "tag": "TextLiteral"
+                                      },
+                                      "segment": "\"Here's some text\""
+                                  }
+                              ]
                           }
                       ]
                   },
@@ -292,52 +269,44 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "NumericLiteral"
+                              "elements": [
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
                                   },
-                                  "segment": "1"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "##Nat.+",
-                                      "tag": "TermReference"
+                                  {
+                                      "annotation": {
+                                          "tag": "NumericLiteral"
+                                      },
+                                      "segment": "1"
                                   },
-                                  "segment": "+"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "contents": "##Nat.+",
+                                          "tag": "TermReference"
+                                      },
+                                      "segment": "+"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  }
+                              ]
                           },
                           {
                               "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "NumericLiteral"
-                                  },
-                                  "segment": "1"
-                              }
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "tag": "NumericLiteral"
+                                      },
+                                      "segment": "1"
+                                  }
+                              ]
                           }
                       ]
                   }
@@ -348,39 +317,32 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "term",
-                                      "tag": "HashQualifier"
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "contents": "term",
+                                          "tag": "HashQualifier"
+                                      },
+                                      "segment": "term"
                                   },
-                                  "segment": "term"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "TypeAscriptionColon"
+                                  {
+                                      "annotation": {
+                                          "tag": "TypeAscriptionColon"
+                                      },
+                                      "segment": " :"
                                   },
-                                  "segment": " :"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "##Nat",
-                                      "tag": "TypeReference"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "Nat"
-                              }
+                                  {
+                                      "annotation": {
+                                          "contents": "##Nat",
+                                          "tag": "TypeReference"
+                                      },
+                                      "segment": "Nat"
+                                  }
+                              ]
                           }
                       ]
                   },
@@ -389,22 +351,21 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "term",
-                                      "tag": "HashQualifier"
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "contents": "term",
+                                          "tag": "HashQualifier"
+                                      },
+                                      "segment": "term"
                                   },
-                                  "segment": "term"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "BindingEquals"
-                                  },
-                                  "segment": " ="
-                              }
+                                  {
+                                      "annotation": {
+                                          "tag": "BindingEquals"
+                                      },
+                                      "segment": " ="
+                                  }
+                              ]
                           }
                       ]
                   },
@@ -413,44 +374,34 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "UseKeyword"
+                              "elements": [
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
                                   },
-                                  "segment": "use "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "UsePrefix"
+                                  {
+                                      "annotation": {
+                                          "tag": "UseKeyword"
+                                      },
+                                      "segment": "use "
                                   },
-                                  "segment": "Nat"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "UseSuffix"
+                                  {
+                                      "annotation": {
+                                          "tag": "UsePrefix"
+                                      },
+                                      "segment": "Nat"
                                   },
-                                  "segment": "+"
-                              }
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "UseSuffix"
+                                      },
+                                      "segment": "+"
+                                  }
+                              ]
                           }
                       ]
                   },
@@ -459,45 +410,40 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "_",
-                                      "tag": "HashQualifier"
+                              "elements": [
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
                                   },
-                                  "segment": "_"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "BindingEquals"
+                                  {
+                                      "annotation": {
+                                          "contents": "_",
+                                          "tag": "HashQualifier"
+                                      },
+                                      "segment": "_"
                                   },
-                                  "segment": " ="
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
+                                  {
+                                      "annotation": {
+                                          "tag": "BindingEquals"
+                                      },
+                                      "segment": " ="
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  }
+                              ]
                           },
                           {
                               "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "TextLiteral"
-                                  },
-                                  "segment": "\"Here's some different text\""
-                              }
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "tag": "TextLiteral"
+                                      },
+                                      "segment": "\"Here's some different text\""
+                                  }
+                              ]
                           }
                       ]
                   },
@@ -506,52 +452,44 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "NumericLiteral"
+                              "elements": [
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
                                   },
-                                  "segment": "1"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "##Nat.+",
-                                      "tag": "TermReference"
+                                  {
+                                      "annotation": {
+                                          "tag": "NumericLiteral"
+                                      },
+                                      "segment": "1"
                                   },
-                                  "segment": "+"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "contents": "##Nat.+",
+                                          "tag": "TermReference"
+                                      },
+                                      "segment": "+"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  }
+                              ]
                           },
                           {
                               "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "NumericLiteral"
-                                  },
-                                  "segment": "2"
-                              }
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "tag": "NumericLiteral"
+                                      },
+                                      "segment": "2"
+                                  }
+                              ]
                           }
                       ]
                   }
@@ -899,230 +837,154 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "take",
-                                      "tag": "HashQualifier"
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "contents": "take",
+                                          "tag": "HashQualifier"
+                                      },
+                                      "segment": "take"
                                   },
-                                  "segment": "take"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "TypeAscriptionColon"
+                                  {
+                                      "annotation": {
+                                          "tag": "TypeAscriptionColon"
+                                      },
+                                      "segment": " :"
                                   },
-                                  "segment": " :"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "##Nat",
-                                      "tag": "TypeReference"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "Nat"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "TypeOperator"
+                                  {
+                                      "annotation": {
+                                          "contents": "##Nat",
+                                          "tag": "TypeReference"
+                                      },
+                                      "segment": "Nat"
                                   },
-                                  "segment": "->"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "DelayForceChar"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "'"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "AbilityBraces"
+                                  {
+                                      "annotation": {
+                                          "tag": "TypeOperator"
+                                      },
+                                      "segment": "->"
                                   },
-                                  "segment": "{"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "g"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "AbilityBraces"
+                                  {
+                                      "annotation": {
+                                          "tag": "DelayForceChar"
+                                      },
+                                      "segment": "'"
                                   },
-                                  "segment": "}"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": {
+                                          "tag": "AbilityBraces"
+                                      },
+                                      "segment": "{"
                                   },
-                                  "segment": "t"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "TypeOperator"
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "g"
                                   },
-                                  "segment": "->"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "AbilityBraces"
+                                  {
+                                      "annotation": {
+                                          "tag": "AbilityBraces"
+                                      },
+                                      "segment": "}"
                                   },
-                                  "segment": "{"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "g"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": ","
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro",
-                                      "tag": "TypeReference"
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "t"
                                   },
-                                  "segment": "Stream"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "a"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "AbilityBraces"
+                                  {
+                                      "annotation": {
+                                          "tag": "TypeOperator"
+                                      },
+                                      "segment": "->"
                                   },
-                                  "segment": "}"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg",
-                                      "tag": "TypeReference"
+                                  {
+                                      "annotation": {
+                                          "tag": "AbilityBraces"
+                                      },
+                                      "segment": "{"
                                   },
-                                  "segment": "Optional"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "g"
                                   },
-                                  "segment": "t"
-                              }
+                                  {
+                                      "annotation": null,
+                                      "segment": ","
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro",
+                                          "tag": "TypeReference"
+                                      },
+                                      "segment": "Stream"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "a"
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "AbilityBraces"
+                                      },
+                                      "segment": "}"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg",
+                                          "tag": "TypeReference"
+                                      },
+                                      "segment": "Optional"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "t"
+                                  }
+                              ]
                           }
                       ]
                   },
@@ -1131,54 +993,41 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "take",
-                                      "tag": "HashQualifier"
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "contents": "take",
+                                          "tag": "HashQualifier"
+                                      },
+                                      "segment": "take"
                                   },
-                                  "segment": "take"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "n"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "n"
                                   },
-                                  "segment": "s"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "BindingEquals"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": " ="
-                              }
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "s"
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "BindingEquals"
+                                      },
+                                      "segment": " ="
+                                  }
+                              ]
                           }
                       ]
                   },
@@ -1187,62 +1036,46 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "UseKeyword"
+                              "elements": [
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
                                   },
-                                  "segment": "use "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "UsePrefix"
+                                  {
+                                      "annotation": {
+                                          "tag": "UseKeyword"
+                                      },
+                                      "segment": "use "
                                   },
-                                  "segment": "Nat"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "UseSuffix"
+                                  {
+                                      "annotation": {
+                                          "tag": "UsePrefix"
+                                      },
+                                      "segment": "Nat"
                                   },
-                                  "segment": "-"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "UseSuffix"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "UseSuffix"
+                                  {
+                                      "annotation": {
+                                          "tag": "UseSuffix"
+                                      },
+                                      "segment": "-"
                                   },
-                                  "segment": ">"
-                              }
+                                  {
+                                      "annotation": {
+                                          "tag": "UseSuffix"
+                                      },
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "UseSuffix"
+                                      },
+                                      "segment": ">"
+                                  }
+                              ]
                           }
                       ]
                   },
@@ -1251,61 +1084,45 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "h",
-                                      "tag": "HashQualifier"
+                              "elements": [
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
                                   },
-                                  "segment": "h"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": {
+                                          "contents": "h",
+                                          "tag": "HashQualifier"
+                                      },
+                                      "segment": "h"
                                   },
-                                  "segment": "n"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "BindingEquals"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": " ="
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "ControlKeyword"
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "n"
                                   },
-                                  "segment": "cases"
-                              }
+                                  {
+                                      "annotation": {
+                                          "tag": "BindingEquals"
+                                      },
+                                      "segment": " ="
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "ControlKeyword"
+                                      },
+                                      "segment": "cases"
+                                  }
+                              ]
                           }
                       ]
                   },
@@ -1314,123 +1131,83 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "DelimiterChar"
+                              "elements": [
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
                                   },
-                                  "segment": "{"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro#a0",
-                                      "tag": "TermReference"
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
                                   },
-                                  "segment": "emit"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": {
+                                          "tag": "DelimiterChar"
+                                      },
+                                      "segment": "{"
                                   },
-                                  "segment": "a"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "ControlKeyword"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "->"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": {
+                                          "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro#a0",
+                                          "tag": "TermReference"
+                                      },
+                                      "segment": "emit"
                                   },
-                                  "segment": "k"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "DelimiterChar"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "}"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "ControlKeyword"
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "a"
                                   },
-                                  "segment": "->"
-                              }
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "ControlKeyword"
+                                      },
+                                      "segment": "->"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "k"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "DelimiterChar"
+                                      },
+                                      "segment": "}"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "ControlKeyword"
+                                      },
+                                      "segment": "->"
+                                  }
+                              ]
                           }
                       ]
                   },
@@ -1439,84 +1216,64 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "ControlKeyword"
+                              "elements": [
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
                                   },
-                                  "segment": "if "
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
                                   },
-                                  "segment": "n"
-                              }
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
+                                  }
+                              ]
                           },
                           {
                               "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "##Nat.>",
-                                      "tag": "TermReference"
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "tag": "ControlKeyword"
+                                      },
+                                      "segment": "if "
                                   },
-                                  "segment": ">"
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "NumericLiteral"
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "n"
                                   },
-                                  "segment": "0"
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "ControlKeyword"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": " then"
-                              }
+                                  {
+                                      "annotation": {
+                                          "contents": "##Nat.>",
+                                          "tag": "TermReference"
+                                      },
+                                      "segment": ">"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "NumericLiteral"
+                                      },
+                                      "segment": "0"
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "ControlKeyword"
+                                      },
+                                      "segment": " then"
+                                  }
+                              ]
                           }
                       ]
                   },
@@ -1525,57 +1282,46 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro#a0",
-                                      "tag": "TermReference"
+                              "elements": [
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
                                   },
-                                  "segment": "emit"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
                                   },
-                                  "segment": "a"
-                              }
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
+                                  }
+                              ]
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro#a0",
+                                          "tag": "TermReference"
+                                      },
+                                      "segment": "emit"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "a"
+                                  }
+                              ]
                           }
                       ]
                   },
@@ -1584,164 +1330,119 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
+                              "elements": [
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
+                                  }
+                              ]
                           },
                           {
                               "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
+                              "elements": [
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
+                                  }
+                              ]
                           },
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "ControlKeyword"
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "tag": "ControlKeyword"
+                                      },
+                                      "segment": "handle"
                                   },
-                                  "segment": "handle"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "k"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Unit"
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "k"
                                   },
-                                  "segment": "()"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "ControlKeyword"
+                                  {
+                                      "annotation": {
+                                          "tag": "Unit"
+                                      },
+                                      "segment": "()"
                                   },
-                                  "segment": "with"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "h"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Parenthesis"
+                                  {
+                                      "annotation": {
+                                          "tag": "ControlKeyword"
+                                      },
+                                      "segment": "with"
                                   },
-                                  "segment": "("
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "n"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "##Nat.drop",
-                                      "tag": "TermReference"
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "h"
                                   },
-                                  "segment": "-"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "NumericLiteral"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "1"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Parenthesis"
+                                  {
+                                      "annotation": {
+                                          "tag": "Parenthesis"
+                                      },
+                                      "segment": "("
                                   },
-                                  "segment": ")"
-                              }
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "n"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "contents": "##Nat.drop",
+                                          "tag": "TermReference"
+                                      },
+                                      "segment": "-"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "NumericLiteral"
+                                      },
+                                      "segment": "1"
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "Parenthesis"
+                                      },
+                                      "segment": ")"
+                                  }
+                              ]
                           }
                       ]
                   },
@@ -1750,50 +1451,42 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "ControlKeyword"
+                              "elements": [
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
                                   },
-                                  "segment": "else"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d1",
-                                      "tag": "TermReference"
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
                                   },
-                                  "segment": "None"
-                              }
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
+                                  }
+                              ]
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "tag": "ControlKeyword"
+                                      },
+                                      "segment": "else"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d1",
+                                          "tag": "TermReference"
+                                      },
+                                      "segment": "None"
+                                  }
+                              ]
                           }
                       ]
                   },
@@ -1802,107 +1495,73 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "DelimiterChar"
+                              "elements": [
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
                                   },
-                                  "segment": "{"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
                                   },
-                                  "segment": "r"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "DelimiterChar"
+                                  {
+                                      "annotation": {
+                                          "tag": "DelimiterChar"
+                                      },
+                                      "segment": "{"
                                   },
-                                  "segment": "}"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "           "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "ControlKeyword"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "->"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d0",
-                                      "tag": "TermReference"
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "r"
                                   },
-                                  "segment": "Some"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "r"
-                              }
+                                  {
+                                      "annotation": {
+                                          "tag": "DelimiterChar"
+                                      },
+                                      "segment": "}"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": "           "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "ControlKeyword"
+                                      },
+                                      "segment": "->"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d0",
+                                          "tag": "TermReference"
+                                      },
+                                      "segment": "Some"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "r"
+                                  }
+                              ]
                           }
                       ]
                   },
@@ -1911,92 +1570,64 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "ControlKeyword"
+                              "elements": [
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
                                   },
-                                  "segment": "handle"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": {
+                                          "tag": "ControlKeyword"
+                                      },
+                                      "segment": "handle"
                                   },
-                                  "segment": "s"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Unit"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "()"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "ControlKeyword"
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "s"
                                   },
-                                  "segment": "with"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": {
+                                          "tag": "Unit"
+                                      },
+                                      "segment": "()"
                                   },
-                                  "segment": "h"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "n"
-                              }
+                                  {
+                                      "annotation": {
+                                          "tag": "ControlKeyword"
+                                      },
+                                      "segment": "with"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "h"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "n"
+                                  }
+                              ]
                           }
                       ]
                   }
@@ -2007,230 +1638,154 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "take",
-                                      "tag": "HashQualifier"
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "contents": "take",
+                                          "tag": "HashQualifier"
+                                      },
+                                      "segment": "take"
                                   },
-                                  "segment": "take"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "TypeAscriptionColon"
+                                  {
+                                      "annotation": {
+                                          "tag": "TypeAscriptionColon"
+                                      },
+                                      "segment": " :"
                                   },
-                                  "segment": " :"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "##Nat",
-                                      "tag": "TypeReference"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "Nat"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "TypeOperator"
+                                  {
+                                      "annotation": {
+                                          "contents": "##Nat",
+                                          "tag": "TypeReference"
+                                      },
+                                      "segment": "Nat"
                                   },
-                                  "segment": "->"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "DelayForceChar"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "'"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "AbilityBraces"
+                                  {
+                                      "annotation": {
+                                          "tag": "TypeOperator"
+                                      },
+                                      "segment": "->"
                                   },
-                                  "segment": "{"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "g"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "AbilityBraces"
+                                  {
+                                      "annotation": {
+                                          "tag": "DelayForceChar"
+                                      },
+                                      "segment": "'"
                                   },
-                                  "segment": "}"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": {
+                                          "tag": "AbilityBraces"
+                                      },
+                                      "segment": "{"
                                   },
-                                  "segment": "t"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "TypeOperator"
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "g"
                                   },
-                                  "segment": "->"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "AbilityBraces"
+                                  {
+                                      "annotation": {
+                                          "tag": "AbilityBraces"
+                                      },
+                                      "segment": "}"
                                   },
-                                  "segment": "{"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "g"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": ","
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro",
-                                      "tag": "TypeReference"
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "t"
                                   },
-                                  "segment": "Stream"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "a"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "AbilityBraces"
+                                  {
+                                      "annotation": {
+                                          "tag": "TypeOperator"
+                                      },
+                                      "segment": "->"
                                   },
-                                  "segment": "}"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg",
-                                      "tag": "TypeReference"
+                                  {
+                                      "annotation": {
+                                          "tag": "AbilityBraces"
+                                      },
+                                      "segment": "{"
                                   },
-                                  "segment": "Optional"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "g"
                                   },
-                                  "segment": "t"
-                              }
+                                  {
+                                      "annotation": null,
+                                      "segment": ","
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro",
+                                          "tag": "TypeReference"
+                                      },
+                                      "segment": "Stream"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "a"
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "AbilityBraces"
+                                      },
+                                      "segment": "}"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg",
+                                          "tag": "TypeReference"
+                                      },
+                                      "segment": "Optional"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "t"
+                                  }
+                              ]
                           }
                       ]
                   },
@@ -2239,54 +1794,41 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "take",
-                                      "tag": "HashQualifier"
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "contents": "take",
+                                          "tag": "HashQualifier"
+                                      },
+                                      "segment": "take"
                                   },
-                                  "segment": "take"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "n"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "n"
                                   },
-                                  "segment": "s"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "BindingEquals"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": " ="
-                              }
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "s"
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "BindingEquals"
+                                      },
+                                      "segment": " ="
+                                  }
+                              ]
                           }
                       ]
                   },
@@ -2295,62 +1837,46 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "UseKeyword"
+                              "elements": [
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
                                   },
-                                  "segment": "use "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "UsePrefix"
+                                  {
+                                      "annotation": {
+                                          "tag": "UseKeyword"
+                                      },
+                                      "segment": "use "
                                   },
-                                  "segment": "Nat"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "UseSuffix"
+                                  {
+                                      "annotation": {
+                                          "tag": "UsePrefix"
+                                      },
+                                      "segment": "Nat"
                                   },
-                                  "segment": "-"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "UseSuffix"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "UseSuffix"
+                                  {
+                                      "annotation": {
+                                          "tag": "UseSuffix"
+                                      },
+                                      "segment": "-"
                                   },
-                                  "segment": ">"
-                              }
+                                  {
+                                      "annotation": {
+                                          "tag": "UseSuffix"
+                                      },
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "UseSuffix"
+                                      },
+                                      "segment": ">"
+                                  }
+                              ]
                           }
                       ]
                   },
@@ -2359,61 +1885,45 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "h",
-                                      "tag": "HashQualifier"
+                              "elements": [
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
                                   },
-                                  "segment": "h"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": {
+                                          "contents": "h",
+                                          "tag": "HashQualifier"
+                                      },
+                                      "segment": "h"
                                   },
-                                  "segment": "n"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "BindingEquals"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": " ="
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "ControlKeyword"
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "n"
                                   },
-                                  "segment": "cases"
-                              }
+                                  {
+                                      "annotation": {
+                                          "tag": "BindingEquals"
+                                      },
+                                      "segment": " ="
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "ControlKeyword"
+                                      },
+                                      "segment": "cases"
+                                  }
+                              ]
                           }
                       ]
                   },
@@ -2422,123 +1932,83 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "DelimiterChar"
+                              "elements": [
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
                                   },
-                                  "segment": "{"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro#a0",
-                                      "tag": "TermReference"
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
                                   },
-                                  "segment": "emit"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": {
+                                          "tag": "DelimiterChar"
+                                      },
+                                      "segment": "{"
                                   },
-                                  "segment": "a"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "ControlKeyword"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "->"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": {
+                                          "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro#a0",
+                                          "tag": "TermReference"
+                                      },
+                                      "segment": "emit"
                                   },
-                                  "segment": "k"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "DelimiterChar"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "}"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "ControlKeyword"
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "a"
                                   },
-                                  "segment": "->"
-                              }
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "ControlKeyword"
+                                      },
+                                      "segment": "->"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "k"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "DelimiterChar"
+                                      },
+                                      "segment": "}"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "ControlKeyword"
+                                      },
+                                      "segment": "->"
+                                  }
+                              ]
                           }
                       ]
                   },
@@ -2547,50 +2017,37 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro#a0",
-                                      "tag": "TermReference"
+                              "elements": [
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
                                   },
-                                  "segment": "emit"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
                                   },
-                                  "segment": "a"
-                              }
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro#a0",
+                                          "tag": "TermReference"
+                                      },
+                                      "segment": "emit"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "a"
+                                  }
+                              ]
                           }
                       ]
                   },
@@ -2599,264 +2056,193 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
+                              "elements": [
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
+                                  }
+                              ]
                           },
                           {
                               "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "ControlKeyword"
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "tag": "ControlKeyword"
+                                      },
+                                      "segment": "if"
                                   },
-                                  "segment": "if"
-                              }
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "n"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "contents": "##Nat.>",
+                                          "tag": "TermReference"
+                                      },
+                                      "segment": ">"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "NumericLiteral"
+                                      },
+                                      "segment": "0"
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "ControlKeyword"
+                                      },
+                                      "segment": " then"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  }
+                              ]
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "tag": "ControlKeyword"
+                                      },
+                                      "segment": "handle"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "k"
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "Unit"
+                                      },
+                                      "segment": "()"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "ControlKeyword"
+                                      },
+                                      "segment": "with"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "h"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "Parenthesis"
+                                      },
+                                      "segment": "("
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "n"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "contents": "##Nat.drop",
+                                          "tag": "TermReference"
+                                      },
+                                      "segment": "-"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "NumericLiteral"
+                                      },
+                                      "segment": "1"
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "Parenthesis"
+                                      },
+                                      "segment": ")"
+                                  }
+                              ]
                           },
                           {
                               "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
+                              "elements": [
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  }
+                              ]
                           },
                           {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                              "diffTag": "both",
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "tag": "ControlKeyword"
+                                      },
+                                      "segment": "else"
                                   },
-                                  "segment": "n"
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "##Nat.>",
-                                      "tag": "TermReference"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": ">"
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "NumericLiteral"
-                                  },
-                                  "segment": "0"
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "ControlKeyword"
-                                  },
-                                  "segment": " then"
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "ControlKeyword"
-                                  },
-                                  "segment": "handle"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
-                                  },
-                                  "segment": "k"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Unit"
-                                  },
-                                  "segment": "()"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "ControlKeyword"
-                                  },
-                                  "segment": "with"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
-                                  },
-                                  "segment": "h"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Parenthesis"
-                                  },
-                                  "segment": "("
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
-                                  },
-                                  "segment": "n"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "##Nat.drop",
-                                      "tag": "TermReference"
-                                  },
-                                  "segment": "-"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "NumericLiteral"
-                                  },
-                                  "segment": "1"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Parenthesis"
-                                  },
-                                  "segment": ")"
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "ControlKeyword"
-                                  },
-                                  "segment": "else"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d1",
-                                      "tag": "TermReference"
-                                  },
-                                  "segment": "None"
-                              }
+                                  {
+                                      "annotation": {
+                                          "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d1",
+                                          "tag": "TermReference"
+                                      },
+                                      "segment": "None"
+                                  }
+                              ]
                           }
                       ]
                   },
@@ -2871,107 +2257,73 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "DelimiterChar"
+                              "elements": [
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
                                   },
-                                  "segment": "{"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
                                   },
-                                  "segment": "r"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "DelimiterChar"
+                                  {
+                                      "annotation": {
+                                          "tag": "DelimiterChar"
+                                      },
+                                      "segment": "{"
                                   },
-                                  "segment": "}"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "           "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "ControlKeyword"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "->"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d0",
-                                      "tag": "TermReference"
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "r"
                                   },
-                                  "segment": "Some"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "r"
-                              }
+                                  {
+                                      "annotation": {
+                                          "tag": "DelimiterChar"
+                                      },
+                                      "segment": "}"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": "           "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "ControlKeyword"
+                                      },
+                                      "segment": "->"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d0",
+                                          "tag": "TermReference"
+                                      },
+                                      "segment": "Some"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "r"
+                                  }
+                              ]
                           }
                       ]
                   },
@@ -2980,250 +2332,190 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "  "
-                              }
+                              "elements": [
+                                  {
+                                      "annotation": null,
+                                      "segment": "  "
+                                  }
+                              ]
                           },
                           {
                               "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "ControlKeyword"
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "tag": "ControlKeyword"
+                                      },
+                                      "segment": "if"
                                   },
-                                  "segment": "if"
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "n"
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "##Nat.>",
-                                      "tag": "TermReference"
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "n"
                                   },
-                                  "segment": ">"
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "NumericLiteral"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "0"
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "ControlKeyword"
+                                  {
+                                      "annotation": {
+                                          "contents": "##Nat.>",
+                                          "tag": "TermReference"
+                                      },
+                                      "segment": ">"
                                   },
-                                  "segment": " then"
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "NumericLiteral"
+                                      },
+                                      "segment": "0"
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "ControlKeyword"
+                                      },
+                                      "segment": " then"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  }
+                              ]
                           },
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "ControlKeyword"
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "tag": "ControlKeyword"
+                                      },
+                                      "segment": "handle"
                                   },
-                                  "segment": "handle"
-                              }
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "s"
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "Unit"
+                                      },
+                                      "segment": "()"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "ControlKeyword"
+                                      },
+                                      "segment": "with"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "h"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  }
+                              ]
+                          },
+                          {
+                              "diffTag": "oneSided",
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "tag": "Parenthesis"
+                                      },
+                                      "segment": "("
+                                  }
+                              ]
                           },
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
-                                  },
-                                  "segment": "s"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Unit"
-                                  },
-                                  "segment": "()"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "ControlKeyword"
-                                  },
-                                  "segment": "with"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
-                                  },
-                                  "segment": "h"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "n"
+                                  }
+                              ]
                           },
                           {
                               "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Parenthesis"
+                              "elements": [
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "("
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": {
+                                          "contents": "##Nat.drop",
+                                          "tag": "TermReference"
+                                      },
+                                      "segment": "-"
                                   },
-                                  "segment": "n"
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "##Nat.drop",
-                                      "tag": "TermReference"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "-"
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "NumericLiteral"
+                                  {
+                                      "annotation": {
+                                          "tag": "NumericLiteral"
+                                      },
+                                      "segment": "1"
                                   },
-                                  "segment": "1"
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Parenthesis"
+                                  {
+                                      "annotation": {
+                                          "tag": "Parenthesis"
+                                      },
+                                      "segment": ")"
                                   },
-                                  "segment": ")"
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "ControlKeyword"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "else"
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d1",
-                                      "tag": "TermReference"
+                                  {
+                                      "annotation": {
+                                          "tag": "ControlKeyword"
+                                      },
+                                      "segment": "else"
                                   },
-                                  "segment": "None"
-                              }
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d1",
+                                          "tag": "TermReference"
+                                      },
+                                      "segment": "None"
+                                  }
+                              ]
                           }
                       ]
                   }
@@ -5022,71 +4314,52 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "unitCase",
-                                      "tag": "HashQualifier"
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "contents": "unitCase",
+                                          "tag": "HashQualifier"
+                                      },
+                                      "segment": "unitCase"
                                   },
-                                  "segment": "unitCase"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "TypeAscriptionColon"
+                                  {
+                                      "annotation": {
+                                          "tag": "TypeAscriptionColon"
+                                      },
+                                      "segment": " :"
                                   },
-                                  "segment": " :"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "x"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "TypeOperator"
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "x"
                                   },
-                                  "segment": "->"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "##Nat",
-                                      "tag": "TypeReference"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "Nat"
-                              }
+                                  {
+                                      "annotation": {
+                                          "tag": "TypeOperator"
+                                      },
+                                      "segment": "->"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "contents": "##Nat",
+                                          "tag": "TypeReference"
+                                      },
+                                      "segment": "Nat"
+                                  }
+                              ]
                           }
                       ]
                   },
@@ -5095,96 +4368,73 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "unitCase",
-                                      "tag": "HashQualifier"
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "contents": "unitCase",
+                                          "tag": "HashQualifier"
+                                      },
+                                      "segment": "unitCase"
                                   },
-                                  "segment": "unitCase"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "BindingEquals"
+                                  {
+                                      "annotation": {
+                                          "tag": "BindingEquals"
+                                      },
+                                      "segment": " ="
                                   },
-                                  "segment": " ="
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "#ttjui80dbufvf3vgaddmcr065dpgl0rtp68i5cdht6tq4t2vk3i2vg60hi77rug368qijgijf8oui27te7o5oq0t0osm6dg65c080i0",
-                                      "tag": "TermReference"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "id"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Parenthesis"
+                                  {
+                                      "annotation": {
+                                          "contents": "#ttjui80dbufvf3vgaddmcr065dpgl0rtp68i5cdht6tq4t2vk3i2vg60hi77rug368qijgijf8oui27te7o5oq0t0osm6dg65c080i0",
+                                          "tag": "TermReference"
+                                      },
+                                      "segment": "id"
                                   },
-                                  "segment": "("
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "x"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "ControlKeyword"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": " ->"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "NumericLiteral"
+                                  {
+                                      "annotation": {
+                                          "tag": "Parenthesis"
+                                      },
+                                      "segment": "("
                                   },
-                                  "segment": "1"
-                              }
+                                  {
+                                      "annotation": null,
+                                      "segment": "x"
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "ControlKeyword"
+                                      },
+                                      "segment": " ->"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "NumericLiteral"
+                                      },
+                                      "segment": "1"
+                                  }
+                              ]
                           },
                           {
                               "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Parenthesis"
-                                  },
-                                  "segment": ")"
-                              }
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "tag": "Parenthesis"
+                                      },
+                                      "segment": ")"
+                                  }
+                              ]
                           }
                       ]
                   }
@@ -5195,113 +4445,91 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "unitCase",
-                                      "tag": "HashQualifier"
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "contents": "unitCase",
+                                          "tag": "HashQualifier"
+                                      },
+                                      "segment": "unitCase"
                                   },
-                                  "segment": "unitCase"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "TypeAscriptionColon"
+                                  {
+                                      "annotation": {
+                                          "tag": "TypeAscriptionColon"
+                                      },
+                                      "segment": " :"
                                   },
-                                  "segment": " :"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "x"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "TypeOperator"
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "x"
                                   },
-                                  "segment": "->"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "("
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "##Nat",
-                                      "tag": "TypeReference"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "Nat"
-                              }
+                                  {
+                                      "annotation": {
+                                          "tag": "TypeOperator"
+                                      },
+                                      "segment": "->"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  }
+                              ]
                           },
                           {
                               "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": ","
-                              }
+                              "elements": [
+                                  {
+                                      "annotation": null,
+                                      "segment": "("
+                                  }
+                              ]
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "contents": "##Nat",
+                                          "tag": "TypeReference"
+                                      },
+                                      "segment": "Nat"
+                                  }
+                              ]
                           },
                           {
                               "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "("
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": ")"
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": ")"
-                              }
+                              "elements": [
+                                  {
+                                      "annotation": null,
+                                      "segment": ","
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": "("
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": ")"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": ")"
+                                  }
+                              ]
                           }
                       ]
                   },
@@ -5310,146 +4538,118 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "unitCase",
-                                      "tag": "HashQualifier"
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "contents": "unitCase",
+                                          "tag": "HashQualifier"
+                                      },
+                                      "segment": "unitCase"
                                   },
-                                  "segment": "unitCase"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "BindingEquals"
+                                  {
+                                      "annotation": {
+                                          "tag": "BindingEquals"
+                                      },
+                                      "segment": " ="
                                   },
-                                  "segment": " ="
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "#ttjui80dbufvf3vgaddmcr065dpgl0rtp68i5cdht6tq4t2vk3i2vg60hi77rug368qijgijf8oui27te7o5oq0t0osm6dg65c080i0",
-                                      "tag": "TermReference"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "id"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Parenthesis"
+                                  {
+                                      "annotation": {
+                                          "contents": "#ttjui80dbufvf3vgaddmcr065dpgl0rtp68i5cdht6tq4t2vk3i2vg60hi77rug368qijgijf8oui27te7o5oq0t0osm6dg65c080i0",
+                                          "tag": "TermReference"
+                                      },
+                                      "segment": "id"
                                   },
-                                  "segment": "("
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": "x"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "ControlKeyword"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": " ->"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
+                                  {
+                                      "annotation": {
+                                          "tag": "Parenthesis"
+                                      },
+                                      "segment": "("
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": "x"
+                                  },
+                                  {
+                                      "annotation": {
+                                          "tag": "ControlKeyword"
+                                      },
+                                      "segment": " ->"
+                                  },
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  }
+                              ]
                           },
                           {
                               "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
-                                      "tag": "TypeReference"
-                                  },
-                                  "segment": "("
-                              }
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                                          "tag": "TypeReference"
+                                      },
+                                      "segment": "("
+                                  }
+                              ]
                           },
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "NumericLiteral"
-                                  },
-                                  "segment": "1"
-                              }
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "tag": "NumericLiteral"
+                                      },
+                                      "segment": "1"
+                                  }
+                              ]
                           },
                           {
                               "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
-                                      "tag": "TypeReference"
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                                          "tag": "TypeReference"
+                                      },
+                                      "segment": ", "
                                   },
-                                  "segment": ", "
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
-                                      "tag": "TypeReference"
+                                  {
+                                      "annotation": {
+                                          "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                                          "tag": "TypeReference"
+                                      },
+                                      "segment": "("
                                   },
-                                  "segment": "("
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
-                                      "tag": "TypeReference"
+                                  {
+                                      "annotation": {
+                                          "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                                          "tag": "TypeReference"
+                                      },
+                                      "segment": ")"
                                   },
-                                  "segment": ")"
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
-                                      "tag": "TypeReference"
+                                  {
+                                      "annotation": {
+                                          "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                                          "tag": "TypeReference"
+                                      },
+                                      "segment": ")"
                                   },
-                                  "segment": ")"
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Parenthesis"
-                                  },
-                                  "segment": ")"
-                              }
+                                  {
+                                      "annotation": {
+                                          "tag": "Parenthesis"
+                                      },
+                                      "segment": ")"
+                                  }
+                              ]
                           }
                       ]
                   }
@@ -5862,38 +5062,31 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "DataTypeKeyword"
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "tag": "DataTypeKeyword"
+                                      },
+                                      "segment": "type"
                                   },
-                                  "segment": "type"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "Type",
-                                      "tag": "HashQualifier"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "Type"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "DelimiterChar"
+                                  {
+                                      "annotation": {
+                                          "contents": "Type",
+                                          "tag": "HashQualifier"
+                                      },
+                                      "segment": "Type"
                                   },
-                                  "segment": " = "
-                              }
+                                  {
+                                      "annotation": {
+                                          "tag": "DelimiterChar"
+                                      },
+                                      "segment": " = "
+                                  }
+                              ]
                           },
                           {
                               "diffTag": "annotationChange",
@@ -5909,20 +5102,24 @@ RESPONSE:
                           },
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
+                              "elements": [
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  }
+                              ]
                           },
                           {
                               "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "##Nat",
-                                      "tag": "TypeReference"
-                                  },
-                                  "segment": "Nat"
-                              }
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "contents": "##Nat",
+                                          "tag": "TypeReference"
+                                      },
+                                      "segment": "Nat"
+                                  }
+                              ]
                           }
                       ]
                   }
@@ -5933,54 +5130,51 @@ RESPONSE:
                       "value": [
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "DataTypeKeyword"
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "tag": "DataTypeKeyword"
+                                      },
+                                      "segment": "type"
                                   },
-                                  "segment": "type"
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "Type",
-                                      "tag": "HashQualifier"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "Type"
-                              }
+                                  {
+                                      "annotation": {
+                                          "contents": "Type",
+                                          "tag": "HashQualifier"
+                                      },
+                                      "segment": "Type"
+                                  }
+                              ]
                           },
                           {
                               "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "DataTypeParams"
+                              "elements": [
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "a"
-                              }
+                                  {
+                                      "annotation": {
+                                          "tag": "DataTypeParams"
+                                      },
+                                      "segment": "a"
+                                  }
+                              ]
                           },
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "DelimiterChar"
-                                  },
-                                  "segment": " = "
-                              }
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "tag": "DelimiterChar"
+                                      },
+                                      "segment": " = "
+                                  }
+                              ]
                           },
                           {
                               "diffTag": "annotationChange",
@@ -5996,36 +5190,34 @@ RESPONSE:
                           },
                           {
                               "diffTag": "both",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
+                              "elements": [
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
+                                  }
+                              ]
                           },
                           {
                               "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "tag": "Var"
+                              "elements": [
+                                  {
+                                      "annotation": {
+                                          "tag": "Var"
+                                      },
+                                      "segment": "a"
                                   },
-                                  "segment": "a"
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": null,
-                                  "segment": " "
-                              }
-                          },
-                          {
-                              "diffTag": "oneSided",
-                              "elements": {
-                                  "annotation": {
-                                      "contents": "##Text",
-                                      "tag": "TypeReference"
+                                  {
+                                      "annotation": null,
+                                      "segment": " "
                                   },
-                                  "segment": "Text"
-                              }
+                                  {
+                                      "annotation": {
+                                          "contents": "##Text",
+                                          "tag": "TypeReference"
+                                      },
+                                      "segment": "Text"
+                                  }
+                              ]
                           }
                       ]
                   }

--- a/unison-src/transcripts/idempotent/definition-diff-api.md
+++ b/unison-src/transcripts/idempotent/definition-diff-api.md
@@ -277,7 +277,7 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "tag": "TextLiteral"
@@ -331,7 +331,7 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "tag": "NumericLiteral"
@@ -491,7 +491,7 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "tag": "TextLiteral"
@@ -545,7 +545,7 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "tag": "NumericLiteral"
@@ -1459,7 +1459,7 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "tag": "ControlKeyword"
@@ -1468,7 +1468,7 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "tag": "Var"
@@ -1477,14 +1477,14 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": null,
                                   "segment": " "
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "contents": "##Nat.>",
@@ -1494,14 +1494,14 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": null,
                                   "segment": " "
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "tag": "NumericLiteral"
@@ -1510,7 +1510,7 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "tag": "ControlKeyword"
@@ -1524,28 +1524,28 @@ RESPONSE:
                       "kind": "changed",
                       "value": [
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": null,
                                   "segment": "  "
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": null,
                                   "segment": "  "
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": null,
                                   "segment": "  "
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": null,
                                   "segment": "  "
@@ -1604,7 +1604,7 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": null,
                                   "segment": "  "
@@ -1749,21 +1749,21 @@ RESPONSE:
                       "kind": "changed",
                       "value": [
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": null,
                                   "segment": "  "
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": null,
                                   "segment": "  "
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": null,
                                   "segment": "  "
@@ -2619,7 +2619,7 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "tag": "ControlKeyword"
@@ -2628,14 +2628,14 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": null,
                                   "segment": " "
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "tag": "Var"
@@ -2644,14 +2644,14 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": null,
                                   "segment": " "
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "contents": "##Nat.>",
@@ -2661,14 +2661,14 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": null,
                                   "segment": " "
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "tag": "NumericLiteral"
@@ -2677,7 +2677,7 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "tag": "ControlKeyword"
@@ -2686,7 +2686,7 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": null,
                                   "segment": " "
@@ -2826,7 +2826,7 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": null,
                                   "segment": " "
@@ -2986,7 +2986,7 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "tag": "ControlKeyword"
@@ -2995,14 +2995,14 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": null,
                                   "segment": " "
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "tag": "Var"
@@ -3011,14 +3011,14 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": null,
                                   "segment": " "
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "contents": "##Nat.>",
@@ -3028,14 +3028,14 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": null,
                                   "segment": " "
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "tag": "NumericLiteral"
@@ -3044,7 +3044,7 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "tag": "ControlKeyword"
@@ -3053,7 +3053,7 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": null,
                                   "segment": " "
@@ -3133,7 +3133,7 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "tag": "Parenthesis"
@@ -3151,14 +3151,14 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": null,
                                   "segment": " "
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "contents": "##Nat.drop",
@@ -3168,14 +3168,14 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": null,
                                   "segment": " "
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "tag": "NumericLiteral"
@@ -3184,7 +3184,7 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "tag": "Parenthesis"
@@ -3193,14 +3193,14 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": null,
                                   "segment": " "
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "tag": "ControlKeyword"
@@ -3209,14 +3209,14 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": null,
                                   "segment": " "
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d1",
@@ -5178,7 +5178,7 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "tag": "Parenthesis"
@@ -5252,7 +5252,7 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": null,
                                   "segment": "("
@@ -5269,35 +5269,35 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": null,
                                   "segment": ","
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": null,
                                   "segment": " "
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": null,
                                   "segment": "("
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": null,
                                   "segment": ")"
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": null,
                                   "segment": ")"
@@ -5384,7 +5384,7 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
@@ -5403,7 +5403,7 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
@@ -5413,7 +5413,7 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
@@ -5423,7 +5423,7 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
@@ -5433,7 +5433,7 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
@@ -5443,7 +5443,7 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "tag": "Parenthesis"
@@ -5915,7 +5915,7 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "contents": "##Nat",
@@ -5958,14 +5958,14 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": null,
                                   "segment": " "
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "tag": "DataTypeParams"
@@ -6002,7 +6002,7 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "tag": "Var"
@@ -6011,14 +6011,14 @@ RESPONSE:
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": null,
                                   "segment": " "
                               }
                           },
                           {
-                              "diffTag": "one-sided",
+                              "diffTag": "oneSided",
                               "elements": {
                                   "annotation": {
                                       "contents": "##Text",

--- a/unison-src/transcripts/idempotent/definition-diff-api.md
+++ b/unison-src/transcripts/idempotent/definition-diff-api.md
@@ -127,187 +127,436 @@ GET /api/projects/scratch/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=
 RESPONSE:
   {
       "diff": {
-          "contents": [
-              {
-                  "diffTag": "both",
-                  "elements": [
-                      {
-                          "annotation": {
-                              "contents": "term",
-                              "tag": "HashQualifier"
+          "contents": {
+              "left": [
+                  {
+                      "kind": "unchanged",
+                      "value": [
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "term",
+                                      "tag": "HashQualifier"
+                                  },
+                                  "segment": "term"
+                              }
                           },
-                          "segment": "term"
-                      },
-                      {
-                          "annotation": {
-                              "tag": "TypeAscriptionColon"
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "TypeAscriptionColon"
+                                  },
+                                  "segment": " :"
+                              }
                           },
-                          "segment": " :"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "contents": "##Nat",
-                              "tag": "TypeReference"
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
                           },
-                          "segment": "Nat"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "\n"
-                      },
-                      {
-                          "annotation": {
-                              "contents": "term",
-                              "tag": "HashQualifier"
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "##Nat",
+                                      "tag": "TypeReference"
+                                  },
+                                  "segment": "Nat"
+                              }
+                          }
+                      ]
+                  },
+                  {
+                      "kind": "unchanged",
+                      "value": [
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "term",
+                                      "tag": "HashQualifier"
+                                  },
+                                  "segment": "term"
+                              }
                           },
-                          "segment": "term"
-                      },
-                      {
-                          "annotation": {
-                              "tag": "BindingEquals"
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "BindingEquals"
+                                  },
+                                  "segment": " ="
+                              }
+                          }
+                      ]
+                  },
+                  {
+                      "kind": "unchanged",
+                      "value": [
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
                           },
-                          "segment": " ="
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "\n"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "  "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "UseKeyword"
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "UseKeyword"
+                                  },
+                                  "segment": "use "
+                              }
                           },
-                          "segment": "use "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "UsePrefix"
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "UsePrefix"
+                                  },
+                                  "segment": "Nat"
+                              }
                           },
-                          "segment": "Nat"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "UseSuffix"
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
                           },
-                          "segment": "+"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "\n"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "  "
-                      },
-                      {
-                          "annotation": {
-                              "contents": "_",
-                              "tag": "HashQualifier"
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "UseSuffix"
+                                  },
+                                  "segment": "+"
+                              }
+                          }
+                      ]
+                  },
+                  {
+                      "kind": "changed",
+                      "value": [
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
                           },
-                          "segment": "_"
-                      },
-                      {
-                          "annotation": {
-                              "tag": "BindingEquals"
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "_",
+                                      "tag": "HashQualifier"
+                                  },
+                                  "segment": "_"
+                              }
                           },
-                          "segment": " ="
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      }
-                  ]
-              },
-              {
-                  "diffTag": "old",
-                  "elements": [
-                      {
-                          "annotation": {
-                              "tag": "TextLiteral"
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "BindingEquals"
+                                  },
+                                  "segment": " ="
+                              }
                           },
-                          "segment": "\"Here's some text\""
-                      }
-                  ]
-              },
-              {
-                  "diffTag": "new",
-                  "elements": [
-                      {
-                          "annotation": {
-                              "tag": "TextLiteral"
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
                           },
-                          "segment": "\"Here's some different text\""
-                      }
-                  ]
-              },
-              {
-                  "diffTag": "both",
-                  "elements": [
-                      {
-                          "annotation": null,
-                          "segment": "\n"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "  "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "NumericLiteral"
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "TextLiteral"
+                                  },
+                                  "segment": "\"Here's some text\""
+                              }
+                          }
+                      ]
+                  },
+                  {
+                      "kind": "changed",
+                      "value": [
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
                           },
-                          "segment": "1"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "contents": "##Nat.+",
-                              "tag": "TermReference"
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "NumericLiteral"
+                                  },
+                                  "segment": "1"
+                              }
                           },
-                          "segment": "+"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      }
-                  ]
-              },
-              {
-                  "diffTag": "old",
-                  "elements": [
-                      {
-                          "annotation": {
-                              "tag": "NumericLiteral"
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
                           },
-                          "segment": "1"
-                      }
-                  ]
-              },
-              {
-                  "diffTag": "new",
-                  "elements": [
-                      {
-                          "annotation": {
-                              "tag": "NumericLiteral"
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "##Nat.+",
+                                      "tag": "TermReference"
+                                  },
+                                  "segment": "+"
+                              }
                           },
-                          "segment": "2"
-                      }
-                  ]
-              }
-          ],
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "NumericLiteral"
+                                  },
+                                  "segment": "1"
+                              }
+                          }
+                      ]
+                  }
+              ],
+              "right": [
+                  {
+                      "kind": "unchanged",
+                      "value": [
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "term",
+                                      "tag": "HashQualifier"
+                                  },
+                                  "segment": "term"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "TypeAscriptionColon"
+                                  },
+                                  "segment": " :"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "##Nat",
+                                      "tag": "TypeReference"
+                                  },
+                                  "segment": "Nat"
+                              }
+                          }
+                      ]
+                  },
+                  {
+                      "kind": "unchanged",
+                      "value": [
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "term",
+                                      "tag": "HashQualifier"
+                                  },
+                                  "segment": "term"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "BindingEquals"
+                                  },
+                                  "segment": " ="
+                              }
+                          }
+                      ]
+                  },
+                  {
+                      "kind": "unchanged",
+                      "value": [
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "UseKeyword"
+                                  },
+                                  "segment": "use "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "UsePrefix"
+                                  },
+                                  "segment": "Nat"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "UseSuffix"
+                                  },
+                                  "segment": "+"
+                              }
+                          }
+                      ]
+                  },
+                  {
+                      "kind": "changed",
+                      "value": [
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "_",
+                                      "tag": "HashQualifier"
+                                  },
+                                  "segment": "_"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "BindingEquals"
+                                  },
+                                  "segment": " ="
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "TextLiteral"
+                                  },
+                                  "segment": "\"Here's some different text\""
+                              }
+                          }
+                      ]
+                  },
+                  {
+                      "kind": "changed",
+                      "value": [
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "NumericLiteral"
+                                  },
+                                  "segment": "1"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "##Nat.+",
+                                      "tag": "TermReference"
+                                  },
+                                  "segment": "+"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "NumericLiteral"
+                                  },
+                                  "segment": "2"
+                              }
+                          }
+                      ]
+                  }
+              ]
+          },
           "tag": "UserObject"
       },
       "diffKind": "diff",
@@ -643,934 +892,2343 @@ GET /api/projects/scratch/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=
 RESPONSE:
   {
       "diff": {
-          "contents": [
-              {
-                  "diffTag": "both",
-                  "elements": [
-                      {
-                          "annotation": {
-                              "contents": "take",
-                              "tag": "HashQualifier"
-                          },
-                          "segment": "take"
-                      },
-                      {
-                          "annotation": {
-                              "tag": "TypeAscriptionColon"
-                          },
-                          "segment": " :"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "contents": "##Nat",
-                              "tag": "TypeReference"
-                          },
-                          "segment": "Nat"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "TypeOperator"
-                          },
-                          "segment": "->"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "DelayForceChar"
-                          },
-                          "segment": "'"
-                      },
-                      {
-                          "annotation": {
-                              "tag": "AbilityBraces"
-                          },
-                          "segment": "{"
-                      },
-                      {
-                          "annotation": {
-                              "tag": "Var"
-                          },
-                          "segment": "g"
-                      },
-                      {
-                          "annotation": {
-                              "tag": "AbilityBraces"
-                          },
-                          "segment": "}"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "Var"
-                          },
-                          "segment": "t"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "TypeOperator"
-                          },
-                          "segment": "->"
-                      },
-                      {
-                          "annotation": {
-                              "tag": "AbilityBraces"
-                          },
-                          "segment": "{"
-                      },
-                      {
-                          "annotation": {
-                              "tag": "Var"
-                          },
-                          "segment": "g"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": ","
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro",
-                              "tag": "TypeReference"
-                          },
-                          "segment": "Stream"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "Var"
-                          },
-                          "segment": "a"
-                      },
-                      {
-                          "annotation": {
-                              "tag": "AbilityBraces"
-                          },
-                          "segment": "}"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg",
-                              "tag": "TypeReference"
-                          },
-                          "segment": "Optional"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "Var"
-                          },
-                          "segment": "t"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "\n"
-                      },
-                      {
-                          "annotation": {
-                              "contents": "take",
-                              "tag": "HashQualifier"
-                          },
-                          "segment": "take"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "Var"
-                          },
-                          "segment": "n"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "Var"
-                          },
-                          "segment": "s"
-                      },
-                      {
-                          "annotation": {
-                              "tag": "BindingEquals"
-                          },
-                          "segment": " ="
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "\n"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "  "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "UseKeyword"
-                          },
-                          "segment": "use "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "UsePrefix"
-                          },
-                          "segment": "Nat"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "UseSuffix"
-                          },
-                          "segment": "-"
-                      },
-                      {
-                          "annotation": {
-                              "tag": "UseSuffix"
-                          },
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "UseSuffix"
-                          },
-                          "segment": ">"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "\n"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "  "
-                      },
-                      {
-                          "annotation": {
-                              "contents": "h",
-                              "tag": "HashQualifier"
-                          },
-                          "segment": "h"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "Var"
-                          },
-                          "segment": "n"
-                      },
-                      {
-                          "annotation": {
-                              "tag": "BindingEquals"
-                          },
-                          "segment": " ="
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "ControlKeyword"
-                          },
-                          "segment": "cases"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "\n"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "  "
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "  "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "DelimiterChar"
-                          },
-                          "segment": "{"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro#a0",
-                              "tag": "TermReference"
-                          },
-                          "segment": "emit"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "Var"
-                          },
-                          "segment": "a"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "ControlKeyword"
-                          },
-                          "segment": "->"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "Var"
-                          },
-                          "segment": "k"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "DelimiterChar"
-                          },
-                          "segment": "}"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "ControlKeyword"
-                          },
-                          "segment": "->"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "\n"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "  "
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "  "
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "  "
-                      }
-                  ]
-              },
-              {
-                  "diffTag": "old",
-                  "elements": [
-                      {
-                          "annotation": {
-                              "tag": "ControlKeyword"
-                          },
-                          "segment": "if "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "Var"
-                          },
-                          "segment": "n"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "contents": "##Nat.>",
-                              "tag": "TermReference"
-                          },
-                          "segment": ">"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "NumericLiteral"
-                          },
-                          "segment": "0"
-                      },
-                      {
-                          "annotation": {
-                              "tag": "ControlKeyword"
-                          },
-                          "segment": " then"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "\n"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "  "
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "  "
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "  "
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "  "
-                      }
-                  ]
-              },
-              {
-                  "diffTag": "both",
-                  "elements": [
-                      {
-                          "annotation": {
-                              "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro#a0",
-                              "tag": "TermReference"
-                          },
-                          "segment": "emit"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "Var"
-                          },
-                          "segment": "a"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "\n"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "  "
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "  "
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "  "
-                      }
-                  ]
-              },
-              {
-                  "diffTag": "old",
-                  "elements": [
-                      {
-                          "annotation": null,
-                          "segment": "  "
-                      }
-                  ]
-              },
-              {
-                  "diffTag": "new",
-                  "elements": [
-                      {
-                          "annotation": {
-                              "tag": "ControlKeyword"
-                          },
-                          "segment": "if"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "Var"
-                          },
-                          "segment": "n"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "contents": "##Nat.>",
-                              "tag": "TermReference"
-                          },
-                          "segment": ">"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "NumericLiteral"
-                          },
-                          "segment": "0"
-                      },
-                      {
-                          "annotation": {
-                              "tag": "ControlKeyword"
-                          },
-                          "segment": " then"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      }
-                  ]
-              },
-              {
-                  "diffTag": "both",
-                  "elements": [
-                      {
-                          "annotation": {
-                              "tag": "ControlKeyword"
-                          },
-                          "segment": "handle"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "Var"
-                          },
-                          "segment": "k"
-                      },
-                      {
-                          "annotation": {
-                              "tag": "Unit"
-                          },
-                          "segment": "()"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "ControlKeyword"
-                          },
-                          "segment": "with"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "Var"
-                          },
-                          "segment": "h"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "Parenthesis"
-                          },
-                          "segment": "("
-                      },
-                      {
-                          "annotation": {
-                              "tag": "Var"
-                          },
-                          "segment": "n"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "contents": "##Nat.drop",
-                              "tag": "TermReference"
-                          },
-                          "segment": "-"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "NumericLiteral"
-                          },
-                          "segment": "1"
-                      },
-                      {
-                          "annotation": {
-                              "tag": "Parenthesis"
-                          },
-                          "segment": ")"
-                      }
-                  ]
-              },
-              {
-                  "diffTag": "old",
-                  "elements": [
-                      {
-                          "annotation": null,
-                          "segment": "\n"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "  "
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "  "
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "  "
-                      }
-                  ]
-              },
-              {
-                  "diffTag": "new",
-                  "elements": [
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      }
-                  ]
-              },
-              {
-                  "diffTag": "both",
-                  "elements": [
-                      {
-                          "annotation": {
-                              "tag": "ControlKeyword"
-                          },
-                          "segment": "else"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d1",
-                              "tag": "TermReference"
-                          },
-                          "segment": "None"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "\n"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "  "
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "  "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "DelimiterChar"
-                          },
-                          "segment": "{"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "Var"
-                          },
-                          "segment": "r"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "DelimiterChar"
-                          },
-                          "segment": "}"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "           "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "ControlKeyword"
-                          },
-                          "segment": "->"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d0",
-                              "tag": "TermReference"
-                          },
-                          "segment": "Some"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "Var"
-                          },
-                          "segment": "r"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "\n"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "  "
-                      }
-                  ]
-              },
-              {
-                  "diffTag": "new",
-                  "elements": [
-                      {
-                          "annotation": {
-                              "tag": "ControlKeyword"
-                          },
-                          "segment": "if"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "Var"
-                          },
-                          "segment": "n"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "contents": "##Nat.>",
-                              "tag": "TermReference"
-                          },
-                          "segment": ">"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "NumericLiteral"
-                          },
-                          "segment": "0"
-                      },
-                      {
-                          "annotation": {
-                              "tag": "ControlKeyword"
-                          },
-                          "segment": " then"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      }
-                  ]
-              },
-              {
-                  "diffTag": "both",
-                  "elements": [
-                      {
-                          "annotation": {
-                              "tag": "ControlKeyword"
-                          },
-                          "segment": "handle"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "Var"
-                          },
-                          "segment": "s"
-                      },
-                      {
-                          "annotation": {
-                              "tag": "Unit"
-                          },
-                          "segment": "()"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "ControlKeyword"
-                          },
-                          "segment": "with"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "Var"
-                          },
-                          "segment": "h"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      }
-                  ]
-              },
-              {
-                  "diffTag": "new",
-                  "elements": [
-                      {
-                          "annotation": {
-                              "tag": "Parenthesis"
-                          },
-                          "segment": "("
-                      }
-                  ]
-              },
-              {
-                  "diffTag": "both",
-                  "elements": [
-                      {
-                          "annotation": {
-                              "tag": "Var"
-                          },
-                          "segment": "n"
-                      }
-                  ]
-              },
-              {
-                  "diffTag": "new",
-                  "elements": [
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "contents": "##Nat.drop",
-                              "tag": "TermReference"
-                          },
-                          "segment": "-"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "NumericLiteral"
-                          },
-                          "segment": "1"
-                      },
-                      {
-                          "annotation": {
-                              "tag": "Parenthesis"
-                          },
-                          "segment": ")"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "ControlKeyword"
-                          },
-                          "segment": "else"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d1",
-                              "tag": "TermReference"
-                          },
-                          "segment": "None"
-                      }
-                  ]
-              }
-          ],
+          "contents": {
+              "left": [
+                  {
+                      "kind": "unchanged",
+                      "value": [
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "take",
+                                      "tag": "HashQualifier"
+                                  },
+                                  "segment": "take"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "TypeAscriptionColon"
+                                  },
+                                  "segment": " :"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "##Nat",
+                                      "tag": "TypeReference"
+                                  },
+                                  "segment": "Nat"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "TypeOperator"
+                                  },
+                                  "segment": "->"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "DelayForceChar"
+                                  },
+                                  "segment": "'"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "AbilityBraces"
+                                  },
+                                  "segment": "{"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "g"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "AbilityBraces"
+                                  },
+                                  "segment": "}"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "t"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "TypeOperator"
+                                  },
+                                  "segment": "->"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "AbilityBraces"
+                                  },
+                                  "segment": "{"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "g"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": ","
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro",
+                                      "tag": "TypeReference"
+                                  },
+                                  "segment": "Stream"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "a"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "AbilityBraces"
+                                  },
+                                  "segment": "}"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg",
+                                      "tag": "TypeReference"
+                                  },
+                                  "segment": "Optional"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "t"
+                              }
+                          }
+                      ]
+                  },
+                  {
+                      "kind": "unchanged",
+                      "value": [
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "take",
+                                      "tag": "HashQualifier"
+                                  },
+                                  "segment": "take"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "n"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "s"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "BindingEquals"
+                                  },
+                                  "segment": " ="
+                              }
+                          }
+                      ]
+                  },
+                  {
+                      "kind": "unchanged",
+                      "value": [
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "UseKeyword"
+                                  },
+                                  "segment": "use "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "UsePrefix"
+                                  },
+                                  "segment": "Nat"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "UseSuffix"
+                                  },
+                                  "segment": "-"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "UseSuffix"
+                                  },
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "UseSuffix"
+                                  },
+                                  "segment": ">"
+                              }
+                          }
+                      ]
+                  },
+                  {
+                      "kind": "unchanged",
+                      "value": [
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "h",
+                                      "tag": "HashQualifier"
+                                  },
+                                  "segment": "h"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "n"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "BindingEquals"
+                                  },
+                                  "segment": " ="
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "ControlKeyword"
+                                  },
+                                  "segment": "cases"
+                              }
+                          }
+                      ]
+                  },
+                  {
+                      "kind": "unchanged",
+                      "value": [
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "DelimiterChar"
+                                  },
+                                  "segment": "{"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro#a0",
+                                      "tag": "TermReference"
+                                  },
+                                  "segment": "emit"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "a"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "ControlKeyword"
+                                  },
+                                  "segment": "->"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "k"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "DelimiterChar"
+                                  },
+                                  "segment": "}"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "ControlKeyword"
+                                  },
+                                  "segment": "->"
+                              }
+                          }
+                      ]
+                  },
+                  {
+                      "kind": "changed",
+                      "value": [
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "ControlKeyword"
+                                  },
+                                  "segment": "if "
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "n"
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "##Nat.>",
+                                      "tag": "TermReference"
+                                  },
+                                  "segment": ">"
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "NumericLiteral"
+                                  },
+                                  "segment": "0"
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "ControlKeyword"
+                                  },
+                                  "segment": " then"
+                              }
+                          }
+                      ]
+                  },
+                  {
+                      "kind": "changed",
+                      "value": [
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro#a0",
+                                      "tag": "TermReference"
+                                  },
+                                  "segment": "emit"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "a"
+                              }
+                          }
+                      ]
+                  },
+                  {
+                      "kind": "changed",
+                      "value": [
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "ControlKeyword"
+                                  },
+                                  "segment": "handle"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "k"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Unit"
+                                  },
+                                  "segment": "()"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "ControlKeyword"
+                                  },
+                                  "segment": "with"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "h"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Parenthesis"
+                                  },
+                                  "segment": "("
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "n"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "##Nat.drop",
+                                      "tag": "TermReference"
+                                  },
+                                  "segment": "-"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "NumericLiteral"
+                                  },
+                                  "segment": "1"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Parenthesis"
+                                  },
+                                  "segment": ")"
+                              }
+                          }
+                      ]
+                  },
+                  {
+                      "kind": "changed",
+                      "value": [
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "ControlKeyword"
+                                  },
+                                  "segment": "else"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d1",
+                                      "tag": "TermReference"
+                                  },
+                                  "segment": "None"
+                              }
+                          }
+                      ]
+                  },
+                  {
+                      "kind": "unchanged",
+                      "value": [
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "DelimiterChar"
+                                  },
+                                  "segment": "{"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "r"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "DelimiterChar"
+                                  },
+                                  "segment": "}"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "           "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "ControlKeyword"
+                                  },
+                                  "segment": "->"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d0",
+                                      "tag": "TermReference"
+                                  },
+                                  "segment": "Some"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "r"
+                              }
+                          }
+                      ]
+                  },
+                  {
+                      "kind": "changed",
+                      "value": [
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "ControlKeyword"
+                                  },
+                                  "segment": "handle"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "s"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Unit"
+                                  },
+                                  "segment": "()"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "ControlKeyword"
+                                  },
+                                  "segment": "with"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "h"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "n"
+                              }
+                          }
+                      ]
+                  }
+              ],
+              "right": [
+                  {
+                      "kind": "unchanged",
+                      "value": [
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "take",
+                                      "tag": "HashQualifier"
+                                  },
+                                  "segment": "take"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "TypeAscriptionColon"
+                                  },
+                                  "segment": " :"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "##Nat",
+                                      "tag": "TypeReference"
+                                  },
+                                  "segment": "Nat"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "TypeOperator"
+                                  },
+                                  "segment": "->"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "DelayForceChar"
+                                  },
+                                  "segment": "'"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "AbilityBraces"
+                                  },
+                                  "segment": "{"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "g"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "AbilityBraces"
+                                  },
+                                  "segment": "}"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "t"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "TypeOperator"
+                                  },
+                                  "segment": "->"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "AbilityBraces"
+                                  },
+                                  "segment": "{"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "g"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": ","
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro",
+                                      "tag": "TypeReference"
+                                  },
+                                  "segment": "Stream"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "a"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "AbilityBraces"
+                                  },
+                                  "segment": "}"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg",
+                                      "tag": "TypeReference"
+                                  },
+                                  "segment": "Optional"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "t"
+                              }
+                          }
+                      ]
+                  },
+                  {
+                      "kind": "unchanged",
+                      "value": [
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "take",
+                                      "tag": "HashQualifier"
+                                  },
+                                  "segment": "take"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "n"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "s"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "BindingEquals"
+                                  },
+                                  "segment": " ="
+                              }
+                          }
+                      ]
+                  },
+                  {
+                      "kind": "unchanged",
+                      "value": [
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "UseKeyword"
+                                  },
+                                  "segment": "use "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "UsePrefix"
+                                  },
+                                  "segment": "Nat"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "UseSuffix"
+                                  },
+                                  "segment": "-"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "UseSuffix"
+                                  },
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "UseSuffix"
+                                  },
+                                  "segment": ">"
+                              }
+                          }
+                      ]
+                  },
+                  {
+                      "kind": "unchanged",
+                      "value": [
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "h",
+                                      "tag": "HashQualifier"
+                                  },
+                                  "segment": "h"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "n"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "BindingEquals"
+                                  },
+                                  "segment": " ="
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "ControlKeyword"
+                                  },
+                                  "segment": "cases"
+                              }
+                          }
+                      ]
+                  },
+                  {
+                      "kind": "unchanged",
+                      "value": [
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "DelimiterChar"
+                                  },
+                                  "segment": "{"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro#a0",
+                                      "tag": "TermReference"
+                                  },
+                                  "segment": "emit"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "a"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "ControlKeyword"
+                                  },
+                                  "segment": "->"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "k"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "DelimiterChar"
+                                  },
+                                  "segment": "}"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "ControlKeyword"
+                                  },
+                                  "segment": "->"
+                              }
+                          }
+                      ]
+                  },
+                  {
+                      "kind": "changed",
+                      "value": [
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro#a0",
+                                      "tag": "TermReference"
+                                  },
+                                  "segment": "emit"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "a"
+                              }
+                          }
+                      ]
+                  },
+                  {
+                      "kind": "changed",
+                      "value": [
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "ControlKeyword"
+                                  },
+                                  "segment": "if"
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "n"
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "##Nat.>",
+                                      "tag": "TermReference"
+                                  },
+                                  "segment": ">"
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "NumericLiteral"
+                                  },
+                                  "segment": "0"
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "ControlKeyword"
+                                  },
+                                  "segment": " then"
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "ControlKeyword"
+                                  },
+                                  "segment": "handle"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "k"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Unit"
+                                  },
+                                  "segment": "()"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "ControlKeyword"
+                                  },
+                                  "segment": "with"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "h"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Parenthesis"
+                                  },
+                                  "segment": "("
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "n"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "##Nat.drop",
+                                      "tag": "TermReference"
+                                  },
+                                  "segment": "-"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "NumericLiteral"
+                                  },
+                                  "segment": "1"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Parenthesis"
+                                  },
+                                  "segment": ")"
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "ControlKeyword"
+                                  },
+                                  "segment": "else"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d1",
+                                      "tag": "TermReference"
+                                  },
+                                  "segment": "None"
+                              }
+                          }
+                      ]
+                  },
+                  {
+                      "kind": "spacer"
+                  },
+                  {
+                      "kind": "spacer"
+                  },
+                  {
+                      "kind": "unchanged",
+                      "value": [
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "DelimiterChar"
+                                  },
+                                  "segment": "{"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "r"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "DelimiterChar"
+                                  },
+                                  "segment": "}"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "           "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "ControlKeyword"
+                                  },
+                                  "segment": "->"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d0",
+                                      "tag": "TermReference"
+                                  },
+                                  "segment": "Some"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "r"
+                              }
+                          }
+                      ]
+                  },
+                  {
+                      "kind": "changed",
+                      "value": [
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "  "
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "ControlKeyword"
+                                  },
+                                  "segment": "if"
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "n"
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "##Nat.>",
+                                      "tag": "TermReference"
+                                  },
+                                  "segment": ">"
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "NumericLiteral"
+                                  },
+                                  "segment": "0"
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "ControlKeyword"
+                                  },
+                                  "segment": " then"
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "ControlKeyword"
+                                  },
+                                  "segment": "handle"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "s"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Unit"
+                                  },
+                                  "segment": "()"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "ControlKeyword"
+                                  },
+                                  "segment": "with"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "h"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Parenthesis"
+                                  },
+                                  "segment": "("
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "n"
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "##Nat.drop",
+                                      "tag": "TermReference"
+                                  },
+                                  "segment": "-"
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "NumericLiteral"
+                                  },
+                                  "segment": "1"
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Parenthesis"
+                                  },
+                                  "segment": ")"
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "ControlKeyword"
+                                  },
+                                  "segment": "else"
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d1",
+                                      "tag": "TermReference"
+                                  },
+                                  "segment": "None"
+                              }
+                          }
+                      ]
+                  }
+              ]
+          },
           "tag": "UserObject"
       },
       "diffKind": "diff",
@@ -3357,236 +5015,446 @@ GET /api/projects/scratch/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=
 RESPONSE:
   {
       "diff": {
-          "contents": [
-              {
-                  "diffTag": "both",
-                  "elements": [
-                      {
-                          "annotation": {
-                              "contents": "unitCase",
-                              "tag": "HashQualifier"
+          "contents": {
+              "left": [
+                  {
+                      "kind": "changed",
+                      "value": [
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "unitCase",
+                                      "tag": "HashQualifier"
+                                  },
+                                  "segment": "unitCase"
+                              }
                           },
-                          "segment": "unitCase"
-                      },
-                      {
-                          "annotation": {
-                              "tag": "TypeAscriptionColon"
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "TypeAscriptionColon"
+                                  },
+                                  "segment": " :"
+                              }
                           },
-                          "segment": " :"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "Var"
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
                           },
-                          "segment": "x"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "TypeOperator"
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "x"
+                              }
                           },
-                          "segment": "->"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      }
-                  ]
-              },
-              {
-                  "diffTag": "new",
-                  "elements": [
-                      {
-                          "annotation": null,
-                          "segment": "("
-                      }
-                  ]
-              },
-              {
-                  "diffTag": "both",
-                  "elements": [
-                      {
-                          "annotation": {
-                              "contents": "##Nat",
-                              "tag": "TypeReference"
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
                           },
-                          "segment": "Nat"
-                      }
-                  ]
-              },
-              {
-                  "diffTag": "new",
-                  "elements": [
-                      {
-                          "annotation": null,
-                          "segment": ","
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "("
-                      },
-                      {
-                          "annotation": null,
-                          "segment": ")"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": ")"
-                      }
-                  ]
-              },
-              {
-                  "diffTag": "both",
-                  "elements": [
-                      {
-                          "annotation": null,
-                          "segment": "\n"
-                      },
-                      {
-                          "annotation": {
-                              "contents": "unitCase",
-                              "tag": "HashQualifier"
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "TypeOperator"
+                                  },
+                                  "segment": "->"
+                              }
                           },
-                          "segment": "unitCase"
-                      },
-                      {
-                          "annotation": {
-                              "tag": "BindingEquals"
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
                           },
-                          "segment": " ="
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "contents": "#ttjui80dbufvf3vgaddmcr065dpgl0rtp68i5cdht6tq4t2vk3i2vg60hi77rug368qijgijf8oui27te7o5oq0t0osm6dg65c080i0",
-                              "tag": "TermReference"
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "##Nat",
+                                      "tag": "TypeReference"
+                                  },
+                                  "segment": "Nat"
+                              }
+                          }
+                      ]
+                  },
+                  {
+                      "kind": "changed",
+                      "value": [
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "unitCase",
+                                      "tag": "HashQualifier"
+                                  },
+                                  "segment": "unitCase"
+                              }
                           },
-                          "segment": "id"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "Parenthesis"
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "BindingEquals"
+                                  },
+                                  "segment": " ="
+                              }
                           },
-                          "segment": "("
-                      },
-                      {
-                          "annotation": null,
-                          "segment": "x"
-                      },
-                      {
-                          "annotation": {
-                              "tag": "ControlKeyword"
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
                           },
-                          "segment": " ->"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      }
-                  ]
-              },
-              {
-                  "diffTag": "new",
-                  "elements": [
-                      {
-                          "annotation": {
-                              "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
-                              "tag": "TypeReference"
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "#ttjui80dbufvf3vgaddmcr065dpgl0rtp68i5cdht6tq4t2vk3i2vg60hi77rug368qijgijf8oui27te7o5oq0t0osm6dg65c080i0",
+                                      "tag": "TermReference"
+                                  },
+                                  "segment": "id"
+                              }
                           },
-                          "segment": "("
-                      }
-                  ]
-              },
-              {
-                  "diffTag": "both",
-                  "elements": [
-                      {
-                          "annotation": {
-                              "tag": "NumericLiteral"
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
                           },
-                          "segment": "1"
-                      }
-                  ]
-              },
-              {
-                  "diffTag": "new",
-                  "elements": [
-                      {
-                          "annotation": {
-                              "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
-                              "tag": "TypeReference"
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Parenthesis"
+                                  },
+                                  "segment": "("
+                              }
                           },
-                          "segment": ", "
-                      },
-                      {
-                          "annotation": {
-                              "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
-                              "tag": "TypeReference"
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "x"
+                              }
                           },
-                          "segment": "("
-                      }
-                  ]
-              },
-              {
-                  "diffTag": "old",
-                  "elements": [
-                      {
-                          "annotation": {
-                              "tag": "Parenthesis"
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "ControlKeyword"
+                                  },
+                                  "segment": " ->"
+                              }
                           },
-                          "segment": ")"
-                      }
-                  ]
-              },
-              {
-                  "diffTag": "new",
-                  "elements": [
-                      {
-                          "annotation": {
-                              "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
-                              "tag": "TypeReference"
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
                           },
-                          "segment": ")"
-                      }
-                  ]
-              },
-              {
-                  "diffTag": "new",
-                  "elements": [
-                      {
-                          "annotation": {
-                              "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
-                              "tag": "TypeReference"
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "NumericLiteral"
+                                  },
+                                  "segment": "1"
+                              }
                           },
-                          "segment": ")"
-                      },
-                      {
-                          "annotation": {
-                              "tag": "Parenthesis"
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Parenthesis"
+                                  },
+                                  "segment": ")"
+                              }
+                          }
+                      ]
+                  }
+              ],
+              "right": [
+                  {
+                      "kind": "changed",
+                      "value": [
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "unitCase",
+                                      "tag": "HashQualifier"
+                                  },
+                                  "segment": "unitCase"
+                              }
                           },
-                          "segment": ")"
-                      }
-                  ]
-              }
-          ],
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "TypeAscriptionColon"
+                                  },
+                                  "segment": " :"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "x"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "TypeOperator"
+                                  },
+                                  "segment": "->"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "("
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "##Nat",
+                                      "tag": "TypeReference"
+                                  },
+                                  "segment": "Nat"
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": ","
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "("
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": ")"
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": ")"
+                              }
+                          }
+                      ]
+                  },
+                  {
+                      "kind": "changed",
+                      "value": [
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "unitCase",
+                                      "tag": "HashQualifier"
+                                  },
+                                  "segment": "unitCase"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "BindingEquals"
+                                  },
+                                  "segment": " ="
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "#ttjui80dbufvf3vgaddmcr065dpgl0rtp68i5cdht6tq4t2vk3i2vg60hi77rug368qijgijf8oui27te7o5oq0t0osm6dg65c080i0",
+                                      "tag": "TermReference"
+                                  },
+                                  "segment": "id"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Parenthesis"
+                                  },
+                                  "segment": "("
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": "x"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "ControlKeyword"
+                                  },
+                                  "segment": " ->"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                                      "tag": "TypeReference"
+                                  },
+                                  "segment": "("
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "NumericLiteral"
+                                  },
+                                  "segment": "1"
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                                      "tag": "TypeReference"
+                                  },
+                                  "segment": ", "
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                                      "tag": "TypeReference"
+                                  },
+                                  "segment": "("
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                                      "tag": "TypeReference"
+                                  },
+                                  "segment": ")"
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                                      "tag": "TypeReference"
+                                  },
+                                  "segment": ")"
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Parenthesis"
+                                  },
+                                  "segment": ")"
+                              }
+                          }
+                      ]
+                  }
+              ]
+          },
           "tag": "UserObject"
       },
       "diffKind": "diff",
@@ -3987,111 +5855,182 @@ GET /api/projects/scratch/diff/types?oldBranchRef=main&newBranchRef=new&oldType=
 RESPONSE:
   {
       "diff": {
-          "contents": [
-              {
-                  "diffTag": "both",
-                  "elements": [
-                      {
-                          "annotation": {
-                              "tag": "DataTypeKeyword"
+          "contents": {
+              "left": [
+                  {
+                      "kind": "changed",
+                      "value": [
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "DataTypeKeyword"
+                                  },
+                                  "segment": "type"
+                              }
                           },
-                          "segment": "type"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "contents": "Type",
-                              "tag": "HashQualifier"
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
                           },
-                          "segment": "Type"
-                      }
-                  ]
-              },
-              {
-                  "diffTag": "new",
-                  "elements": [
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "tag": "DataTypeParams"
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "Type",
+                                      "tag": "HashQualifier"
+                                  },
+                                  "segment": "Type"
+                              }
                           },
-                          "segment": "a"
-                      }
-                  ]
-              },
-              {
-                  "diffTag": "both",
-                  "elements": [
-                      {
-                          "annotation": {
-                              "tag": "DelimiterChar"
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "DelimiterChar"
+                                  },
+                                  "segment": " = "
+                              }
                           },
-                          "segment": " = "
-                      }
-                  ]
-              },
-              {
-                  "diffTag": "annotationChange",
-                  "fromAnnotation": {
-                      "contents": "#m5hlrmkn9a3kuqabta2e9qs934em1qmkotpsh9tjvta2u86nuesbjbk2k2sprbdiljq7uqibp49vku4gfpg2u60ceiv8net1f0bu2n8#d0",
-                      "tag": "TermReference"
-                  },
-                  "segment": "Type",
-                  "toAnnotation": {
-                      "contents": "#uik7pl3klg4u2obtf2fattdaeldui46ohmsi0knpp5hu8tn4d5o8vp570qgh7esgap0pmq9cfrh9dfg1r8qa7qh33g45a3tric24o20#d0",
-                      "tag": "TermReference"
+                          {
+                              "diffTag": "annotationChange",
+                              "fromAnnotation": {
+                                  "contents": "#m5hlrmkn9a3kuqabta2e9qs934em1qmkotpsh9tjvta2u86nuesbjbk2k2sprbdiljq7uqibp49vku4gfpg2u60ceiv8net1f0bu2n8#d0",
+                                  "tag": "TermReference"
+                              },
+                              "segment": "Type",
+                              "toAnnotation": {
+                                  "contents": "#uik7pl3klg4u2obtf2fattdaeldui46ohmsi0knpp5hu8tn4d5o8vp570qgh7esgap0pmq9cfrh9dfg1r8qa7qh33g45a3tric24o20#d0",
+                                  "tag": "TermReference"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "##Nat",
+                                      "tag": "TypeReference"
+                                  },
+                                  "segment": "Nat"
+                              }
+                          }
+                      ]
                   }
-              },
-              {
-                  "diffTag": "both",
-                  "elements": [
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      }
-                  ]
-              },
-              {
-                  "diffTag": "old",
-                  "elements": [
-                      {
-                          "annotation": {
-                              "contents": "##Nat",
-                              "tag": "TypeReference"
+              ],
+              "right": [
+                  {
+                      "kind": "changed",
+                      "value": [
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "DataTypeKeyword"
+                                  },
+                                  "segment": "type"
+                              }
                           },
-                          "segment": "Nat"
-                      }
-                  ]
-              },
-              {
-                  "diffTag": "new",
-                  "elements": [
-                      {
-                          "annotation": {
-                              "tag": "Var"
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
                           },
-                          "segment": "a"
-                      },
-                      {
-                          "annotation": null,
-                          "segment": " "
-                      },
-                      {
-                          "annotation": {
-                              "contents": "##Text",
-                              "tag": "TypeReference"
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "Type",
+                                      "tag": "HashQualifier"
+                                  },
+                                  "segment": "Type"
+                              }
                           },
-                          "segment": "Text"
-                      }
-                  ]
-              }
-          ],
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "DataTypeParams"
+                                  },
+                                  "segment": "a"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "DelimiterChar"
+                                  },
+                                  "segment": " = "
+                              }
+                          },
+                          {
+                              "diffTag": "annotationChange",
+                              "fromAnnotation": {
+                                  "contents": "#uik7pl3klg4u2obtf2fattdaeldui46ohmsi0knpp5hu8tn4d5o8vp570qgh7esgap0pmq9cfrh9dfg1r8qa7qh33g45a3tric24o20#d0",
+                                  "tag": "TermReference"
+                              },
+                              "segment": "Type",
+                              "toAnnotation": {
+                                  "contents": "#m5hlrmkn9a3kuqabta2e9qs934em1qmkotpsh9tjvta2u86nuesbjbk2k2sprbdiljq7uqibp49vku4gfpg2u60ceiv8net1f0bu2n8#d0",
+                                  "tag": "TermReference"
+                              }
+                          },
+                          {
+                              "diffTag": "both",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "tag": "Var"
+                                  },
+                                  "segment": "a"
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": null,
+                                  "segment": " "
+                              }
+                          },
+                          {
+                              "diffTag": "one-sided",
+                              "elements": {
+                                  "annotation": {
+                                      "contents": "##Text",
+                                      "tag": "TypeReference"
+                                  },
+                                  "segment": "Text"
+                              }
+                          }
+                      ]
+                  }
+              ]
+          },
           "tag": "UserObject"
       },
       "diffKind": "diff",


### PR DESCRIPTION
## Overview

This represents a full overhaul of our diffing algorithm. The goal is to better align diffs in spite of change.

The old algorithm was entirely token-oriented, it didn't do anything to special-case lines, so if a bunch of lines were deleted on one side, the other side's diff would get out of alignment.

The new algorithm inserts spacers where necessary to keep similar chunks in line.

Here's an example diff using the new algorithm,
Each line is marked with -/+ when changed, and changed tokens within changed lines are highlighted by wrapping with `{}` (Don't worry, Simon will make the rendered version prettier)

```
=====left====
unchangedDefinition = 1
myDefinition : Nat -> Text -> Text
myDefinition n txt =
  -- Check for non-positive n
  if n == 0 then txt
  else Text.drop n txt

====right====
unchangedDefinition = 1
myNewDefinition : Int -> Text -> Text
myNewDefinition k input =
  -- Check for non-positive n
  if n <= 0
    then txt
  else
    Text.take n input

====diff====
  unchangedDefinition = 1                |   unchangedDefinition = 1
- {myDefinition} : {Nat} -> Text -> Text | + {myNewDefinition} : {Int} -> Text -> Text
- {myDefinition} {n} {txt} =             | + {myNewDefinition} {k} {input} =
    -- Check for non-positive n          |     -- Check for non-positive n
-   if n {==} 0 then txt                 | +   if n {<=} 0
-   else {Text.drop} n {txt}             | +  { }{ }{ }then txt
////                                     | +   else
////                                     | +   { }{ }{Text.take}{ }n {input}
```

## Implementation notes

At a high level, the algorithm:
* First runs the diff algorithm using _entire lines_ as tokens, this gives us a list of equal lines, with chunks of changed lines in between
* Now we can map over the changed trunks and run a token-diff on each of those. This behaves similar to the old algorithm
* We then compute the difference between the number of lines in the lhs and rhs diff sides; and add padding to fill out the smaller.
* This gives us two lists of lines, one for lhs, one for rhs. Each line is tagged with whether it's been changed or not. Lines with changes include annotations on each token indicating whether that particular token exists on the other side. This includes annotations for cases where the name is the same but the hash changed and vice versa.

This replaces the other diff algorithm entirely, which is currently unused in UCM, but will need matching updates from Simon when deploying to Share.

## Test coverage

I added property tests to generate random diffs and assert that the diffs always have matching line-counts (asserting that spacers are being added)

I also added explicit test-cases using a text-rending of diffs.

There are also transcript tests to show the output json, but those aren't good for evaluating the diff effectiveness.

## Loose ends

There's still another pass we can do on this to be smarter about where _within_ a change block we put spacers, e.g. look at this VS code diff where spacers are interleaved within the change block to line up similar words.

<img width="1085" height="209" alt="image" src="https://github.com/user-attachments/assets/eca1464b-f3f3-4c09-ac97-25bfa32fe84c" />

Pretty sure I can iterate on this to get the same, but this is already a significant enough change that it's worth it to ship.