### PR TITLE
Speed up serialized value loading

### DIFF
--- a/unison-runtime/src/Unison/Runtime/ANF.hs
+++ b/unison-runtime/src/Unison/Runtime/ANF.hs
@@ -79,6 +79,7 @@ module Unison.Runtime.ANF
     anfTerm,
     codeGroup,
     valueTermLinks,
+    collectValueLinks,
     valueLinks,
     groupTermLinks,
     replaceConstructors,
@@ -2177,17 +2178,23 @@ valueTermLinks = Set.toList . valueLinks f
     f False r = Set.singleton r
     f _ _ = Set.empty
 
+collectValueLinks :: (Ord ref) => Value ref -> (Set ref, Set ref)
+collectValueLinks = valueLinks f
+  where
+    f False r = (mempty, Set.singleton r)
+    f True r = (Set.singleton r, mempty)
+
 -- Folds over the references necessary to _load_ a `Value`. This does
 -- not include references in quoted code or values, or literal
 -- term/type links.
 valueLinks :: (Monoid a) => (Bool -> ref -> a) -> Value ref -> a
-valueLinks f (Partial (GR cr _) vs) =
-  f False cr <> foldMap (valueLinks f) vs
-valueLinks f (Data dr _ vs) =
-  f True dr <> foldMap (valueLinks f) vs
-valueLinks f (Cont vs k) =
-  foldMap (valueLinks f) vs <> contLinks f k
-valueLinks f (BLit l) = blitLinks f l
+valueLinks f = go
+  where
+    go (Partial (GR cr _) vs) = f False cr <> foldMap go vs
+    go (Data dr _ vs) = f True dr <> foldMap go vs
+    go (Cont vs k) = foldMap go vs <> contLinks f k
+    go (BLit l) = blitLinks f l
+{-# INLINE valueLinks #-}
 
 -- Traversals of _all_ references in a `Value`, for e.g.
 -- canonicalization.
@@ -2223,13 +2230,16 @@ instance Referential Value where
     BLit l -> BLit <$> traverseRefs h l
 
 contLinks :: (Monoid a) => (Bool -> ref -> a) -> Cont ref -> a
-contLinks f (Push _ _ (GR cr _) k) =
-  f False cr <> contLinks f k
-contLinks f (Mark _ ps de k) =
-  foldMap (f True) ps
-    <> foldMap (\(k, c) -> f True k <> valueLinks f c) de
-    <> contLinks f k
-contLinks _ KE = mempty
+contLinks f = go
+  where
+    go (Push _ _ (GR cr _) k) =
+      f False cr <> go k
+    go (Mark _ ps de k) =
+      foldMap (f True) ps
+        <> foldMap (\(k, c) -> f True k <> valueLinks f c) de
+        <> go k
+    go KE = mempty
+{-# INLINE contLinks #-}
 
 -- Traversals over references in a cont.
 --
@@ -2268,11 +2278,14 @@ instance Referential Cont where
         <*> traverseRefs h k
 
 blitLinks :: (Monoid a) => (Bool -> ref -> a) -> BLit ref -> a
-blitLinks f (List s) = foldMap (valueLinks f) s
-blitLinks f (Arr a) = foldMap (valueLinks f) a
-blitLinks f (Map m) =
-  foldMap (\(k, v) -> valueLinks f k <> valueLinks f v) m
-blitLinks _ _ = mempty
+blitLinks f = go
+  where
+    go (List s) = foldMap (valueLinks f) s
+    go (Arr a) = foldMap (valueLinks f) a
+    go (Map m) =
+      foldMap (\(k, v) -> valueLinks f k <> valueLinks f v) m
+    go _ = mempty
+{-# INLINE blitLinks #-}
 
 instance Referential BLit where
   overRefs h = \case

--- a/unison-runtime/src/Unison/Runtime/ANF/Serialize.hs
+++ b/unison-runtime/src/Unison/Runtime/ANF/Serialize.hs
@@ -28,7 +28,6 @@ import Data.Serialize.Get qualified as SGet
 import Data.Serialize.Put (runPutLazy)
 import Data.Serialize.Put qualified as SPut
 import Data.Word (Word32, Word64)
-import GHC.IsList qualified (fromList)
 import GHC.Stack
 import Unison.ABT.Normalized (Term (..))
 import Unison.Builtin.Decls (mapBin, mapRef, mapTip)
@@ -529,7 +528,7 @@ getBLit =
     NegT -> Neg <$> getPositive
     CharT -> Char <$> getChar
     FloatT -> Float <$> getFloat
-    ArrT -> Arr . GHC.IsList.fromList <$> getList getValue
+    ArrT -> Arr <$> getArray getValue
     CachedCodeT -> Code . flip CodeRep Cacheable <$> getGroup
     MapT -> exn [] "getBLit: unsupported literal map"
 {-# SPECIALIZE getBLit :: BDeserial (BLit Reference) #-}

--- a/unison-runtime/src/Unison/Runtime/ANF/Serialize/ValueV5.hs
+++ b/unison-runtime/src/Unison/Runtime/ANF/Serialize/ValueV5.hs
@@ -11,7 +11,6 @@ import Data.Bytes.Get hiding (getBytes)
 import Data.Bytes.Put
 import Data.Serialize.Get qualified as SGet
 import Data.Serialize.Put qualified as SPut
-import GHC.IsList qualified (fromList)
 import Unison.Reference (Reference)
 import Unison.Runtime.ANF as ANF hiding (Tag)
 import Unison.Runtime.ANF.Serialize.CodeV4
@@ -194,7 +193,7 @@ getBLit =
     NegT -> Neg <$> getPositive
     CharT -> Char <$> getChar
     FloatT -> Float <$> getFloat
-    ArrT -> Arr . GHC.IsList.fromList <$> getList getValue
+    ArrT -> Arr <$> getArray getValue
     CachedCodeT -> Code . flip CodeRep Cacheable <$> getGroup
     MapT -> Map <$> getMapping getValue getValue
 {-# SPECIALIZE getBLit :: BGet.Get (BLit RefNum) #-}

--- a/unison-runtime/src/Unison/Runtime/Array.hs
+++ b/unison-runtime/src/Unison/Runtime/Array.hs
@@ -15,6 +15,7 @@ module Unison.Runtime.Array
     readArray,
     writeArray,
     copyArray,
+    traverseArrayIO,
     copyMutableArray,
     cloneMutableArray,
     readByteArray,
@@ -29,6 +30,7 @@ module Unison.Runtime.Array
   )
 where
 
+import Control.Exception (evaluate)
 import Control.Monad.Primitive
 import Data.Kind (Constraint)
 import Data.Primitive.Array as EPA hiding
@@ -427,3 +429,16 @@ indexPrimArray = checkIPArray "indexPrimArray" PA.indexPrimArray
 
 byteArrayToList :: ByteArray -> [Word8]
 byteArrayToList = toList
+
+traverseArrayIO :: (a -> IO b) -> Array a -> IO (Array b)
+traverseArrayIO f src = do
+  dst <- newArray sz (error "traverseArray: impossible")
+  let fill i
+        | i < sz = do
+            PA.writeArray dst i =<< evaluate =<< f =<< indexArrayM src i
+            fill (i+1)
+        | otherwise = unsafeFreezeArray dst
+  fill 0
+  where
+    sz = sizeofArray src
+{-# INLINE traverseArrayIO #-}

--- a/unison-runtime/src/Unison/Runtime/Array.hs
+++ b/unison-runtime/src/Unison/Runtime/Array.hs
@@ -432,14 +432,13 @@ indexPrimArray = checkIPArray "indexPrimArray" PA.indexPrimArray
 byteArrayToList :: ByteArray -> [Word8]
 byteArrayToList = toList
 
-
 traverseArrayIO :: (a -> IO b) -> Array a -> IO (Array b)
 traverseArrayIO f src = do
   dst <- newArray sz (error "traverseArray: impossible")
   let fill i
         | i < sz = do
             PA.writeArray dst i =<< evaluate =<< f =<< indexArrayM src i
-            fill (i+1)
+            fill (i + 1)
         | otherwise = unsafeFreezeArray dst
   fill 0
   where
@@ -448,4 +447,3 @@ traverseArrayIO f src = do
 
 byteArrayToShortByteString :: ByteArray -> ShortByteString
 byteArrayToShortByteString (ByteArray ba) = SBS ba
-

--- a/unison-runtime/src/Unison/Runtime/Machine.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine.hs
@@ -64,7 +64,7 @@ import Unison.Runtime.ANF as ANF
     foldGroupLinks,
     maskTags,
     packTags,
-    valueLinks,
+    collectValueLinks,
   )
 import Unison.Runtime.ANF qualified as ANF
 import Unison.Runtime.ANF.Optimize qualified as ANF
@@ -1711,9 +1711,24 @@ data ReflectExn = ReflectExn String deriving (Show)
 
 instance Exception ReflectExn
 
+ixArr :: String -> Array a -> RefNum -> IO a
+ixArr pfx arr (RefNum i)
+  | 0 <= i, i < sizeofArray arr = indexArrayM arr i
+  | otherwise = die [] . (pfx ++) $ " index out of bounds: " ++ show i
+{-# INLINE ixArr #-}
+
 reifyValue ::
   CCache p -> Referenced ANF.Value -> IO (Either [Reference] Val)
 reifyValue cc val = do
+  (tyLinks, tmLinks) <- case val of
+    Plain v -> pure $ collectValueLinks v
+    WithRefs tys tms v -> {-# SCC reifyValueWithRefs #-} do
+      let tya = arrayFromList tys
+          tma = arrayFromList tms
+          (tyns, tmns) = collectValueLinks v
+          travSet f = fmap S.fromList . traverse f . S.toList
+      (,) <$> travSet (ixArr "reifyValue: type" tya) tyns
+          <*> travSet (ixArr "reifyValue: term" tma) tmns
   erc <-
     atomically $ do
       combs <- readTVar (combs cc)
@@ -1724,11 +1739,6 @@ reifyValue cc val = do
           pure . Right $ (combs, newTy, rtm)
         l -> pure (Left l)
   traverse (\rfs -> reifyValue1 rfs val) erc
-  where
-    f False r = (mempty, S.singleton r)
-    f True r = (S.singleton r, mempty)
-
-    (tyLinks, tmLinks) = valueLinks f (dereference val)
 
 reifyValue1 ::
   (EnumMap Word64 MCombs, M.Map Reference Word64, M.Map Reference Word64) ->

--- a/unison-runtime/src/Unison/Runtime/Machine.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine.hs
@@ -1738,7 +1738,7 @@ reifyValue ::
 reifyValue cc val = do
   (tyLinks, tmLinks) <- case val of
     Plain v -> pure $ collectValueLinks v
-    WithRefs tys tms v -> {-# SCC reifyValueWithRefs #-} do
+    WithRefs tys tms v -> do
       let tya = arrayFromList tys
           tma = arrayFromList tms
           (tyns, tmns) = collectValueLinks v

--- a/unison-runtime/src/Unison/Runtime/Machine.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine.hs
@@ -60,11 +60,11 @@ import Unison.Runtime.ANF as ANF
     PackedTag (..),
     SuperGroup,
     codeGroup,
+    collectValueLinks,
     foldGroup,
     foldGroupLinks,
     maskTags,
     packTags,
-    collectValueLinks,
   )
 import Unison.Runtime.ANF qualified as ANF
 import Unison.Runtime.ANF.Optimize qualified as ANF
@@ -1671,11 +1671,10 @@ reflectValue0 rty rtm = goV0
             r <- resolveTy rty $ TT.typeTag t
             u <- goV u
             v <- goV v
-            pure $ ANF.Data r (maskTags t) [u,v]
+            pure $ ANF.Data r (maskTags t) [u, v]
           DataG _ t seg -> do
             r <- resolveTy rty $ TT.typeTag t
             ANF.Data r (maskTags t) <$> goVs seg
-
           Captured k _ segs ->
             ANF.Cont <$> goVs segs <*> goK k
           Foreign f -> ANF.BLit <$> goF f
@@ -1743,8 +1742,9 @@ reifyValue cc val = do
           tma = arrayFromList tms
           (tyns, tmns) = collectValueLinks v
           travSet f = fmap S.fromList . traverse f . S.toList
-      (,) <$> travSet (ixArr "reifyValue: type" tya) tyns
-          <*> travSet (ixArr "reifyValue: term" tma) tmns
+      (,)
+        <$> travSet (ixArr "reifyValue: type" tya) tyns
+        <*> travSet (ixArr "reifyValue: term" tma) tmns
   erc <-
     atomically $ do
       combs <- readTVar (combs cc)

--- a/unison-runtime/src/Unison/Runtime/Machine.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine.hs
@@ -1642,6 +1642,9 @@ reflectValue0 rty rtm = goV0
     goV0 :: Val -> IO (Referenced ANF.Value)
     goV0 v = finish <$> runStateT (goV v) emptyRS
 
+    goVs :: Seg -> Reflect [ANF.Value RefNum]
+    goVs sg = traverseAccumSegToList goV sg
+
     goV :: Val -> Reflect (ANF.Value RefNum)
     goV = \case
       -- For back-compatibility we reflect all Unboxed values into boxed literals, we could change this in the future,
@@ -1655,13 +1658,26 @@ reflectValue0 rty rtm = goV0
       CharVal c -> pure . ANF.BLit $ ANF.Char c
       Val _ clos ->
         case clos of
-          PApV cix _rComb args ->
-            ANF.Partial <$> goIx cix <*> traverse goV args
-          DataC _ t segs -> do
+          PAp cix _rComb args ->
+            ANF.Partial <$> goIx cix <*> goVs args
+          Enum _ t -> do
             r <- resolveTy rty $ TT.typeTag t
-            ANF.Data r (maskTags t) <$> traverse goV segs
-          CapV k _ segs ->
-            ANF.Cont <$> traverse goV segs <*> goK k
+            pure $ ANF.Data r (maskTags t) []
+          Data1 _ t u -> do
+            r <- resolveTy rty $ TT.typeTag t
+            u <- goV u
+            pure $ ANF.Data r (maskTags t) [u]
+          Data2 _ t u v -> do
+            r <- resolveTy rty $ TT.typeTag t
+            u <- goV u
+            v <- goV v
+            pure $ ANF.Data r (maskTags t) [u,v]
+          DataG _ t seg -> do
+            r <- resolveTy rty $ TT.typeTag t
+            ANF.Data r (maskTags t) <$> goVs seg
+
+          Captured k _ segs ->
+            ANF.Cont <$> goVs segs <*> goK k
           Foreign f -> ANF.BLit <$> goF f
           BlackHole -> reflExn "black hole"
           UnboxedTypeTag {} ->
@@ -1797,10 +1813,20 @@ reifyValue0Canon combs tys tms rty rtm = goV
       let cix = (CIx rf n i)
       pure (cix, rCombSection combs cix)
 
+    goVs :: [ANF.Value RefNum] -> IO Seg
+    goVs vs = traverseListToSeg goV vs
+
+    goVArr :: Array (ANF.Value RefNum) -> IO (Array Val)
+    goVArr vs = traverseArrayIO goV vs
+
+    goVSeq :: Seq (ANF.Value RefNum) -> IO (Seq Val)
+    goVSeq vs = traverse goV vs
+
     goV :: ANF.Value RefNum -> IO Val
     goV (ANF.Partial gr vs) =
       goIx gr >>= \case
-        (cix, RComb (Comb rcomb)) -> boxedVal . PApV cix rcomb <$> traverse goV vs
+        (cix, RComb (Comb rcomb)) ->
+          boxedVal . PAp cix rcomb <$> goVs vs
         (_, RComb (CachedVal _ val))
           | [] <- vs -> pure val
           | otherwise -> die [] . err $ msg
@@ -1809,13 +1835,13 @@ reifyValue0Canon combs tys tms rty rtm = goV
     goV (ANF.Data rn t0 vs) = do
       t <- flip packTags (fromIntegral t0) . fromIntegral <$> refTy rn
       rf <- ixTy rn
-      boxedVal . formDataReplaced rf t <$> traverse goV vs
+      boxedVal . formDataReplaced rf t <$> goVs vs
     goV (ANF.Cont vs k) = do
       k' <- goK k
-      vs' <- traverse goV vs
+      vs' <- goVs vs
       pure . boxedVal $ cv k' vs'
       where
-        cv k s = CapV k a s
+        cv k s = Captured k a s
           where
             ksz = frameDataSize k
             a = fromIntegral $ length s - ksz
@@ -1847,7 +1873,7 @@ reifyValue0Canon combs tys tms rty rtm = goV
 
     goL :: ANF.BLit RefNum -> IO Val
     goL (ANF.Text t) = pure $ encodeVal t
-    goL (ANF.List l) = boxedVal . Foreign . Wrap Rf.listRef <$> traverse goV l
+    goL (ANF.List l) = encodeVal <$> goVSeq l
     goL (ANF.TmLink r) = encodeVal <$> traverseRefs numToRef r
     goL (ANF.TyLink r) = encodeVal <$> ixTy r
     goL (ANF.Bytes b) = pure $ encodeVal b
@@ -1860,7 +1886,7 @@ reifyValue0Canon combs tys tms rty rtm = goV
       pure $ NatVal w
     goL (ANF.Neg w) = pure $ IntVal (negate (fromIntegral w :: Int))
     goL (ANF.Float d) = pure $ DoubleVal d
-    goL (ANF.Arr a) = boxedVal . Foreign . Wrap Rf.iarrayRef <$> traverse goV a
+    goL (ANF.Arr a) = encodeVal <$> goVArr a
     goL (ANF.Map l) = encodeVal . M.fromList <$> traverse goP l
       where
         goP (x, y) = (,) <$> goV x <*> goV y
@@ -1886,10 +1912,17 @@ reifyValue0 (combs, rty, rtm) = goV
       where
         r = M.findWithDefault r0 r0 functionReplacements
 
+    goVs :: [ANF.Value Reference] -> IO Seg
+    goVs vs = traverseListToSeg goV vs
+
+    goVArr :: Array (ANF.Value Reference) -> IO (Array Val)
+    goVArr vs = traverseArrayIO goV vs
+
     goV :: ANF.Value Reference -> IO Val
     goV (ANF.Partial gr vs) =
       goIx gr >>= \case
-        (cix, RComb (Comb rcomb)) -> boxedVal . PApV cix rcomb <$> traverse goV vs
+        (cix, RComb (Comb rcomb)) ->
+          boxedVal . PAp cix rcomb <$> goVs vs
         (_, RComb (CachedVal _ val))
           | [] <- vs -> pure val
           | otherwise -> die [] . err $ msg
@@ -1897,13 +1930,13 @@ reifyValue0 (combs, rty, rtm) = goV
             msg = "reifyValue0: non-trivial partial application to cached value"
     goV (ANF.Data r t0 vs) = do
       t <- flip packTags (fromIntegral t0) . fromIntegral <$> refTy r
-      boxedVal . formDataReplaced r t <$> traverse goV vs
+      boxedVal . formDataReplaced r t <$> goVs vs
     goV (ANF.Cont vs k) = do
       k' <- goK k
-      vs' <- traverse goV vs
+      vs' <- goVs vs
       pure . boxedVal $ cv k' vs'
       where
-        cv k s = CapV k a s
+        cv k s = Captured k a s
           where
             ksz = frameDataSize k
             a = fromIntegral $ length s - ksz
@@ -1948,7 +1981,7 @@ reifyValue0 (combs, rty, rtm) = goV
       pure $ NatVal w
     goL (ANF.Neg w) = pure $ IntVal (negate (fromIntegral w :: Int))
     goL (ANF.Float d) = pure $ DoubleVal d
-    goL (ANF.Arr a) = encodeVal <$> traverse goV a
+    goL (ANF.Arr a) = encodeVal <$> goVArr a
     goL (ANF.Map l) = encodeVal . M.fromList <$> traverse goP l
       where
         goP (x, y) = (,) <$> goV x <*> goV y

--- a/unison-runtime/src/Unison/Runtime/Stack.hs
+++ b/unison-runtime/src/Unison/Runtime/Stack.hs
@@ -531,7 +531,9 @@ formDataSeg r t (usg, bsg) = case sizeofArray bsg of
   0 -> Enum r t
   1 -> Data1 r t (Val (indexByteArray usg 0) (indexArray bsg 0))
   2 ->
-    Data2 r t
+    Data2
+      r
+      t
       (Val (indexByteArray usg 1) (indexArray bsg 1))
       (Val (indexByteArray usg 0) (indexArray bsg 0))
   _ -> DataG r t (usg, bsg)
@@ -544,7 +546,8 @@ formDataReplaced r t sg@(usg, bsg)
       0 -> tipClosure
       _ -> error "formDataReplaced: bad `Map`"
   | t == TT.mapBinTag = case sizeofArray bsg of
-      5 | !bk <- indexArray bsg 3,
+      5
+        | !bk <- indexArray bsg 3,
           !uk <- indexByteArray usg 3,
           !bv <- indexArray bsg 2,
           !uv <- indexByteArray usg 2,
@@ -693,12 +696,12 @@ traverseListToSeg f src = do
         udst <- unsafeFreezeByteArray udst
         bdst <- unsafeFreezeArray bdst
         pure (udst, bdst)
-      fill i (x:xs) = do
+      fill i (x : xs) = do
         Val un bx <- f x
         writeByteArray udst i un
         writeArray bdst i bx
-        fill (i-1) xs
-  fill (sz-1) src
+        fill (i - 1) xs
+  fill (sz - 1) src
   where
     sz = length src
 {-# INLINE traverseListToSeg #-}
@@ -720,7 +723,7 @@ traverseAccumSegToList f (usrc, bsrc) = StateT \s -> go s [] 0
           bx <- indexArrayM bsrc i
           (x, s) <- runStateT (f (Val un bx)) s
           x <- evaluate x
-          go s (x:xs) (i+1)
+          go s (x : xs) (i + 1)
       | otherwise = pure (xs, s)
 {-# INLINE traverseAccumSegToList #-}
 

--- a/unison-runtime/src/Unison/Runtime/Stack.hs
+++ b/unison-runtime/src/Unison/Runtime/Stack.hs
@@ -153,6 +153,8 @@ module Unison.Runtime.Stack
     useg,
     bseg,
     segFromList,
+    traverseListToSeg,
+    traverseAccumSegToList,
 
     -- * Unboxed type tags
     natTypeTag,
@@ -170,8 +172,9 @@ where
 
 import Control.Concurrent (MVar)
 import Control.Concurrent.STM (TVar)
-import Control.Exception (throw, throwIO)
+import Control.Exception (evaluate, throw, throwIO)
 import Control.Monad.Primitive
+import Control.Monad.State.Strict (StateT (..))
 import Data.Atomics qualified as Atomic
 import Data.Bits (clearBit)
 import Data.Char qualified as Char
@@ -523,19 +526,34 @@ formData r t [v1] = Data1 r t v1
 formData r t [v1, v2] = Data2 r t v1 v2
 formData r t segList = DataG r t (segFromList segList)
 
+formDataSeg :: Reference -> PackedTag -> Seg -> Closure
+formDataSeg r t (usg, bsg) = case sizeofArray bsg of
+  0 -> Enum r t
+  1 -> Data1 r t (Val (indexByteArray usg 0) (indexArray bsg 0))
+  2 ->
+    Data2 r t
+      (Val (indexByteArray usg 1) (indexArray bsg 1))
+      (Val (indexByteArray usg 0) (indexArray bsg 0))
+  _ -> DataG r t (usg, bsg)
+{-# INLINE formDataSeg #-}
+
 -- Build a data type, but apply replacements
-formDataReplaced :: Reference -> PackedTag -> SegList -> Closure
-formDataReplaced r t l
-  | t == TT.mapTipTag = case l of
-      [] -> tipClosure
+formDataReplaced :: Reference -> PackedTag -> Seg -> Closure
+formDataReplaced r t sg@(usg, bsg)
+  | t == TT.mapTipTag = case sizeofArray bsg of
+      0 -> tipClosure
       _ -> error "formDataReplaced: bad `Map`"
-  | t == TT.mapBinTag = case l of
-      [NatVal sz, k, v, BoxedVal (Foreign l), BoxedVal (Foreign r)]
-        | Just ul <- maybeUnwrapForeign Ty.hmapRef l,
-          Just ur <- maybeUnwrapForeign Ty.hmapRef r ->
-            Foreign . Wrap Ty.hmapRef $ Bin (fromIntegral sz) k v ul ur
+  | t == TT.mapBinTag = case sizeofArray bsg of
+      5 | k <- indexArray bsg 3,
+          v <- indexArray bsg 2,
+          Foreign l <- indexArray bsg 1,
+          Just ul <- maybeUnwrapForeign Ty.hmapRef l,
+          Foreign r <- indexArray bsg 0,
+          Just ur <- maybeUnwrapForeign Ty.hmapRef r,
+          sz <- indexByteArray usg 4 ->
+            Foreign . Wrap Ty.hmapRef $ Bin sz k v ul ur
       _ -> error "formDataReplaced: bad `Map`"
-  | otherwise = formData r t l
+  | otherwise = formDataSeg r t sg
 
 tipClosure :: Closure
 tipClosure = Foreign $ Wrap Ty.hmapRef Tip
@@ -662,6 +680,45 @@ segFromList xs =
       ( \(Val unboxed boxed) -> ([unboxed], [boxed])
       )
     & \(us, bs) -> (useg us, bseg bs)
+
+traverseListToSeg :: (a -> IO Val) -> [a] -> IO Seg
+traverseListToSeg f src = do
+  udst <- newByteArray $ bytes sz
+  bdst <- newArray sz BlackHole
+  let fill _ [] = do
+        udst <- unsafeFreezeByteArray udst
+        bdst <- unsafeFreezeArray bdst
+        pure (udst, bdst)
+      fill i (x:xs) = do
+        Val un bx <- f x
+        writeByteArray udst i un
+        writeArray bdst i bx
+        fill (i-1) xs
+  fill (sz-1) src
+  where
+    sz = length src
+{-# INLINE traverseListToSeg #-}
+
+-- Note: this traverses the Seg left-to-right, which is backwards in
+-- element terms. This is more efficient for building the correct
+-- (reversed) list, but it means the effects happen in the opposite
+-- order of the resulting values. This is not a problem for intended
+-- uses, though, since the effect orders do not really matter.
+traverseAccumSegToList ::
+  (Val -> StateT s IO a) -> Seg -> StateT s IO [a]
+traverseAccumSegToList f (usrc, bsrc) = StateT \s -> go s [] 0
+  where
+    sz = sizeofArray bsrc
+
+    go s xs i
+      | i < sz = do
+          let !un = indexByteArray usrc i
+          bx <- indexArrayM bsrc i
+          (x, s) <- runStateT (f (Val un bx)) s
+          x <- evaluate x
+          go s (x:xs) (i+1)
+      | otherwise = pure (xs, s)
+{-# INLINE traverseAccumSegToList #-}
 
 marshalToForeign :: (HasCallStack) => Closure -> Foreign
 marshalToForeign (Foreign x) = x

--- a/unison-runtime/src/Unison/Runtime/Stack.hs
+++ b/unison-runtime/src/Unison/Runtime/Stack.hs
@@ -544,14 +544,18 @@ formDataReplaced r t sg@(usg, bsg)
       0 -> tipClosure
       _ -> error "formDataReplaced: bad `Map`"
   | t == TT.mapBinTag = case sizeofArray bsg of
-      5 | k <- indexArray bsg 3,
-          v <- indexArray bsg 2,
+      5 | !bk <- indexArray bsg 3,
+          !uk <- indexByteArray usg 3,
+          !bv <- indexArray bsg 2,
+          !uv <- indexByteArray usg 2,
           Foreign l <- indexArray bsg 1,
-          Just ul <- maybeUnwrapForeign Ty.hmapRef l,
+          Just (ul :: Map Val Val) <- maybeUnwrapBuiltin l,
           Foreign r <- indexArray bsg 0,
-          Just ur <- maybeUnwrapForeign Ty.hmapRef r,
-          sz <- indexByteArray usg 4 ->
-            Foreign . Wrap Ty.hmapRef $ Bin sz k v ul ur
+          Just (ur :: Map Val Val) <- maybeUnwrapBuiltin r,
+          sz <- indexByteArray usg 4,
+          Closure (GUnboxedTypeTag NatTag) <- indexArray bsg 4 ->
+            Foreign . Wrap Ty.hmapRef $
+              Bin sz (Val uk bk) (Val uv bv) ul ur
       _ -> error "formDataReplaced: bad `Map`"
   | otherwise = formDataSeg r t sg
 


### PR DESCRIPTION
This PR optimizes the process of reification of serialized values back into runtime values a bit. It can be around twice as fast as it previously was, depending on what you're reifying. The bulk of the work is just making various traversals involved better, and go through fewer intermediate representations.