### PR TITLE
LSP scratch-file outline

### DIFF
--- a/unison-cli/src/Unison/LSP.hs
+++ b/unison-cli/src/Unison/LSP.hs
@@ -36,6 +36,7 @@ import Unison.LSP.CodeLens (codeLensHandler)
 import Unison.LSP.Commands (executeCommandHandler, supportedCommands)
 import Unison.LSP.Completion (completionHandler, completionItemResolveHandler)
 import Unison.LSP.Configuration qualified as Config
+import Unison.LSP.DocumentSymbols (documentSymbolsHandler)
 import Unison.LSP.FileAnalysis qualified as Analysis
 import Unison.LSP.FoldingRange (foldingRangeRequest)
 import Unison.LSP.Formatting (formatDocRequest, formatRangeRequest)
@@ -185,6 +186,7 @@ lspRequestHandlers lspFormattingConfig =
     & SMM.insert Msg.SMethod_TextDocumentDeclaration (mkHandler goToDeclarationHandler)
     & SMM.insert Msg.SMethod_TextDocumentDefinition (mkHandler goToDefinitionHandler)
     & SMM.insert Msg.SMethod_TextDocumentImplementation (mkHandler goToImplementationHandler)
+    & SMM.insert Msg.SMethod_TextDocumentDocumentSymbol (mkHandler documentSymbolsHandler)
     & addFormattingHandlers
   where
     addFormattingHandlers handlers =

--- a/unison-cli/src/Unison/LSP/DocumentSymbols.hs
+++ b/unison-cli/src/Unison/LSP/DocumentSymbols.hs
@@ -1,0 +1,57 @@
+module Unison.LSP.DocumentSymbols
+  ( documentSymbolsHandler,
+  )
+where
+
+import Control.Lens hiding (List)
+import Data.Text qualified as Text
+import Language.LSP.Protocol.Lens hiding (error)
+import Language.LSP.Protocol.Message qualified as Msg
+import Language.LSP.Protocol.Types
+import Unison.LSP.FileAnalysis
+import Unison.LSP.FileAnalysis qualified as FileAnalysis
+import Unison.LSP.Types
+import Unison.Prelude
+import Unison.PrettyPrintEnv (PrettyPrintEnv)
+import Unison.PrettyPrintEnvDecl qualified as PPED
+import Unison.Syntax.Name qualified as Name
+import Unison.Syntax.TypePrinter qualified as TypePrinter
+import Unison.Util.Pretty qualified as Pretty
+
+-- | Go to Definition handler
+documentSymbolsHandler :: Msg.TRequestMessage 'Msg.Method_TextDocumentDocumentSymbol -> (Either Msg.ResponseError (Msg.MessageResult 'Msg.Method_TextDocumentDocumentSymbol) -> Lsp ()) -> Lsp ()
+documentSymbolsHandler m respond = do
+  respond . Right . maybe (InR . InL $ []) (InR . InL) =<< runMaybeT do
+    let fileUri = m ^. params . textDocument . uri
+    FileAnalysis {documentSymbols} <- FileAnalysis.getFileAnalysis fileUri
+    ppe <- PPED.suffixifiedPPE <$> lift (ppedForFile fileUri)
+    pure (asLspDocumentSymbols ppe <$> documentSymbols)
+
+asLspDocumentSymbols :: PrettyPrintEnv -> UDocumentSymbol -> DocumentSymbol
+asLspDocumentSymbols
+  ppe
+  UDocumentSymbol
+    { symbolName,
+      symbolSignature,
+      symbolKind,
+      symbolRange,
+      symbolChildren
+    } =
+    DocumentSymbol
+      { _name = Name.toText symbolName,
+        _detail = do
+          typ <- symbolSignature
+          pure $ ": " <> (Text.pack $ TypePrinter.prettyStr typeWidth ppe typ),
+        _kind = lspSymbolKind symbolKind,
+        _tags = Just [],
+        _deprecated = Nothing,
+        _range = symbolRange,
+        _selectionRange = symbolRange,
+        _children = if null symbolChildren then Nothing else Just (asLspDocumentSymbols ppe <$> symbolChildren)
+      }
+    where
+      typeWidth = Pretty.Width 120
+      lspSymbolKind = \case
+        DataDeclSymbol -> SymbolKind_Class
+        EffectDeclSymbol -> SymbolKind_Interface
+        TermSymbol -> SymbolKind_Function

--- a/unison-cli/src/Unison/LSP/FileAnalysis.hs
+++ b/unison-cli/src/Unison/LSP/FileAnalysis.hs
@@ -17,6 +17,7 @@ import Control.Lens
 import Control.Monad.Reader
 import Crypto.Random qualified as Random
 import Data.Align (alignWith)
+import Data.Align qualified as Align
 import Data.Foldable
 import Data.Foldable qualified as Foldable
 import Data.IntervalMap.Lazy (IntervalMap)
@@ -158,6 +159,7 @@ checkFileContents fileUri sourceName fileVersion contents = do
           & foldMap (\(RangedCodeAction {_codeActionRanges, _codeAction}) -> (,_codeAction) <$> _codeActionRanges)
           & toRangeMap
   let typeSignatureHints = fromMaybe mempty (mkTypeSignatureHints <$> parsedFile <*> typecheckedFile)
+  let documentSymbols = fromMaybe mempty (mkDocumentSymbols <$> parsedFile <*> typecheckedFile)
   let fileSummary = FileSummary.mkFileSummary parsedFile typecheckedFile
   let unusedBindingDiagnostics = fileSummary ^.. _Just . to termsBySymbol . folded . folding (\(_topLevelAnn, _refId, trm, _type) -> UnusedBindings.analyseTerm fileUri trm)
   let tokenMap = getTokenMap tokens
@@ -181,7 +183,8 @@ checkFileContents fileUri sourceName fileVersion contents = do
             parsedFile,
             typecheckedFile,
             notes,
-            localBindingInfo
+            localBindingInfo,
+            documentSymbols
           }
   pure fileAnalysis
 
@@ -537,3 +540,47 @@ mkTypeSignatureHints parsedFile typecheckedFile = do
                 pure $ TypeSignatureHint name (Referent.fromTermReferenceId ref) newRange typ
             )
    in typeHints
+
+-- | Get info on the top-level symbols in the file.
+mkDocumentSymbols :: UF.UnisonFile Symbol Ann -> UF.TypecheckedUnisonFile Symbol Ann -> [UDocumentSymbol]
+mkDocumentSymbols parsedFile typecheckedFile =
+  let alignTerms = \case
+        This (ann, _trm) -> (ann, Nothing)
+        That (ann, _ref, _wk, _trm, typ) -> (ann, Just typ)
+        These _ (ann, _ref, _wk, _trm, typ) -> (ann, Just typ)
+      termSymbols :: [UDocumentSymbol]
+      termSymbols =
+        Align.alignWith alignTerms parsedFile.terms typecheckedFile.hashTermsId
+          & Map.toList
+          & mapMaybe \(v, (ann, mayTyp)) -> do
+            name <- Name.parseText (Var.name v)
+            range <- annToRange ann
+            let children = []
+            pure $ UDocumentSymbol name mayTyp TermSymbol range children
+      declSymbols :: [UDocumentSymbol]
+      declSymbols =
+        parsedFile.dataDeclarationsId
+          & Map.toList
+          & mapMaybe \(v, (_ref, decl)) -> do
+            name <- Name.parseText (Var.name v)
+            range <- annToRange (DD.annotation decl)
+            let children = declChildren decl
+            pure $ UDocumentSymbol name Nothing DataDeclSymbol range children
+      effectSymbols :: [UDocumentSymbol]
+      effectSymbols =
+        parsedFile.effectDeclarationsId
+          & Map.toList
+          & mapMaybe \(v, (_ref, eff)) -> do
+            let decl = DD.toDataDecl eff
+            name <- Name.parseText (Var.name v)
+            range <- annToRange (DD.annotation decl)
+            let children = declChildren decl
+            pure $ UDocumentSymbol name Nothing EffectDeclSymbol range children
+   in termSymbols <> declSymbols <> effectSymbols
+  where
+    declChildren :: DD.DataDeclaration Symbol Ann -> [UDocumentSymbol]
+    declChildren decl = do
+      (ann, sym, typ) <- DD.constructors' decl
+      name <- maybeToList $ Name.parseText (Var.name sym)
+      range <- maybeToList $ annToRange ann
+      pure $ UDocumentSymbol name (Just typ) TermSymbol range []

--- a/unison-cli/src/Unison/LSP/FileAnalysis.hs
+++ b/unison-cli/src/Unison/LSP/FileAnalysis.hs
@@ -159,7 +159,7 @@ checkFileContents fileUri sourceName fileVersion contents = do
           & foldMap (\(RangedCodeAction {_codeActionRanges, _codeAction}) -> (,_codeAction) <$> _codeActionRanges)
           & toRangeMap
   let typeSignatureHints = fromMaybe mempty (mkTypeSignatureHints <$> parsedFile <*> typecheckedFile)
-  let documentSymbols = fromMaybe mempty (mkDocumentSymbols <$> parsedFile <*> typecheckedFile)
+  let documentSymbols = fromMaybe mempty (mkDocumentSymbols <$> parsedFile <*> pure typecheckedFile)
   let fileSummary = FileSummary.mkFileSummary parsedFile typecheckedFile
   let unusedBindingDiagnostics = fileSummary ^.. _Just . to termsBySymbol . folded . folding (\(_topLevelAnn, _refId, trm, _type) -> UnusedBindings.analyseTerm fileUri trm)
   let tokenMap = getTokenMap tokens
@@ -542,7 +542,7 @@ mkTypeSignatureHints parsedFile typecheckedFile = do
    in typeHints
 
 -- | Get info on the top-level symbols in the file.
-mkDocumentSymbols :: UF.UnisonFile Symbol Ann -> UF.TypecheckedUnisonFile Symbol Ann -> [UDocumentSymbol]
+mkDocumentSymbols :: UF.UnisonFile Symbol Ann -> Maybe (UF.TypecheckedUnisonFile Symbol Ann) -> [UDocumentSymbol]
 mkDocumentSymbols parsedFile typecheckedFile =
   let alignTerms = \case
         This (ann, _trm) -> (ann, Nothing)
@@ -550,7 +550,7 @@ mkDocumentSymbols parsedFile typecheckedFile =
         These _ (ann, _ref, _wk, _trm, typ) -> (ann, Just typ)
       termSymbols :: [UDocumentSymbol]
       termSymbols =
-        Align.alignWith alignTerms parsedFile.terms typecheckedFile.hashTermsId
+        Align.alignWith alignTerms parsedFile.terms (maybe mempty UF.hashTermsId typecheckedFile)
           & Map.toList
           & mapMaybe \(v, (ann, mayTyp)) -> do
             name <- Name.parseText (Var.name v)

--- a/unison-cli/src/Unison/LSP/Types.hs
+++ b/unison-cli/src/Unison/LSP/Types.hs
@@ -112,6 +112,22 @@ type FileVersion = Int32
 
 type LexedSource = (Text, [Lexer.Token Lexer.Lexeme])
 
+data USymbolKind
+  = DataDeclSymbol
+  | EffectDeclSymbol
+  | TermSymbol
+  deriving (Show, Eq)
+
+-- | Info we use to build LSP document symbols
+data UDocumentSymbol = UDocumentSymbol
+  { symbolName :: Name,
+    symbolSignature :: Maybe (Type Symbol Ann),
+    symbolKind :: USymbolKind,
+    symbolRange :: Range,
+    symbolChildren :: [UDocumentSymbol]
+  }
+  deriving (Show)
+
 data TypeSignatureHint = TypeSignatureHint
   { name :: Name,
     referent :: Referent,
@@ -133,7 +149,8 @@ data FileAnalysis = FileAnalysis
     -- | The types of local variable bindings keyed by the mention's location.
     localBindingInfo :: IntervalMap Position (Context.Type Symbol Ann {- type of binding -}, Range {- binding definition site -}),
     typeSignatureHints :: Map Symbol TypeSignatureHint,
-    fileSummary :: Maybe FileSummary
+    fileSummary :: Maybe FileSummary,
+    documentSymbols :: [UDocumentSymbol]
   }
   deriving stock (Show)
 

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.38.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -134,6 +134,7 @@ library
       Unison.LSP.Configuration
       Unison.LSP.Conversions
       Unison.LSP.Diagnostics
+      Unison.LSP.DocumentSymbols
       Unison.LSP.FileAnalysis
       Unison.LSP.FileAnalysis.UnusedBindings
       Unison.LSP.FoldingRange


### PR DESCRIPTION
## Overview

@aryairani  requested something like this today and it was super quick to hammer out;

Just implements the "Document Symbols" LSP endpoint so you get a scratch-file outline in supported editors.
Clicking the thing brings you there.

<img width="981" height="610" alt="image" src="https://github.com/user-attachments/assets/80412891-c1b4-45f7-8e78-8a72761571c7" />

Shows definitions, types, abilities, and named watches.

Shows type signatures if the file typechecks, but still works if it just parses.

## Implementation notes

Essentially just converts our unison file type into DocumentSymbols output, it was pretty straight-forward.

## Test coverage

Nah, it's pretty simple, we should just dogfood it.

## Loose ends

Future improvements:

* Would be nice to fall-back to a previous typecheck/parse if the file is currently not parsing.
* Would be nice to add a special icon for test watches