### PR TITLE
Fix Cabal smoke-test workflow

### DIFF
--- a/.github/workflows/cabal.yaml
+++ b/.github/workflows/cabal.yaml
@@ -34,12 +34,17 @@ jobs:
       # Since we’re using `on.pull_request_target`, this workflow would check out the code from the target branch by
       # default. This step fetches the SHA for the merge commit, so we can check out that (as `on.pull_request` would
       # do).
-      - uses: suzuki-shunsuke/get-pr-action@b002e41164d7a39586b41f17f9caca4e98a1efe4 # v0.1.0
+      - if: ${{ github.event_name == 'pull_request_target' }}
+        uses: suzuki-shunsuke/get-pr-action@b002e41164d7a39586b41f17f9caca4e98a1efe4 # v0.1.0
         id: get-pr
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - if: ${{ github.event_name == 'pull_request_target' }}
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{steps.get-pr.outputs.merge_commit_sha}}
+
+      - if: ${{ github.event_name != 'pull_request_target' }}
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - id: setup-haskell
         uses: haskell-actions/setup@7909071ceec0344debcc968c6c7a96a52e8dd0d7 # v2.8.1
@@ -60,9 +65,10 @@ jobs:
       # --only-configure skips some build steps, but should ensure all dependencies are correct.
       - id: build
         run: cabal build all --only-configure --project-file contrib/cabal.project
-        continue-on-error: true
+        continue-on-error: ${{ github.event_name == 'pull_request_target' }}
 
-      - uses: mainmatter/continue-on-error-comment@b2606cc5ef2525ec21692999676a19f047e3e082 # v1
+      - if: ${{ github.event_name == 'pull_request_target' }}
+        uses: mainmatter/continue-on-error-comment@b2606cc5ef2525ec21692999676a19f047e3e082 # v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           outcome: ${{ steps.build.outcome }}

--- a/.github/workflows/cabal.yaml
+++ b/.github/workflows/cabal.yaml
@@ -58,8 +58,9 @@ jobs:
           path: |
             ${{ steps.setup-haskell.outputs.cabal-store }}
             dist-newstyle
-          key: cabal-freeze-${{ hashFiles('**/cabal.project.freeze') }}
+          key: cabal-freeze-${{ hashFiles('**/cabal.project.freeze') }}-${{ hashFiles('**/cabal.project', '**/*.cabal') }}
           restore-keys: |
+            cabal-freeze-${{ hashFiles('**/cabal.project.freeze') }}
             cabal-freeze
 
       # --only-configure skips some build steps, but should ensure all dependencies are correct.


### PR DESCRIPTION
## Overview

There are two issues fixed here:
1. The manual `workflow_dispatch` trigger didn’t work because the workflow was trying to look up the PR number, which doesn’t exist for `workflow_dispatch` and
2. The cache key wasn’t precise enough – there would be a cache hit, but we’d still have to rebuild everything.

## Implementation notes

This also makes the workflow behave a bit better under `workflow_dispatch` than it would have – with a PR, we let the job pass on failure, and add a comment to the PR. Since `workflow_dispatch` doesn’t give us a place to comment, we let the job fail on failure.

## Test coverage

The modified workflow won’t run on this repo until it’s merged, so I’ve [run the updated workflow on my fork](https://github.com/sellout/unison/actions/runs/18509343056/job/52746172460). This at least lets us know that there are no syntax errors, and we get a successful run after triggering with `workflow_dispatch`.

Unfortunately, my fork doesn’t have a cache for this, so there’s a cache miss – but the keys look correct in the output, and once run on this repo, we should expect to see a cache miss, with the cache restored from the freeze-file-hashed prefix, and then the cache updated with the new dependency builds.