### PR TITLE
Add (pure) tests command to MCP

### DIFF
--- a/unison-cli/src/Unison/MCP/Tools.hs
+++ b/unison-cli/src/Unison/MCP/Tools.hs
@@ -56,7 +56,8 @@ tools =
     searchDefinitionsTool,
     searchByTypeTool,
     dependenciesTool,
-    dependentsTool
+    dependentsTool,
+    runTestsTool
   ]
 
 currentProjectContext :: (MonadIO m, MonadReader Env m) => m ProjectContext
@@ -446,6 +447,35 @@ dependentsTool =
       toolArgType = Proxy,
       toolHandler = \(ProjectDefinitionNameArgument {projectContext, definitionName}) -> handleToolError $ do
         output <- handleInputMCP projectContext [Right $ Input.ListDependentsI (HQ.NameOnly definitionName)]
+        let outputJSON = Text.decodeUtf8 . BL.toStrict $ Aeson.encode output
+        pure $ textToolResult outputJSON
+    }
+
+runTestsTool :: Tool MCP
+runTestsTool =
+  Tool
+    { toolName = toToolName TestsTool,
+      toolDescription = "Run the pure tests within a project.",
+      toolAnnotations =
+        ToolAnnotations
+          { title = Just "Run Pure Tests",
+            readOnlyHint = Just True,
+            destructiveHint = Just False,
+            idempotentHint = Just True,
+            openWorldHint = Just False
+          },
+      toolArgType = Proxy,
+      toolHandler = \(TestToolArguments {projectContext, subnamespace}) -> handleToolError $ do
+        let testInput =
+              Input.TestInput
+                { includeLibNamespace = False,
+                  path = case subnamespace of
+                    Nothing -> mempty
+                    Just ns -> ns,
+                  showFailures = True,
+                  showSuccesses = False
+                }
+        output <- handleInputMCP projectContext [Right $ Input.TestI testInput]
         let outputJSON = Text.decodeUtf8 . BL.toStrict $ Aeson.encode output
         pure $ textToolResult outputJSON
     }

--- a/unison-cli/src/Unison/MCP/Types.hs
+++ b/unison-cli/src/Unison/MCP/Types.hs
@@ -19,6 +19,7 @@ module Unison.MCP.Types
     ProjectContextArgument (..),
     ProjectNameArgument (..),
     ProjectDefinitionNameArgument (..),
+    TestToolArguments (..),
     toToolName,
     fromToolName,
   )
@@ -32,6 +33,7 @@ import Data.Text qualified as Text
 import Unison.Auth.HTTPClient (AuthenticatedHttpClient)
 import Unison.Codebase (Codebase)
 import Unison.Codebase.Editor.UCMVersion (UCMVersion)
+import Unison.Codebase.Path qualified as Path
 import Unison.Core.Project (ProjectBranchName (UnsafeProjectBranchName), ProjectName (UnsafeProjectName))
 import Unison.MCP.Wrapper (HasInputSchema (..))
 import Unison.Name (Name)
@@ -77,6 +79,7 @@ data ToolKind
   | GetCurrentProjectContextTool
   | DependenciesTool
   | DependentsTool
+  | TestsTool
   deriving (Eq, Ord, Show, Bounded, Enum)
 
 kindNameMapping :: Map ToolKind Text
@@ -98,7 +101,8 @@ kindNameMapping =
       (ListProjectBranchesTool, "list-project-branches"),
       (GetCurrentProjectContextTool, "get-current-project-context"),
       (DependenciesTool, "list-definition-dependencies"),
-      (DependentsTool, "list-definition-dependents")
+      (DependentsTool, "list-definition-dependents"),
+      (TestsTool, "run-tests")
     ]
 
 data ProjectDefinitionNameArgument = ProjectDefinitionNameArgument
@@ -525,6 +529,34 @@ instance FromJSON ShareProjectSearchToolArguments where
   parseJSON = withObject "ShareProjectSearchToolArguments" $ \o -> do
     query <- o .: "query"
     pure $ ShareProjectSearchToolArguments {query}
+
+data TestToolArguments = TestToolArguments
+  { projectContext :: ProjectContext,
+    subnamespace :: Maybe Path.Relative
+  }
+  deriving (Eq, Show)
+
+instance HasInputSchema TestToolArguments where
+  toInputSchema _ =
+    object
+      [ "type" .= ("object" :: Text),
+        "properties"
+          .= object
+            [ "projectContext" .= toInputSchema (Proxy :: Proxy ProjectContext),
+              "subnamespace"
+                .= object
+                  [ "type" .= ["string" :: Text, "null"],
+                    "description" .= ("An optional subnamespace within the project to run tests in. E.g. `mynamespace.tests`. If null, tests in the entire project will be run." :: Text)
+                  ]
+            ],
+        "required" .= ["projectContext" :: Text]
+      ]
+
+instance FromJSON TestToolArguments where
+  parseJSON = withObject "TestToolArguments" $ \o -> do
+    projectContext <- o .: "projectContext"
+    subnamespace <- fmap (Path.Relative . Path.unsafeParseText) <$> (o .:? "subnamespace")
+    pure $ TestToolArguments {projectContext, subnamespace}
 
 nameKindMapping :: Map Text ToolKind
 nameKindMapping =

--- a/unison-src/transcripts/idempotent/mcp.md
+++ b/unison-src/transcripts/idempotent/mcp.md
@@ -12,6 +12,9 @@ README = {{
 myTerm = 99
 
 type MyType = MyConstructor
+
+test> myPassingTest = [Ok "passing"]
+test> myFailingTest = [Fail "failing"]
 ```
 
 ``` ucm
@@ -158,7 +161,7 @@ RESPONSE:
       "result": {
           "content": [
               {
-                  "text": "{\"content\":[{\"text\":\"{\\\"outputMessages\\\":[\\\"1. myTerm : Nat\\\\n2. type MyType\\\\n3. MyType.MyConstructor : MyType\\\\n4. README : Doc2\\\\n\\\"],\\\"sourceCodeUpdates\\\":[]}\",\"type\":\"text\"}],\"isError\":false}",
+                  "text": "{\"content\":[{\"text\":\"{\\\"outputMessages\\\":[\\\"1. myFailingTest : [Result]\\\\n2. myPassingTest : [Result]\\\\n3. myTerm : Nat\\\\n4. type MyType\\\\n5. MyType.MyConstructor : MyType\\\\n6. README : Doc2\\\\n\\\"],\\\"sourceCodeUpdates\\\":[]}\",\"type\":\"text\"}],\"isError\":false}",
                   "type": "text"
               }
           ],
@@ -303,7 +306,7 @@ RESPONSE:
       "result": {
           "content": [
               {
-                  "text": "{\"outputMessages\":[\"1. myTerm : Nat\\n2. type MyType\\n3. MyType.MyConstructor : MyType\\n\"],\"sourceCodeUpdates\":[]}",
+                  "text": "{\"outputMessages\":[\"1. myFailingTest : [Result]\\n2. myPassingTest : [Result]\\n3. myTerm : Nat\\n4. type MyType\\n5. MyType.MyConstructor : MyType\\n\"],\"sourceCodeUpdates\":[]}",
                   "type": "text"
               }
           ],
@@ -373,6 +376,43 @@ RESPONSE:
           "content": [
               {
                   "text": "{\"branchName\":\"main\",\"projectName\":\"scratch\"}",
+                  "type": "text"
+              }
+          ],
+          "isError": false
+      }
+  }
+
+```
+
+## tests
+
+``` api
+POST /mcp
+BODY:
+  {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "run-tests",
+      "arguments": {
+        "projectContext": {
+          "projectName": "scratch",
+          "branchName": "main"
+        }
+      }
+    }
+  }
+
+RESPONSE:
+  {
+      "id": 1,
+      "jsonrpc": "2.0",
+      "result": {
+          "content": [
+              {
+                  "text": "{\"outputMessages\":[\"Cached test results (`help testcache` to learn more)\\n\\n  1. myPassingTest   â passing\\n\\n  2. myFailingTest   â failing\\n\\nð« 1 test(s) failing, â 1 test(s) passing\\n\\nTip: Use view 1 to view the source of a test.\"],\"sourceCodeUpdates\":[]}",
                   "type": "text"
               }
           ],


### PR DESCRIPTION
## Overview

Allow the MCP to effectively run `> test`.

## Implementation notes

* Add a new tool for running (pure) tests, with an optional sub-namespace.

## Test coverage

Added a transcript test.

## Loose ends

How do we want to handle IO tests? Presumably tests are made to be run so it should be "safe" to allow the MCP to run them?

But also it's possible that it's an IO test that the AI itself just added... which makes it a bit more of a grey area :neutral_face: