### PR TITLE
Add Run tool to MCP

### DIFF
--- a/unison-cli/src/Unison/MCP/Cli.hs
+++ b/unison-cli/src/Unison/MCP/Cli.hs
@@ -11,7 +11,6 @@ import Crypto.Random qualified as Random
 import Data.Aeson
 import Data.IORef
 import Data.Sequence qualified as Seq
-import Data.Text qualified as Text
 import Data.Text.IO qualified as Text
 import GHC.IO.Handle (hDuplicate, hDuplicateTo)
 import U.Codebase.Sqlite.Queries qualified as Queries
@@ -40,23 +39,25 @@ import Prelude hiding (readFile, writeFile)
 data CliOutput = CliOutput
   { sourceCodeUpdates :: [Text],
     outputMessages :: [Text],
-    stdout :: Text
+    stdout :: Text,
+    stderr :: Text
   }
   deriving (Eq, Show)
 
 instance Semigroup CliOutput where
-  CliOutput src1 out1 stdout1 <> CliOutput src2 out2 stdout2 =
-    CliOutput (src1 <> src2) (out1 <> out2) (stdout1 <> stdout2)
+  CliOutput src1 out1 stdout1 stderr1 <> CliOutput src2 out2 stdout2 stderr2 =
+    CliOutput (src1 <> src2) (out1 <> out2) (stdout1 <> stdout2) (stderr1 <> stderr2)
 
 instance Monoid CliOutput where
-  mempty = CliOutput [] [] ""
+  mempty = CliOutput [] [] "" ""
 
 instance ToJSON CliOutput where
-  toJSON (CliOutput sourceCodeUpdates outputMessages stdout) =
+  toJSON CliOutput {sourceCodeUpdates, outputMessages, stdout, stderr} =
     object
       [ "sourceCodeUpdates" .= sourceCodeUpdates,
         "outputMessages" .= outputMessages,
-        "stdout" .= stdout
+        "stdout" .= stdout,
+        "stderr" .= stderr
       ]
 
 ppForProjectContext :: ProjectContext -> ExceptT Text Transaction PP.ProjectPath
@@ -128,8 +129,8 @@ cliToMCP projCtx cli = do
 
   let startState = (Cli.loopState0 (PP.toIds initialPP))
   -- The actual output isn't important, all communication comes from notify, notifyNumbered, and writeSource.
-  (stdout, (cliResult, _loopState)) <- liftIO $ do
-    captureStdout (Cli.runCli cliEnv startState cli)
+  (stdout, stderr, (cliResult, _loopState)) <- liftIO $ do
+    captureHandles (Cli.runCli cliEnv startState cli)
   -- flush the output buffer since it should now be filled.
   cliOut <- atomically $ do
     msgs <- readTVar outputVar
@@ -142,7 +143,8 @@ cliToMCP projCtx cli = do
       ( CliOutput
           { sourceCodeUpdates,
             outputMessages,
-            stdout
+            stdout,
+            stderr
           }
       )
   case cliResult of
@@ -150,27 +152,34 @@ cliToMCP projCtx cli = do
     Cli.HaltRepl -> pure (Nothing, cliOut)
     Cli.Success a -> pure (Just a, cliOut)
 
--- | Replace stdout for the duration of the given action,
+-- | Capture stdout, stderr for the duration of the given action,
 -- useful for providing input to programs and capturing results to return to agents.
-captureStdout :: IO a -> IO (Text, a)
-captureStdout action = do
+captureHandles :: IO a -> IO (Text, Text, a)
+captureHandles action = do
   -- Create temporary files for the fake stdin and captured stdout
   withSystemTempFile "stdout.txt" $ \stdoutPath stdoutHandle -> do
-    -- Replace stdin and stdout, run action, then restore
-    a <-
-      UnliftIO.bracket
-        ( do
-            oldStdout <- hDuplicate IO.stdout
-            hDuplicateTo stdoutHandle IO.stdout
-            pure oldStdout
-        )
-        ( \oldStdout -> do
-            hDuplicateTo oldStdout IO.stdout
-            IO.hClose oldStdout
-        )
-        ( \_ -> do
-            action
-        )
-    IO.hClose stdoutHandle
-    output <- Text.readFile stdoutPath
-    pure (output, a)
+    withSystemTempFile "stderr.txt" $ \stderrPath stderrHandle -> do
+      -- Replace stdin and stdout, run action, then restore
+      a <-
+        UnliftIO.bracket
+          ( do
+              oldStdout <- hDuplicate IO.stdout
+              hDuplicateTo stdoutHandle IO.stdout
+              oldStderr <- hDuplicate IO.stderr
+              hDuplicateTo stderrHandle IO.stderr
+              pure (oldStdout, oldStderr)
+          )
+          ( \(oldStdout, oldStderr) -> do
+              hDuplicateTo oldStdout IO.stdout
+              IO.hClose oldStdout
+              hDuplicateTo oldStderr IO.stderr
+              IO.hClose oldStderr
+          )
+          ( \_ -> do
+              action
+          )
+      IO.hClose stdoutHandle
+      output <- Text.readFile stdoutPath
+      IO.hClose stderrHandle
+      errOutput <- Text.readFile stderrPath
+      pure (output, errOutput, a)

--- a/unison-cli/src/Unison/MCP/Cli.hs
+++ b/unison-cli/src/Unison/MCP/Cli.hs
@@ -11,6 +11,9 @@ import Crypto.Random qualified as Random
 import Data.Aeson
 import Data.IORef
 import Data.Sequence qualified as Seq
+import Data.Text qualified as Text
+import Data.Text.IO qualified as Text
+import GHC.IO.Handle (hDuplicate, hDuplicateTo)
 import U.Codebase.Sqlite.Queries qualified as Queries
 import Unison.Auth.CredentialManager qualified as AuthN
 import Unison.Auth.HTTPClient qualified as AuthN
@@ -28,27 +31,32 @@ import Unison.Prelude
 import Unison.Sqlite (Transaction)
 import Unison.Syntax.Parser qualified as Parser
 import Unison.Util.Pretty qualified as Pretty
+import UnliftIO qualified
+import UnliftIO.IO qualified as IO
 import UnliftIO.STM
+import UnliftIO.Temporary (withSystemTempFile)
 import Prelude hiding (readFile, writeFile)
 
 data CliOutput = CliOutput
   { sourceCodeUpdates :: [Text],
-    outputMessages :: [Text]
+    outputMessages :: [Text],
+    stdout :: Text
   }
   deriving (Eq, Show)
 
 instance Semigroup CliOutput where
-  CliOutput src1 out1 <> CliOutput src2 out2 =
-    CliOutput (src1 <> src2) (out1 <> out2)
+  CliOutput src1 out1 stdout1 <> CliOutput src2 out2 stdout2 =
+    CliOutput (src1 <> src2) (out1 <> out2) (stdout1 <> stdout2)
 
 instance Monoid CliOutput where
-  mempty = CliOutput [] []
+  mempty = CliOutput [] [] ""
 
 instance ToJSON CliOutput where
-  toJSON (CliOutput sourceCodeUpdates outputMessages) =
+  toJSON (CliOutput sourceCodeUpdates outputMessages stdout) =
     object
       [ "sourceCodeUpdates" .= sourceCodeUpdates,
-        "outputMessages" .= outputMessages
+        "outputMessages" .= outputMessages,
+        "stdout" .= stdout
       ]
 
 ppForProjectContext :: ProjectContext -> ExceptT Text Transaction PP.ProjectPath
@@ -120,7 +128,8 @@ cliToMCP projCtx cli = do
 
   let startState = (Cli.loopState0 (PP.toIds initialPP))
   -- The actual output isn't important, all communication comes from notify, notifyNumbered, and writeSource.
-  (cliResult, _loopState) <- liftIO (Cli.runCli cliEnv startState cli)
+  (stdout, (cliResult, _loopState)) <- liftIO $ do
+    captureStdout (Cli.runCli cliEnv startState cli)
   -- flush the output buffer since it should now be filled.
   cliOut <- atomically $ do
     msgs <- readTVar outputVar
@@ -132,10 +141,36 @@ cliToMCP projCtx cli = do
     pure $
       ( CliOutput
           { sourceCodeUpdates,
-            outputMessages
+            outputMessages,
+            stdout
           }
       )
   case cliResult of
     Cli.Continue -> pure (Nothing, cliOut)
     Cli.HaltRepl -> pure (Nothing, cliOut)
     Cli.Success a -> pure (Just a, cliOut)
+
+-- | Replace stdout for the duration of the given action,
+-- useful for providing input to programs and capturing results to return to agents.
+captureStdout :: IO a -> IO (Text, a)
+captureStdout action = do
+  -- Create temporary files for the fake stdin and captured stdout
+  withSystemTempFile "stdout.txt" $ \stdoutPath stdoutHandle -> do
+    -- Replace stdin and stdout, run action, then restore
+    a <-
+      UnliftIO.bracket
+        ( do
+            oldStdout <- hDuplicate IO.stdout
+            hDuplicateTo stdoutHandle IO.stdout
+            pure oldStdout
+        )
+        ( \oldStdout -> do
+            hDuplicateTo oldStdout IO.stdout
+            IO.hClose oldStdout
+        )
+        ( \_ -> do
+            action
+        )
+    IO.hClose stdoutHandle
+    output <- Text.readFile stdoutPath
+    pure (output, a)

--- a/unison-cli/src/Unison/MCP/Tools.hs
+++ b/unison-cli/src/Unison/MCP/Tools.hs
@@ -19,6 +19,7 @@ import Unison.Codebase.Editor.Input (Event (..), FindScope (..), Input (..))
 import Unison.Codebase.Editor.Input qualified as Input
 import Unison.Codebase.Path qualified as Path
 import Unison.Codebase.ProjectPath
+import Unison.Codebase.Runtime.Profile (ProfileSpec (..))
 import Unison.Core.Project (ProjectBranchName (..), ProjectName (..))
 import Unison.HashQualified qualified as HQ
 import Unison.MCP.Cli (cliToMCP, handleInputMCP)
@@ -45,6 +46,7 @@ tools =
     shareProjectSearchTool,
     typecheckCodeTool,
     docsTool,
+    runTool,
     shareProjectReadmeTool,
     listProjectDefinitionsTool,
     listProjectLibrariesTool,
@@ -186,6 +188,27 @@ docsTool =
       toolArgType = Proxy,
       toolHandler = \(DocsToolArguments {name, projectContext}) -> handleToolError $ do
         output <- handleInputMCP projectContext [Right $ DocToMarkdownI name]
+        let outputJSON = Text.decodeUtf8 . BL.toStrict $ Aeson.encode output
+        pure $ textToolResult outputJSON
+    }
+
+runTool :: Tool MCP
+runTool =
+  Tool
+    { toolName = toToolName RunTool,
+      toolDescription = "Execute/Run a given definition.",
+      toolAnnotations =
+        ToolAnnotations
+          { title = Just "Run",
+            readOnlyHint = Just False,
+            destructiveHint = Just True,
+            idempotentHint = Just False,
+            openWorldHint = Just False
+          },
+      toolArgType = Proxy,
+      toolHandler = \(RunToolArguments {mainFunctionName, projectContext, args}) -> handleToolError $ do
+        let input = ExecuteI NoProf (HQ.NameOnly mainFunctionName) (Text.unpack <$> args)
+        output <- handleInputMCP projectContext [Right input]
         let outputJSON = Text.decodeUtf8 . BL.toStrict $ Aeson.encode output
         pure $ textToolResult outputJSON
     }

--- a/unison-cli/src/Unison/MCP/Types.hs
+++ b/unison-cli/src/Unison/MCP/Types.hs
@@ -15,6 +15,7 @@ module Unison.MCP.Types
     SearchDefinitionsToolArguments (..),
     SearchByTypeToolArguments (..),
     DocsToolArguments (..),
+    RunToolArguments (..),
     ProjectContext (..),
     ProjectContextArgument (..),
     ProjectNameArgument (..),
@@ -68,6 +69,7 @@ data ToolKind
   | ShareProjectReadmeTool
   | TypecheckCodeTool
   | DocsTool
+  | RunTool
   | ListProjectDefinitionsTool
   | ListProjectLibrariesTool
   | ListLibraryDefinitionsTool
@@ -91,6 +93,7 @@ kindNameMapping =
       (ShareProjectReadmeTool, "share-project-readme"),
       (TypecheckCodeTool, "typecheck-code"),
       (DocsTool, "docs"),
+      (RunTool, "run"),
       (ListProjectDefinitionsTool, "list-project-definitions"),
       (ListProjectLibrariesTool, "list-project-libraries"),
       (ListLibraryDefinitionsTool, "list-library-definitions"),
@@ -404,6 +407,49 @@ instance FromJSON DocsToolArguments where
     projectContext <- o .: "projectContext"
     name <- Name.unsafeParseText <$> o .: "name"
     pure $ DocsToolArguments {projectContext, name}
+
+data RunToolArguments = RunToolArguments
+  { projectContext :: ProjectContext,
+    mainFunctionName :: Name,
+    args :: [Text]
+  }
+  deriving (Eq, Show)
+
+instance HasInputSchema RunToolArguments where
+  toInputSchema _ =
+    object
+      [ "type" .= ("object" :: Text),
+        "properties"
+          .= object
+            [ "projectContext" .= toInputSchema (Proxy :: Proxy ProjectContext),
+              "mainFunctionName"
+                .= object
+                  [ "type" .= ("string" :: Text),
+                    "description" .= ("The name of the main function to run, e.g. `main` or `mynamespace.myprogram`." :: Text)
+                  ],
+              "args"
+                .= object
+                  [ "type" .= ("array" :: Text),
+                    "items"
+                      .= object
+                        [ "type" .= ("string" :: Text),
+                          "description" .= ("An argument to pass to the main function." :: Text)
+                        ],
+                    "description" .= ("The arguments to pass to the main function." :: Text)
+                  ]
+            ],
+        "required" .= ["projectContext", "mainFunctionName", "args" :: Text]
+      ]
+
+instance FromJSON RunToolArguments where
+  parseJSON = withObject "RunToolArguments" $ \o -> do
+    projectContext <- o .: "projectContext"
+    mainFunctionNameText <- o .: "mainFunctionName"
+    mainFunctionName <- case Name.parseTextEither mainFunctionNameText of
+      Left err -> fail $ "Invalid main function name: " ++ show err
+      Right name -> pure name
+    args <- o .: "args"
+    pure $ RunToolArguments {projectContext, mainFunctionName, args}
 
 data ProjectCodeToolArguments = ProjectCodeToolArguments
   { projectContext :: ProjectContext

--- a/unison-src/transcripts/idempotent/mcp.md
+++ b/unison-src/transcripts/idempotent/mcp.md
@@ -61,7 +61,7 @@ RESPONSE:
       "result": {
           "content": [
               {
-                  "text": "{\"outputMessages\":[\"     Branch   Remote branch\\n1.   main     \"],\"sourceCodeUpdates\":[],\"stdout\":\"\"}",
+                  "text": "{\"outputMessages\":[\"     Branch   Remote branch\\n1.   main     \"],\"sourceCodeUpdates\":[],\"stderr\":\"\",\"stdout\":\"\"}",
                   "type": "text"
               }
           ],
@@ -98,7 +98,7 @@ RESPONSE:
       "result": {
           "content": [
               {
-                  "text": "{\"outputMessages\":[\"Loading changes detected in scratch.u.\",\"No changes found.\",\"  1 | > x = 1 + 2\\n        â§©\\n        3\"],\"sourceCodeUpdates\":[],\"stdout\":\"\"}",
+                  "text": "{\"outputMessages\":[\"Loading changes detected in scratch.u.\",\"No changes found.\",\"  1 | > x = 1 + 2\\n        â§©\\n        3\"],\"sourceCodeUpdates\":[],\"stderr\":\"\",\"stdout\":\"\"}",
                   "type": "text"
               }
           ],
@@ -135,7 +135,7 @@ RESPONSE:
       "result": {
           "content": [
               {
-                  "text": "{\"outputMessages\":[\"This is a scratch project for testing tools in MCP.\\n\\n\\n\"],\"sourceCodeUpdates\":[],\"stdout\":\"\"}",
+                  "text": "{\"outputMessages\":[\"This is a scratch project for testing tools in MCP.\\n\\n\\n\"],\"sourceCodeUpdates\":[],\"stderr\":\"\",\"stdout\":\"\"}",
                   "type": "text"
               }
           ],
@@ -174,7 +174,7 @@ RESPONSE:
       "result": {
           "content": [
               {
-                  "text": "{\"outputMessages\":[\"Some \\\"hello\\\"\"],\"sourceCodeUpdates\":[],\"stdout\":\"hello\"}",
+                  "text": "{\"outputMessages\":[\"Some \\\"hello\\\"\"],\"sourceCodeUpdates\":[],\"stderr\":\"\",\"stdout\":\"hello\"}",
                   "type": "text"
               }
           ],
@@ -211,7 +211,7 @@ RESPONSE:
       "result": {
           "content": [
               {
-                  "text": "{\"content\":[{\"text\":\"{\\\"outputMessages\\\":[\\\"1. main : '{IO, Exception} Optional Text\\\\n2. myFailingTest : [Result]\\\\n3. myPassingTest : [Result]\\\\n4. myTerm : Nat\\\\n5. type MyType\\\\n6. MyType.MyConstructor : MyType\\\\n7. README : Doc2\\\\n\\\"],\\\"sourceCodeUpdates\\\":[],\\\"stdout\\\":\\\"\\\"}\",\"type\":\"text\"}],\"isError\":false}",
+                  "text": "{\"content\":[{\"text\":\"{\\\"outputMessages\\\":[\\\"1. main : '{IO, Exception} Optional Text\\\\n2. myFailingTest : [Result]\\\\n3. myPassingTest : [Result]\\\\n4. myTerm : Nat\\\\n5. type MyType\\\\n6. MyType.MyConstructor : MyType\\\\n7. README : Doc2\\\\n\\\"],\\\"sourceCodeUpdates\\\":[],\\\"stderr\\\":\\\"\\\",\\\"stdout\\\":\\\"\\\"}\",\"type\":\"text\"}],\"isError\":false}",
                   "type": "text"
               }
           ],
@@ -248,7 +248,7 @@ RESPONSE:
       "result": {
           "content": [
               {
-                  "text": "{\"outputMessages\":[\"1. builtins. (840 terms, 121 types)\"],\"sourceCodeUpdates\":[],\"stdout\":\"\"}",
+                  "text": "{\"outputMessages\":[\"1. builtins. (840 terms, 121 types)\"],\"sourceCodeUpdates\":[],\"stderr\":\"\",\"stdout\":\"\"}",
                   "type": "text"
               }
           ],
@@ -282,7 +282,7 @@ RESPONSE:
       "result": {
           "content": [
               {
-                  "text": "{\"outputMessages\":[\"     Branch   Remote branch\\n1.   main     \"],\"sourceCodeUpdates\":[],\"stdout\":\"\"}",
+                  "text": "{\"outputMessages\":[\"     Branch   Remote branch\\n1.   main     \"],\"sourceCodeUpdates\":[],\"stderr\":\"\",\"stdout\":\"\"}",
                   "type": "text"
               }
           ],
@@ -319,7 +319,7 @@ RESPONSE:
       "result": {
           "content": [
               {
-                  "text": "{\"outputMessages\":[\"type MyType = MyConstructor\\n\\nmyTerm : Nat\\nmyTerm = 99\"],\"sourceCodeUpdates\":[],\"stdout\":\"\"}",
+                  "text": "{\"outputMessages\":[\"type MyType = MyConstructor\\n\\nmyTerm : Nat\\nmyTerm = 99\"],\"sourceCodeUpdates\":[],\"stderr\":\"\",\"stdout\":\"\"}",
                   "type": "text"
               }
           ],
@@ -356,7 +356,7 @@ RESPONSE:
       "result": {
           "content": [
               {
-                  "text": "{\"outputMessages\":[\"1. myFailingTest : [Result]\\n2. myPassingTest : [Result]\\n3. myTerm : Nat\\n4. type MyType\\n5. MyType.MyConstructor : MyType\\n\"],\"sourceCodeUpdates\":[],\"stdout\":\"\"}",
+                  "text": "{\"outputMessages\":[\"1. myFailingTest : [Result]\\n2. myPassingTest : [Result]\\n3. myTerm : Nat\\n4. type MyType\\n5. MyType.MyConstructor : MyType\\n\"],\"sourceCodeUpdates\":[],\"stderr\":\"\",\"stdout\":\"\"}",
                   "type": "text"
               }
           ],
@@ -393,7 +393,7 @@ RESPONSE:
       "result": {
           "content": [
               {
-                  "text": "{\"outputMessages\":[\"1. myTerm : Nat\\n\"],\"sourceCodeUpdates\":[],\"stdout\":\"\"}",
+                  "text": "{\"outputMessages\":[\"1. myTerm : Nat\\n\"],\"sourceCodeUpdates\":[],\"stderr\":\"\",\"stdout\":\"\"}",
                   "type": "text"
               }
           ],
@@ -462,7 +462,7 @@ RESPONSE:
       "result": {
           "content": [
               {
-                  "text": "{\"outputMessages\":[\"Cached test results (`help testcache` to learn more)\\n\\n  1. myPassingTest   â passing\\n\\n  2. myFailingTest   â failing\\n\\nð« 1 test(s) failing, â 1 test(s) passing\\n\\nTip: Use view 1 to view the source of a test.\"],\"sourceCodeUpdates\":[],\"stdout\":\"\"}",
+                  "text": "{\"outputMessages\":[\"Cached test results (`help testcache` to learn more)\\n\\n  1. myPassingTest   â passing\\n\\n  2. myFailingTest   â failing\\n\\nð« 1 test(s) failing, â 1 test(s) passing\\n\\nTip: Use view 1 to view the source of a test.\"],\"sourceCodeUpdates\":[],\"stderr\":\"\",\"stdout\":\"\"}",
                   "type": "text"
               }
           ],

--- a/unison-src/transcripts/idempotent/mcp.md
+++ b/unison-src/transcripts/idempotent/mcp.md
@@ -16,11 +16,16 @@ type MyType = MyConstructor
 test> myPassingTest = [Ok "passing"]
 test> myFailingTest = [Fail "failing"]
 
-main : '{IO} (Optional Text)
+main : '{IO, Exception} (Optional Text)
 main = do
   match getArgs.impl() with
     Left _err -> None
-    Right args -> List.at 0 args
+    Right args ->
+      match List.at 0 args with
+        None -> None
+        Some txt ->
+          _ = putBytes.impl (io2.IO.stdHandle StdOut) (Text.toUtf8 txt)
+          Some txt
 ```
 
 ``` ucm
@@ -56,7 +61,7 @@ RESPONSE:
       "result": {
           "content": [
               {
-                  "text": "{\"outputMessages\":[\"     Branch   Remote branch\\n1.   main     \"],\"sourceCodeUpdates\":[]}",
+                  "text": "{\"outputMessages\":[\"     Branch   Remote branch\\n1.   main     \"],\"sourceCodeUpdates\":[],\"stdout\":\"\"}",
                   "type": "text"
               }
           ],
@@ -93,7 +98,7 @@ RESPONSE:
       "result": {
           "content": [
               {
-                  "text": "{\"outputMessages\":[\"Loading changes detected in scratch.u.\",\"No changes found.\",\"  1 | > x = 1 + 2\\n        â§©\\n        3\"],\"sourceCodeUpdates\":[]}",
+                  "text": "{\"outputMessages\":[\"Loading changes detected in scratch.u.\",\"No changes found.\",\"  1 | > x = 1 + 2\\n        â§©\\n        3\"],\"sourceCodeUpdates\":[],\"stdout\":\"\"}",
                   "type": "text"
               }
           ],
@@ -130,7 +135,7 @@ RESPONSE:
       "result": {
           "content": [
               {
-                  "text": "{\"outputMessages\":[\"This is a scratch project for testing tools in MCP.\\n\\n\\n\"],\"sourceCodeUpdates\":[]}",
+                  "text": "{\"outputMessages\":[\"This is a scratch project for testing tools in MCP.\\n\\n\\n\"],\"sourceCodeUpdates\":[],\"stdout\":\"\"}",
                   "type": "text"
               }
           ],
@@ -169,7 +174,7 @@ RESPONSE:
       "result": {
           "content": [
               {
-                  "text": "{\"outputMessages\":[\"Some \\\"hello\\\"\"],\"sourceCodeUpdates\":[]}",
+                  "text": "{\"outputMessages\":[\"Some \\\"hello\\\"\"],\"sourceCodeUpdates\":[],\"stdout\":\"hello\"}",
                   "type": "text"
               }
           ],
@@ -206,7 +211,7 @@ RESPONSE:
       "result": {
           "content": [
               {
-                  "text": "{\"content\":[{\"text\":\"{\\\"outputMessages\\\":[\\\"1. main : '{IO} Optional Text\\\\n2. myFailingTest : [Result]\\\\n3. myPassingTest : [Result]\\\\n4. myTerm : Nat\\\\n5. type MyType\\\\n6. MyType.MyConstructor : MyType\\\\n7. README : Doc2\\\\n\\\"],\\\"sourceCodeUpdates\\\":[]}\",\"type\":\"text\"}],\"isError\":false}",
+                  "text": "{\"content\":[{\"text\":\"{\\\"outputMessages\\\":[\\\"1. main : '{IO, Exception} Optional Text\\\\n2. myFailingTest : [Result]\\\\n3. myPassingTest : [Result]\\\\n4. myTerm : Nat\\\\n5. type MyType\\\\n6. MyType.MyConstructor : MyType\\\\n7. README : Doc2\\\\n\\\"],\\\"sourceCodeUpdates\\\":[],\\\"stdout\\\":\\\"\\\"}\",\"type\":\"text\"}],\"isError\":false}",
                   "type": "text"
               }
           ],
@@ -243,7 +248,7 @@ RESPONSE:
       "result": {
           "content": [
               {
-                  "text": "{\"outputMessages\":[\"1. builtins. (840 terms, 121 types)\"],\"sourceCodeUpdates\":[]}",
+                  "text": "{\"outputMessages\":[\"1. builtins. (840 terms, 121 types)\"],\"sourceCodeUpdates\":[],\"stdout\":\"\"}",
                   "type": "text"
               }
           ],
@@ -277,7 +282,7 @@ RESPONSE:
       "result": {
           "content": [
               {
-                  "text": "{\"outputMessages\":[\"     Branch   Remote branch\\n1.   main     \"],\"sourceCodeUpdates\":[]}",
+                  "text": "{\"outputMessages\":[\"     Branch   Remote branch\\n1.   main     \"],\"sourceCodeUpdates\":[],\"stdout\":\"\"}",
                   "type": "text"
               }
           ],
@@ -314,7 +319,7 @@ RESPONSE:
       "result": {
           "content": [
               {
-                  "text": "{\"outputMessages\":[\"type MyType = MyConstructor\\n\\nmyTerm : Nat\\nmyTerm = 99\"],\"sourceCodeUpdates\":[]}",
+                  "text": "{\"outputMessages\":[\"type MyType = MyConstructor\\n\\nmyTerm : Nat\\nmyTerm = 99\"],\"sourceCodeUpdates\":[],\"stdout\":\"\"}",
                   "type": "text"
               }
           ],
@@ -351,7 +356,7 @@ RESPONSE:
       "result": {
           "content": [
               {
-                  "text": "{\"outputMessages\":[\"1. myFailingTest : [Result]\\n2. myPassingTest : [Result]\\n3. myTerm : Nat\\n4. type MyType\\n5. MyType.MyConstructor : MyType\\n\"],\"sourceCodeUpdates\":[]}",
+                  "text": "{\"outputMessages\":[\"1. myFailingTest : [Result]\\n2. myPassingTest : [Result]\\n3. myTerm : Nat\\n4. type MyType\\n5. MyType.MyConstructor : MyType\\n\"],\"sourceCodeUpdates\":[],\"stdout\":\"\"}",
                   "type": "text"
               }
           ],
@@ -388,7 +393,7 @@ RESPONSE:
       "result": {
           "content": [
               {
-                  "text": "{\"outputMessages\":[\"1. myTerm : Nat\\n\"],\"sourceCodeUpdates\":[]}",
+                  "text": "{\"outputMessages\":[\"1. myTerm : Nat\\n\"],\"sourceCodeUpdates\":[],\"stdout\":\"\"}",
                   "type": "text"
               }
           ],
@@ -457,7 +462,7 @@ RESPONSE:
       "result": {
           "content": [
               {
-                  "text": "{\"outputMessages\":[\"Cached test results (`help testcache` to learn more)\\n\\n  1. myPassingTest   â passing\\n\\n  2. myFailingTest   â failing\\n\\nð« 1 test(s) failing, â 1 test(s) passing\\n\\nTip: Use view 1 to view the source of a test.\"],\"sourceCodeUpdates\":[]}",
+                  "text": "{\"outputMessages\":[\"Cached test results (`help testcache` to learn more)\\n\\n  1. myPassingTest   â passing\\n\\n  2. myFailingTest   â failing\\n\\nð« 1 test(s) failing, â 1 test(s) passing\\n\\nTip: Use view 1 to view the source of a test.\"],\"sourceCodeUpdates\":[],\"stdout\":\"\"}",
                   "type": "text"
               }
           ],

--- a/unison-src/transcripts/idempotent/mcp.md
+++ b/unison-src/transcripts/idempotent/mcp.md
@@ -15,6 +15,12 @@ type MyType = MyConstructor
 
 test> myPassingTest = [Ok "passing"]
 test> myFailingTest = [Fail "failing"]
+
+main : '{IO} (Optional Text)
+main = do
+  match getArgs.impl() with
+    Left _err -> None
+    Right args -> List.at 0 args
 ```
 
 ``` ucm
@@ -134,6 +140,45 @@ RESPONSE:
 
 ```
 
+## run
+
+``` api
+POST /mcp
+BODY:
+  {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "run",
+      "arguments": {
+        "projectContext": {
+          "projectName": "scratch",
+          "branchName": "main"
+        },
+        "mainFunctionName": "main",
+        "args": ["hello"]
+      }
+    }
+  }
+
+RESPONSE:
+  {
+      "id": 1,
+      "jsonrpc": "2.0",
+      "result": {
+          "content": [
+              {
+                  "text": "{\"outputMessages\":[\"Some \\\"hello\\\"\"],\"sourceCodeUpdates\":[]}",
+                  "type": "text"
+              }
+          ],
+          "isError": false
+      }
+  }
+
+```
+
 ## list-project-definitions
 
 ``` api
@@ -161,7 +206,7 @@ RESPONSE:
       "result": {
           "content": [
               {
-                  "text": "{\"content\":[{\"text\":\"{\\\"outputMessages\\\":[\\\"1. myFailingTest : [Result]\\\\n2. myPassingTest : [Result]\\\\n3. myTerm : Nat\\\\n4. type MyType\\\\n5. MyType.MyConstructor : MyType\\\\n6. README : Doc2\\\\n\\\"],\\\"sourceCodeUpdates\\\":[]}\",\"type\":\"text\"}],\"isError\":false}",
+                  "text": "{\"content\":[{\"text\":\"{\\\"outputMessages\\\":[\\\"1. main : '{IO} Optional Text\\\\n2. myFailingTest : [Result]\\\\n3. myPassingTest : [Result]\\\\n4. myTerm : Nat\\\\n5. type MyType\\\\n6. MyType.MyConstructor : MyType\\\\n7. README : Doc2\\\\n\\\"],\\\"sourceCodeUpdates\\\":[]}\",\"type\":\"text\"}],\"isError\":false}",
                   "type": "text"
               }
           ],


### PR DESCRIPTION
## Overview

Adds a "run" mcp tool.

https://claude.ai/share/cb8f95db-57c7-49b4-aac8-a530bff1d97a

Note: I've marked the command as destructive, but there are otherwise no safeguards against how agents can choose to call this.

## Implementation notes

* Adds a "run" mcp tool
* Allows choosing what to run, and a list of string args
* Returns the function's returned value.
* Captures and returns stdout/stderr from the computation.

## Test coverage

transcript

## Loose Ends
We can probably allow replacing stdin with text or a file or something if we like.