### PR TITLE
Try to fix typecheck schema usage in Codex

### DIFF
--- a/unison-cli/src/Unison/MCP/Types.hs
+++ b/unison-cli/src/Unison/MCP/Types.hs
@@ -344,7 +344,7 @@ instance HasInputSchema TypecheckCodeToolArguments where
             [ "projectContext" .= toInputSchema (Proxy :: Proxy ProjectContext),
               "code"
                 .= object
-                  [ "description" .= ("The source code to typecheck. If a string, it is the source code itself. If a file path, it is the path to a file containing the source code." :: Text),
+                  [ "description" .= ("The source code to typecheck. Pass an object containing either a `text` key or a `filePath` key as described." :: Text),
                     "oneOf"
                       .= [ object
                              [ "description" .= ("The file path to the source code." :: Text),

--- a/unison-cli/src/Unison/MCP/Types.hs
+++ b/unison-cli/src/Unison/MCP/Types.hs
@@ -344,37 +344,24 @@ instance HasInputSchema TypecheckCodeToolArguments where
             [ "projectContext" .= toInputSchema (Proxy :: Proxy ProjectContext),
               "code"
                 .= object
-                  [ "description" .= ("The source code to typecheck. Pass an object containing either a `text` key or a `filePath` key as described." :: Text),
-                    "oneOf"
-                      .= [ object
-                             [ "description" .= ("The file path to the source code." :: Text),
-                               "type" .= ("object" :: Text),
-                               "properties"
-                                 .= object
-                                   [ "filePath"
-                                       .= object
-                                         [ "type" .= ("string" :: Text),
-                                           "description" .= ("An absolute file path to the source code." :: Text)
-                                         ]
-                                   ],
-                               "required" .= ["filePath" :: Text],
-                               "additionalProperties" .= False
-                             ],
-                           object
-                             [ "description" .= ("The source code to typecheck." :: Text),
-                               "type" .= ("object" :: Text),
-                               "properties"
-                                 .= object
-                                   [ "text"
-                                       .= object
-                                         [ "type" .= ("string" :: Text),
-                                           "description" .= ("The source code to typecheck." :: Text)
-                                         ]
-                                   ],
-                               "required" .= ["text" :: Text],
-                               "additionalProperties" .= False
-                             ]
-                         ]
+                  [ "description" .= ("The source code to typecheck. Either the `sourceCode` key or the `filePath`, but not both." :: Text),
+                    "type" .= ("object" :: Text),
+                    "properties"
+                      .= object
+                        [ "sourceCode"
+                            .= object
+                              [ "type" .= ("string" :: Text),
+                                "description" .= ("The source code to typecheck." :: Text)
+                              ],
+                          "filePath"
+                            .= object
+                              [ "type" .= ("string" :: Text),
+                                "description" .= ("The absolute file path to the source code to typecheck." :: Text)
+                              ]
+                        ],
+                    "additionalProperties" .= False,
+                    "minProperties" .= (1 :: Int),
+                    "maxProperties" .= (1 :: Int)
                   ]
             ],
         "required" .= ["projectContext", "code" :: Text]
@@ -387,7 +374,7 @@ instance FromJSON TypecheckCodeToolArguments where
     source .:? "filePath" >>= \case
       Just filePath -> pure $ TypecheckCodeToolArguments {projectContext, code = Left filePath}
       Nothing -> do
-        text <- source .: "text"
+        text <- source .: "sourceCode"
         pure $ TypecheckCodeToolArguments {projectContext, code = Right text}
 
 data DocsToolArguments = DocsToolArguments

--- a/unison-src/transcripts/idempotent/mcp.md
+++ b/unison-src/transcripts/idempotent/mcp.md
@@ -75,7 +75,7 @@ BODY:
         "projectContext": {
           "projectName": "scratch",
           "branchName": "main"
-        }, "code": {"text": "> x = 1 + 2"}
+        }, "code": {"sourceCode": "> x = 1 + 2"}
       }
     }
   }


### PR DESCRIPTION
## Overview

Seems like there are some (not fully explored) [problems with oneOf/allOf](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/834) in _some_ Agent's validation of JSON Schemas.
This seemed to be confusing Codex, so I switched the typecheck tool to just take one of two optional params instead; which will hopefully be more portable across agents.

## Implementation notes

* Switch from a `oneOf` tagged union schema to just two optional keys with a requirement that at least one is provided.

## Test coverage

Can't test it on codex, but the transcript still applies.
