### PR TITLE
Convert a bunch of types and functions from String -> Text

### DIFF
--- a/lib/unison-prelude/src/Unison/Util/Timing.hs
+++ b/lib/unison-prelude/src/Unison/Util/Timing.hs
@@ -5,6 +5,7 @@ module Unison.Util.Timing
   )
 where
 
+import Data.Text (Text)
 import Data.Word (Word64)
 import GHC.Clock (getMonotonicTimeNSec)
 import System.CPUTime (getCPUTime)
@@ -12,7 +13,7 @@ import Text.Printf (printf)
 import Unison.Debug qualified as Debug
 import UnliftIO (MonadIO, liftIO)
 
-time :: (MonadIO m) => String -> m a -> m a
+time :: (MonadIO m) => Text -> m a -> m a
 time label action =
   if Debug.shouldDebug Debug.Timing
     then do
@@ -25,7 +26,7 @@ time label action =
 startTiming :: IO (Word64, Integer)
 startTiming = (,) <$> getMonotonicTimeNSec <*> getCPUTime
 
-stopTiming :: String -> (Word64, Integer) -> IO ()
+stopTiming :: Text -> (Word64, Integer) -> IO ()
 stopTiming label (systemTimeStart, cpuTimeStart) = do
   (systemTimeEnd, cpuTimeEnd) <- startTiming
   let systemDiff = realToFrac @Word64 @Double (systemTimeEnd - systemTimeStart)

--- a/lib/unison-pretty-printer/package.yaml
+++ b/lib/unison-pretty-printer/package.yaml
@@ -76,4 +76,5 @@ tests:
       - easytest
       - containers
       - code-page
+      - text
       - unison-syntax

--- a/lib/unison-pretty-printer/prettyprintdemo/Main.hs
+++ b/lib/unison-pretty-printer/prettyprintdemo/Main.hs
@@ -4,13 +4,14 @@ module Main where
 
 import Data.String (fromString)
 import Data.Text (Text)
+import Data.Text.IO qualified as Text
 import Unison.Util.Pretty as PP
 
 main :: IO ()
 main = do
   -- putStrLn . PP.toANSI 60 $ ex1
   -- print $ examples
-  putStrLn . PP.toANSI 25 $ examples
+  Text.putStrLn . PP.toANSI 25 $ examples
   where
     -- ex1 = PP.linesSpaced [PP.red "hi", PP.blue "blue"]
     examples =

--- a/lib/unison-pretty-printer/src/Unison/PrettyTerminal.hs
+++ b/lib/unison-pretty-printer/src/Unison/PrettyTerminal.hs
@@ -2,6 +2,7 @@ module Unison.PrettyTerminal where
 
 import Data.Char (isSpace)
 import Data.List (dropWhileEnd)
+import Data.Text.IO qualified as Text
 import System.Console.Terminal.Size qualified as Terminal
 import Unison.Util.ColorText qualified as CT
 import Unison.Util.Less (less)
@@ -23,7 +24,7 @@ putPrettyLnUnpaged :: P.Pretty CT.ColorText -> IO ()
 putPrettyLnUnpaged p | p == mempty = pure ()
 putPrettyLnUnpaged p = do
   width <- getAvailableWidth
-  putStrLn . P.toANSI width $ P.border 2 p
+  Text.putStrLn . P.toANSI width $ P.border 2 p
 
 putPrettyLn' :: P.Pretty CT.ColorText -> IO ()
 putPrettyLn' p | p == mempty = pure ()
@@ -41,7 +42,7 @@ clearCurrentLine = do
 putPretty' :: P.Pretty CT.ColorText -> IO ()
 putPretty' p = do
   width <- getAvailableWidth
-  putStr $ P.toANSI width p
+  Text.putStr $ P.toANSI width p
 
 -- | Returns a `P.Width` in the range 80–100, depending on the terminal width.
 getAvailableWidth :: IO P.Width

--- a/lib/unison-pretty-printer/src/Unison/Util/AnnotatedText.hs
+++ b/lib/unison-pretty-printer/src/Unison/Util/AnnotatedText.hs
@@ -14,16 +14,17 @@ import Data.ListLike qualified as LL
 import Data.Map qualified as Map
 import Data.Sequence (Seq ((:<|), (:|>)))
 import Data.Sequence qualified as Seq
+import Data.Text qualified as Text
 import GHC.Exts qualified
 import Unison.Lexer.Pos (Line, Pos (..))
 import Unison.Prelude
 import Unison.Util.Monoid (intercalateMap)
 import Unison.Util.Range (Range (..), inRange)
 
-data Segment a = Segment {segment :: String, annotation :: Maybe a}
+data Segment a = Segment {segment :: Text, annotation :: Maybe a}
   deriving (Eq, Show, Ord, Functor, Foldable, Generic)
 
-toPair :: Segment a -> (String, Maybe a)
+toPair :: Segment a -> (Text, Maybe a)
 toPair (Segment s a) = (s, a)
 
 newtype AnnotatedText a = AnnotatedText (Seq (Segment a))
@@ -40,16 +41,16 @@ instance Monoid (AnnotatedText a) where
 instance LL.FoldableLL (AnnotatedText a) Char where
   foldl' f z (AnnotatedText at) = Foldable.foldl' f' z at
     where
-      f' z (Segment str _) = L.foldl' f z str
+      f' z (Segment str _) = L.foldl' f z $ Text.unpack str
   foldl = LL.foldl
   foldr f z (AnnotatedText at) = Foldable.foldr f' z at
     where
-      f' (Segment str _) z = L.foldr f z str
+      f' (Segment str _) z = L.foldr f z $ Text.unpack str
 
 instance LL.ListLike (AnnotatedText a) Char where
   singleton ch = fromString [ch]
   uncons (AnnotatedText at) = case at of
-    Segment s a :<| tl -> case L.uncons s of
+    Segment s a :<| tl -> case Text.uncons s of
       Nothing -> LL.uncons (AnnotatedText tl)
       Just (hd, s) -> Just (hd, AnnotatedText $ Segment s a :<| tl)
     Seq.Empty -> Nothing
@@ -57,32 +58,32 @@ instance LL.ListLike (AnnotatedText a) Char where
   takeWhile f (AnnotatedText at) = case at of
     Seq.Empty -> AnnotatedText Seq.Empty
     Segment s a :<| tl ->
-      let s' = L.takeWhile f s
-       in if length s' == length s
+      let s' = Text.takeWhile f s
+       in if Text.length s' == Text.length s
             then
               AnnotatedText (pure $ Segment s a)
                 <> LL.takeWhile f (AnnotatedText tl)
             else AnnotatedText (pure $ Segment s' a)
   dropWhile f (AnnotatedText at) = case at of
     Seq.Empty -> AnnotatedText Seq.Empty
-    Segment s a :<| tl -> case L.dropWhile f s of
-      [] -> LL.dropWhile f (AnnotatedText tl)
+    Segment s a :<| tl -> case Text.dropWhile f s of
+      "" -> LL.dropWhile f (AnnotatedText tl)
       s -> AnnotatedText $ (Segment s a) :<| tl
   take n (AnnotatedText at) = case at of
     Seq.Empty -> AnnotatedText Seq.Empty
     Segment s a :<| tl ->
-      if n <= length s
-        then AnnotatedText $ pure (Segment (take n s) a)
+      if n <= Text.length s
+        then AnnotatedText $ pure (Segment (Text.take n s) a)
         else
           AnnotatedText (pure (Segment s a))
-            <> LL.take (n - length s) (AnnotatedText tl)
+            <> LL.take (n - Text.length s) (AnnotatedText tl)
   drop n (AnnotatedText at) = case at of
     Seq.Empty -> AnnotatedText Seq.Empty
     Segment s a :<| tl ->
-      if n <= length s
-        then AnnotatedText $ (Segment (drop n s) a) :<| tl
-        else LL.drop (n - length s) (AnnotatedText tl)
-  null (AnnotatedText at) = all (null . segment) at
+      if n <= Text.length s
+        then AnnotatedText $ (Segment (Text.drop n s) a) :<| tl
+        else LL.drop (n - Text.length s) (AnnotatedText tl)
+  null (AnnotatedText at) = all (Text.null . segment) at
 
 -- Quoted text (indented, with source line numbers) with annotated portions.
 data AnnotatedExcerpt a = AnnotatedExcerpt
@@ -110,10 +111,9 @@ annotateMaybe (AnnotatedText segments) =
 
 trailingNewLine :: AnnotatedText a -> Bool
 trailingNewLine (AnnotatedText (init :|> (Segment s _))) =
-  case lastMay s of
-    Just '\n' -> True
-    Just _ -> False
-    _ -> trailingNewLine (AnnotatedText init)
+  if Text.null s
+    then trailingNewLine (AnnotatedText init)
+    else Text.last s == '\n'
 trailingNewLine _ = False
 
 markup :: AnnotatedExcerpt a -> Map Range a -> AnnotatedExcerpt a
@@ -126,7 +126,7 @@ markup a r = a {annotations = r `Map.union` annotations a}
 textLength :: AnnotatedText a -> Int
 textLength (AnnotatedText chunks) = foldl' go 0 chunks
   where
-    go len (toPair -> (text, _a)) = len + length text
+    go len (toPair -> (text, _a)) = len + Text.length text
 
 textEmpty :: AnnotatedText a -> Bool
 textEmpty = (== 0) . textLength
@@ -204,7 +204,6 @@ snipWithContext margin source =
           -- if all annotations so far can be joined without .. separations
           if null rest
             then -- if this one can be joined to the new region without .. separation
-
               if withinMargin r0 r1
                 then -- add it to the first set and grow the compare region
                   (Just $ r0 <> r1, Map.insert r1 a1 taken, mempty)
@@ -214,7 +213,7 @@ snipWithContext margin source =
               (Just r0, taken, Map.insert r1 a1 rest)
 
 instance IsString (AnnotatedText a) where
-  fromString s = AnnotatedText . pure $ Segment s Nothing
+  fromString s = AnnotatedText . pure $ Segment (Text.pack s) Nothing
 
 instance IsString (AnnotatedExcerpt a) where
   fromString s = AnnotatedExcerpt 1 s mempty
@@ -222,4 +221,4 @@ instance IsString (AnnotatedExcerpt a) where
 instance GHC.Exts.IsList (AnnotatedText a) where
   type Item (AnnotatedText a) = Char
   fromList s = fromString s
-  toList (AnnotatedText s) = join . Foldable.toList $ fmap segment s
+  toList (AnnotatedText s) = foldMap Text.unpack . Foldable.toList $ fmap segment s

--- a/lib/unison-pretty-printer/src/Unison/Util/AnnotatedText.hs
+++ b/lib/unison-pretty-printer/src/Unison/Util/AnnotatedText.hs
@@ -204,6 +204,7 @@ snipWithContext margin source =
           -- if all annotations so far can be joined without .. separations
           if null rest
             then -- if this one can be joined to the new region without .. separation
+
               if withinMargin r0 r1
                 then -- add it to the first set and grow the compare region
                   (Just $ r0 <> r1, Map.insert r1 a1 taken, mempty)

--- a/lib/unison-pretty-printer/src/Unison/Util/ColorText.hs
+++ b/lib/unison-pretty-printer/src/Unison/Util/ColorText.hs
@@ -34,6 +34,7 @@ module Unison.Util.ColorText
   )
 where
 
+import Data.Text qualified as Text
 import System.Console.ANSI qualified as ANSI
 import Unison.Prelude
 import Unison.Util.AnnotatedText
@@ -102,31 +103,31 @@ invert ct = ct <&> Invert
 style :: Color -> ColorText -> ColorText
 style = annotate
 
-toHTML :: String -> ColorText -> String
+toHTML :: Text -> ColorText -> Text
 toHTML cssPrefix (AnnotatedText at) =
-  toList at >>= \case
-    Segment s color -> wrap color (s >>= newlineToBreak)
+  toList at
+    <&> (\(Segment s color) -> wrap color (newlinesToBreak s))
+    & Text.concat
   where
-    newlineToBreak '\n' = "<br/>\n"
-    newlineToBreak ch = [ch]
+    newlinesToBreak = Text.replace "\n" "<br/>\n"
     wrap Nothing s = "<code>" <> s <> "</code>"
     wrap (Just c) s =
       "<code class=" <> colorName c <> ">" <> s <> "</code>"
-    colorName c = "\"" <> cssPrefix <> "-" <> show c <> "\""
+    colorName c = "\"" <> cssPrefix <> "-" <> tShow c <> "\""
 
 -- Convert a `ColorText` to a `String`, ignoring colors
-toPlain :: ColorText -> String
-toPlain (AnnotatedText at) = join (toList $ segment <$> at)
+toPlain :: ColorText -> Text
+toPlain (AnnotatedText at) = (foldMap segment at)
 
 -- Convert a `ColorText` to a `String`, using ANSI codes to produce colors
-toANSI :: ColorText -> String
+toANSI :: ColorText -> Text
 toANSI (AnnotatedText chunks) =
-  join . toList $ snd (foldl' go (Nothing, mempty) chunks) <> resetANSI
+  Text.concat . toList $ snd (foldl' go (Nothing, mempty) chunks) <> resetANSI
   where
     go ::
-      (Maybe Color, Seq String) ->
+      (Maybe Color, Seq Text) ->
       Segment Color ->
-      (Maybe Color, Seq String)
+      (Maybe Color, Seq Text)
     go (prev, r) (toPair -> (text, new)) =
       if prev == new
         then (prev, r <> pure text)
@@ -136,10 +137,10 @@ toANSI (AnnotatedText chunks) =
               Nothing -> r <> resetANSI <> pure text
               Just style -> r <> resetANSI <> toANSI style <> pure text
           )
-    resetANSI :: Seq String
-    resetANSI = pure $ ANSI.setSGRCode [ANSI.Reset]
-    toANSI :: Color -> Seq String
-    toANSI c = pure $ ANSI.setSGRCode (toANSI' c)
+    resetANSI :: Seq Text
+    resetANSI = pure . Text.pack $ ANSI.setSGRCode [ANSI.Reset]
+    toANSI :: Color -> Seq Text
+    toANSI c = pure . Text.pack $ ANSI.setSGRCode (toANSI' c)
 
     toANSI' :: Color -> [ANSI.SGR]
     toANSI' c = case c of

--- a/lib/unison-pretty-printer/src/Unison/Util/Less.hs
+++ b/lib/unison-pretty-printer/src/Unison/Util/Less.hs
@@ -1,14 +1,15 @@
 module Unison.Util.Less where
 
 import Control.Exception.Extra (ignore)
+import Data.Text.IO qualified as Text
 import System.Environment (lookupEnv)
-import System.IO (hClose, hPutStr)
+import System.IO (hClose)
 import System.Process
 import Unison.Prelude
 import UnliftIO qualified
 import UnliftIO.Directory (findExecutable)
 
-less :: String -> IO ()
+less :: Text -> IO ()
 less str = do
   isInteractive <-
     lookupEnv "INSIDE_EMACS" >>= \case
@@ -19,7 +20,7 @@ less str = do
     else noPager
   where
     noPager :: IO ()
-    noPager = putStr str
+    noPager = Text.putStr str
     usePager :: IO ()
     usePager = do
       pager <-
@@ -37,7 +38,7 @@ less str = do
             createProcess process {std_in = CreatePipe}
 
           -- If pager exits before consuming all of stdin, `hPutStr` will crash.
-          ignore $ hPutStr stdin str
+          ignore $ Text.hPutStr stdin str
 
           -- If pager has already exited, hClose throws an exception.
           ignore $ hClose stdin

--- a/lib/unison-pretty-printer/src/Unison/Util/Pretty.hs
+++ b/lib/unison-pretty-printer/src/Unison/Util/Pretty.hs
@@ -296,13 +296,13 @@ wrap_ ps = Pretty (foldMap delta ps) (Wrap ps)
 group :: Pretty s -> Pretty s
 group p = Pretty (delta p) (Group p)
 
-toANSI :: Width -> Pretty CT.ColorText -> String
+toANSI :: Width -> Pretty CT.ColorText -> Text
 toANSI avail = CT.toANSI . render avail
 
-toPlain :: Width -> Pretty CT.ColorText -> String
+toPlain :: Width -> Pretty CT.ColorText -> Text
 toPlain avail = CT.toPlain . render avail
 
-toHTML :: String -> Pretty CT.ColorText -> String
+toHTML :: Text -> Pretty CT.ColorText -> Text
 toHTML cssPrefix = CT.toHTML cssPrefix . render 0
 
 syntaxToColor :: Pretty (ST.SyntaxText' r) -> Pretty ColorText
@@ -1034,8 +1034,8 @@ plural f p = case length f of
   1 -> p
   -- todo: consider use of plural package
   _ ->
-    p <> case reverse (toPlain 0 p) of
-      's' : _ -> "es"
+    p <> case Text.unsnoc (toPlain 0 p) of
+      Just (_, 's') -> "es"
       _ -> "s"
 
 border :: (LL.ListLike s Char, IsString s) => Width -> Pretty s -> Pretty s

--- a/lib/unison-pretty-printer/src/Unison/Util/SyntaxText.hs
+++ b/lib/unison-pretty-printer/src/Unison/Util/SyntaxText.hs
@@ -1,5 +1,6 @@
 module Unison.Util.SyntaxText where
 
+import Data.Text qualified as Text
 import Unison.HashQualified (HashQualified)
 import Unison.Name (Name)
 import Unison.Pattern (SeqOp)
@@ -58,4 +59,7 @@ syntax = annotate
 
 -- Convert a `SyntaxText` to a `String`, ignoring syntax markup
 toPlain :: SyntaxText' r -> String
-toPlain (AnnotatedText at) = join (toList $ segment <$> at)
+toPlain st = Text.unpack $ toPlainText st
+
+toPlainText :: SyntaxText' r -> Text
+toPlainText (AnnotatedText at) = foldMap segment at

--- a/lib/unison-pretty-printer/src/Unison/Util/SyntaxText.hs
+++ b/lib/unison-pretty-printer/src/Unison/Util/SyntaxText.hs
@@ -1,6 +1,5 @@
 module Unison.Util.SyntaxText where
 
-import Data.Text qualified as Text
 import Unison.HashQualified (HashQualified)
 import Unison.Name (Name)
 import Unison.Pattern (SeqOp)
@@ -57,9 +56,6 @@ data Element r
 syntax :: Element r -> SyntaxText' r -> SyntaxText' r
 syntax = annotate
 
--- Convert a `SyntaxText` to a `String`, ignoring syntax markup
-toPlain :: SyntaxText' r -> String
-toPlain st = Text.unpack $ toPlainText st
-
-toPlainText :: SyntaxText' r -> Text
-toPlainText (AnnotatedText at) = foldMap segment at
+-- Convert a `SyntaxText` to a `Text`, ignoring syntax markup
+toPlain :: SyntaxText' r -> Text
+toPlain (AnnotatedText at) = foldMap segment at

--- a/lib/unison-pretty-printer/tests/Unison/Test/ColorText.hs
+++ b/lib/unison-pretty-printer/tests/Unison/Test/ColorText.hs
@@ -31,7 +31,7 @@ ex4e = toANSI . condensedExcerptToText 1 $ markup "abc" m
   where
     m = Map.singleton (Range (Pos 1 2) (Pos 1 3)) Red
 
-ex4t :: String
+ex4t :: Text
 ex4t = toANSI $ "    1 | " <> "a" <> ColorText.style Red "b" <> "c" <> "\n"
 
 ex2 :: AnnotatedExcerpt Color

--- a/lib/unison-pretty-printer/tests/Unison/Test/ColorText.hs
+++ b/lib/unison-pretty-printer/tests/Unison/Test/ColorText.hs
@@ -16,6 +16,7 @@ import Unison.Util.AnnotatedText
 import Unison.Util.ColorText (Color (..), toANSI)
 import Unison.Util.ColorText qualified as ColorText
 import Unison.Util.Range (Range (..))
+import Data.Text (Text)
 
 test :: Test ()
 test =
@@ -25,7 +26,7 @@ test =
 -- commented out because they don't render exactly the same escape sequences, but they're equivalent4 as of this writing
 -- scope "inclusive-exclusive range" . expect . trace ("ex4e: " ++ show (rawRender ex4e) ++ "\n" ++ "ex4t: " ++ show (rawRender ex4t) ++ "\n")$ ex4e == ex4t
 
-ex4e :: String
+ex4e :: Text
 ex4e = toANSI . condensedExcerptToText 1 $ markup "abc" m
   where
     m = Map.singleton (Range (Pos 1 2) (Pos 1 3)) Red
@@ -46,7 +47,7 @@ ex2 =
         ]
     )
 
-renderEx2 :: String
+renderEx2 :: Text
 renderEx2 = toANSI . condensedExcerptToText 3 $ ex2
 
 ex3 :: AnnotatedExcerpt Color

--- a/lib/unison-pretty-printer/tests/Unison/Test/ColorText.hs
+++ b/lib/unison-pretty-printer/tests/Unison/Test/ColorText.hs
@@ -5,6 +5,7 @@ module Unison.Test.ColorText where
 
 -- import EasyTest
 import Data.Map qualified as Map
+import Data.Text (Text)
 import EasyTest
 import Text.RawString.QQ
 import Unison.Lexer.Pos (Pos (..))
@@ -16,7 +17,6 @@ import Unison.Util.AnnotatedText
 import Unison.Util.ColorText (Color (..), toANSI)
 import Unison.Util.ColorText qualified as ColorText
 import Unison.Util.Range (Range (..))
-import Data.Text (Text)
 
 test :: Test ()
 test =

--- a/lib/unison-pretty-printer/unison-pretty-printer.cabal
+++ b/lib/unison-pretty-printer/unison-pretty-printer.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.38.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -138,6 +138,7 @@ test-suite pretty-printer-tests
     , containers
     , easytest
     , raw-strings-qq
+    , text
     , unison-pretty-printer
     , unison-syntax
   default-language: Haskell2010

--- a/lib/unison-sqlite/src/Unison/Sqlite/Transaction.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite/Transaction.hs
@@ -364,7 +364,7 @@ transactionRetryDelay = 100_000
 -- Debug timing
 
 -- | Time a transaction.
-time :: String -> Transaction a -> Transaction a
+time :: Text -> Transaction a -> Transaction a
 time label action =
   if Debug.shouldDebug Debug.Timing
     then Transaction \conn -> do

--- a/parser-typechecker/src/Unison/Codebase/Runtime/Profile.hs
+++ b/parser-typechecker/src/Unison/Codebase/Runtime/Profile.hs
@@ -22,6 +22,7 @@ import Data.Map.Strict qualified as M
 import Data.Set (Set)
 import Data.Set qualified as S
 import Data.String
+import Data.Text (Text)
 import Numeric
 import Unison.PrettyPrintEnv
 import Unison.Reference
@@ -364,7 +365,7 @@ foldedProfile ::
   PrettyPrintEnv ->
   Map Reference (Pretty ColorText) ->
   Profile k ->
-  (String, String)
+  (Text, Text)
 foldedProfile ppe misc (Prof _ tr refs) =
   ( toPlain 0 $ foldMapTrie f comp,
     toPlain 0 $ foldMapTrie f wake

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations.hs
@@ -244,5 +244,5 @@ runIntegrityChecks regionVar = do
     IntegrityErrorDetected errs -> do
       let msg = prettyPrintIntegrityErrors errs
       let rendered = Pretty.toPlain 80 (Pretty.border 2 msg)
-      Sqlite.unsafeIO $ Region.setConsoleRegion region (Text.pack rendered)
+      Sqlite.unsafeIO $ Region.setConsoleRegion region rendered
       (abortMigration "Codebase integrity error detected.")

--- a/parser-typechecker/src/Unison/KindInference/Solve.hs
+++ b/parser-typechecker/src/Unison/KindInference/Solve.hs
@@ -18,6 +18,7 @@ import Control.Monad.Trans.Except
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.List.NonEmpty qualified as Nel
 import Data.Set qualified as Set
+import Data.Text qualified as Text
 import Unison.Codebase.BuiltinAnnotation (BuiltinAnnotation)
 import Unison.Debug (DebugFlag (KindInference), shouldDebug)
 import Unison.KindInference.Constraint.Provenance (Provenance (..))
@@ -463,4 +464,4 @@ prettyUVar :: (Var v) => PrettyPrintEnv -> UVar v loc -> P.Pretty P.ColorText
 prettyUVar ppe (UVar s t) = TP.pretty ppe t <> " :: " <> P.prettyVar s
 
 tracePretty :: P.Pretty P.ColorText -> a -> a
-tracePretty p = trace (P.toANSI 0 p)
+tracePretty p = trace (Text.unpack $ P.toANSI 0 p)

--- a/parser-typechecker/src/Unison/Parsers.hs
+++ b/parser-typechecker/src/Unison/Parsers.hs
@@ -18,7 +18,7 @@ import Unison.Var (Var)
 
 unsafeGetRightFrom :: (Var v, Show v) => String -> Either (Parser.Err v) a -> a
 unsafeGetRightFrom src =
-  either (error . Pr.toANSI defaultWidth . prettyParseError src) id
+  either (error . Text.unpack . Pr.toANSI defaultWidth . prettyParseError src) id
 
 parse ::
   (Monad m, Var v) =>

--- a/parser-typechecker/src/Unison/PatternMatchCoverage.hs
+++ b/parser-typechecker/src/Unison/PatternMatchCoverage.hs
@@ -36,6 +36,7 @@ module Unison.PatternMatchCoverage
 where
 
 import Data.Set qualified as Set
+import Data.Text qualified as Text
 import Debug.Trace
 import Unison.Debug
 import Unison.Pattern (Pattern)
@@ -82,5 +83,5 @@ checkMatch scrutineeType cases = do
   where
     title = P.bold
     doDebug out = case shouldDebug PatternCoverage of
-      True -> trace (P.toANSI 0 out)
+      True -> trace (Text.unpack $ P.toANSI 0 out)
       False -> id

--- a/parser-typechecker/src/Unison/PatternMatchCoverage/Solve.hs
+++ b/parser-typechecker/src/Unison/PatternMatchCoverage/Solve.hs
@@ -19,6 +19,7 @@ import Data.Functor.Compose
 import Data.Map qualified as Map
 import Data.Sequence qualified as Seq
 import Data.Set qualified as Set
+import Data.Text qualified as Text
 import Unison.Builtin.Decls (unitRef)
 import Unison.ConstructorReference (ConstructorReference, reference_)
 import Unison.Debug (DebugFlag (PatternCoverageConstraintSolver), shouldDebug)
@@ -650,7 +651,7 @@ addConstraint con0 nc = do
                 P.hang (P.green "resulting constraint: ") (maybe "contradiction" (prettyNormalizedConstraints ppe) x),
                 ""
               ]
-       in if shouldDebug PatternCoverageConstraintSolver then trace (P.toANSI 0 debugOutput) x else x
+       in if shouldDebug PatternCoverageConstraintSolver then trace (Text.unpack $ P.toANSI 0 debugOutput) x else x
 
 -- | Like 'addConstraint', but for a list of constraints
 addConstraints ::

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -1262,7 +1262,7 @@ renderContext env ctx@(C.Context es) =
 
 renderTerm :: (IsString s, Var v) => Env -> Term.Term' (TypeVar.TypeVar loc0 v) v loc1 -> s
 renderTerm env e =
-  fromString (Color.toPlain $ TermPrinter.pretty' 80 env (TypeVar.lowerTerm e))
+  fromString (Text.unpack $ Color.toPlain $ TermPrinter.pretty' 80 env (TypeVar.lowerTerm e))
 
 renderPattern :: Env -> Pattern ann -> ColorText
 renderPattern env =
@@ -1273,7 +1273,7 @@ renderPattern env =
 
 -- | renders a type with no special styling
 renderType' :: (IsString s, Var v) => Env -> Type v loc -> s
-renderType' env = fromString . Pr.toPlain defaultWidth . renderType env (const id)
+renderType' env = fromString . Text.unpack . Pr.toPlain defaultWidth . renderType env (const id)
 
 -- | `f` may do some styling based on `loc`.
 -- | You can pass `(const id)` if no styling is needed, or call `renderType'`.
@@ -1415,10 +1415,10 @@ renderNoteAsANSI ::
   Env ->
   String ->
   Note v a ->
-  String
+  Text
 renderNoteAsANSI w e s = Pr.toANSI w . printNoteWithSource e s
 
-renderParseErrorAsANSI :: (Var v) => Pr.Width -> String -> Parser.Err v -> String
+renderParseErrorAsANSI :: (Var v) => Pr.Width -> String -> Parser.Err v -> Text
 renderParseErrorAsANSI w src = Pr.toANSI w . prettyParseError src
 
 printNoteWithSource ::

--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -1939,8 +1939,8 @@ prettyDoc2 ac tm = do
       longestRun c s =
         case filter (\s -> Text.take 2 s == Text.pack [c, c]) $
           Text.group (PP.toPlain 0 $ PP.syntaxToColor s) of
-            [] -> 2
-            x -> 1 + maximum (map Text.length x)
+          [] -> 2
+          x -> 1 + maximum (map Text.length x)
       oneMore c inner = replicate (longestRun c inner) c
       makeFence inner = PP.string $ replicate (max 3 $ longestRun '`' inner) '`'
       go :: Width -> Term3 v PrintAnnotation -> m (Pretty SyntaxText)

--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -1934,13 +1934,13 @@ prettyDoc2 ac tm = do
       contains :: Char -> Pretty SyntaxText -> Bool
       contains c p =
         PP.toPlain 0 (PP.syntaxToColor p)
-          & elem c
+          & Text.elem c
       -- Finds the longest run of a character and return one bigger than that
       longestRun c s =
-        case filter (\s -> take 2 s == [c, c]) $
-          List.group (PP.toPlain 0 $ PP.syntaxToColor s) of
-          [] -> 2
-          x -> 1 + maximum (map length x)
+        case filter (\s -> Text.take 2 s == Text.pack [c, c]) $
+          Text.group (PP.toPlain 0 $ PP.syntaxToColor s) of
+            [] -> 2
+            x -> 1 + maximum (map Text.length x)
       oneMore c inner = replicate (longestRun c inner) c
       makeFence inner = PP.string $ replicate (max 3 $ longestRun '`' inner) '`'
       go :: Width -> Term3 v PrintAnnotation -> m (Pretty SyntaxText)

--- a/parser-typechecker/src/Unison/Syntax/TypePrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TypePrinter.hs
@@ -46,7 +46,7 @@ pretty ppe = PP.syntaxToColor . prettySyntax ppe
 prettySyntax :: (Var v) => PrettyPrintEnv -> Type v a -> Pretty SyntaxText
 prettySyntax ppe = runPretty ppe . pretty0 Map.empty (-1)
 
-prettyStr :: (Var v) => Width -> PrettyPrintEnv -> Type v a -> String
+prettyStr :: (Var v) => Width -> PrettyPrintEnv -> Type v a -> Text
 prettyStr width ppe = PP.toPlain width . pretty ppe
 
 {- Explanation of precedence handling

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -636,21 +636,21 @@ debugShow :: (Show a) => a -> Bool
 debugShow e | debugEnabled = traceShow e False
 debugShow _ = False
 
-debugTrace :: String -> Bool
-debugTrace e | debugEnabled = trace e False
+debugTrace :: Text -> Bool
+debugTrace e | debugEnabled = trace (Text.unpack e) False
 debugTrace _ = False
 
-showType :: (Var v) => Type.Type v a -> String
+showType :: (Var v) => Type.Type v a -> Text
 showType ty = TP.prettyStr 120 PPE.empty ty
 
 debugType :: (Var v) => String -> Type.Type v a -> Bool
 debugType tag ty
-  | debugEnabled = debugTrace $ "(" <> show tag <> "," <> showType ty <> ")"
+  | debugEnabled = debugTrace $ "(" <> tShow tag <> "," <> showType ty <> ")"
   | otherwise = False
 
-debugTypes :: (Var v) => String -> Type.Type v a -> Type.Type v a -> Bool
+debugTypes :: (Var v) => Text -> Type.Type v a -> Type.Type v a -> Bool
 debugTypes tag t1 t2
-  | debugEnabled = debugTrace $ "(" <> show tag <> ",\n  " <> showType t1 <> ",\n  " <> showType t2 <> ")"
+  | debugEnabled = debugTrace $ "(" <> tShow tag <> ",\n  " <> showType t1 <> ",\n  " <> showType t2 <> ")"
   | otherwise = False
 
 debugPatternsEnabled :: Bool
@@ -3567,11 +3567,11 @@ instance (Var v) => Show (Element v loc) where
   show (Var v) = case v of
     TypeVar.Universal x -> "@" <> show x
     e -> show e
-  show (Solved _ v t) = "'" ++ Text.unpack (Var.name v) ++ " = " ++ TP.prettyStr 0 PPE.empty (Type.getPolytype t)
+  show (Solved _ v t) = "'" ++ Text.unpack (Var.name v) ++ " = " ++ Text.unpack (TP.prettyStr 0 PPE.empty (Type.getPolytype t))
   show (Ann v _loc t) =
     Text.unpack (Var.name v)
       ++ " : "
-      ++ TP.prettyStr 0 PPE.empty t
+      ++ Text.unpack (TP.prettyStr 0 PPE.empty t)
   show (Marker v) = "|" ++ Text.unpack (Var.name v) ++ "|"
 
 instance (Ord loc, Var v) => Show (Context v loc) where
@@ -3580,8 +3580,8 @@ instance (Ord loc, Var v) => Show (Context v loc) where
       showElem _ctx (Var v) = case v of
         TypeVar.Universal x -> "@" <> show x
         e -> show e
-      showElem ctx (Solved _ v (Type.Monotype t)) = "'" ++ Text.unpack (Var.name v) ++ " = " ++ TP.prettyStr 0 PPE.empty (apply ctx t)
-      showElem ctx (Ann v _loc t) = Text.unpack (Var.name v) ++ " : " ++ TP.prettyStr 0 PPE.empty (apply ctx t)
+      showElem ctx (Solved _ v (Type.Monotype t)) = "'" ++ Text.unpack (Var.name v) ++ " = " ++ Text.unpack (TP.prettyStr 0 PPE.empty (apply ctx t))
+      showElem ctx (Ann v _loc t) = Text.unpack (Var.name v) ++ " : " ++ Text.unpack (TP.prettyStr 0 PPE.empty (apply ctx t))
       showElem _ (Marker v) = "|" ++ Text.unpack (Var.name v) ++ "|"
 
 instance (Monad f) => Monad (MT v loc f) where

--- a/parser-typechecker/tests/Unison/Test/Common.hs
+++ b/parser-typechecker/tests/Unison/Test/Common.hs
@@ -10,6 +10,7 @@ where
 import Control.Monad.Writer (tell)
 import Data.Functor.Identity (Identity (..))
 import Data.Sequence (Seq)
+import Data.Text qualified as Text
 import Text.Megaparsec.Error qualified as MPE
 import Unison.ABT qualified as ABT
 import Unison.Builtin qualified as B
@@ -28,7 +29,6 @@ import Unison.Type qualified as Type
 import Unison.UnisonFile (TypecheckedUnisonFile, UnisonFile)
 import Unison.Util.Pretty qualified as Pr
 import Unison.Var (Var)
-import Data.Text qualified as Text
 
 type Term v = Term.Term v Ann
 

--- a/parser-typechecker/tests/Unison/Test/Common.hs
+++ b/parser-typechecker/tests/Unison/Test/Common.hs
@@ -28,6 +28,7 @@ import Unison.Type qualified as Type
 import Unison.UnisonFile (TypecheckedUnisonFile, UnisonFile)
 import Unison.Util.Pretty qualified as Pr
 import Unison.Var (Var)
+import Data.Text qualified as Text
 
 type Term v = Term.Term v Ann
 
@@ -60,7 +61,7 @@ showParseError ::
   String ->
   MPE.ParseError Parser.Input (Parser.Error v) ->
   String
-showParseError s = Pr.toANSI 60 . prettyParseError s
+showParseError s = Text.unpack . Pr.toANSI 60 . prettyParseError s
 
 parseAndSynthesizeAsFile ::
   [Type Symbol] ->

--- a/parser-typechecker/tests/Unison/Test/Syntax/FileParser.hs
+++ b/parser-typechecker/tests/Unison/Test/Syntax/FileParser.hs
@@ -3,6 +3,7 @@ module Unison.Test.Syntax.FileParser where
 import Data.Functor.Identity (Identity (..))
 import Data.List (uncons)
 import Data.Set (elems)
+import Data.Text qualified as Text
 import EasyTest
 import Text.Megaparsec.Error qualified as MPE
 import Unison.Parser.Ann qualified as P
@@ -14,7 +15,6 @@ import Unison.Syntax.Parser qualified as P
 import Unison.Test.Common qualified as Common
 import Unison.UnisonFile (UnisonFile)
 import Unison.Var (Var)
-import Data.Text qualified as Text
 
 test1 :: Test ()
 test1 =

--- a/parser-typechecker/tests/Unison/Test/Syntax/FileParser.hs
+++ b/parser-typechecker/tests/Unison/Test/Syntax/FileParser.hs
@@ -14,6 +14,7 @@ import Unison.Syntax.Parser qualified as P
 import Unison.Test.Common qualified as Common
 import Unison.UnisonFile (UnisonFile)
 import Unison.Var (Var)
+import Data.Text qualified as Text
 
 test1 :: Test ()
 test1 =
@@ -73,7 +74,7 @@ expectFileParseFailure s expectation = scope s $ do
         Just (MPE.ErrorCustom e) -> expectation e
         Just _ -> crash "Error encountered was not custom"
         Nothing -> crash "No error found"
-    Left e -> crash ("Parser failed with an error which was a trivial parser error: " ++ renderParseErrorAsANSI 80 s e)
+    Left e -> crash . Text.unpack $ ("Parser failed with an error which was a trivial parser error: " <> renderParseErrorAsANSI 80 s e)
 
 emptyWatchTest :: Test ()
 emptyWatchTest =

--- a/parser-typechecker/tests/Unison/Test/Syntax/TermParser.hs
+++ b/parser-typechecker/tests/Unison/Test/Syntax/TermParser.hs
@@ -15,6 +15,7 @@ import Unison.Symbol (Symbol)
 import Unison.Syntax.Parser
 import Unison.Syntax.TermParser qualified as TP
 import Unison.Test.Common qualified as Common
+import Data.Text qualified as Text
 
 test1 :: Test ()
 test1 =
@@ -218,6 +219,6 @@ parseWith :: P Symbol Identity a -> String -> Test ()
 parseWith p s = scope (join . take 1 $ lines s) $
   case runIdentity (Ps.parse @_ @Symbol p s Common.parsingEnv) of
     Left e -> do
-      note $ renderParseErrorAsANSI 60 s e
-      crash $ renderParseErrorAsANSI 60 s e
+      note . Text.unpack $ renderParseErrorAsANSI 60 s e
+      crash . Text.unpack $ renderParseErrorAsANSI 60 s e
     Right _ -> ok

--- a/parser-typechecker/tests/Unison/Test/Syntax/TermParser.hs
+++ b/parser-typechecker/tests/Unison/Test/Syntax/TermParser.hs
@@ -6,6 +6,7 @@ module Unison.Test.Syntax.TermParser where
 import Control.Applicative
 import Control.Monad (join)
 import Data.Functor.Identity (Identity (..))
+import Data.Text qualified as Text
 import EasyTest
 import Text.Megaparsec qualified as P
 import Text.RawString.QQ
@@ -15,7 +16,6 @@ import Unison.Symbol (Symbol)
 import Unison.Syntax.Parser
 import Unison.Syntax.TermParser qualified as TP
 import Unison.Test.Common qualified as Common
-import Data.Text qualified as Text
 
 test1 :: Test ()
 test1 =

--- a/parser-typechecker/tests/Unison/Test/Syntax/TypePrinter.hs
+++ b/parser-typechecker/tests/Unison/Test/Syntax/TypePrinter.hs
@@ -4,6 +4,7 @@
 
 module Unison.Test.Syntax.TypePrinter where
 
+import Data.Text qualified as Text
 import Data.Map qualified as Map
 import EasyTest
 import Unison.Builtin qualified
@@ -22,7 +23,7 @@ tc_diff_rtt :: Bool -> String -> String -> PP.Width -> Test ()
 tc_diff_rtt rtt s expected width =
   let input_type = Common.t s
       get_names = PPE.makePPE (PPE.hqNamer Common.hqLength Unison.Builtin.names) PPE.dontSuffixify
-      prettied = fmap toPlain $ PP.syntaxToColor . runPretty get_names $ prettyRaw Map.empty (-1) input_type
+      prettied = fmap (Text.unpack . toPlain) $ PP.syntaxToColor . runPretty get_names $ prettyRaw Map.empty (-1) input_type
       actual = PP.render width prettied
       actual_reparsed = Common.t actual
    in scope s $

--- a/parser-typechecker/tests/Unison/Test/Syntax/TypePrinter.hs
+++ b/parser-typechecker/tests/Unison/Test/Syntax/TypePrinter.hs
@@ -4,8 +4,8 @@
 
 module Unison.Test.Syntax.TypePrinter where
 
-import Data.Text qualified as Text
 import Data.Map qualified as Map
+import Data.Text qualified as Text
 import EasyTest
 import Unison.Builtin qualified
 import Unison.PrettyPrintEnv.Names qualified as PPE

--- a/unison-cli/src/Unison/Cli/Monad.hs
+++ b/unison-cli/src/Unison/Cli/Monad.hs
@@ -334,7 +334,7 @@ labelE f =
     Right <$> f (goto . Left)
 
 -- | Time an action.
-time :: String -> Cli a -> Cli a
+time :: Text -> Cli a -> Cli a
 time label action =
   if Debug.shouldDebug Debug.Timing
     then Cli \env k s -> do

--- a/unison-cli/src/Unison/Cli/UpdateUtils.hs
+++ b/unison-cli/src/Unison/Cli/UpdateUtils.hs
@@ -26,6 +26,7 @@ import Data.Foldable qualified as Foldable
 import Data.List qualified as List
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
+import Data.Text qualified as Text
 import U.Codebase.Decl qualified as V2.Decl
 import U.Codebase.Reference (Reference' (..), TermReferenceId, TypeReferenceId)
 import U.Codebase.Sqlite.Operations qualified as Operations
@@ -214,7 +215,7 @@ parseAndTypecheck ::
   Cli (Maybe (TypecheckedUnisonFile Symbol Ann))
 parseAndTypecheck prettyUf parsingEnv = do
   env <- ask
-  let stringUf = Pretty.toPlain 80 prettyUf
+  let stringUf = Text.unpack $ Pretty.toPlain 80 prettyUf
   Debug.whenDebug Debug.Update do
     liftIO do
       putStrLn "--- Scratch ---"

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -666,7 +666,7 @@ loop e = do
                  in do
                       let d = Output.DN.DumpNamespace terms types patches children causalParents
                       -- the alternate implementation that doesn't rely on `traceM` blows up
-                      traceM $ P.toPlain 200 (prettyDump (h, d))
+                      traceM . Text.unpack $ P.toPlain 200 (prettyDump (h, d))
                       set h
                       goCausal (map getCausal (Foldable.toList (b ^. Branch.children_)) ++ queue)
               prettyDump (h, Output.DN.DumpNamespace terms types patches children causalParents) =
@@ -1019,7 +1019,7 @@ doDisplay outputLoc names tm = do
     FileLocation path _ -> Just <$> Directory.canonicalizePath path
     LatestFileLocation _ -> traverse Directory.canonicalizePath $ fmap fst (loopState ^. #latestFile) <|> Just "scratch.u"
   whenJust mayFP \fp -> do
-    liftIO $ prependFile fp (Text.pack . P.toPlain 80 $ rendered)
+    liftIO $ prependFile fp (P.toPlain 80 $ rendered)
   Cli.respond $ DisplayRendered mayFP rendered
   where
     suffixify =

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/DebugSynhashTerm.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/DebugSynhashTerm.hs
@@ -51,7 +51,6 @@ handleDebugSynhashTerm name = do
               & map prettyToken
               & Pretty.lines
               & Pretty.toANSI 0
-              & Text.pack
       liftIO (Text.writeFile (Text.unpack filename) renderedTokens)
       Cli.respond (Output'DebugSynhashTerm ref (Hashable.accumulate tokens) filename)
 

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Delete.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Delete.hs
@@ -242,7 +242,7 @@ handleDelete False {- force? -} which (List.nubOrd -> targetNames) = do
                       & over (#terms . mapped) snd
                   )
 
-      liftIO $ env.writeSource (Text.pack scratchFilePath) (Text.pack $ Pretty.toPlain 80 prettyUnisonFile) True
+      liftIO $ env.writeSource (Text.pack scratchFilePath) (Pretty.toPlain 80 prettyUnisonFile) True
 
       Cli.returnEarly (Output.DeleteFailure scratchFilePath projectAndBranch.branch.name updateBranchName)
 

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/FindAndReplace.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/FindAndReplace.hs
@@ -65,7 +65,7 @@ handleStructuredFindReplaceI rule = do
       uf' = (vs, finish uf0')
   #latestTypecheckedFile .= Just (Left . snd $ uf')
   let msg = "| Rewrote using: "
-  let rendered = Text.pack . P.toPlain 80 $ renderRewrittenFile ppe msg uf'
+  let rendered = P.toPlain 80 $ renderRewrittenFile ppe msg uf'
   liftIO $ env.writeSource (Text.pack dest) rendered True
   Cli.respond $ OutputRewrittenFile dest vs
 

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/FormatFile.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/FormatFile.hs
@@ -118,7 +118,7 @@ formatFile makePPEDForFile formattingWidth currentPath inputParsedFile inputType
   let textEdits =
         nonGeneratedDefs & foldMap \((start, end), txt) -> do
           range <- maybeToList $ annToRange (Ann.Ann start end)
-          pure $ (TextReplacement (Text.pack $ Pretty.toPlain (Pretty.Width formattingWidth) txt) range)
+          pure $ (TextReplacement (Pretty.toPlain (Pretty.Width formattingWidth) txt) range)
   pure textEdits
   where
     isInFormatRange :: Ann.Ann -> Bool

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Merge2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Merge2.hs
@@ -400,7 +400,7 @@ doMerge info = do
                 liftIO $
                   env.writeSource
                     (Text.pack scratchFilePath)
-                    (Text.pack $ Pretty.toPlain 80 mergeblob.unparsedFile)
+                    (Pretty.toPlain 80 mergeblob.unparsedFile)
                     True
                 done (Output.MergeFailure scratchFilePath mergeSourceAndTarget)
               Just mergetool0 -> do
@@ -439,7 +439,7 @@ doMerge info = do
                         & Text.replace "$REMOTE" filenames.bob
                 exitCode <-
                   liftIO do
-                    let fileContents = Text.pack . Pretty.toPlain 80 <$> mergeblob.unparsedSoloFiles
+                    let fileContents = Pretty.toPlain 80 <$> mergeblob.unparsedSoloFiles
                     removeFile (Text.unpack mergedFilename) <|> pure ()
                     for_ ((,) <$> filenames <*> fileContents) \(name, contents) ->
                       env.writeSource name contents True

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/ShowDefinition.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/ShowDefinition.hs
@@ -166,7 +166,7 @@ showDefinitions outputLoc pped terms types misses = do
       let isSourceFile = True
       let (renderedCodePretty, numRendered) = renderCodePretty pped isSourceFile isTest terms types excludeNames
       when (numRendered > 0) do
-        let renderedCodeText = Text.pack $ Pretty.toPlain 80 renderedCodePretty
+        let renderedCodeText = Pretty.toPlain 80 renderedCodePretty
 
         -- We set latestFile to be programmatically generated, if we
         -- are viewing these definitions to a file - this will skip the

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Tests.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Tests.hs
@@ -14,6 +14,7 @@ import Data.Map qualified as Map
 import Data.Set qualified as Set
 import Data.Set.NonEmpty (NESet)
 import Data.Set.NonEmpty qualified as NESet
+import Data.Text.IO qualified as Text
 import Unison.ABT qualified as ABT
 import Unison.Builtin.Decls qualified as DD
 import Unison.Cli.Monad (Cli)
@@ -117,7 +118,7 @@ handleTest TestInput {includeLibNamespace, path, showFailures, showSuccesses} = 
         Just tm -> do
           let testName = Cli.prettyTermName fqnPPE (Referent.fromTermReferenceId r)
           Debug.whenDebug Debug.Tests $
-            liftIO (putStrLn $ "\nAbout to run test:" <> ("\n" <> P.toPlain 80 testName))
+            liftIO (Text.putStrLn $ "\nAbout to run test:" <> ("\n" <> P.toPlain 80 testName))
           Cli.respond $ TestIncrementalOutputStart fqnPPE (n, total) r
           --                        v don't cache; test cache populated below
           tm' <- Cli.time ("\n" <> P.toPlain 80 testName) $ RuntimeUtils.evalPureUnison fqnPPE False tm

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
@@ -185,7 +185,7 @@ handleUpdate2 = do
                         then do
                           Cli.updateProjectBranchRoot_ pp.branch "update" (const nextNamespace)
                           scratchFilePath <- fst <$> Cli.expectLatestFile
-                          liftIO $ env.writeSource (Text.pack scratchFilePath) (Text.pack $ Pretty.toPlain 80 prettyUnisonFile) True
+                          liftIO $ env.writeSource (Text.pack scratchFilePath) (Pretty.toPlain 80 prettyUnisonFile) True
                           done Output.UpdateTypecheckingFailure
                         else do
                           uniqueTypeGuidsByName <-
@@ -208,12 +208,12 @@ handleUpdate2 = do
                               )
                           scratchFilePath <- fst <$> Cli.expectLatestFile
                           #latestFile ?= (scratchFilePath, True)
-                          liftIO $ env.writeSource (Text.pack scratchFilePath) (Text.pack $ Pretty.toPlain 80 prettyUnisonFile) True
+                          liftIO $ env.writeSource (Text.pack scratchFilePath) (Pretty.toPlain 80 prettyUnisonFile) True
                           done (Output.UpdateTypecheckingFailure2 scratchFilePath pp.branch.name updateBranchName)
                     else do
                       scratchFilePath <- fst <$> Cli.expectLatestFile
                       #latestFile ?= (scratchFilePath, True)
-                      liftIO $ env.writeSource (Text.pack scratchFilePath) (Text.pack $ Pretty.toPlain 80 prettyUnisonFile) True
+                      liftIO $ env.writeSource (Text.pack scratchFilePath) (Pretty.toPlain 80 prettyUnisonFile) True
                       done Output.UpdateTypecheckingFailure
 
               respondRegion (Output.Literal (Pretty.wrap "Everything typechecks, so I'm saving the results..."))

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Upgrade.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Upgrade.hs
@@ -224,7 +224,7 @@ handleUpgrade oldName newName = do
           Nothing -> "scratch.u"
           Just (file, _) -> file
       #latestFile ?= (scratchFilePath, True)
-      liftIO $ env.writeSource (Text.pack scratchFilePath) (Text.pack $ Pretty.toPlain 80 prettyUnisonFile) True
+      liftIO $ env.writeSource (Text.pack scratchFilePath) (Pretty.toPlain 80 prettyUnisonFile) True
       Cli.returnEarly (Output.UpgradeFailure pp.branch.name scratchFilePath oldName newName)
 
   branchUpdates <-

--- a/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
+++ b/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
@@ -220,7 +220,7 @@ run isTest verbosity codebase runtime sbRuntime ucmVersion baseURL authenticated
       outputUcmResult :: Pretty.Pretty Pretty.ColorText -> IO ()
       outputUcmResult line = do
         hide <- hideOutput False
-        unless hide . outputUcmLine . UcmOutputLine . Text.pack $
+        unless hide . outputUcmLine . UcmOutputLine $
           -- We shorten the terminal width, because "Transcript" manages a 2-space indent for output lines.
           Pretty.toPlain (terminalWidth - 2) line
 
@@ -236,7 +236,7 @@ run isTest verbosity codebase runtime sbRuntime ucmVersion baseURL authenticated
                 [ "The stanza above marked with `:error :bug` is now failing with",
                   "",
                   "```",
-                  Text.pack $ Pretty.toPlain terminalWidth msg,
+                  Pretty.toPlain terminalWidth msg,
                   "```",
                   "",
                   "so you can remove `:bug` and close any appropriate Github issues. If the error message is different \
@@ -248,7 +248,7 @@ run isTest verbosity codebase runtime sbRuntime ucmVersion baseURL authenticated
       doHttpRequest req = do
         resp <- HTTP.responseBody <$> HTTP.httpLbs req httpManager
         case Aeson.eitherDecode @Aeson.Value resp of
-          Left err -> dieWithMsg $ "Error decoding response from " <> BSC.unpack (HTTP.method req) <> ": " <> err
+          Left err -> dieWithMsg . Text.pack $ "Error decoding response from " <> (BSC.unpack (HTTP.method req)) <> ": " <> err
           Right v -> do
             let prettyBytes = Aeson.encodePretty' (Aeson.defConfig {Aeson.confCompare = compare}) v
             pure $ Text.pack . BL.unpack $ prettyBytes
@@ -261,7 +261,7 @@ run isTest verbosity codebase runtime sbRuntime ucmVersion baseURL authenticated
           APIComment {} -> pure $ pure req
           GetRequest path -> do
             httpReq <- case HTTP.parseRequest (Text.unpack $ baseURL <> path) of
-              Left err -> dieWithMsg (show err)
+              Left err -> dieWithMsg (tShow err)
               Right r -> pure r
             respTxt <- doHttpRequest httpReq
             if hide
@@ -269,7 +269,7 @@ run isTest verbosity codebase runtime sbRuntime ucmVersion baseURL authenticated
               else pure [req, APIResponse respTxt]
           PostRequest path body -> do
             httpReq <- case HTTP.parseRequest (Text.unpack $ baseURL <> path) of
-              Left err -> dieWithMsg (show err)
+              Left err -> dieWithMsg (tShow err)
               Right r ->
                 pure $
                   r
@@ -482,7 +482,7 @@ run isTest verbosity codebase runtime sbRuntime ucmVersion baseURL authenticated
           (\block -> unless (elem (pure block) currentOut) $ modifyIORef' out (<> pure (pure block)))
           blockOpt
 
-      dieWithMsg :: forall a. String -> IO a
+      dieWithMsg :: forall a. Text -> IO a
       dieWithMsg msg = do
         appendFailingStanza
         transcriptFailure
@@ -490,7 +490,7 @@ run isTest verbosity codebase runtime sbRuntime ucmVersion baseURL authenticated
           out
           "The transcript failed due to an error in the stanza above. The error is:"
           . pure
-          $ Text.pack msg
+          $ msg
 
       dieUnexpectedSuccess :: IO ()
       dieUnexpectedSuccess = do

--- a/unison-cli/src/Unison/CommandLine/Completion.hs
+++ b/unison-cli/src/Unison/CommandLine/Completion.hs
@@ -76,12 +76,12 @@ haskelineTabComplete patterns codebase authedHTTPClient ppCtx = Line.completeWor
   if null prev
     then pure . exactComplete word $ Map.keys patterns
     else -- User has finished a command name; use completions for that command
-    case words $ reverse prev of
-      h : t -> fromMaybe (pure []) $ do
-        p <- Map.lookup h patterns
-        paramType <- IP.paramType (IP.params p) (length t)
-        pure $ IP.suggestions paramType word codebase authedHTTPClient ppCtx
-      _ -> pure []
+      case words $ reverse prev of
+        h : t -> fromMaybe (pure []) $ do
+          p <- Map.lookup h patterns
+          paramType <- IP.paramType (IP.params p) (length t)
+          pure $ IP.suggestions paramType word codebase authedHTTPClient ppCtx
+        _ -> pure []
 
 -- | Things which we may want to complete for.
 data CompletionType
@@ -301,13 +301,13 @@ prettyCompletionWithQueryPrefix ::
   Line.Completion
 prettyCompletionWithQueryPrefix endWithSpace query s =
   let coloredMatch = P.hiBlack (P.string query) <> P.string (drop (length query) s)
-   in Line.Completion s (P.toANSI 0 coloredMatch) endWithSpace
+   in Line.Completion s (Text.unpack $ P.toANSI 0 coloredMatch) endWithSpace
 
 -- discards formatting in favor of better alignment
 -- prettyCompletion (s, p) = Line.Completion s (P.toPlain 0 p) True
 -- preserves formatting, but Haskeline doesn't know how to align
 prettyCompletion :: Bool -> (String, P.Pretty P.ColorText) -> Line.Completion
-prettyCompletion endWithSpace (s, p) = Line.Completion s (P.toANSI 0 p) endWithSpace
+prettyCompletion endWithSpace (s, p) = Line.Completion s (Text.unpack $ P.toANSI 0 p) endWithSpace
 
 -- | Constructs a list of 'Completion's from a query and completion options by
 -- filtering them for prefix matches. A completion will be selected if it's an exact match for

--- a/unison-cli/src/Unison/CommandLine/Completion.hs
+++ b/unison-cli/src/Unison/CommandLine/Completion.hs
@@ -76,12 +76,12 @@ haskelineTabComplete patterns codebase authedHTTPClient ppCtx = Line.completeWor
   if null prev
     then pure . exactComplete word $ Map.keys patterns
     else -- User has finished a command name; use completions for that command
-      case words $ reverse prev of
-        h : t -> fromMaybe (pure []) $ do
-          p <- Map.lookup h patterns
-          paramType <- IP.paramType (IP.params p) (length t)
-          pure $ IP.suggestions paramType word codebase authedHTTPClient ppCtx
-        _ -> pure []
+    case words $ reverse prev of
+      h : t -> fromMaybe (pure []) $ do
+        p <- Map.lookup h patterns
+        paramType <- IP.paramType (IP.params p) (length t)
+        pure $ IP.suggestions paramType word codebase authedHTTPClient ppCtx
+      _ -> pure []
 
 -- | Things which we may want to complete for.
 data CompletionType

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -281,7 +281,7 @@ formatStructuredArgument schLength = \case
               else "." <> s
         pathArgStr = Path.toText pathArg
 
--- | Converts an arbitrary argument to a `String`.
+-- | Converts an arbitrary argument to a `Text`.
 --
 -- This is for cases where the
 -- command /should/ accept a structured argument of some type, but currently

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -4078,7 +4078,7 @@ projectToCompletion :: Sqlite.Project -> Completion
 projectToCompletion project =
   Completion
     { replacement = stringProjectName,
-      display = P.toANSI 0 (prettyProjectNameSlash (project ^. #name)),
+      display = Text.unpack $ P.toANSI 0 (prettyProjectNameSlash (project ^. #name)),
       isFinished = False
     }
   where
@@ -4088,7 +4088,7 @@ projectBranchToCompletion :: ProjectName -> (ProjectBranchId, ProjectBranchName)
 projectBranchToCompletion projectName (_, branchName) =
   Completion
     { replacement = Text.unpack (into @Text (ProjectAndBranch projectName branchName)),
-      display = P.toANSI 0 (prettySlashProjectBranchName branchName),
+      display = Text.unpack $ P.toANSI 0 (prettySlashProjectBranchName branchName),
       isFinished = False
     }
 
@@ -4118,7 +4118,7 @@ currentProjectBranchToCompletion :: (ProjectBranchId, ProjectBranchName) -> Comp
 currentProjectBranchToCompletion (_, branchName) =
   Completion
     { replacement = '/' : Text.unpack (into @Text branchName),
-      display = P.toANSI 0 (prettySlashProjectBranchName branchName),
+      display = Text.unpack $ P.toANSI 0 (prettySlashProjectBranchName branchName),
       isFinished = False
     }
 
@@ -4164,7 +4164,7 @@ branchRelativePathSuggestions config inputStr codebase _httpClient pp = do
     projectBranchToCompletionWithSep projectName (_, branchName) =
       Completion
         { replacement = Text.unpack (into @Text (ProjectAndBranch projectName branchName) <> branchPathSep),
-          display = P.toANSI 0 (prettySlashProjectBranchName branchName <> branchPathSepPretty),
+          display = Text.unpack $ P.toANSI 0 (prettySlashProjectBranchName branchName <> branchPathSepPretty),
           isFinished = False
         }
 
@@ -4172,14 +4172,14 @@ branchRelativePathSuggestions config inputStr codebase _httpClient pp = do
     prefixPathSep c =
       c
         { Line.replacement = branchPathSep <> Line.replacement c,
-          Line.display = P.toANSI 0 branchPathSepPretty <> Line.display c
+          Line.display = Text.unpack (P.toANSI 0 branchPathSepPretty) <> Line.display c
         }
 
     suffixPathSep :: Completion -> Completion
     suffixPathSep c =
       c
         { Line.replacement = Line.replacement c <> branchPathSep,
-          Line.display = Line.display c <> P.toANSI 0 branchPathSepPretty
+          Line.display = Line.display c <> Text.unpack (P.toANSI 0 branchPathSepPretty)
         }
 
     addBranchPrefix ::
@@ -4199,7 +4199,7 @@ branchRelativePathSuggestions config inputStr codebase _httpClient pp = do
        in \c ->
             c
               { Line.replacement = Text.unpack prefixText <> branchPathSep <> Line.replacement c,
-                Line.display = P.toANSI 0 (prefixPretty <> branchPathSepPretty) <> Line.display c
+                Line.display = Text.unpack (P.toANSI 0 (prefixPretty <> branchPathSepPretty)) <> Line.display c
               }
 
     branchPathSepPretty = P.hiBlack branchPathSep
@@ -4280,7 +4280,7 @@ projectNameSuggestions slash (Text.strip . Text.pack -> input) codebase = do
        in \project ->
             Completion
               { replacement = Text.unpack (toText project),
-                display = P.toANSI 0 (toPretty (project ^. #name)),
+                display = Text.unpack $ P.toANSI 0 (toPretty (project ^. #name)),
                 isFinished = False
               }
 

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -103,7 +103,7 @@ getUserInput codebase authHTTPClient pp currentProjectRoot numberedArgs =
                   branchString,
                   fromString prompt
                 ]
-      line <- Line.getInputLine fullPrompt
+      line <- Line.getInputLine $ Text.unpack fullPrompt
       case line of
         Nothing -> pure QuitI
         Just l -> case words l of
@@ -123,7 +123,7 @@ getUserInput codebase authHTTPClient pp currentProjectRoot numberedArgs =
                 let expandedArgs' = IP.unifyArgument <$> expandedArgs
                     expandedArgsStr = unwords expandedArgs'
                 when (expandedArgs' /= ws) $ do
-                  liftIO . putStrLn $ fullPrompt <> expandedArgsStr
+                  liftIO . Text.putStrLn $ fullPrompt <> Text.pack expandedArgsStr
                 Line.modifyHistory $ Line.addHistoryUnlessConsecutiveDupe expandedArgsStr
                 pure i
     settings :: Line.Settings IO

--- a/unison-cli/src/Unison/LSP/CodeLens.hs
+++ b/unison-cli/src/Unison/LSP/CodeLens.hs
@@ -8,7 +8,6 @@ module Unison.LSP.CodeLens where
 import Control.Lens hiding (List)
 import Data.Aeson qualified as Aeson
 import Data.Map qualified as Map
-import Data.Text qualified as Text
 import Language.LSP.Protocol.Lens hiding (error)
 import Language.LSP.Protocol.Message qualified as Msg
 import Language.LSP.Protocol.Types
@@ -54,7 +53,7 @@ codeLensHandler m respond =
     codeLenses <- ifor typeSignatureHints \_v (TypeSignatureHint name ref range typ) -> do
       ppe <- PPED.suffixifiedPPE <$> lift (ppedForFile fileUri)
       let rendered = case TypePrinter.prettySignaturesCT ppe [(ref, HQ.NameOnly name, typ)] of
-            [sig] -> Text.pack . CT.toPlain 80 $ sig
+            [sig] -> CT.toPlain 80 $ sig
             _ -> error "codeLensHandler: prettySignaturesCT returned more than one signature"
       let insertLocation =
             range

--- a/unison-cli/src/Unison/LSP/Completion.hs
+++ b/unison-cli/src/Unison/LSP/Completion.hs
@@ -320,7 +320,7 @@ completionItemResolveHandler message respond = do
         case dep of
           LD.TermReferent ref -> do
             typ <- LSPQ.getTypeOfReferent fileUri ref
-            let renderedType = ": " <> (Text.pack $ TypePrinter.prettyStr typeWidth (PPED.suffixifiedPPE pped) typ)
+            let renderedType = ": " <> (TypePrinter.prettyStr typeWidth (PPED.suffixifiedPPE pped) typ)
             let doc = toMarkup (Text.unlines $ ["``` unison", Name.toText fullyQualifiedName, "```"] ++ renderedDocs)
             pure $ (completion {_detail = Just renderedType, _documentation = Just doc} :: CompletionItem)
           LD.TypeReference ref ->
@@ -333,7 +333,7 @@ completionItemResolveHandler message respond = do
                 decl <- LSPQ.getTypeDeclaration fileUri refId
                 let renderedDecl =
                       ": "
-                        <> ( Text.pack . Pretty.toPlain typeWidth . Pretty.syntaxToColor $
+                        <> ( Pretty.toPlain typeWidth . Pretty.syntaxToColor $
                                DeclPrinter.prettyDecl
                                  pped
                                  DeclPrinter.RenderUniqueTypeGuids'No

--- a/unison-cli/src/Unison/LSP/DocumentSymbols.hs
+++ b/unison-cli/src/Unison/LSP/DocumentSymbols.hs
@@ -4,7 +4,6 @@ module Unison.LSP.DocumentSymbols
 where
 
 import Control.Lens hiding (List)
-import Data.Text qualified as Text
 import Language.LSP.Protocol.Lens hiding (error)
 import Language.LSP.Protocol.Message qualified as Msg
 import Language.LSP.Protocol.Types
@@ -41,7 +40,7 @@ asLspDocumentSymbols
       { _name = Name.toText symbolName,
         _detail = do
           typ <- symbolSignature
-          pure $ ": " <> (Text.pack $ TypePrinter.prettyStr typeWidth ppe typ),
+          pure $ ": " <> (TypePrinter.prettyStr typeWidth ppe typ),
         _kind = lspSymbolKind symbolKind,
         _tags = Just [],
         _deprecated = Nothing,

--- a/unison-cli/src/Unison/LSP/FileAnalysis.hs
+++ b/unison-cli/src/Unison/LSP/FileAnalysis.hs
@@ -350,7 +350,7 @@ analyseNotes fileUri ppe src notes = do
       Result.Parsing err -> do
         let diags = do
               (errMsg, ranges) <- PrintError.renderParseErrors src err
-              let txtMsg = Text.pack $ Pretty.toPlain 80 errMsg
+              let txtMsg = Pretty.toPlain 80 errMsg
               range <- ranges
               pure $ mkDiagnostic fileUri (uToLspRange range) DiagnosticSeverity_Error [] txtMsg []
         -- TODO: Some parsing errors likely have reasonable code actions
@@ -403,7 +403,7 @@ analyseNotes fileUri ppe src notes = do
       [(Range, [(Text, Range)])] ->
       [Diagnostic]
     noteDiagnostic note ranges =
-      let msg = Text.pack $ Pretty.toPlain 80 $ PrintError.printNoteWithSource ppe src note
+      let msg = Pretty.toPlain 80 $ PrintError.printNoteWithSource ppe src note
        in do
             (range, references) <- ranges
             pure $ mkDiagnostic fileUri range DiagnosticSeverity_Error [] msg references
@@ -413,7 +413,7 @@ analyseNotes fileUri ppe src notes = do
       Context.Suggestion {suggestionName, suggestionType, suggestionMatch} <- sortOn nameResolutionSuggestionPriority suggestions
       let prettyType = TypePrinter.prettyStr 0 ppe suggestionType
       let ranges = (diags ^.. folded . range)
-      let rca = rangedCodeAction ("Use " <> Name.toText suggestionName <> " : " <> Text.pack prettyType) diags ranges
+      let rca = rangedCodeAction ("Use " <> Name.toText suggestionName <> " : " <> prettyType) diags ranges
       pure $
         rca
           & includeEdits fileUri (Name.toText suggestionName) ranges
@@ -439,7 +439,7 @@ analyseNotes fileUri ppe src notes = do
             let prettyType = TypePrinter.prettyStr 0 ppe typ
             let txtName = HQ'.toText hqNameSuggestion
             let ranges = (diags ^.. folded . range)
-            let rca = rangedCodeAction ("Use " <> txtName <> " : " <> Text.pack prettyType) diags ranges
+            let rca = rangedCodeAction ("Use " <> txtName <> " : " <> prettyType) diags ranges
             pure $ includeEdits fileUri txtName ranges rca
     isUserBlank :: Symbol -> Bool
     isUserBlank v = case Var.typeOf v of

--- a/unison-cli/src/Unison/LSP/Hover.hs
+++ b/unison-cli/src/Unison/LSP/Hover.hs
@@ -96,7 +96,7 @@ hoverInfo uri pos =
             nameAtCursor <- MaybeT . pure $ Name.parseText symAtCursor
             decl <- LSPQ.getTypeDeclaration uri refId
             let typ =
-                  Text.pack . Pretty.toPlain prettyWidth . Pretty.syntaxToColor $
+                  Pretty.toPlain prettyWidth . Pretty.syntaxToColor $
                     DeclPrinter.prettyDecl pped DeclPrinter.RenderUniqueTypeGuids'No ref (HQ.NameOnly nameAtCursor) decl
             pure typ
           LD.TermReferent ref -> do
@@ -106,7 +106,7 @@ hoverInfo uri pos =
 
     renderTypeSigForHover :: (Var v) => PPED.PrettyPrintEnvDecl -> Text -> Type.Type v a -> Text
     renderTypeSigForHover pped name typ =
-      let renderedType = Text.pack $ TypePrinter.prettyStr prettyWidth (PPED.suffixifiedPPE pped) typ
+      let renderedType = TypePrinter.prettyStr prettyWidth (PPED.suffixifiedPPE pped) typ
        in markdownify (name <> " : " <> renderedType)
 
     hoverInfoForLiteral :: MaybeT m Text

--- a/unison-cli/src/Unison/MCP/Cli.hs
+++ b/unison-cli/src/Unison/MCP/Cli.hs
@@ -11,7 +11,6 @@ import Crypto.Random qualified as Random
 import Data.Aeson
 import Data.IORef
 import Data.Sequence qualified as Seq
-import Data.Text qualified as Text
 import U.Codebase.Sqlite.Queries qualified as Queries
 import Unison.Auth.CredentialManager qualified as AuthN
 import Unison.Auth.HTTPClient qualified as AuthN
@@ -128,7 +127,7 @@ cliToMCP projCtx cli = do
     sourceCodeUpdates <- toList <$> readTVar sourceCodeUpdatesVar
     let outputMessages =
           msgs
-            & fmap (Text.pack . Pretty.toPlain 0)
+            & fmap (Pretty.toPlain 0)
             & toList
     pure $
       ( CliOutput

--- a/unison-cli/tests/Unison/Test/Ucm.hs
+++ b/unison-cli/tests/Unison/Test/Ucm.hs
@@ -58,7 +58,7 @@ initCodebase fmt = do
       >>= flip Temp.createTempDirectory "ucm-test"
   result <- Codebase.Init.withCreatedCodebase cbInit "ucm-test" tmp SC.DoLock (const $ pure ())
   case result of
-    Left CreateCodebaseAlreadyExists -> fail $ P.toANSI 80 "Codebase already exists"
+    Left CreateCodebaseAlreadyExists -> fail . Text.unpack $ P.toANSI 80 "Codebase already exists"
     Right _ -> pure $ Codebase tmp fmt
 
 deleteCodebase :: Codebase -> IO ()
@@ -77,7 +77,7 @@ runTranscript (Codebase codebasePath fmt) transcript = do
         output <- either err (Text.unpack . Transcript.format) <$> runner "transcript" transcriptSrc codebase
         when debugTranscriptOutput $ traceM output
         pure output
-      either (fail . P.toANSI 80 . P.shown) pure result
+      either (fail . Text.unpack . P.toANSI 80 . P.shown) pure result
 
 lowLevel :: Codebase -> (Codebase.Codebase IO Symbol Ann -> IO a) -> IO a
 lowLevel (Codebase root fmt) action = do

--- a/unison-cli/transcripts/Transcripts.hs
+++ b/unison-cli/transcripts/Transcripts.hs
@@ -57,7 +57,7 @@ testBuilder ::
   [FilePath] ->
   FilePath ->
   Test ()
-testBuilder expectFailure replaceOriginal recordFailure inputDir outputDir prelude transcript = time transcript $ do
+testBuilder expectFailure replaceOriginal recordFailure inputDir outputDir prelude transcript = time (Text.pack transcript) $ do
   scope transcript do
     outputs <-
       io $ withTemporaryUcmCodebase SC.init Verbosity.Silent "transcript" SC.DoLock \codebase ->

--- a/unison-merge/src/Unison/Merge/Mergeblob.hs
+++ b/unison-merge/src/Unison/Merge/Mergeblob.hs
@@ -14,6 +14,7 @@ import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 import Data.Set.NonEmpty (NESet)
 import Data.Set.NonEmpty qualified as Set.NonEmpty
+import Data.Text qualified as Text
 import Unison.ConstructorReference (GConstructorReference (..))
 import Unison.DataDeclaration (Decl)
 import Unison.DataDeclaration qualified as DataDeclaration
@@ -219,7 +220,7 @@ makeMergeblob hydrate loadDependents loadLibdepsNames loadTypeLookup blob author
                     maybeNamespace = Nothing,
                     localNamespacePrefixedTypesAndConstructors = mempty
                   }
-           in case runIdentity (Parsers.parseFile "<merge>" (Pretty.toPlain 80 unparsedFile) parsingEnv) of
+           in case runIdentity (Parsers.parseFile "<merge>" (Text.unpack $ Pretty.toPlain 80 unparsedFile) parsingEnv) of
                 Left _err -> pure Nothing
                 Right file -> do
                   typeLookup <- loadTypeLookup (UnisonFile.dependencies file)

--- a/unison-runtime/src/Unison/Runtime/ANF.hs
+++ b/unison-runtime/src/Unison/Runtime/ANF.hs
@@ -108,6 +108,7 @@ import Data.Map qualified as Map
 import Data.Ord (comparing)
 import Data.Set qualified as Set
 import Data.Text qualified as Data.Text
+import Data.Text qualified as Text
 import Unison.ABT qualified as ABT
 import Unison.ABT.Normalized qualified as ABTN
 import Unison.Blank (nameb)
@@ -139,7 +140,6 @@ import Unison.Util.Text qualified as Util.Text
 import Unison.Var (Var, typed)
 import Unison.Var qualified as Var
 import Prelude hiding (abs, and, or, seq)
-import qualified Data.Text as Text
 
 closure :: (Var v) => Map v (Set v, Set v) -> Map v (Set v)
 closure m0 = trace (snd <$> m0)

--- a/unison-runtime/src/Unison/Runtime/ANF.hs
+++ b/unison-runtime/src/Unison/Runtime/ANF.hs
@@ -139,6 +139,7 @@ import Unison.Util.Text qualified as Util.Text
 import Unison.Var (Var, typed)
 import Unison.Var qualified as Var
 import Prelude hiding (abs, and, or, seq)
+import qualified Data.Text as Text
 
 closure :: (Var v) => Map v (Set v, Set v) -> Map v (Set v)
 closure m0 = trace (snd <$> m0)
@@ -2649,7 +2650,7 @@ prettyFunc (FPrim op) = either shows shows op . showString " "
 
 showsShort :: Reference -> ShowS
 showsShort =
-  showString . Pretty.toPlain 0 . prettyShortHash . shortenTo 10 . toShortHash
+  showString . Text.unpack . Pretty.toPlain 0 . prettyShortHash . shortenTo 10 . toShortHash
 
 prettyBranches ::
   (Var v) => Int -> Branched Reference (ANormal Reference v) -> ShowS

--- a/unison-runtime/src/Unison/Runtime/Debug.hs
+++ b/unison-runtime/src/Unison/Runtime/Debug.hs
@@ -15,6 +15,7 @@ where
 
 import Data.Map qualified as Map
 import Data.Monoid (Endo (..))
+import Data.Text qualified as Text
 import Data.Word
 import Debug.Trace
 import Unison.PrettyPrintEnv (PrettyPrintEnv)
@@ -50,7 +51,7 @@ tracePretty ::
   Term v ->
   Term v
 tracePretty _ False tm = tm
-tracePretty ppe True tm = trace (toANSI 50 $ pretty ppe tm) tm
+tracePretty ppe True tm = trace (Text.unpack . toANSI 50 $ pretty ppe tm) tm
 
 tracePrettyDefs ::
   (Var v) =>
@@ -62,7 +63,7 @@ tracePrettyDefs _ False tms = tms
 tracePrettyDefs ppe True tms = map f tms
   where
     f p@(r, tm) =
-      trace (toANSI 50 $ prettyRef r <> " := " <> pretty ppe tm) p
+      trace (Text.unpack . toANSI 50 $ prettyRef r <> " := " <> pretty ppe tm) p
 
 tracePrettyNormal ::
   (Var v) =>
@@ -112,7 +113,7 @@ prettyRef :: Reference -> Pretty ColorText
 prettyRef = prettyShortHash . shortenTo 10 . toShortHash
 
 prettyRefStr :: Reference -> String
-prettyRefStr = toANSI 0 . prettyRef
+prettyRefStr = Text.unpack . toANSI 0 . prettyRef
 
 tracePrettyCodes ::
   Bool -> [(Reference, Code Reference)] -> [(Reference, Code Reference)]

--- a/unison-runtime/src/Unison/Runtime/IOSource.hs
+++ b/unison-runtime/src/Unison/Runtime/IOSource.hs
@@ -58,7 +58,7 @@ typecheckingEnv =
 parsedFile :: UF.UnisonFile Symbol Ann
 parsedFile =
   case runIdentity (Parsers.parseFile "<IO.u builtin>" sourceString parsingEnv) of
-    Left err -> error (Pretty.toANSI 0 (PrintError.prettyParseError sourceString err))
+    Left err -> error (Text.unpack $ Pretty.toANSI 0 (PrintError.prettyParseError sourceString err))
     Right file -> file
 
 typecheckedFile :: UF.TypecheckedUnisonFile Symbol Ann
@@ -1022,8 +1022,8 @@ type SynthResult =
 type EitherResult = Either String TFile
 
 showNotes :: (Foldable f) => String -> PrintError.Env -> f Note -> String
-showNotes source env =
-  intercalateMap "\n\n" $ PrintError.renderNoteAsANSI 60 env source
+showNotes source env notes =
+  Text.unpack $ intercalateMap "\n\n" (PrintError.renderNoteAsANSI 60 env source) notes
 
 ppEnv :: PPE.PrettyPrintEnv
 ppEnv = PPE.makePPE (PPE.hqNamer 10 Builtin.names) PPE.dontSuffixify

--- a/unison-runtime/src/Unison/Runtime/Interface.hs
+++ b/unison-runtime/src/Unison/Runtime/Interface.hs
@@ -548,13 +548,13 @@ profileEval actThr cleanThr ctxVar cl ppe mout tm = do
           Just loc
             | ticky $ takeExtension loc -> do
                 let (comp, wake) = foldedProfile ppe fnames pout
-                writeFile loc comp
-                writeFile (loc <.> "wakeup") wake
+                writeUtf8 loc comp
+                writeUtf8 (loc <.> "wakeup") wake
                 pure $ Right (errs, tmr)
             | otherwise -> do
                 let (comp, wake) = fullProfile ppe fnames pout
-                writeFile loc $ toPlain 0 comp
-                writeFile (loc <.> "wakeup") $ toPlain 0 wake
+                writeUtf8 loc $ toPlain 0 comp
+                writeUtf8 (loc <.> "wakeup") $ toPlain 0 wake
                 pure $ Right (errs, tmr)
           Nothing ->
             pure $ Right (errs <> Profile (miniProfile ppe fnames pout), tmr)
@@ -957,7 +957,7 @@ getStoredCache =
 
 debugTextFormat :: Bool -> Pretty ColorText -> String
 debugTextFormat fancy =
-  render 50
+  Text.unpack . render 50
   where
     render = if fancy then toANSI else toPlain
 

--- a/unison-runtime/src/Unison/Runtime/Machine.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine.hs
@@ -34,7 +34,6 @@ import Control.Monad.State.Strict
 import Data.Atomics qualified as Atomic
 import Data.HashMap.Lazy qualified as HM
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
-import Data.List qualified as List
 import Data.Map.Strict qualified as M
 import Data.Map.Strict.Internal qualified as M
 import Data.Sequence qualified as Sq
@@ -71,6 +70,7 @@ import Unison.Runtime.ANF.Optimize qualified as ANF
 #ifdef CODE_SERIAL_CHECK
 import Unison.Runtime.ANF.Serialize (serializeCode, deserializeCode)
 #endif
+import Data.Text qualified as Text
 import Unison.Runtime.Array as PA
 import Unison.Runtime.Builtin hiding (unitValue)
 import Unison.Runtime.Exception (RuntimeExn (BU, PE), die, exn)
@@ -506,7 +506,7 @@ encodeExn stk exc = do
               (Rf.ioFailureRef, disp ioe, unitValue)
           | Just re <- fromException exn = case re of
               PE _stk _issues msg ->
-                (Rf.runtimeFailureRef, Util.Text.pack $ P.toPlain 0 msg, unitValue)
+                (Rf.runtimeFailureRef, Util.Text.fromText $ P.toPlain 0 msg, unitValue)
               BU _ tx val -> (Rf.runtimeFailureRef, Util.Text.fromText tx, val)
           | Just (ae :: ArithException) <- fromException exn =
               (Rf.arithmeticFailureRef, disp ae, unitValue)
@@ -1475,7 +1475,7 @@ preEvalTopLevelConstants cacheableCombs newCombs cc = do
 -- case the docs don't actually evaluate them.
 isSandboxingException :: RuntimeExn -> Bool
 isSandboxingException (PE _ _ (P.toPlain 0 -> msg)) =
-  List.isPrefixOf sdbx1 msg || List.isPrefixOf sdbx2 msg
+  Text.isPrefixOf sdbx1 msg || Text.isPrefixOf sdbx2 msg
   where
     sdbx1 = "attempted to use sandboxed operation"
     sdbx2 = "Attempted to use disallowed builtin in sandboxed"

--- a/unison-runtime/tests/Unison/Test/Common.hs
+++ b/unison-runtime/tests/Unison/Test/Common.hs
@@ -10,6 +10,7 @@ where
 import Control.Monad.Writer (tell)
 import Data.Functor.Identity (Identity (..))
 import Data.Sequence (Seq)
+import Data.Text qualified as Text
 import Text.Megaparsec.Error qualified as MPE
 import Unison.ABT qualified as ABT
 import Unison.Builtin qualified as B
@@ -28,7 +29,6 @@ import Unison.Type qualified as Type
 import Unison.UnisonFile (TypecheckedUnisonFile, UnisonFile)
 import Unison.Util.Pretty qualified as Pr
 import Unison.Var (Var)
-import Data.Text qualified as Text
 
 type Term v = Term.Term v Ann
 

--- a/unison-runtime/tests/Unison/Test/Common.hs
+++ b/unison-runtime/tests/Unison/Test/Common.hs
@@ -28,6 +28,7 @@ import Unison.Type qualified as Type
 import Unison.UnisonFile (TypecheckedUnisonFile, UnisonFile)
 import Unison.Util.Pretty qualified as Pr
 import Unison.Var (Var)
+import Data.Text qualified as Text
 
 type Term v = Term.Term v Ann
 
@@ -60,7 +61,7 @@ showParseError ::
   String ->
   MPE.ParseError Parser.Input (Parser.Error v) ->
   String
-showParseError s = Pr.toANSI 60 . prettyParseError s
+showParseError s = Text.unpack . Pr.toANSI 60 . prettyParseError s
 
 parseAndSynthesizeAsFile ::
   [Type Symbol] ->

--- a/unison-runtime/tests/Unison/Test/UnisonSources.hs
+++ b/unison-runtime/tests/Unison/Test/UnisonSources.hs
@@ -4,6 +4,7 @@ import Control.Exception (throwIO)
 import Control.Lens.Tuple (_5)
 import Data.Map qualified as Map
 import Data.Text (unpack)
+import Data.Text qualified as Text
 import EasyTest
 import System.Directory (doesFileExist)
 import System.FilePath (joinPath, replaceExtension, splitPath)
@@ -29,7 +30,6 @@ import Unison.UnisonFile qualified as UF
 import Unison.UnisonFile.Names qualified as UF
 import Unison.Util.Monoid (intercalateMap)
 import Unison.Util.Pretty qualified as Pretty
-import Data.Text qualified as Text
 
 type Note = Result.Note Symbol Ann
 

--- a/unison-runtime/tests/Unison/Test/UnisonSources.hs
+++ b/unison-runtime/tests/Unison/Test/UnisonSources.hs
@@ -29,6 +29,7 @@ import Unison.UnisonFile qualified as UF
 import Unison.UnisonFile.Names qualified as UF
 import Unison.Util.Monoid (intercalateMap)
 import Unison.Util.Pretty qualified as Pretty
+import Data.Text qualified as Text
 
 type Note = Result.Note Symbol Ann
 
@@ -83,8 +84,8 @@ go rt files how = do
   tests (makePassingTest rt how <$> files')
 
 showNotes :: (Foldable f) => String -> PrintError.Env -> f Note -> String
-showNotes source env =
-  intercalateMap "\n\n" $ PrintError.renderNoteAsANSI 60 env source
+showNotes source env notes =
+  intercalateMap "\n\n" (Text.unpack . PrintError.renderNoteAsANSI 60 env source) notes
 
 decodeResult ::
   String -> SynthResult -> EitherResult --  String (UF.TypecheckedUnisonFile Symbol Ann)
@@ -123,11 +124,11 @@ resultTest rt uf filepath = do
   if rFileExists
     then scope "result" $ do
       values <- io $ unpack <$> readUtf8 valueFile
-      let report = throwIO . userError . Pretty.toPlain 0 <=< RTI.prettyError (pure . Pretty.shown)
+      let report = throwIO . userError . Text.unpack . Pretty.toPlain 0 <=< RTI.prettyError (pure . Pretty.shown)
       (bindings, _, watches) <-
         io $ either report pure =<< evaluateWatches Builtin.codeLookup PPE.empty NoProf (const $ pure Nothing) rt uf
       either
-        (crash . PrintError.renderParseErrorAsANSI 80 values)
+        (crash . Text.unpack . PrintError.renderParseErrorAsANSI 80 values)
         ( \tm -> do
             -- compare the watch expression from the .u with the expr in .ur
             let watchResult = head (view _5 <$> Map.elems watches)

--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -962,8 +962,7 @@ docsInBranchToHtmlFiles runtime codebase currentBranch directory = do
 bestNameForTerm ::
   forall v. (Var v) => PPE.PrettyPrintEnv -> Width -> Referent -> Text
 bestNameForTerm ppe width =
-  Text.pack
-    . Pretty.render width
+  Pretty.render width
     . fmap UST.toPlain
     . TermPrinter.runPretty ppe
     . TermPrinter.pretty0 @v TermPrinter.emptyAc
@@ -972,8 +971,7 @@ bestNameForTerm ppe width =
 bestNameForType ::
   forall v. (Var v) => PPE.PrettyPrintEnv -> Width -> Reference -> Text
 bestNameForType ppe width =
-  Text.pack
-    . Pretty.render width
+  Pretty.render width
     . fmap UST.toPlain
     . TypePrinter.prettySyntax @v ppe
     . Type.ref ()

--- a/unison-share-api/src/Unison/Server/Doc/Markdown/Render.hs
+++ b/unison-share-api/src/Unison/Server/Doc/Markdown/Render.hs
@@ -45,11 +45,11 @@ embeddedSourceToMarkdown :: EmbeddedSource -> [Md.Markdown]
 embeddedSourceToMarkdown source =
   case source of
     Builtin summary ->
-      [ Md.CodeBlock "unison" (Syntax.toPlainText summary),
+      [ Md.CodeBlock "unison" (Syntax.toPlain summary),
         Md.Txt "Built-in provided by the Unison runtime"
       ]
     EmbeddedSource _summary details ->
-      [Md.CodeBlock "unison" $ Syntax.toPlainText details]
+      [Md.CodeBlock "unison" $ Syntax.toPlain details]
 
 -- | Used when a contained block is expected to be raw text. E.g. inside a CodeBlock.
 -- Other renderers may need to handle links and things in code blocks, but for Markdown we don't.
@@ -196,25 +196,25 @@ toMarkdown_ doc =
           -- We can't fold in markdown
           pure $ foldMap (foldMap embeddedSourceToMarkdown . embeddedSource) sources
         Example syntax -> do
-          pure [Md.InlineCode (Syntax.toPlainText syntax)]
+          pure [Md.InlineCode (Syntax.toPlain syntax)]
         ExampleBlock syntax -> do
-          pure [Md.CodeBlock "unison" (Syntax.toPlainText syntax)]
+          pure [Md.CodeBlock "unison" (Syntax.toPlain syntax)]
         Link syntax -> do
-          pure [Md.InlineCode (Syntax.toPlainText syntax)]
+          pure [Md.InlineCode (Syntax.toPlain syntax)]
         Signature signatures -> do
           signatures
-            & foldMap (pure @[] . Md.CodeBlock "unison" . Syntax.toPlainText)
+            & foldMap (pure @[] . Md.CodeBlock "unison" . Syntax.toPlain)
             & pure
         SignatureInline sig -> do
-          pure [Md.InlineCode $ Syntax.toPlainText sig]
+          pure [Md.InlineCode $ Syntax.toPlain sig]
         Eval source result -> do
           pure
             [ Md.CodeBlock
                 "unison"
                 ( Text.unlines
-                    [ Syntax.toPlainText source,
+                    [ Syntax.toPlain source,
                       "⧨",
-                      Syntax.toPlainText result
+                      Syntax.toPlain result
                     ]
                 )
             ]
@@ -223,9 +223,9 @@ toMarkdown_ doc =
           pure
             [ Md.CodeBlock "unison" $
                 Text.unlines
-                  [ Syntax.toPlainText source,
+                  [ Syntax.toPlain source,
                     "⧨",
-                    Syntax.toPlainText result
+                    Syntax.toPlain result
                   ]
             ]
         Video sources _attrs -> do
@@ -238,11 +238,11 @@ toMarkdown_ doc =
           pure [Md.CodeBlock "latex" latex]
         Svg {} -> do pure [Md.Txt "{inline svg}"]
         Embed syntax -> do
-          pure [Md.CodeBlock "unison" (Syntax.toPlainText syntax)]
+          pure [Md.CodeBlock "unison" (Syntax.toPlain syntax)]
         EmbedInline syntax -> do
-          pure [Md.InlineCode (Syntax.toPlainText syntax)]
+          pure [Md.InlineCode (Syntax.toPlain syntax)]
         RenderError (InvalidTerm err) -> do
-          pure [Md.Txt $ Syntax.toPlainText err]
+          pure [Md.Txt $ Syntax.toPlain err]
     Join docs -> do
       foldMapM toMarkdown_ docs
     UntitledSection docs -> do

--- a/unison-share-api/src/Unison/Server/Syntax.hs
+++ b/unison-share-api/src/Unison/Server/Syntax.hs
@@ -244,12 +244,9 @@ reference (Segment _ el) =
           _ -> Nothing
    in el >>= reference'
 
--- | Convert a `SyntaxText` to a `String`, ignoring syntax markup
-toPlainText :: SyntaxText -> Text
-toPlainText (AnnotatedText at) = Text.concat . toList $ segment <$> at
-
-toPlain :: SyntaxText -> String
-toPlain = Text.unpack . toPlainText
+-- | Convert a `SyntaxText` to a `Text`, ignoring syntax markup
+toPlain :: SyntaxText -> Text
+toPlain (AnnotatedText at) = Text.concat . toList $ segment <$> at
 
 -- HTML -----------------------------------------------------------------------
 

--- a/unison-share-api/src/Unison/Server/Syntax.hs
+++ b/unison-share-api/src/Unison/Server/Syntax.hs
@@ -245,11 +245,11 @@ reference (Segment _ el) =
    in el >>= reference'
 
 -- | Convert a `SyntaxText` to a `String`, ignoring syntax markup
-toPlain :: SyntaxText -> String
-toPlain (AnnotatedText at) = join (toList $ segment <$> at)
-
 toPlainText :: SyntaxText -> Text
-toPlainText = Text.pack . toPlain
+toPlainText (AnnotatedText at) = Text.concat . toList $ segment <$> at
+
+toPlain :: SyntaxText -> String
+toPlain = Text.unpack . toPlainText
 
 -- HTML -----------------------------------------------------------------------
 
@@ -276,10 +276,8 @@ nameToHtml name =
       List.intersperse sep segments
 
 segmentToHtml :: SyntaxSegment -> Html ()
-segmentToHtml (Segment segmentText element) =
-  let sText = Text.pack segmentText
-
-      el = fromMaybe Blank element
+segmentToHtml (Segment sText element) =
+  let el = fromMaybe Blank element
 
       ref =
         case el of

--- a/unison-share-api/src/Unison/Server/Types.hs
+++ b/unison-share-api/src/Unison/Server/Types.hs
@@ -293,9 +293,9 @@ data SemanticSyntaxDiff a
   = OnlyThisSide (NonEmpty (Segment a))
   | Both (NonEmpty (Segment a))
   | --  (fromSegment, toSegment) (shared annotation)
-    SegmentChange (String, String) (Maybe a)
+    SegmentChange (Text, Text) (Maybe a)
   | -- (shared segment) (fromAnnotation, toAnnotation)
-    AnnotationChange String (Maybe a, Maybe a)
+    AnnotationChange Text (Maybe a, Maybe a)
   deriving (Eq, Show, Ord, Generic)
 
 deriving instance (ToSchema a) => ToSchema (SemanticSyntaxDiff a)

--- a/unison-share-api/tests/Unison/Test/Server/Backend/DefinitionDiff.hs
+++ b/unison-share-api/tests/Unison/Test/Server/Backend/DefinitionDiff.hs
@@ -90,7 +90,6 @@ textToSegment txt =
       ( \t ->
           t
             & Text.splitOn " "
-            & fmap (Text.unpack)
             & fmap \case
               "" -> Nothing
               w -> Just (Segment w Nothing)
@@ -202,7 +201,7 @@ unchangedDefinition = 1                 | unchangedDefinition = 1
 renderDiffText :: [Changed [Paired (Segment a)]] -> Text
 renderDiffText diffs =
   let renderSegment :: Segment a -> Text
-      renderSegment (Segment {segment}) = Text.pack segment
+      renderSegment (Segment {segment}) = segment
       renderPaired :: Paired (Segment a) -> Text
       renderPaired (OneSided s) = "{" <> renderSegment s <> "}"
       renderPaired (Paired s1 _) = renderSegment s1


### PR DESCRIPTION
## Overview

Sorry, I know this is annoying and spans a big chunk of the codebase.

Switches a bunch of stuff from String -> Text;
We're still using `String` in a lot of low-level stuff, which is going to be inefficient both in memory and cpu when doing a bunch of text munging.

Specifically I wanted to switch AnnotatedText to actually use Text so I can use Text primitives when working with it (without needing to switch back and forth a bunch).

I'll be building some of the diffing improvements on top of this.

## Implementation notes

* Switch AnnotatedText to use Text, then propagate that out to natural stopping points.
* I didn't push it all the way out, but went as far as I reasonably coul.

## Test coverage

Existing tests
