### PR TITLE
disable nix development cache job due to failures

### DIFF
--- a/.github/workflows/nix-dev-cache.yaml
+++ b/.github/workflows/nix-dev-cache.yaml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-24.04
+          # - ubuntu-24.04 disabling this because it's been failing for a while
           # - ubuntu-24.04-arm https://github.com/unisonweb/unison/issues/5789
           - macos-13
           - macos-15


### PR DESCRIPTION
can re-add it if we can figure out how to make it pass normally :)