### PR TITLE
Add support for quoted UCM args.

### DIFF
--- a/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
+++ b/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
@@ -50,6 +50,7 @@ import Unison.Codebase.Verbosity qualified as Verbosity
 import Unison.CommandLine
 import Unison.CommandLine.FuzzySelect qualified as Fuzzy
 import Unison.CommandLine.InputPattern (aliases, patternName)
+import Unison.CommandLine.InputPattern qualified as IP
 import Unison.CommandLine.InputPatterns qualified as IP
 import Unison.CommandLine.OutputMessages (notifyNumbered, notifyUser, showIssueUrl)
 import Unison.CommandLine.Welcome (asciiartUnison)
@@ -341,7 +342,7 @@ run isTest verbosity codebase runtime sbRuntime ucmVersion baseURL authenticated
                 atomically . Q.undequeue cmdQueue $ Just p
                 pure $ Right switchCommand
               Nothing -> do
-                case words . Text.unpack $ lineTxt of
+                case fromMaybe [] $ IP.parseArgs (Text.unpack lineTxt) of
                   [] -> Cli.returnEarlyWithoutOutput
                   args -> do
                     liftIO $ outputUcmLine p

--- a/unison-cli/src/Unison/CommandLine/Completion.hs
+++ b/unison-cli/src/Unison/CommandLine/Completion.hs
@@ -90,15 +90,19 @@ haskelineTabComplete patterns codebase authedHTTPClient ppCtx = \(beforeCursorRe
         let completions = exactComplete cmdPrefix $ Map.keys patterns
         pure (prefix, completions)
       ((cmd : midArgs), lastArgStr) -> do
-        let requote = case lastArg of
-              Left _ -> \str -> "\"" <> str <> "\""
-              Right _ -> id
+        let requote completion =
+              let newReplacement = case lastArg of
+                    Left _ | completion.isFinished -> "\"" <> completion.replacement <> "\""
+                    Left (_, False) -> "\"" <> completion.replacement <> "\""
+                    Left (_, True) -> "\"" <> completion.replacement
+                    Right _ -> completion.replacement
+               in completion {Line.replacement = newReplacement}
         p <- hoistMaybe $ Map.lookup (argStr cmd) patterns
         paramType <- hoistMaybe $ IP.paramType (IP.params p) (length midArgs)
         completions <-
           lift $
             IP.suggestions paramType lastArgStr codebase authedHTTPClient ppCtx
-              <&> fmap (\completion -> completion {Line.replacement = requote (Line.replacement completion)})
+              <&> fmap requote
         pure (prefix, completions)
   where
     argStr :: Either (String, Bool) String -> String

--- a/unison-cli/src/Unison/CommandLine/Completion.hs
+++ b/unison-cli/src/Unison/CommandLine/Completion.hs
@@ -25,7 +25,6 @@ where
 import Control.Lens
 import Data.Aeson (FromJSON)
 import Data.Aeson qualified as Aeson
-import Data.Char qualified as Char
 import Data.List (isPrefixOf)
 import Data.List qualified as List
 import Data.List.Extra (nubOrdOn)
@@ -40,7 +39,6 @@ import System.Console.Haskeline qualified as Line
 import System.Console.Haskeline.Completion (Completion)
 import System.Console.Haskeline.Completion qualified as Haskeline
 import Text.Megaparsec qualified as MP
-import Text.Megaparsec.Char qualified as MP
 import U.Codebase.Branch qualified as V2Branch
 import U.Codebase.Causal qualified as V2Causal
 import U.Codebase.Reference qualified as Reference
@@ -75,72 +73,36 @@ haskelineTabComplete ::
   Line.CompletionFunc m
 haskelineTabComplete patterns codebase authedHTTPClient ppCtx = \(beforeCursorRev, _afterCursor) ->
   fmap (fromMaybe (beforeCursorRev, [])) $ runMaybeT $ do
-    args <- hoistMaybe (MP.parseMaybe argsP beforeCursorRev)
+    args <- hoistMaybe $ IP.parseArgsQuoted (reverse beforeCursorRev)
     (prefixArgs, lastArg) <- hoistMaybe $ unsnoc args
     let prefix =
           prefixArgs
             <&> ( \case
-                    Left (txt, False) -> "\"" <> Text.unpack txt <> "\""
-                    Left (txt, True) -> "\"" <> Text.unpack txt
-                    Right txt -> Text.unpack txt
+                    Left (txt, False) -> "\"" <> txt <> "\""
+                    Left (txt, True) -> "\"" <> txt
+                    Right txt -> txt
                 )
             & unwords
             & reverse
+            & (" " <>)
     case (prefixArgs, argStr lastArg) of
       ([], cmdPrefix) -> do
         let completions = exactComplete cmdPrefix $ Map.keys patterns
         pure (prefix, completions)
-      ((cmd : midArgs), lastArg) -> do
+      ((cmd : midArgs), lastArgStr) -> do
+        let requote = case lastArg of
+              Left _ -> \str -> "\"" <> str <> "\""
+              Right _ -> id
         p <- hoistMaybe $ Map.lookup (argStr cmd) patterns
-        paramType <- hoistMaybe $ IP.paramType (IP.params p) (length midArgs + 1)
-        completions <- lift $ IP.suggestions paramType lastArg codebase authedHTTPClient ppCtx
+        paramType <- hoistMaybe $ IP.paramType (IP.params p) (length midArgs)
+        completions <-
+          lift $
+            IP.suggestions paramType lastArgStr codebase authedHTTPClient ppCtx
+              <&> fmap (\completion -> completion {Line.replacement = requote (Line.replacement completion)})
         pure (prefix, completions)
   where
-    argStr :: Either (Text, Bool) Text -> String
-    argStr = Text.unpack . either fst id
-
-type Parser = MP.Parsec Void String
-
--- | Parser for a single CLI argument, which may be a single word, or a quoted string.
---
--- Also handles backslash-escaped quotes within quoted strings.
-argP :: Parser (Either (Text, Bool) Text)
-argP = do
-  MP.try (Left <$> quotedP) MP.<|> (Right <$> unquotedP)
-  where
-    escapedQuote :: Parser Char
-    escapedQuote = do
-      _ <- MP.char '\\'
-      MP.char '"'
-
-    quotedP :: Parser (Text, Bool)
-    quotedP = do
-      _ <- MP.char '"'
-      (content, hasUnterminatedQuote) <-
-        MP.manyTill_
-          (escapedQuote <|> MP.anySingle)
-          -- Treat EOF as closing quote so completion still functions on unterminated quotes
-          (((MP.char '"') $> False) <|> (MP.eof $> True))
-      pure $ (Text.pack content, hasUnterminatedQuote)
-    unquotedP :: Parser (Text)
-    unquotedP = do
-      Text.pack <$> MP.some (MP.satisfy (not . Char.isSpace))
-
--- >>> MP.parseMaybe argsP "one two three"
--- Just [Right "one",Right "two",Right "three"]
---
--- >>> MP.parseMaybe argsP "\"one two\" three"
--- Just [Left ("one two",False),Right "three"]
---
--- >>> MP.parseMaybe argsP "one    two    three"
--- Just [Right "one",Right "two",Right "three"]
---
--- Unfinished quote should auto-close quote at end of input, but indicate that it was unterminated
--- >>> MP.parseMaybe argsP "one two \"three four"
--- Just [Right "one",Right "two",Left ("three four",True)]
-argsP :: Parser [Either (Text, Bool) Text]
-argsP = do
-  MP.sepBy argP MP.space
+    argStr :: Either (String, Bool) String -> String
+    argStr = either fst id
 
 -- | Things which we may want to complete for.
 data CompletionType

--- a/unison-cli/src/Unison/CommandLine/Completion.hs
+++ b/unison-cli/src/Unison/CommandLine/Completion.hs
@@ -40,7 +40,6 @@ import System.Console.Haskeline qualified as Line
 import System.Console.Haskeline.Completion (Completion)
 import System.Console.Haskeline.Completion qualified as Haskeline
 import Text.Megaparsec qualified as MP
-import Text.Megaparsec qualified as P
 import Text.Megaparsec.Char qualified as MP
 import U.Codebase.Branch qualified as V2Branch
 import U.Codebase.Causal qualified as V2Causal
@@ -74,58 +73,74 @@ haskelineTabComplete ::
   AuthenticatedHttpClient ->
   PP.ProjectPath ->
   Line.CompletionFunc m
-haskelineTabComplete patterns codebase authedHTTPClient ppCtx = Line.completeWordWithPrev Nothing " " $ \prev word ->
-  -- User hasn't finished a command name, complete from command names
-  if null prev
-    then pure . exactComplete word $ Map.keys patterns
-    else -- User has finished a command name; use completions for that command
-      case words $ reverse prev of
-        h : t -> fromMaybe (pure []) $ do
-          p <- Map.lookup h patterns
-          paramType <- IP.paramType (IP.params p) (length t)
-          pure $ IP.suggestions paramType word codebase authedHTTPClient ppCtx
-        _ -> pure []
+haskelineTabComplete patterns codebase authedHTTPClient ppCtx = \(beforeCursorRev, _afterCursor) ->
+  fmap (fromMaybe (beforeCursorRev, [])) $ runMaybeT $ do
+    args <- hoistMaybe (MP.parseMaybe argsP beforeCursorRev)
+    (prefixArgs, lastArg) <- hoistMaybe $ unsnoc args
+    let prefix =
+          prefixArgs
+            <&> ( \case
+                    Left (txt, False) -> "\"" <> Text.unpack txt <> "\""
+                    Left (txt, True) -> "\"" <> Text.unpack txt
+                    Right txt -> Text.unpack txt
+                )
+            & unwords
+            & reverse
+    case (prefixArgs, argStr lastArg) of
+      ([], cmdPrefix) -> do
+        let completions = exactComplete cmdPrefix $ Map.keys patterns
+        pure (prefix, completions)
+      ((cmd : midArgs), lastArg) -> do
+        p <- hoistMaybe $ Map.lookup (argStr cmd) patterns
+        paramType <- hoistMaybe $ IP.paramType (IP.params p) (length midArgs + 1)
+        completions <- lift $ IP.suggestions paramType lastArg codebase authedHTTPClient ppCtx
+        pure (prefix, completions)
+  where
+    argStr :: Either (Text, Bool) Text -> String
+    argStr = Text.unpack . either fst id
 
 type Parser = MP.Parsec Void String
 
 -- | Parser for a single CLI argument, which may be a single word, or a quoted string.
 --
 -- Also handles backslash-escaped quotes within quoted strings.
-argP :: Parser Text
+argP :: Parser (Either (Text, Bool) Text)
 argP = do
-  MP.try quotedP MP.<|> unquotedP
+  MP.try (Left <$> quotedP) MP.<|> (Right <$> unquotedP)
   where
     escapedQuote :: Parser Char
     escapedQuote = do
       _ <- MP.char '\\'
       MP.char '"'
 
-    quotedP :: Parser Text
+    quotedP :: Parser (Text, Bool)
     quotedP = do
       _ <- MP.char '"'
-      content <-
-        MP.manyTill
+      (content, hasUnterminatedQuote) <-
+        MP.manyTill_
           (escapedQuote <|> MP.anySingle)
           -- Treat EOF as closing quote so completion still functions on unterminated quotes
-          (void (MP.char '"') <|> MP.eof)
-      pure $ Text.pack content
-    unquotedP :: Parser Text
-    unquotedP = Text.pack <$> MP.some (MP.satisfy (not . Char.isSpace))
+          (((MP.char '"') $> False) <|> (MP.eof $> True))
+      pure $ (Text.pack content, hasUnterminatedQuote)
+    unquotedP :: Parser (Text)
+    unquotedP = do
+      Text.pack <$> MP.some (MP.satisfy (not . Char.isSpace))
 
 -- >>> MP.parseMaybe argsP "one two three"
--- Just ["one","two","three"]
+-- Just [Right "one",Right "two",Right "three"]
 --
 -- >>> MP.parseMaybe argsP "\"one two\" three"
--- Just ["one two","three"]
+-- Just [Left ("one two",False),Right "three"]
 --
 -- >>> MP.parseMaybe argsP "one    two    three"
--- Just ["one","two","three"]
+-- Just [Right "one",Right "two",Right "three"]
 --
--- Unfinished quote should auto-close quote at end of input
+-- Unfinished quote should auto-close quote at end of input, but indicate that it was unterminated
 -- >>> MP.parseMaybe argsP "one two \"three four"
--- Just ["one","two","three four"]
-argsP :: Parser [Text]
-argsP = MP.sepBy argP MP.space
+-- Just [Right "one",Right "two",Left ("three four",True)]
+argsP :: Parser [Either (Text, Bool) Text]
+argsP = do
+  MP.sepBy argP MP.space
 
 -- | Things which we may want to complete for.
 data CompletionType
@@ -300,7 +315,7 @@ completeWithinNamespace compTypes query ppCtx = do
 -- (base,"List")
 parseLaxPath'Query :: Text -> (Path.Path', Text)
 parseLaxPath'Query txt =
-  case P.runParser ((,) <$> Path.splitP' <*> P.takeRest) "" (Text.unpack txt) of
+  case MP.runParser ((,) <$> Path.splitP' <*> MP.takeRest) "" (Text.unpack txt) of
     Left _err -> (Path.Current', txt)
     Right (name, rest) ->
       if take 1 rest == "."

--- a/unison-cli/src/Unison/CommandLine/Completion.hs
+++ b/unison-cli/src/Unison/CommandLine/Completion.hs
@@ -25,6 +25,7 @@ where
 import Control.Lens
 import Data.Aeson (FromJSON)
 import Data.Aeson qualified as Aeson
+import Data.Char qualified as Char
 import Data.List (isPrefixOf)
 import Data.List qualified as List
 import Data.List.Extra (nubOrdOn)
@@ -38,7 +39,9 @@ import Network.URI qualified as URI
 import System.Console.Haskeline qualified as Line
 import System.Console.Haskeline.Completion (Completion)
 import System.Console.Haskeline.Completion qualified as Haskeline
+import Text.Megaparsec qualified as MP
 import Text.Megaparsec qualified as P
+import Text.Megaparsec.Char qualified as MP
 import U.Codebase.Branch qualified as V2Branch
 import U.Codebase.Causal qualified as V2Causal
 import U.Codebase.Reference qualified as Reference
@@ -76,12 +79,53 @@ haskelineTabComplete patterns codebase authedHTTPClient ppCtx = Line.completeWor
   if null prev
     then pure . exactComplete word $ Map.keys patterns
     else -- User has finished a command name; use completions for that command
-    case words $ reverse prev of
-      h : t -> fromMaybe (pure []) $ do
-        p <- Map.lookup h patterns
-        paramType <- IP.paramType (IP.params p) (length t)
-        pure $ IP.suggestions paramType word codebase authedHTTPClient ppCtx
-      _ -> pure []
+      case words $ reverse prev of
+        h : t -> fromMaybe (pure []) $ do
+          p <- Map.lookup h patterns
+          paramType <- IP.paramType (IP.params p) (length t)
+          pure $ IP.suggestions paramType word codebase authedHTTPClient ppCtx
+        _ -> pure []
+
+type Parser = MP.Parsec Void String
+
+-- | Parser for a single CLI argument, which may be a single word, or a quoted string.
+--
+-- Also handles backslash-escaped quotes within quoted strings.
+argP :: Parser Text
+argP = do
+  MP.try quotedP MP.<|> unquotedP
+  where
+    escapedQuote :: Parser Char
+    escapedQuote = do
+      _ <- MP.char '\\'
+      MP.char '"'
+
+    quotedP :: Parser Text
+    quotedP = do
+      _ <- MP.char '"'
+      content <-
+        MP.manyTill
+          (escapedQuote <|> MP.anySingle)
+          -- Treat EOF as closing quote so completion still functions on unterminated quotes
+          (void (MP.char '"') <|> MP.eof)
+      pure $ Text.pack content
+    unquotedP :: Parser Text
+    unquotedP = Text.pack <$> MP.some (MP.satisfy (not . Char.isSpace))
+
+-- >>> MP.parseMaybe argsP "one two three"
+-- Just ["one","two","three"]
+--
+-- >>> MP.parseMaybe argsP "\"one two\" three"
+-- Just ["one two","three"]
+--
+-- >>> MP.parseMaybe argsP "one    two    three"
+-- Just ["one","two","three"]
+--
+-- Unfinished quote should auto-close quote at end of input
+-- >>> MP.parseMaybe argsP "one two \"three four"
+-- Just ["one","two","three four"]
+argsP :: Parser [Text]
+argsP = MP.sepBy argP MP.space
 
 -- | Things which we may want to complete for.
 data CompletionType

--- a/unison-cli/src/Unison/CommandLine/InputPattern.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPattern.hs
@@ -33,6 +33,7 @@ import Control.Lens
 import Data.Char qualified as Char
 import Data.List.Extra qualified as List
 import Data.List.NonEmpty (NonEmpty (..))
+import Data.Text qualified as Text
 import System.Console.Haskeline qualified as Line
 import Text.Megaparsec qualified as MP
 import Text.Megaparsec.Char qualified as MP
@@ -241,12 +242,14 @@ type Parser = MP.Parsec Void String
 
 parseArgs :: String -> Maybe [String]
 parseArgs input =
-  fmap (either fst id) <$> MP.parseMaybe argsP input
+  fmap (either fst id) <$> parseArgsQuoted input
 
 -- | Like `parseArgs`, but indicates whether each argument was quoted, and also whether the quote was terminated..
 -- This is for things like tab-completion where the original string is important.
 parseArgsQuoted :: String -> Maybe [Either (String, Bool) String]
-parseArgsQuoted input = MP.parseMaybe argsP input
+parseArgsQuoted input = MP.parseMaybe argsP (strip input)
+  where
+    strip = Text.unpack . Text.strip . Text.pack
 
 -- | Parser for a single CLI argument, which may be a single word, or a quoted string.
 --

--- a/unison-cli/src/Unison/CommandLine/InputPattern.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPattern.hs
@@ -17,6 +17,10 @@ module Unison.CommandLine.InputPattern
     FZFResolver (..),
     Visibility (..),
 
+    -- * Parse Arguments
+    parseArgs,
+    parseArgsQuoted,
+
     -- * Currently Unused
     minArgs,
     maxArgs,
@@ -26,9 +30,12 @@ module Unison.CommandLine.InputPattern
 where
 
 import Control.Lens
+import Data.Char qualified as Char
 import Data.List.Extra qualified as List
 import Data.List.NonEmpty (NonEmpty (..))
 import System.Console.Haskeline qualified as Line
+import Text.Megaparsec qualified as MP
+import Text.Megaparsec.Char qualified as MP
 import Unison.Auth.HTTPClient (AuthenticatedHttpClient)
 import Unison.Codebase (Codebase)
 import Unison.Codebase.Editor.Input (Input (..))
@@ -229,3 +236,55 @@ suggestionFallbacks suggesters inp codebase httpClient path = go suggesters
         then go rest
         else pure suggestions
     go [] = pure []
+
+type Parser = MP.Parsec Void String
+
+parseArgs :: String -> Maybe [String]
+parseArgs input =
+  fmap (either fst id) <$> MP.parseMaybe argsP input
+
+-- | Like `parseArgs`, but indicates whether each argument was quoted, and also whether the quote was terminated..
+-- This is for things like tab-completion where the original string is important.
+parseArgsQuoted :: String -> Maybe [Either (String, Bool) String]
+parseArgsQuoted input = MP.parseMaybe argsP input
+
+-- | Parser for a single CLI argument, which may be a single word, or a quoted string.
+--
+-- Also handles backslash-escaped quotes within quoted strings.
+argP :: Parser (Either (String, Bool) String)
+argP = do
+  MP.try (Left <$> quotedP) MP.<|> (Right <$> unquotedP)
+  where
+    escapedQuote :: Parser Char
+    escapedQuote = do
+      _ <- MP.char '\\'
+      MP.char '"'
+
+    quotedP :: Parser (String, Bool)
+    quotedP = do
+      _ <- MP.char '"'
+      (content, hasUnterminatedQuote) <-
+        MP.manyTill_
+          (escapedQuote <|> MP.anySingle)
+          -- Treat EOF as closing quote so completion still functions on unterminated quotes
+          (((MP.char '"') $> False) <|> (MP.eof $> True))
+      pure $ (content, hasUnterminatedQuote)
+    unquotedP :: Parser String
+    unquotedP = do
+      MP.some (MP.satisfy (not . Char.isSpace))
+
+-- >>> MP.parseMaybe argsP "one two three"
+-- Just [Right "one",Right "two",Right "three"]
+--
+-- >>> MP.parseMaybe argsP "\"one two\" three"
+-- Just [Left ("one two",False),Right "three"]
+--
+-- >>> MP.parseMaybe argsP "one    two    three"
+-- Just [Right "one",Right "two",Right "three"]
+--
+-- Unfinished quote should auto-close quote at end of input, but indicate that it was unterminated
+-- >>> MP.parseMaybe argsP "one two \"three four"
+-- Just [Right "one",Right "two",Left ("three four",True)]
+argsP :: Parser [Either (String, Bool) String]
+argsP = do
+  MP.sepBy argP MP.space

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -122,11 +122,19 @@ getUserInput codebase authHTTPClient pp currentProjectRoot numberedArgs =
                 go
               Right (Just (expandedArgs, i)) -> do
                 let expandedArgs' = IP.unifyArgument <$> expandedArgs
-                    expandedArgsStr = unwords expandedArgs'
+                    expandedArgsStr =
+                      expandedArgs'
+                        <&> requote
+                        & unwords
                 when (expandedArgs' /= ws) $ do
                   liftIO . Text.putStrLn $ fullPrompt <> Text.pack expandedArgsStr
                 Line.modifyHistory $ Line.addHistoryUnlessConsecutiveDupe expandedArgsStr
                 pure i
+    requote :: String -> String
+    requote s =
+      if elem ' ' s
+        then "\"" <> s <> "\""
+        else s
     settings :: Line.Settings IO
     settings =
       Line.Settings

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -40,6 +40,7 @@ import Unison.Codebase.ProjectPath qualified as PP
 import Unison.Codebase.Watch qualified as Watch
 import Unison.CommandLine
 import Unison.CommandLine.Completion (haskelineTabComplete)
+import Unison.CommandLine.InputPattern qualified as IP
 import Unison.CommandLine.InputPatterns qualified as IP
 import Unison.CommandLine.OutputMessages (fetchIssueFromGitHub, notifyNumbered, notifyUser)
 import Unison.CommandLine.Types (ShouldWatchFiles (..))
@@ -106,7 +107,7 @@ getUserInput codebase authHTTPClient pp currentProjectRoot numberedArgs =
       line <- Line.getInputLine $ Text.unpack fullPrompt
       case line of
         Nothing -> pure QuitI
-        Just l -> case words l of
+        Just l -> case fromMaybe [] $ IP.parseArgs l of
           [] -> go
           ws -> do
             liftIO (parseInput codebase pp currentProjectRoot numberedArgs IP.patternMap ws) >>= \case

--- a/unison-src/transcripts/idempotent/input-parsing.md
+++ b/unison-src/transcripts/idempotent/input-parsing.md
@@ -1,0 +1,31 @@
+Should parse quoted arguments as expected.
+
+``` ucm
+scratch/main> builtins.mergeio
+
+  Done.
+```
+
+``` unison
+main = do
+  getArgs.impl ()
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  + main : '{IO} Either Failure [Text]
+
+  Run `update` to apply these changes to your codebase.
+```
+
+``` ucm
+scratch/main> run main "all one arg" "contains escaped \" quote" second third
+
+  Right
+    [ "all one arg"
+    , "contains escaped \" quote"
+    , "second"
+    , "third"
+    ]
+```

--- a/unison-src/transcripts/idempotent/tab-completion.md
+++ b/unison-src/transcripts/idempotent/tab-completion.md
@@ -230,3 +230,12 @@ myproject/main> debug.tab-complete merge mybr
 
    /mybranch
 ```
+
+# Tab complete quoted string
+
+``` ucm
+scratch/main> debug.tab-complete "vi
+
+   view
+   view.global
+```


### PR DESCRIPTION
## Overview

Allows passing quoted args to ucm commands.

Motivated by the desire to use this for `config.set-author` and `annotate`

fixes https://github.com/unisonweb/unison/issues/5417


https://github.com/user-attachments/assets/39790bc7-2363-47df-8db2-163f68b65f9f



## Implementation notes

* Adds a custom megaparsec parser for parsing line-reader args
* Rewrite the basic completion handler entirely to correctly respect quoted args
* Some fixups for quoted args in history

## Interesting/controversial decisions

There is a [`completeQuotedWord`](https://hackage-content.haskell.org/package/haskeline-0.8.4.1/docs/System-Console-Haskeline-Completion.html#v:completeQuotedWord) in Haskeline, but it doesn't provide the line prefix (which we need for determining the command).
Plus, writing our own parser means we can be consistent between the line parser and the completion parser.

## Test coverage

Added a transcript for completion and a simple unison prog which demos quoted args to `run`.

## Loose ends

* Should probably skip argument expansion on quoted args so that we can finally pass numbers as arguments to `run` haha

I'm sure we'll find some more tweaks for this in the future, but shouldn't be hard to add those as they come up.