### PR TITLE
slurp unnamed test watches properly

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Load.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Load.hs
@@ -76,7 +76,8 @@ import Unison.Util.Relation (Relation)
 import Unison.Util.Relation qualified as Relation
 import Unison.Util.Timing qualified as Timing
 import Unison.Var qualified as Var
-import Unison.WatchKind qualified as WK
+import Unison.WatchKind (WatchKind)
+import Unison.WatchKind qualified as WatchKind
 
 handleLoad :: Maybe FilePath -> Cli ()
 handleLoad maybePath = do
@@ -246,11 +247,38 @@ slurpTerms codebase unisonFile isUpdate =
         Just (ConstructorReference _ conId, decl) ->
           pure (DataDeclaration.expectTypeOfConstructor (DataDeclaration.asDataDecl decl) conId)
         Nothing -> Codebase.expectTypeOfConstructor codebase ref
+
     getNewRefType :: Name -> TermReference -> Sqlite.Transaction (Type Symbol Ann)
     getNewRefType name ref =
       case Map.lookup (Name.toVar name) (UF.hashTermsId unisonFile) of
         Just (_, _, _, _, ty) -> pure ty
-        Nothing -> Codebase.expectTypeOfTerm codebase ref
+        Nothing ->
+          -- This is super unlikely in practice (but has been observed in a transcript) - the term name matches an
+          -- unnamed test watch's generated name. In this case, the map lookup above (by Name.toVar name) won't find the
+          -- unnamed test watch, as it has a var type of UnnamedWatch, not User.
+          case Map.lookup name unnamedTestWatchesByName of
+            Nothing -> Codebase.expectTypeOfTerm codebase ref
+            Just ty -> pure ty
+
+    unnamedTestWatchesByName :: Map Name (Type Symbol Ann)
+    unnamedTestWatchesByName =
+      foldr f Map.empty unisonFile.watchComponents
+      where
+        f ::
+          (WatchKind, [(Symbol, Ann, Term Symbol Ann, Type Symbol Ann)]) ->
+          Map Name (Type Symbol Ann) ->
+          Map Name (Type Symbol Ann)
+        f (WatchKind.TestWatch, component) acc = foldr g acc component
+        f _ acc = acc
+
+        g ::
+          (Symbol, Ann, Term Symbol Ann, Type Symbol Ann) ->
+          Map Name (Type Symbol Ann) ->
+          Map Name (Type Symbol Ann)
+        g (var, _, _, ty) acc =
+          case Var.typeOf var of
+            Var.UnnamedWatch _ _ -> Map.insert (Name.unsafeParseVar var) ty acc
+            _ -> acc
 
 slurpTypes ::
   Codebase m Symbol Ann ->
@@ -427,7 +455,7 @@ evalUnisonFile ::
     ( Either
         Error
         ( [(Symbol, Term Symbol ())],
-          Map Symbol (Ann, WK.WatchKind, Reference.Id, Term Symbol (), Term Symbol (), Bool)
+          Map Symbol (Ann, WatchKind, Reference.Id, Term Symbol (), Term Symbol (), Bool)
         )
     )
 evalUnisonFile mode ppe unisonFile args = do

--- a/unison-src/transcripts/idempotent/builtins.md
+++ b/unison-src/transcripts/idempotent/builtins.md
@@ -524,6 +524,10 @@ test> checks [
       ]
 ```
 
+``` ucm :hide
+> add
+```
+
 ## `Any` functions
 
 ``` unison
@@ -884,17 +888,18 @@ Now that all the tests have been added to the codebase, let's view the test repo
     25. Sandbox.test1                       ◉ Passed
     26. Sandbox.test2                       ◉ Passed
     27. Sandbox.test3                       ◉ Passed
-    28. test.ebobca6b0t                     ◉ Passed
-    29. Text.tests.alignment                ◉ Passed
-    30. Text.tests.indexOf                  ◉ Passed
-    31. Text.tests.indexOfEmoji             ◉ Passed
-    32. Text.tests.literalsEq               ◉ Passed
-    33. Text.tests.patterns                 ◉ Passed
-    34. Text.tests.repeat                   ◉ Passed
-    35. Text.tests.takeDropAppend           ◉ Passed
-    36. Universal.murmurHash.tests          ◉ Passed
+    28. test.dtrliu8iuq                     ◉ Passed
+    29. test.ebobca6b0t                     ◉ Passed
+    30. Text.tests.alignment                ◉ Passed
+    31. Text.tests.indexOf                  ◉ Passed
+    32. Text.tests.indexOfEmoji             ◉ Passed
+    33. Text.tests.literalsEq               ◉ Passed
+    34. Text.tests.patterns                 ◉ Passed
+    35. Text.tests.repeat                   ◉ Passed
+    36. Text.tests.takeDropAppend           ◉ Passed
+    37. Universal.murmurHash.tests          ◉ Passed
 
-  ✅ 36 test(s) passing
+  ✅ 37 test(s) passing
 
   Tip: Use view 1 to view the source of a test.
 ```


### PR DESCRIPTION
## Overview

This PR fixes a small bug in slurp related to unnamed test watches. Previously, we assumed that, when trying to resolve a term by `Name` to its type, its `Name.toVar name` would either be found in the latest typechecked unison file, else it'd be in the codebase.

Now, between those two, we check whether it exists as an unnamed test watch in the latest typechecked unison file (whose generated `Name`, i.e. `test.<guid>`, matches the name we're looking for.

I also amended `builtins.md` to include a test that looks like it was accidentally omitted.

## Test coverage

I tested this change manually by merging into https://github.com/unisonweb/unison/pull/5962 where the bug was observed. I don't entirely have an explanation for why that branch was hitting this error but trunk wasn't, as the changes to the load logic are superficial.