### PR TITLE
Fix a runtime problem from overapplying ability requests

### DIFF
--- a/unison-runtime/src/Unison/Runtime/Machine.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine.hs
@@ -881,8 +881,8 @@ repush !yld env !activeThreads !stk (HEnv aenv denv0) = go denv0
       -- Pending arguments. The continuation argument must be a function
       -- to be applied to them.
       | asize stk > 0 =
-          peek stk >>=
-            apply yld env henv activeThreads stk k False ZArgs
+          peek stk
+            >>= apply yld env henv activeThreads stk k False ZArgs
       | otherwise = yield yld env henv activeThreads stk k
       where
         henv = HEnv aenv denv

--- a/unison-runtime/src/Unison/Runtime/Machine.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine.hs
@@ -877,7 +877,15 @@ repush ::
   IO ()
 repush !yld env !activeThreads !stk (HEnv aenv denv0) = go denv0
   where
-    go !denv KE !k = yield yld env (HEnv aenv denv) activeThreads stk k
+    go !denv KE !k
+      -- Pending arguments. The continuation argument must be a function
+      -- to be applied to them.
+      | asize stk > 0 =
+          peek stk >>=
+            apply yld env henv activeThreads stk k False ZArgs
+      | otherwise = yield yld env henv activeThreads stk k
+      where
+        henv = HEnv aenv denv
     go !denv (Mark a ps cs sk) !k = go denv' sk $ Mark a ps cs' k
       where
         denv' = cs <> EC.withoutKeys denv ps

--- a/unison-src/transcripts/idempotent/fix5947.md
+++ b/unison-src/transcripts/idempotent/fix5947.md
@@ -1,0 +1,135 @@
+Test case for bad behavior of over-applied ability requests.
+Unfortunately I haven't found a simpler example than this. *Just*
+overapplying any ability isn't good enough, it requires some more
+complicated stuff to be going on.
+
+``` ucm :hide
+scratch/main> builtins.merge
+```
+
+``` unison
+structural ability Store a where
+  put : a -> ()
+  get : a
+
+structural ability Stream e where
+  emit : e -> ()
+
+structural ability Each where
+  lazily : '{Stream a} () ->{Each} a
+
+Store.modify : (a ->{g} a) ->{g, Store a} ()
+Store.modify f = put (f get)
+
+List.range start stopEx =
+  go i acc =
+    if i < stopEx
+    then go (i+1) (acc :+ i)
+    else acc
+  go 0 []
+
+withInitialValue : a -> '{g, Store a} v ->{g} v
+withInitialValue init thunk =
+  handle thunk()
+  with cases
+    {v} -> v
+    {Store.get -> k} ->
+      withInitialValue init do k init
+    {Store.put v -> k} ->
+      withInitialValue v do k ()
+
+Stream.consume : '{g, Stream a} r ->{g} r
+Stream.consume th =
+  handle th()
+  with cases
+    {r} -> r
+    {emit _ -> k} -> Stream.consume k
+
+Stream.flatMap :
+  (a ->{g, Stream b} r) -> '{g, Stream a} r -> '{g, Stream b} r
+Stream.flatMap f s = do
+  Stream.flatMap! f s
+
+Stream.flatMap! :
+  (a ->{g, Stream b} r) -> '{g, Stream a} r ->{g, Stream b} r
+Stream.flatMap! f s = handle s() with cases
+  {r} -> r
+  {emit e -> k} ->
+    _ = f e
+    flatMap! f k
+
+Stream.fromList : [a] -> '{Stream a} ()
+Stream.fromList l = do List.foreach emit l
+
+Each.run : '{g, Each} a ->{g} ()
+Each.run g =
+  handle g()
+  with cases
+    {_} -> ()
+    {lazily s -> k} ->
+      Stream.consume (Stream.flatMap (a -> toStream! do k a) s)
+
+Each.each : [a] ->{Each} a
+Each.each as = lazily (Stream.fromList as)
+
+toStream! : '{g, Each} a ->{g, Stream a} ()
+toStream! a =
+  handle a()
+  with cases
+    {a} -> emit a
+    {lazily s -> k} -> flatMap! (a -> toStream! do k a) s
+
+List.map : (a ->{g} b) -> [a] ->{g} [b]
+List.map f =
+  go acc = cases
+    a +: as -> go (acc :+ f a) as
+    [] -> acc
+  go []
+
+List.foreach : (a ->{g} b) -> [a] ->{g} ()
+List.foreach f = cases
+  [] -> ()
+  a +: as ->
+    _ = f a
+    List.foreach f as
+
+repro = do
+  update n = do Store.modify (m -> m Nat.+ n)
+  list = List.map update (List.range 0 10)
+  withInitialValue 0 do
+    Each.run do each list ()
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  + structural ability Each
+  + structural ability Store a
+  + structural ability Stream e
+
+  + Each.each        : [a] ->{Each} a
+  + Each.run         : '{g, Each} a ->{g} ()
+  + List.foreach     : (a ->{g} b) -> [a] ->{g} ()
+  + List.map         : (a ->{g} b) -> [a] ->{g} [b]
+  + List.range       : start -> Nat -> [Nat]
+  + repro            : '()
+  + Store.modify     : (a ->{g} a) ->{g, Store a} ()
+  + Stream.consume   : '{g, Stream a} r ->{g} r
+  + Stream.flatMap   : (a ->{g, Stream b} r)
+                       -> '{g, Stream a} r
+                       -> '{g, Stream b} r
+  + Stream.flatMap!  : (a ->{g, Stream b} r)
+                       -> '{g, Stream a} r
+                       ->{g, Stream b} r
+  + Stream.fromList  : [a] -> '{Stream a} ()
+  + toStream!        : '{g, Each} a ->{g, Stream a} ()
+  + withInitialValue : a -> '{g, Store a} v ->{g} v
+
+  Run `update` to apply these changes to your codebase.
+```
+
+``` ucm
+scratch/main> run repro
+
+  ()
+```


### PR DESCRIPTION
This fixes a bug in the runtime implementation of calling continuations.

There was missing logic related to the continuation having captured pending arguments. In the `Yield` case there is logic that looks for these, and applies a function result to the pending arguments. This was missing from the continuation call case, which should behave similarly (because a continuation call is implemented as 'push captured continuation back and yield arguments').

It's apparently tricky to actually get into situations that actually trigger the previously bad logic. I think usually it is covered by the logic for `Yield`, because the continuation happens to have also captured a frame that just `Yield`s its argument. However, we have an example of a more complicated situation that triggers the old bug, included in a test case here.

Fixes #5947.