### PR TITLE
Parse number expansions in args

### DIFF
--- a/unison-cli/package.yaml
+++ b/unison-cli/package.yaml
@@ -64,7 +64,6 @@ library:
     - random-shuffle
     - raw-strings-qq
     - recover-rtti
-    - regex-tdfa
     - semialign
     - serialise
     - servant

--- a/unison-cli/src/Unison/CommandLine.hs
+++ b/unison-cli/src/Unison/CommandLine.hs
@@ -63,26 +63,37 @@ data ExpansionFailure
 expandArguments ::
   NumberedArgs ->
   InputPattern.Parameters ->
-  [String] ->
+  [Either (String {- quoted -}) String] ->
   Either ExpansionFailure (InputPattern.Arguments, InputPattern.Parameters)
-expandArguments numberedArgs params =
-  bimap TooManyArguments (first $ reverse)
-    <=< InputPattern.foldParamsWithM
+expandArguments numberedArgs params args =
+  args
+    & (fmap . fmap) Left
+    & InputPattern.foldParamsWithM
       ( \acc (_, param) arg ->
-          if InputPattern.isStructured param
-            then
-              pure $
-                either
-                  ( maybe (arg : acc, []) (maybe (acc, []) (\(h :| t) -> (h : acc, t)) . nonEmpty . fmap pure)
-                      . expandNumber numberedArgs
-                  )
-                  ((,[]) . (: acc) . pure)
-                  arg
-            else (,[]) . (: acc) <$> either (pure . Left) (Left . UnexpectedStructuredArgument) arg
+          case arg of
+            -- Don't expand numbers in quoted args
+            Left quoted -> Right (Left quoted : acc, [])
+            Right structuredOrRaw ->
+              if InputPattern.isStructured param
+                -- If it's a structured argument, we can try to expand numbered args.
+                then case structuredOrRaw of
+                  Left raw ->
+                    case expandNumber numberedArgs raw of
+                      -- No valid number expansion, just a raw argument
+                      Nothing -> Right (Left raw : acc, [])
+                      -- The expansion resulted in no arguments
+                      Just [] -> Right (acc, [])
+                      -- The expansion resulted in one or more arguments, keep folding
+                      Just (h : t) -> Right $ (Right h : acc, (pure . pure) <$> t)
+                  Right structured -> Right $ ((Right structured : acc), [])
+                -- If it's not a structured argument, pass the raw argument or fail.
+                else case structuredOrRaw of
+                  Left raw -> Right $ (Left raw : acc, [])
+                  Right structured -> Left . UnexpectedStructuredArgument $ structured
       )
       []
       params
-    . fmap Left
+    >>= bimap (TooManyArguments . fmap join) (first $ reverse)
 
 data ParseFailure
   = NoCommand
@@ -154,7 +165,7 @@ parseInput ::
   -- | Input Pattern Map
   Map String InputPattern ->
   -- | command:arguments
-  [String] ->
+  [Either (String {- quoted -}) String] ->
   -- Returns either an error message or the fully expanded arguments list and parsed input.
   -- If the output is `Nothing`, the user cancelled the input (e.g. ctrl-c)
   IO (Either ParseFailure (Maybe (InputPattern.Arguments, Input)))
@@ -167,12 +178,13 @@ parseInput codebase projPath currentProjectRoot numberedArgs patterns segments =
   case segments of
     [] -> throwE NoCommand
     command : args -> do
-      pat@(InputPattern {params, parse}) <- case Map.lookup command patterns of
+      let cmd = unquote command
+      pat@(InputPattern {params, parse}) <- case Map.lookup cmd patterns of
         Just pat -> pure pat
-        Nothing -> throwE $ UnknownCommand command
-      let mkResult finalArgs = except . bimap (SubParseFailure command pat) (Left command : finalArgs,) $ parse finalArgs
+        Nothing -> throwE $ UnknownCommand cmd
+      let mkResult finalArgs = except . bimap (SubParseFailure cmd pat) (Left command : finalArgs,) $ parse finalArgs
       (expandedArgs, remainingParams) <-
-        except . first (ExpansionFailure command pat) $ expandArguments numberedArgs params args
+        except . first (ExpansionFailure cmd pat) $ expandArguments numberedArgs params args
 
       if Fuzzy.isFZFInstalled
         then do
@@ -191,6 +203,8 @@ parseInput codebase projPath currentProjectRoot numberedArgs patterns segments =
         else do
           -- fzf isn't installed, just try to parse the args we have and probably get an error from the parser
           Just <$> mkResult expandedArgs
+  where
+    unquote = either id id
 
 -- Expand a numeric argument like `1` or a range like `3-9`
 expandNumber :: NumberedArgs -> String -> Maybe NumberedArgs

--- a/unison-cli/src/Unison/CommandLine.hs
+++ b/unison-cli/src/Unison/CommandLine.hs
@@ -17,14 +17,12 @@ import Control.Lens hiding (aside)
 import Control.Monad.Except
 import Control.Monad.Trans.Except
 import Data.List (isPrefixOf, isSuffixOf)
-import Data.List.NonEmpty (NonEmpty ((:|)), nonEmpty)
+import Data.List.NonEmpty (NonEmpty, nonEmpty)
 import Data.Map qualified as Map
 import Data.Text qualified as Text
-import Data.Vector qualified as Vector
 import System.FilePath (takeFileName)
 import Text.Numeral (defaultInflection)
 import Text.Numeral.Language.ENG qualified as Numeral
-import Text.Regex.TDFA ((=~))
 import Unison.Codebase (Codebase)
 import Unison.Codebase.Branch (Branch0)
 import Unison.Codebase.Branch qualified as Branch
@@ -35,7 +33,7 @@ import Unison.Codebase.ProjectPath qualified as PP
 import Unison.CommandLine.FZFResolvers qualified as FZFResolvers
 import Unison.CommandLine.FuzzySelect qualified as Fuzzy
 import Unison.CommandLine.Helpers (warn)
-import Unison.CommandLine.InputPattern (InputPattern (..))
+import Unison.CommandLine.InputPattern (Argument (..), CliArg (..), InputPattern (..), NumberedArg (..))
 import Unison.CommandLine.InputPattern qualified as InputPattern
 import Unison.CommandLine.InputPatterns qualified as IP
 import Unison.Parser.Ann (Ann)
@@ -52,7 +50,7 @@ allow p =
     && (isSuffixOf ".u" p || isSuffixOf ".uu" p)
 
 data ExpansionFailure
-  = TooManyArguments (NonEmpty InputPattern.Argument)
+  = TooManyArguments (Data.List.NonEmpty.NonEmpty (Either CliArg StructuredArgument))
   | UnexpectedStructuredArgument StructuredArgument
 
 -- | Expanding numbers is a bit complicated. Each `Parameter` expects either structured or “unstructured” arguments. So
@@ -63,37 +61,40 @@ data ExpansionFailure
 expandArguments ::
   NumberedArgs ->
   InputPattern.Parameters ->
-  [Either (String {- quoted -}) String] ->
+  [CliArg] ->
   Either ExpansionFailure (InputPattern.Arguments, InputPattern.Parameters)
-expandArguments numberedArgs params args =
-  args
-    & (fmap . fmap) Left
-    & InputPattern.foldParamsWithM
-      ( \acc (_, param) arg ->
-          case arg of
-            -- Don't expand numbers in quoted args
-            Left quoted -> Right (Left quoted : acc, [])
-            Right structuredOrRaw ->
-              if InputPattern.isStructured param
-                -- If it's a structured argument, we can try to expand numbered args.
-                then case structuredOrRaw of
-                  Left raw ->
-                    case expandNumber numberedArgs raw of
-                      -- No valid number expansion, just a raw argument
-                      Nothing -> Right (Left raw : acc, [])
-                      -- The expansion resulted in no arguments
-                      Just [] -> Right (acc, [])
-                      -- The expansion resulted in one or more arguments, keep folding
-                      Just (h : t) -> Right $ (Right h : acc, (pure . pure) <$> t)
-                  Right structured -> Right $ ((Right structured : acc), [])
-                -- If it's not a structured argument, pass the raw argument or fail.
-                else case structuredOrRaw of
-                  Left raw -> Right $ (Left raw : acc, [])
-                  Right structured -> Left . UnexpectedStructuredArgument $ structured
-      )
-      []
-      params
-    >>= bimap (TooManyArguments . fmap join) (first $ reverse)
+expandArguments numberedArgs params args = do
+  result <-
+    args
+      & fmap Left
+      & InputPattern.foldParamsWithM @(Either ExpansionFailure) @[Argument] @(Either CliArg StructuredArgument)
+        ( \acc (_, param) arg ->
+            case arg of
+              -- Don't expand numbers in quoted args
+              Left (InputPattern.QuotedArg quoted _) -> Right (RawArg quoted : acc, [])
+              Left (InputPattern.UnquotedArg raw) -> Right $ (RawArg raw : acc, [])
+              Left (InputPattern.NumberedArg n) ->
+                case expandNumber numberedArgs n of
+                  -- We parsed a number, but no numbered args were available. Resolve to no arguments.
+                  Nothing -> Right (acc, [])
+                  -- The expansion resulted in no arguments
+                  Just [] -> Right (acc, [])
+                  -- The expansion resulted in one or more arguments,
+                  -- Add the expanded args to the stack and keep folding.
+                  Just (h : t)
+                    | InputPattern.isStructured param -> Right $ (StructuredArg h : acc, Right <$> t)
+                    | otherwise -> Left . UnexpectedStructuredArgument $ h
+              Right structured
+                | InputPattern.isStructured param -> Right $ ((StructuredArg structured : acc), [])
+                | otherwise ->
+                    Left . UnexpectedStructuredArgument $ structured
+        )
+        []
+        params
+
+  case result of
+    Left eArgs -> Left $ TooManyArguments eArgs
+    Right (rArgs, params) -> Right (reverse rArgs, params)
 
 data ParseFailure
   = NoCommand
@@ -165,64 +166,64 @@ parseInput ::
   -- | Input Pattern Map
   Map String InputPattern ->
   -- | command:arguments
-  [Either (String {- quoted -}) String] ->
+  [CliArg] ->
   -- Returns either an error message or the fully expanded arguments list and parsed input.
   -- If the output is `Nothing`, the user cancelled the input (e.g. ctrl-c)
   IO (Either ParseFailure (Maybe (InputPattern.Arguments, Input)))
-parseInput codebase projPath currentProjectRoot numberedArgs patterns segments = runExceptT do
+parseInput codebase projPath currentProjectRoot numberedArgs patterns cliArgs = runExceptT do
   let getCurrentBranch0 :: IO (Branch0 IO)
       getCurrentBranch0 = do
         projRoot <- currentProjectRoot
         pure . Branch.head $ Branch.getAt' (projPath ^. PP.path_) projRoot
-
-  case segments of
+  (cmd, args) <- case cliArgs of
     [] -> throwE NoCommand
-    command : args -> do
-      let cmd = unquote command
-      pat@(InputPattern {params, parse}) <- case Map.lookup cmd patterns of
-        Just pat -> pure pat
-        Nothing -> throwE $ UnknownCommand cmd
-      let mkResult finalArgs = except . bimap (SubParseFailure cmd pat) (Left command : finalArgs,) $ parse finalArgs
-      (expandedArgs, remainingParams) <-
-        except . first (ExpansionFailure cmd pat) $ expandArguments numberedArgs params args
+    (NumberedArg {} : _) -> throwE NoCommand
+    (UnquotedArg cmd : args) -> pure (cmd, args)
+    (QuotedArg cmd _ : args) -> pure (cmd, args)
+  pat@(InputPattern {params, parse}) <- case Map.lookup cmd patterns of
+    Just pat -> pure pat
+    Nothing -> throwE $ UnknownCommand cmd
+  let mkResult :: [Argument] -> ExceptT ParseFailure IO ([Argument], Input)
+      mkResult finalArgs = except . bimap (SubParseFailure cmd pat) (RawArg cmd : finalArgs,) $ parse finalArgs
+  (expandedArgs, remainingParams) <-
+    except . first (ExpansionFailure cmd pat) $ expandArguments numberedArgs params args
 
-      if Fuzzy.isFZFInstalled
-        then do
-          argResult <- lift (fzfResolve codebase projPath getCurrentBranch0 remainingParams)
-          case argResult of
-            -- If there are no completion options, indicate that with an error.
-            Left err@(NoFZFOptions {}) -> throwError $ FZFResolveFailure pat err
-            -- If there's no resolver, just parse the args we have.
-            Left (NoFZFResolverForArgumentType {}) ->
-              Just <$> mkResult expandedArgs
-            Right mayResolvedArgs -> case mayResolvedArgs of
-              -- If fzf was cancelled, indicate that
-              Nothing -> pure $ Nothing
-              -- otherwise, parse the args we resolved
-              Just resolvedArgs -> Just <$> mkResult (expandedArgs <> resolvedArgs)
-        else do
-          -- fzf isn't installed, just try to parse the args we have and probably get an error from the parser
+  if Fuzzy.isFZFInstalled
+    then do
+      argResult <- lift (fzfResolve codebase projPath getCurrentBranch0 remainingParams)
+      case argResult of
+        -- If there are no completion options, indicate that with an error.
+        Left err@(NoFZFOptions {}) -> throwError $ FZFResolveFailure pat err
+        -- If there's no resolver, just parse the args we have.
+        Left (NoFZFResolverForArgumentType {}) ->
           Just <$> mkResult expandedArgs
-  where
-    unquote = either id id
+        Right mayResolvedArgs -> case mayResolvedArgs of
+          -- If fzf was cancelled, indicate that
+          Nothing -> pure $ Nothing
+          -- otherwise, parse the args we resolved
+          Just resolvedArgs -> Just <$> mkResult (expandedArgs <> resolvedArgs)
+    else do
+      -- fzf isn't installed, just try to parse the args we have and probably get an error from the parser
+      Just <$> mkResult expandedArgs
 
 -- Expand a numeric argument like `1` or a range like `3-9`
-expandNumber :: NumberedArgs -> String -> Maybe NumberedArgs
-expandNumber numberedArgs s =
-  catMaybes . fmap ((vargs Vector.!?) . pred) <$> expandedNumber
-  where
-    vargs = Vector.fromList numberedArgs
-    rangeRegex = "([0-9]+)-([0-9]+)" :: String
-    (junk, _, moreJunk, ns) =
-      s =~ rangeRegex :: (String, String, String, [String])
-    expandedNumber =
-      case readMay s of
-        Just i -> Just [i]
-        Nothing ->
-          -- check for a range
-          case (junk, moreJunk, ns) of
-            ("", "", [from, to]) -> enumFromTo <$> readMay from <*> readMay to
-            (_, _, _) -> Nothing
+expandNumber :: NumberedArgs -> NumberedArg -> Maybe NumberedArgs
+expandNumber numberedArgs selection =
+  case selection of
+    NumberedSingle n -> pure @[] <$> (numberedArgs ^? ix (pred n))
+    NumberedRange start end ->
+      numberedArgs
+        & drop (pred start)
+        & take (end - pred start)
+        & Just
+    NumberedBeforeEnd end ->
+      numberedArgs
+        & take end
+        & Just
+    NumberedAfterStart start ->
+      numberedArgs
+        & drop (pred start)
+        & Just
 
 data FZFResolveFailure
   = NoFZFResolverForArgumentType InputPattern.ParameterDescription
@@ -240,7 +241,7 @@ fzfResolve codebase ppCtx getCurrentBranch InputPattern.Parameters {requiredPara
   -- We build up a list of `ExceptT` inside an outer `ExceptT` to allow us to fail immediately if /any/ required
   -- argument is missing a resolver, before we start prompting the user to actually do a fuzzy search. Otherwise, we
   -- might ask the user to perform a search only to realize we don't have a resolver for a later arg.
-  argumentResolvers :: [MaybeT (ExceptT FZFResolveFailure IO) (NonEmpty InputPattern.Argument)] <-
+  argumentResolvers :: [MaybeT (ExceptT FZFResolveFailure IO) (Data.List.NonEmpty.NonEmpty InputPattern.Argument)] <-
     liftA2 (<>) (traverse (maybeFillArg False) requiredParams) case trailingParams of
       InputPattern.Optional _ _ -> pure mempty
       InputPattern.OnePlus p -> pure <$> maybeFillArg True p
@@ -252,7 +253,7 @@ fzfResolve codebase ppCtx getCurrentBranch InputPattern.Parameters {requiredPara
         (pure . fuzzyFillArg allowMulti argName)
         fzfResolver
     fuzzyFillArg ::
-      Bool -> Text -> InputPattern.FZFResolver -> MaybeT (ExceptT FZFResolveFailure IO) (NonEmpty InputPattern.Argument)
+      Bool -> Text -> InputPattern.FZFResolver -> MaybeT (ExceptT FZFResolveFailure IO) (Data.List.NonEmpty.NonEmpty InputPattern.Argument)
     fuzzyFillArg allowMulti argDesc fzfResolver = MaybeT do
       currentBranch <- Branch.withoutTransitiveLibs <$> liftIO getCurrentBranch
       results <- case fzfResolver of
@@ -268,7 +269,7 @@ fzfResolve codebase ppCtx getCurrentBranch InputPattern.Parameters {requiredPara
           liftIO (Fuzzy.fuzzySelect Fuzzy.defaultOptions {Fuzzy.allowMultiSelect = allowMulti} selections)
       -- If the user triggered the fuzzy finder, but selected nothing, abort the command rather than continuing
       -- execution with no arguments.
-      pure $ fmap (Left . Text.unpack <$>) . nonEmpty =<< results
+      pure $ fmap (RawArg . Text.unpack <$>) . Data.List.NonEmpty.nonEmpty =<< results
 
 prompt :: String
 prompt = "> "

--- a/unison-cli/src/Unison/CommandLine/Completion.hs
+++ b/unison-cli/src/Unison/CommandLine/Completion.hs
@@ -50,6 +50,7 @@ import Unison.Codebase.Path qualified as Path
 import Unison.Codebase.Path.Parse qualified as Path
 import Unison.Codebase.ProjectPath qualified as PP
 import Unison.Codebase.SqliteCodebase.Conversions qualified as Cv
+import Unison.CommandLine.InputPattern (CliArg (..))
 import Unison.CommandLine.InputPattern qualified as IP
 import Unison.HashQualifiedPrime qualified as HQ'
 import Unison.NameSegment.Internal (NameSegment (NameSegment))
@@ -77,36 +78,32 @@ haskelineTabComplete patterns codebase authedHTTPClient ppCtx = \(beforeCursorRe
     (prefixArgs, lastArg) <- hoistMaybe $ unsnoc args
     let prefix =
           prefixArgs
-            <&> ( \case
-                    Left (txt, False) -> "\"" <> txt <> "\""
-                    Left (txt, True) -> "\"" <> txt
-                    Right txt -> txt
-                )
+            <&> IP.renderCliArg
             & unwords
             & reverse
             & (" " <>)
-    case (prefixArgs, argStr lastArg) of
+    case (prefixArgs, lastArg) of
+      -- No completions for numbered args
+      (_, NumberedArg {}) -> pure (beforeCursorRev, [])
       ([], cmdPrefix) -> do
-        let completions = exactComplete cmdPrefix $ Map.keys patterns
+        let completions = exactComplete (IP.renderCliArgUnquoted cmdPrefix) $ Map.keys patterns
         pure (prefix, completions)
-      ((cmd : midArgs), lastArgStr) -> do
+      ((cmd : midArgs), lastArg) -> do
         let requote completion =
               let newReplacement = case lastArg of
-                    Left _ | completion.isFinished -> "\"" <> completion.replacement <> "\""
-                    Left (_, False) -> "\"" <> completion.replacement <> "\""
-                    Left (_, True) -> "\"" <> completion.replacement
-                    Right _ -> completion.replacement
+                    QuotedArg _ _
+                      | completion.isFinished -> "\"" <> completion.replacement <> "\""
+                    QuotedArg _ False -> "\"" <> completion.replacement <> "\""
+                    QuotedArg _ True -> "\"" <> completion.replacement
+                    UnquotedArg _ -> completion.replacement
                in completion {Line.replacement = newReplacement}
-        p <- hoistMaybe $ Map.lookup (argStr cmd) patterns
+        p <- hoistMaybe $ Map.lookup (IP.renderCliArgUnquoted cmd) patterns
         paramType <- hoistMaybe $ IP.paramType (IP.params p) (length midArgs)
         completions <-
           lift $
-            IP.suggestions paramType lastArgStr codebase authedHTTPClient ppCtx
+            IP.suggestions paramType (IP.renderCliArgUnquoted lastArg) codebase authedHTTPClient ppCtx
               <&> fmap requote
         pure (prefix, completions)
-  where
-    argStr :: Either (String, Bool) String -> String
-    argStr = either fst id
 
 -- | Things which we may want to complete for.
 data CompletionType

--- a/unison-cli/src/Unison/CommandLine/Completion.hs
+++ b/unison-cli/src/Unison/CommandLine/Completion.hs
@@ -73,7 +73,7 @@ haskelineTabComplete ::
   Line.CompletionFunc m
 haskelineTabComplete patterns codebase authedHTTPClient ppCtx = \(beforeCursorRev, _afterCursor) ->
   fmap (fromMaybe (beforeCursorRev, [])) $ runMaybeT $ do
-    args <- hoistMaybe $ IP.parseArgsQuoted (reverse beforeCursorRev)
+    args <- hoistMaybe $ IP.parseArgs (reverse beforeCursorRev)
     (prefixArgs, lastArg) <- hoistMaybe $ unsnoc args
     let prefix =
           prefixArgs

--- a/unison-cli/src/Unison/CommandLine/InputPattern.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPattern.hs
@@ -9,7 +9,7 @@ module Unison.CommandLine.InputPattern
     Parameter,
     TrailingParameters (..),
     Parameters (..),
-    Argument,
+    Argument (..),
     Arguments,
     noParams,
     foldParamsWithM,
@@ -19,7 +19,8 @@ module Unison.CommandLine.InputPattern
 
     -- * Parse Arguments
     parseArgs,
-    parseArgsQuoted,
+    CliArg (..),
+    NumberedArg (..),
 
     -- * Currently Unused
     minArgs,
@@ -55,7 +56,9 @@ data Visibility = Hidden | Visible
 -- needs to be parsed or a numbered argument that doesn’t need to be parsed, as
 -- we’ve preserved its representation (although the numbered argument could
 -- still be of the wrong type, which should result in an error).
-type Argument = Either String StructuredArgument
+data Argument
+  = RawArg String
+  | StructuredArg StructuredArgument
 
 type Arguments = [Argument]
 
@@ -240,41 +243,73 @@ suggestionFallbacks suggesters inp codebase httpClient path = go suggesters
 
 type Parser = MP.Parsec Void String
 
-parseArgs :: String -> Maybe [String]
-parseArgs input =
-  fmap (either fst id) <$> parseArgsQuoted input
+data NumberedArg
+  = NumberedSingle Int
+  | NumberedRange Int Int -- e.g. "3-5", inclusive on both sides.
+  | NumberedAfterStart Int -- e.g. "3-", inclusive
+  | NumberedBeforeEnd Int -- e.g. "-5", inclusive
+  deriving (Eq, Show)
+
+data CliArg
+  = NumberedArg NumberedArg
+  | QuotedArg
+      String
+      Bool -- whether the quote was terminated
+  | UnquotedArg String
 
 -- | Like `parseArgs`, but indicates whether each argument was quoted, and also whether the quote was terminated..
 -- This is for things like tab-completion where the original string is important.
-parseArgsQuoted :: String -> Maybe [Either (String, Bool) String]
-parseArgsQuoted input = MP.parseMaybe argsP (strip input)
+parseArgs :: String -> Maybe [CliArg]
+parseArgs input = MP.parseMaybe argsP (strip input)
   where
     strip = Text.unpack . Text.strip . Text.pack
 
 -- | Parser for a single CLI argument, which may be a single word, or a quoted string.
 --
 -- Also handles backslash-escaped quotes within quoted strings.
-argP :: Parser (Either (String, Bool) String)
+argP :: Parser CliArg
 argP = do
-  MP.try (Left <$> quotedP) MP.<|> (Right <$> unquotedP)
+  MP.try numberedArgP MP.<|> quotedArgP MP.<|> unquotedArgP
   where
     escapedQuote :: Parser Char
     escapedQuote = do
       _ <- MP.char '\\'
       MP.char '"'
 
-    quotedP :: Parser (String, Bool)
-    quotedP = do
+    numberedArgP :: Parser CliArg
+    numberedArgP = do
+      NumberedArg <$> (MP.try rangeP MP.<|> singleP)
+      where
+        singleP :: Parser NumberedArg
+        singleP = do
+          digits <- some MP.digitChar
+          case readMay digits of
+            Just n -> pure $ NumberedSingle n
+            Nothing -> empty
+        rangeP :: Parser NumberedArg
+        rangeP = do
+          start <- optional $ some MP.digitChar
+          _dash <- MP.char '-'
+          end <- optional $ some MP.digitChar
+          case (start >>= readMay, end >>= readMay) of
+            (Just s, Just e) -> pure $ NumberedRange s e
+            (Just s, Nothing) -> pure $ NumberedAfterStart s
+            (Nothing, Just e) -> pure $ NumberedBeforeEnd e
+            -- Fail, the parser will fallback to other arg types
+            (Nothing, Nothing) -> empty
+
+    quotedArgP :: Parser CliArg
+    quotedArgP = do
       _ <- MP.char '"'
       (content, hasUnterminatedQuote) <-
         MP.manyTill_
           (escapedQuote <|> MP.anySingle)
           -- Treat EOF as closing quote so completion still functions on unterminated quotes
           (((MP.char '"') $> False) <|> (MP.eof $> True))
-      pure $ (content, hasUnterminatedQuote)
-    unquotedP :: Parser String
-    unquotedP = do
-      MP.some (MP.satisfy (not . Char.isSpace))
+      pure $ QuotedArg content hasUnterminatedQuote
+    unquotedArgP :: Parser CliArg
+    unquotedArgP = do
+      UnquotedArg <$> MP.some (MP.satisfy (not . Char.isSpace))
 
 -- >>> MP.parseMaybe argsP "one two three"
 -- Just [Right "one",Right "two",Right "three"]
@@ -288,6 +323,6 @@ argP = do
 -- Unfinished quote should auto-close quote at end of input, but indicate that it was unterminated
 -- >>> MP.parseMaybe argsP "one two \"three four"
 -- Just [Right "one",Right "two",Left ("three four",True)]
-argsP :: Parser [Either (String, Bool) String]
+argsP :: Parser [CliArg]
 argsP = do
   MP.sepBy argP MP.space

--- a/unison-cli/src/Unison/CommandLine/InputPattern.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPattern.hs
@@ -21,6 +21,8 @@ module Unison.CommandLine.InputPattern
     parseArgs,
     CliArg (..),
     NumberedArg (..),
+    renderCliArg,
+    renderCliArgUnquoted,
 
     -- * Currently Unused
     minArgs,
@@ -256,6 +258,32 @@ data CliArg
       String
       Bool -- whether the quote was terminated
   | UnquotedArg String
+
+-- | Get the text representing a given 'CliArg'.
+renderCliArg :: CliArg -> String
+renderCliArg =
+  \case
+    NumberedArg n -> case n of
+      NumberedSingle i -> show i
+      NumberedRange s e -> show s <> "-" <> show e
+      NumberedAfterStart s -> show s <> "-"
+      NumberedBeforeEnd e -> "-" <> show e
+    QuotedArg s False -> "\"" <> s <> "\""
+    QuotedArg s True -> "\"" <> s
+    UnquotedArg s -> s
+
+-- | Like `renderCliArg`, but does not include quotes regardless of whether the argument was quoted.
+renderCliArgUnquoted :: CliArg -> String
+renderCliArgUnquoted =
+  \case
+    NumberedArg n -> case n of
+      NumberedSingle i -> show i
+      NumberedRange s e -> show s <> "-" <> show e
+      NumberedAfterStart s -> show s <> "-"
+      NumberedBeforeEnd e -> "-" <> show e
+    QuotedArg s False -> s
+    QuotedArg s True -> s
+    UnquotedArg s -> s
 
 -- | Like `parseArgs`, but indicates whether each argument was quoted, and also whether the quote was terminated..
 -- This is for things like tab-completion where the original string is important.

--- a/unison-cli/src/Unison/CommandLine/InputPattern.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPattern.hs
@@ -359,6 +359,9 @@ argP = do
 -- Should require args to take up a whole segment, and should fall back to raw args.
 -- >>> MP.parseMaybe argsP "1.2.3 abc-def"
 -- Just [NumberedArg (NumberedSingle 1),UnquotedArg ".2.3",UnquotedArg "abc-def"]
+--
+-- >>> MP.parseMaybe argsP "release.draft 1.2.3"
+-- Just [UnquotedArg "release.draft",NumberedArg (NumberedSingle 1),UnquotedArg ".2.3"]
 argsP :: Parser [CliArg]
 argsP = do
   MP.sepBy argP MP.space

--- a/unison-cli/src/Unison/CommandLine/InputPattern.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPattern.hs
@@ -258,6 +258,7 @@ data CliArg
       String
       Bool -- whether the quote was terminated
   | UnquotedArg String
+  deriving (Eq, Show)
 
 -- | Get the text representing a given 'CliArg'.
 renderCliArg :: CliArg -> String
@@ -297,8 +298,11 @@ parseArgs input = MP.parseMaybe argsP (strip input)
 -- Also handles backslash-escaped quotes within quoted strings.
 argP :: Parser CliArg
 argP = do
-  MP.try numberedArgP MP.<|> quotedArgP MP.<|> unquotedArgP
+  MP.try (numberedArgP <* wordBoundary)
+    MP.<|> (quotedArgP <* wordBoundary)
+    MP.<|> (unquotedArgP <* wordBoundary)
   where
+    wordBoundary = MP.lookAhead (MP.space1 <|> MP.eof)
     escapedQuote :: Parser Char
     escapedQuote = do
       _ <- MP.char '\\'
@@ -340,17 +344,21 @@ argP = do
       UnquotedArg <$> MP.some (MP.satisfy (not . Char.isSpace))
 
 -- >>> MP.parseMaybe argsP "one two three"
--- Just [Right "one",Right "two",Right "three"]
+-- Just [UnquotedArg "one",UnquotedArg "two",UnquotedArg "three"]
 --
 -- >>> MP.parseMaybe argsP "\"one two\" three"
--- Just [Left ("one two",False),Right "three"]
+-- Just [QuotedArg "one two" False,UnquotedArg "three"]
 --
 -- >>> MP.parseMaybe argsP "one    two    three"
--- Just [Right "one",Right "two",Right "three"]
+-- Just [UnquotedArg "one",UnquotedArg "two",UnquotedArg "three"]
 --
 -- Unfinished quote should auto-close quote at end of input, but indicate that it was unterminated
 -- >>> MP.parseMaybe argsP "one two \"three four"
--- Just [Right "one",Right "two",Left ("three four",True)]
+-- Just [UnquotedArg "one",UnquotedArg "two",QuotedArg "three four" True]
+--
+-- Should require args to take up a whole segment, and should fall back to raw args.
+-- >>> MP.parseMaybe argsP "1.2.3 abc-def"
+-- Just [NumberedArg (NumberedSingle 1),UnquotedArg ".2.3",UnquotedArg "abc-def"]
 argsP :: Parser [CliArg]
 argsP = do
   MP.sepBy argP MP.space

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -289,7 +289,9 @@ formatStructuredArgument schLength = \case
 --
 -- This can also be used where the input argument needs to be included in the output.
 unifyArgument :: I.Argument -> String
-unifyArgument = either id (Text.unpack . formatStructuredArgument Nothing)
+unifyArgument = \case
+  I.RawArg raw -> raw
+  I.StructuredArg sa -> Text.unpack $ formatStructuredArgument Nothing sa
 
 showPatternHelp :: InputPattern -> P.Pretty CT.ColorText
 showPatternHelp i =
@@ -321,12 +323,14 @@ searchResultToHQ oprefix = \case
     addPrefix = maybe id Path.prefixNameIfRel oprefix
 
 unsupportedStructuredArgument :: InputPattern -> Text -> I.Argument -> Either (P.Pretty CT.ColorText) String
-unsupportedStructuredArgument command expected =
-  either pure . const . Left . P.wrap $
-    makeExample' command
-      <> "can’t accept a numbered argument for"
-      <> P.text expected
-      <> "and it’s not yet possible to provide un-expanded numbers as arguments."
+unsupportedStructuredArgument command expected = \case
+  I.RawArg raw -> pure raw
+  I.StructuredArg _sa ->
+    Left . P.wrap $
+      makeExample' command
+        <> "can’t accept a numbered argument for"
+        <> P.text expected
+        <> "and it’s not yet possible to provide un-expanded numbers as arguments."
 
 expectedButActually' :: Text -> String -> P.Pretty CT.ColorText
 expectedButActually' expected actualValue =
@@ -389,45 +393,41 @@ helpFor :: InputPattern -> P.Pretty CT.ColorText
 helpFor = I.help
 
 handleProjectArg :: I.Argument -> Either (P.Pretty CT.ColorText) ProjectName
-handleProjectArg =
-  either
-    (\name -> first (const $ expectedButActually' "a project" name) . tryInto @ProjectName $ Text.pack name)
-    \case
-      SA.Project project -> pure project
-      otherArgType -> Left $ wrongStructuredArgument "a project" otherArgType
+handleProjectArg = \case
+  I.RawArg name -> first (const $ expectedButActually' "a project" name) . tryInto @ProjectName $ Text.pack name
+  I.StructuredArg sa -> case sa of
+    SA.Project project -> pure project
+    otherArgType -> Left $ wrongStructuredArgument "a project" otherArgType
 
 handleMaybeProjectBranchArg ::
   I.Argument -> Either (P.Pretty CT.ColorText) (ProjectAndBranch (Maybe ProjectName) ProjectBranchName)
-handleMaybeProjectBranchArg =
-  either
-    (megaparse branchWithOptionalProjectParser . Text.pack)
-    \case
-      SA.ProjectBranch pb -> pure pb
-      otherArgType -> Left $ wrongStructuredArgument "a branch" otherArgType
+handleMaybeProjectBranchArg = \case
+  I.RawArg raw -> megaparse branchWithOptionalProjectParser . Text.pack $ raw
+  I.StructuredArg sa -> case sa of
+    SA.ProjectBranch pb -> pure pb
+    otherArgType -> Left $ wrongStructuredArgument "a branch" otherArgType
 
 handleProjectMaybeBranchArg ::
   I.Argument -> Either (P.Pretty CT.ColorText) (ProjectAndBranch ProjectName (Maybe ProjectBranchNameOrLatestRelease))
-handleProjectMaybeBranchArg =
-  either
-    (\str -> first (const $ expectedButActually' "a project or branch" str) . tryInto $ Text.pack str)
-    \case
-      SA.Project proj -> pure $ ProjectAndBranch proj Nothing
-      SA.ProjectBranch (ProjectAndBranch (Just proj) branch) ->
-        pure . ProjectAndBranch proj . pure $ ProjectBranchNameOrLatestRelease'Name branch
-      otherArgType -> Left $ wrongStructuredArgument "a project or branch" otherArgType
+handleProjectMaybeBranchArg = \case
+  I.RawArg raw -> first (const $ expectedButActually' "a project or branch" raw) . tryInto $ Text.pack raw
+  I.StructuredArg sa -> case sa of
+    SA.Project proj -> pure $ ProjectAndBranch proj Nothing
+    SA.ProjectBranch (ProjectAndBranch (Just proj) branch) ->
+      pure . ProjectAndBranch proj . pure $ ProjectBranchNameOrLatestRelease'Name branch
+    otherArgType -> Left $ wrongStructuredArgument "a project or branch" otherArgType
 
 handleProjectBranchArg ::
   I.Argument -> Either (P.Pretty CT.ColorText) (ProjectAndBranch ProjectName ProjectBranchName)
-handleProjectBranchArg arg =
-  case arg of
-    Left str ->
-      parseProjBranchName str <|> parseJustProjName str
-        & maybeToEither (P.string $ "Invalid project/branch name: " <> str)
-    Right structured -> case structured of
-      SA.Project proj -> pure $ ProjectAndBranch proj defaultBranchName
-      SA.ProjectBranch (ProjectAndBranch (Just proj) branch) ->
-        pure $ ProjectAndBranch proj branch
-      otherArgType -> Left $ wrongStructuredArgument "a project or branch" otherArgType
+handleProjectBranchArg = \case
+  I.RawArg str ->
+    parseProjBranchName str <|> parseJustProjName str
+      & maybeToEither (P.string $ "Invalid project/branch name: " <> str)
+  I.StructuredArg structured -> case structured of
+    SA.Project proj -> pure $ ProjectAndBranch proj defaultBranchName
+    SA.ProjectBranch (ProjectAndBranch (Just proj) branch) ->
+      pure $ ProjectAndBranch proj branch
+    otherArgType -> Left $ wrongStructuredArgument "a project or branch" otherArgType
   where
     parseProjBranchName str = eitherToMaybe (tryInto @(ProjectAndBranch ProjectName ProjectBranchName) $ Text.pack str)
     parseJustProjName str = do
@@ -435,119 +435,113 @@ handleProjectBranchArg arg =
       pure $ projMayBranch & field @"branch" %~ fromMaybe defaultBranchName
 
 handleHashQualifiedNameArg :: I.Argument -> Either (P.Pretty CT.ColorText) (HQ.HashQualified Name)
-handleHashQualifiedNameArg =
-  either
-    parseHashQualifiedName
-    \case
-      SA.Name name -> pure $ HQ.NameOnly name
-      SA.NameWithBranchPrefix mprefix name ->
-        pure . HQ.NameOnly $ foldr (Path.prefixNameIfRel . Path.AbsolutePath') name mprefix
-      SA.HashQualified hqname -> pure hqname
-      SA.HashQualifiedWithBranchPrefix mprefix hqname ->
-        pure . HQ'.toHQ $ foldr (\prefix -> fmap $ Path.prefixNameIfRel (Path.AbsolutePath' prefix)) hqname mprefix
-      SA.ShallowListEntry prefix entry ->
-        pure . HQ'.toHQ . fmap (Path.prefixNameIfRel prefix) $ shallowListEntryToHQ' entry
-      SA.SearchResult mpath result -> pure $ searchResultToHQ mpath result
-      otherArgType -> Left $ wrongStructuredArgument "a hash-qualified name" otherArgType
+handleHashQualifiedNameArg = \case
+  I.RawArg raw -> parseHashQualifiedName raw
+  I.StructuredArg sa -> case sa of
+    SA.Name name -> pure $ HQ.NameOnly name
+    SA.NameWithBranchPrefix mprefix name ->
+      pure . HQ.NameOnly $ foldr (Path.prefixNameIfRel . Path.AbsolutePath') name mprefix
+    SA.HashQualified hqname -> pure hqname
+    SA.HashQualifiedWithBranchPrefix mprefix hqname ->
+      pure . HQ'.toHQ $ foldr (\prefix -> fmap $ Path.prefixNameIfRel (Path.AbsolutePath' prefix)) hqname mprefix
+    SA.ShallowListEntry prefix entry ->
+      pure . HQ'.toHQ . fmap (Path.prefixNameIfRel prefix) $ shallowListEntryToHQ' entry
+    SA.SearchResult mpath result -> pure $ searchResultToHQ mpath result
+    otherArgType -> Left $ wrongStructuredArgument "a hash-qualified name" otherArgType
 
 handlePathArg :: I.Argument -> Either (P.Pretty CT.ColorText) Path
-handlePathArg =
-  either
-    (first P.text . Path.parsePath)
-    \case
-      SA.Name name -> pure $ Path.fromName name
-      SA.NameWithBranchPrefix _ name -> pure $ Path.fromName name
-      otherArgType ->
-        either
-          (const . Left $ wrongStructuredArgument "a relative path" otherArgType)
-          ( \name ->
-              if Name.isRelative name
-                then pure $ Path.fromName name
-                else Left $ wrongStructuredArgument "a relative path" otherArgType
-          )
-          . handleNameArg
-          $ pure otherArgType
+handlePathArg = \case
+  I.RawArg raw -> first P.text . Path.parsePath $ raw
+  I.StructuredArg sa -> case sa of
+    SA.Name name -> pure $ Path.fromName name
+    SA.NameWithBranchPrefix _ name -> pure $ Path.fromName name
+    otherArgType ->
+      case handleNameArg (I.StructuredArg otherArgType) of
+        Left _ -> Left $ wrongStructuredArgument "a relative path" otherArgType
+        Right name ->
+          if Name.isRelative name
+            then pure $ Path.fromName name
+            else Left $ wrongStructuredArgument "a relative path" otherArgType
 
 handlePath'Arg :: I.Argument -> Either (P.Pretty CT.ColorText) Path'
-handlePath'Arg =
-  either
-    (first P.text . Path.parsePath')
-    \case
+handlePath'Arg = \case
+  I.RawArg raw -> first P.text . Path.parsePath' $ raw
+  I.StructuredArg sa ->
+    case sa of
       SA.AbsolutePath path -> pure $ Path.absoluteToPath' path
       SA.Name name -> pure $ Path.fromName' name
       SA.NameWithBranchPrefix mprefix name ->
         pure . Path.fromName' $ foldr (Path.prefixNameIfRel . Path.AbsolutePath') name mprefix
       otherArgType ->
-        bimap (const $ wrongStructuredArgument "a path" otherArgType) Path.fromName' . handleNameArg $ pure otherArgType
+        bimap (const $ wrongStructuredArgument "a path" otherArgType) Path.fromName' . handleNameArg $ I.StructuredArg otherArgType
 
 handleNewName :: I.Argument -> Either (P.Pretty CT.ColorText) (Path.Split Path')
-handleNewName =
-  either
-    (first P.text . Path.parseSplit')
-    (const . Left $ "can’t use a numbered argument for a new name")
+handleNewName = \case
+  I.RawArg raw -> first P.text . Path.parseSplit' $ raw
+  I.StructuredArg _sa -> Left $ "can’t use a numbered argument for a new name"
 
 handleNewPath :: I.Argument -> Either (P.Pretty CT.ColorText) Path'
-handleNewPath =
-  either
-    (first P.text . Path.parsePath')
-    (const . Left $ "can’t use a numbered argument for a new namespace")
+handleNewPath = \case
+  I.RawArg raw -> first P.text . Path.parsePath' $ raw
+  I.StructuredArg _sa -> Left $ "can’t use a numbered argument for a new namespace"
 
 -- | When only a relative name is allowed.
 handleSplitArg :: I.Argument -> Either (P.Pretty CT.ColorText) (Path.Split Path.Relative)
-handleSplitArg =
-  fmap (first Path.Relative) . either
-    (first P.text . Path.parseSplit)
-    \case
-      SA.Name name | Name.isRelative name -> pure $ Path.splitFromName name
-      SA.NameWithBranchPrefix _ name | Name.isRelative name -> pure $ Path.splitFromName name
-      otherNumArg -> Left $ wrongStructuredArgument "a relative name" otherNumArg
+handleSplitArg arg =
+  fmap (first Path.Relative) $
+    case arg of
+      I.RawArg raw -> first P.text . Path.parseSplit $ raw
+      I.StructuredArg sa ->
+        case sa of
+          SA.Name name | Name.isRelative name -> pure $ Path.splitFromName name
+          SA.NameWithBranchPrefix _ name | Name.isRelative name -> pure $ Path.splitFromName name
+          otherNumArg -> Left $ wrongStructuredArgument "a relative name" otherNumArg
 
 handleSplit'Arg :: I.Argument -> Either (P.Pretty CT.ColorText) (Path.Split Path')
 handleSplit'Arg = fmap Path.parentOfName . handleNameArg
 
 handleProjectBranchNameArg :: I.Argument -> Either (P.Pretty CT.ColorText) ProjectBranchName
-handleProjectBranchNameArg =
-  either
-    (first (const $ P.text "Wanted a branch name, but it wasn’t") . tryInto . Text.pack)
-    \case
+handleProjectBranchNameArg = \case
+  I.RawArg raw ->
+    first (const $ P.text "Wanted a branch name, but it wasn’t") . tryInto . Text.pack $ raw
+  I.StructuredArg sa ->
+    case sa of
       SA.ProjectBranch (ProjectAndBranch _ branch) -> pure branch
       otherNumArg -> Left $ wrongStructuredArgument "a branch name" otherNumArg
 
 handleBranchIdArg :: I.Argument -> Either (P.Pretty CT.ColorText) Input.BranchId
-handleBranchIdArg =
-  either
-    (first P.text . Input.parseBranchId)
-    \case
-      SA.AbsolutePath path -> pure . BranchAtPath $ Path.absoluteToPath' path
-      SA.Name name -> pure . BranchAtPath $ Path.fromName' name
-      SA.NameWithBranchPrefix mprefix name ->
-        pure $ case mprefix of
-          BranchAtSCH _sch -> BranchAtPath . Path.fromName' $ name
-          BranchAtPath prefix -> BranchAtPath . Path.fromName' $ Path.prefixNameIfRel (Path.AbsolutePath' prefix) name
-          BranchAtProjectPath pp ->
-            pp
-              & PP.absPath_
-                %~ (\pathPrefix -> Path.resolve pathPrefix (Path.fromName name))
-              & BranchAtProjectPath
-      SA.Namespace hash -> pure . BranchAtSCH $ SCH.fromFullHash hash
-      otherNumArg -> Left $ wrongStructuredArgument "a branch id" otherNumArg
+handleBranchIdArg = \case
+  I.RawArg raw -> first P.text . Input.parseBranchId $ raw
+  I.StructuredArg sa -> case sa of
+    SA.AbsolutePath path -> pure . BranchAtPath $ Path.absoluteToPath' path
+    SA.Name name -> pure . BranchAtPath $ Path.fromName' name
+    SA.NameWithBranchPrefix mprefix name ->
+      pure $ case mprefix of
+        BranchAtSCH _sch -> BranchAtPath . Path.fromName' $ name
+        BranchAtPath prefix -> BranchAtPath . Path.fromName' $ Path.prefixNameIfRel (Path.AbsolutePath' prefix) name
+        BranchAtProjectPath pp ->
+          pp
+            & PP.absPath_
+              %~ (\pathPrefix -> Path.resolve pathPrefix (Path.fromName name))
+            & BranchAtProjectPath
+    SA.Namespace hash -> pure . BranchAtSCH $ SCH.fromFullHash hash
+    otherNumArg -> Left $ wrongStructuredArgument "a branch id" otherNumArg
 
 -- | TODO: Maybe remove?
 _handleBranchIdOrProjectArg ::
   I.Argument ->
   Either (P.Pretty CT.ColorText) (These Input.BranchId (ProjectAndBranch (Maybe ProjectName) ProjectBranchName))
-_handleBranchIdOrProjectArg =
-  either
-    (\str -> maybe (Left $ expectedButActually' "a branch" str) pure $ branchIdOrProject str)
-    \case
-      SA.Namespace hash -> pure . This . BranchAtSCH $ SCH.fromFullHash hash
-      SA.AbsolutePath path -> pure . This . BranchAtPath $ Path.absoluteToPath' path
-      SA.Name name -> pure . This . BranchAtPath $ Path.fromName' name
-      SA.NameWithBranchPrefix (BranchAtSCH _) name -> pure . This . BranchAtPath $ Path.fromName' name
-      SA.NameWithBranchPrefix (BranchAtPath prefix) name ->
-        pure . This . BranchAtPath . Path.fromName' $ Path.prefixNameIfRel (Path.AbsolutePath' prefix) name
-      SA.ProjectBranch pb -> pure $ That pb
-      otherArgType -> Left $ wrongStructuredArgument "a branch" otherArgType
+_handleBranchIdOrProjectArg = \case
+  I.RawArg raw -> maybe (Left $ expectedButActually' "a branch" raw) pure $ branchIdOrProject raw
+  I.StructuredArg sa -> case sa of
+    SA.Namespace hash -> pure . This . BranchAtSCH $ SCH.fromFullHash hash
+    SA.AbsolutePath path -> pure . This . BranchAtPath $ Path.absoluteToPath' path
+    SA.Name name -> pure . This . BranchAtPath $ Path.fromName' name
+    SA.NameWithBranchPrefix (BranchAtSCH _) name -> pure . This . BranchAtPath $ Path.fromName' name
+    SA.NameWithBranchPrefix (BranchAtPath prefix) name ->
+      pure . This . BranchAtPath . Path.fromName' $ Path.prefixNameIfRel (Path.AbsolutePath' prefix) name
+    SA.ProjectBranch pb -> pure $ That pb
+    otherArgType -> Left $ wrongStructuredArgument "a branch" otherArgType
   where
     branchIdOrProject ::
       String ->
@@ -568,103 +562,97 @@ _handleBranchIdOrProjectArg =
             (Right bid, Right pr) -> Just (These bid pr)
 
 handleBranchId2Arg :: I.Argument -> Either (P.Pretty P.ColorText) Input.BranchId2
-handleBranchId2Arg =
-  either
-    Input.parseBranchId2
-    \case
-      SA.Namespace hash -> pure . Left $ SCH.fromFullHash hash
-      SA.AbsolutePath path -> pure . pure . UnqualifiedPath $ Path.absoluteToPath' path
-      SA.Name name -> pure . pure . UnqualifiedPath $ Path.fromName' name
-      SA.NameWithBranchPrefix (BranchAtSCH _) name -> pure . pure . UnqualifiedPath $ Path.fromName' name
-      SA.NameWithBranchPrefix (BranchAtPath prefix) name ->
-        pure . pure . UnqualifiedPath . Path.fromName' $ Path.prefixNameIfRel (Path.AbsolutePath' prefix) name
-      SA.ProjectBranch (ProjectAndBranch mproject branch) ->
-        case mproject of
-          Just proj -> pure . pure $ QualifiedBranchPath proj branch Path.Root
-          Nothing -> pure . pure $ BranchPathInCurrentProject branch Path.Root
-      otherNumArg -> Left $ wrongStructuredArgument "a branch id" otherNumArg
+handleBranchId2Arg = \case
+  I.RawArg raw -> Input.parseBranchId2 raw
+  I.StructuredArg sa -> case sa of
+    SA.Namespace hash -> pure . Left $ SCH.fromFullHash hash
+    SA.AbsolutePath path -> pure . pure . UnqualifiedPath $ Path.absoluteToPath' path
+    SA.Name name -> pure . pure . UnqualifiedPath $ Path.fromName' name
+    SA.NameWithBranchPrefix (BranchAtSCH _) name -> pure . pure . UnqualifiedPath $ Path.fromName' name
+    SA.NameWithBranchPrefix (BranchAtPath prefix) name ->
+      pure . pure . UnqualifiedPath . Path.fromName' $ Path.prefixNameIfRel (Path.AbsolutePath' prefix) name
+    SA.ProjectBranch (ProjectAndBranch mproject branch) ->
+      case mproject of
+        Just proj -> pure . pure $ QualifiedBranchPath proj branch Path.Root
+        Nothing -> pure . pure $ BranchPathInCurrentProject branch Path.Root
+    otherNumArg -> Left $ wrongStructuredArgument "a branch id" otherNumArg
 
 handleBranchRelativePathArg :: I.Argument -> Either (P.Pretty P.ColorText) BranchRelativePath
-handleBranchRelativePathArg =
-  either
-    parseBranchRelativePath
-    \case
-      SA.AbsolutePath path -> pure . UnqualifiedPath $ Path.absoluteToPath' path
-      SA.Name name -> pure . UnqualifiedPath $ Path.fromName' name
-      SA.NameWithBranchPrefix (BranchAtSCH _) name -> pure . UnqualifiedPath $ Path.fromName' name
-      SA.NameWithBranchPrefix (BranchAtPath prefix) name ->
-        pure . UnqualifiedPath . Path.fromName' $ Path.prefixNameIfRel (Path.AbsolutePath' prefix) name
-      SA.ProjectBranch (ProjectAndBranch mproject branch) ->
-        case mproject of
-          Just proj -> pure $ QualifiedBranchPath proj branch Path.Root
-          Nothing -> pure $ BranchPathInCurrentProject branch Path.Root
-      otherNumArg -> Left $ wrongStructuredArgument "a branch id" otherNumArg
+handleBranchRelativePathArg = \case
+  I.RawArg raw -> parseBranchRelativePath raw
+  I.StructuredArg sa -> case sa of
+    SA.AbsolutePath path -> pure . UnqualifiedPath $ Path.absoluteToPath' path
+    SA.Name name -> pure . UnqualifiedPath $ Path.fromName' name
+    SA.NameWithBranchPrefix (BranchAtSCH _) name -> pure . UnqualifiedPath $ Path.fromName' name
+    SA.NameWithBranchPrefix (BranchAtPath prefix) name ->
+      pure . UnqualifiedPath . Path.fromName' $ Path.prefixNameIfRel (Path.AbsolutePath' prefix) name
+    SA.ProjectBranch (ProjectAndBranch mproject branch) ->
+      case mproject of
+        Just proj -> pure $ QualifiedBranchPath proj branch Path.Root
+        Nothing -> pure $ BranchPathInCurrentProject branch Path.Root
+    otherNumArg -> Left $ wrongStructuredArgument "a branch id" otherNumArg
 
 handleHashQualifiedSplit'Arg :: I.Argument -> Either (P.Pretty CT.ColorText) (HQ'.HashQualified (Path.Split Path'))
-handleHashQualifiedSplit'Arg =
-  either
-    (first P.text . Path.parseHQSplit')
-    \case
-      SA.Name name -> pure $ HQ'.fromName $ Path.parentOfName name
-      hq@(SA.HashQualified name) ->
-        bimap (const $ expectedButActually "a name" hq "a hash") (Path.parentOfName <$>) $ HQ'.fromHQ name
-      SA.HashQualifiedWithBranchPrefix (BranchAtSCH _) hqname -> pure $ Path.parentOfName <$> hqname
-      SA.HashQualifiedWithBranchPrefix (BranchAtPath prefix) hqname ->
-        pure $ Path.parentOfName . Path.prefixNameIfRel (Path.AbsolutePath' prefix) <$> hqname
-      SA.ShallowListEntry prefix entry ->
-        pure $ Path.parentOfName . Path.prefixNameIfRel prefix <$> shallowListEntryToHQ' entry
-      sr@(SA.SearchResult mpath result) ->
-        bimap (const $ expectedButActually "a name" sr "a hash") (Path.parentOfName <$>) . HQ'.fromHQ $
-          searchResultToHQ mpath result
-      otherNumArg -> Left $ wrongStructuredArgument "a name" otherNumArg
+handleHashQualifiedSplit'Arg = \case
+  I.RawArg raw -> first P.text . Path.parseHQSplit' $ raw
+  I.StructuredArg sa -> case sa of
+    SA.Name name -> pure $ HQ'.fromName $ Path.parentOfName name
+    hq@(SA.HashQualified name) ->
+      bimap (const $ expectedButActually "a name" hq "a hash") (Path.parentOfName <$>) $ HQ'.fromHQ name
+    SA.HashQualifiedWithBranchPrefix (BranchAtSCH _) hqname -> pure $ Path.parentOfName <$> hqname
+    SA.HashQualifiedWithBranchPrefix (BranchAtPath prefix) hqname ->
+      pure $ Path.parentOfName . Path.prefixNameIfRel (Path.AbsolutePath' prefix) <$> hqname
+    SA.ShallowListEntry prefix entry ->
+      pure $ Path.parentOfName . Path.prefixNameIfRel prefix <$> shallowListEntryToHQ' entry
+    sr@(SA.SearchResult mpath result) ->
+      bimap (const $ expectedButActually "a name" sr "a hash") (Path.parentOfName <$>) . HQ'.fromHQ $
+        searchResultToHQ mpath result
+    otherNumArg -> Left $ wrongStructuredArgument "a name" otherNumArg
 
 handleHashQualifiedSplitArg :: I.Argument -> Either (P.Pretty CT.ColorText) (HQ'.HashQualified (Path.Split Path))
-handleHashQualifiedSplitArg =
-  either
-    (first P.text . Path.parseHQSplit)
-    \case
-      n@(SA.Name name) ->
-        fmap HQ'.fromName
-          . bitraverse
-            ( \case
-                Path.AbsolutePath' _ -> Left $ expectedButActually "a relative name" n "an absolute name"
-                Path.RelativePath' p -> pure $ Path.unrelative p
-            )
-            pure
-          $ Path.parentOfName name
-      hq@(SA.HashQualified name) ->
-        first (const $ expectedButActually "a name" hq "a hash") . HQ'.fromHQ $ Path.splitFromName <$> name
-      SA.HashQualifiedWithBranchPrefix (BranchAtSCH _) hqname -> pure $ Path.splitFromName <$> hqname
-      SA.HashQualifiedWithBranchPrefix (BranchAtPath prefix) hqname ->
-        pure $ Path.splitFromName . Path.prefixNameIfRel (Path.AbsolutePath' prefix) <$> hqname
-      SA.ShallowListEntry _ entry -> pure $ Path.splitFromName <$> shallowListEntryToHQ' entry
-      sr@(SA.SearchResult mpath result) ->
-        first (const $ expectedButActually "a name" sr "a hash") . HQ'.fromHQ $
-          Path.splitFromName <$> searchResultToHQ mpath result
-      otherNumArg -> Left $ wrongStructuredArgument "a relative name" otherNumArg
+handleHashQualifiedSplitArg = \case
+  I.RawArg raw -> first P.text . Path.parseHQSplit $ raw
+  I.StructuredArg sa -> case sa of
+    n@(SA.Name name) ->
+      fmap HQ'.fromName
+        . bitraverse
+          ( \case
+              Path.AbsolutePath' _ -> Left $ expectedButActually "a relative name" n "an absolute name"
+              Path.RelativePath' p -> pure $ Path.unrelative p
+          )
+          pure
+        $ Path.parentOfName name
+    hq@(SA.HashQualified name) ->
+      first (const $ expectedButActually "a name" hq "a hash") . HQ'.fromHQ $ Path.splitFromName <$> name
+    SA.HashQualifiedWithBranchPrefix (BranchAtSCH _) hqname -> pure $ Path.splitFromName <$> hqname
+    SA.HashQualifiedWithBranchPrefix (BranchAtPath prefix) hqname ->
+      pure $ Path.splitFromName . Path.prefixNameIfRel (Path.AbsolutePath' prefix) <$> hqname
+    SA.ShallowListEntry _ entry -> pure $ Path.splitFromName <$> shallowListEntryToHQ' entry
+    sr@(SA.SearchResult mpath result) ->
+      first (const $ expectedButActually "a name" sr "a hash") . HQ'.fromHQ $
+        Path.splitFromName <$> searchResultToHQ mpath result
+    otherNumArg -> Left $ wrongStructuredArgument "a relative name" otherNumArg
 
 handleShortCausalHashArg :: I.Argument -> Either (P.Pretty CT.ColorText) ShortCausalHash
-handleShortCausalHashArg =
-  either
-    (first (P.text . Text.pack) . Input.parseShortCausalHash)
-    \case
-      SA.Namespace hash -> pure $ SCH.fromFullHash hash
-      otherNumArg -> Left $ wrongStructuredArgument "a causal hash" otherNumArg
+handleShortCausalHashArg = \case
+  I.RawArg raw -> first (P.text . Text.pack) . Input.parseShortCausalHash $ raw
+  I.StructuredArg sa -> case sa of
+    SA.Namespace hash -> pure $ SCH.fromFullHash hash
+    otherNumArg -> Left $ wrongStructuredArgument "a causal hash" otherNumArg
 
 handleHashOrHQSplit'Arg ::
   I.Argument -> Either (P.Pretty CT.ColorText) (HQ'.HashOrHQ (Path.Split Path'))
-handleHashOrHQSplit'Arg =
-  either
-    (first P.text . Path.parseHashOrHQSplit')
-    \case
-      SA.HashQualified name -> pure . HQ'.fromHQ $ Path.parentOfName <$> name
-      SA.HashQualifiedWithBranchPrefix (BranchAtSCH _) hqname -> pure . pure $ Path.parentOfName <$> hqname
-      SA.HashQualifiedWithBranchPrefix (BranchAtPath prefix) hqname ->
-        pure . pure $ Path.parentOfName . Path.prefixNameIfRel (Path.AbsolutePath' prefix) <$> hqname
-      SA.ShallowListEntry prefix entry ->
-        pure . pure $ Path.parentOfName . Path.prefixNameIfRel prefix <$> shallowListEntryToHQ' entry
-      SA.SearchResult mpath result -> pure . HQ'.fromHQ $ Path.parentOfName <$> searchResultToHQ mpath result
-      otherNumArg -> Left $ wrongStructuredArgument "a hash or name" otherNumArg
+handleHashOrHQSplit'Arg = \case
+  I.RawArg raw -> first P.text . Path.parseHashOrHQSplit' $ raw
+  I.StructuredArg sa -> case sa of
+    SA.HashQualified name -> pure . HQ'.fromHQ $ Path.parentOfName <$> name
+    SA.HashQualifiedWithBranchPrefix (BranchAtSCH _) hqname -> pure . pure $ Path.parentOfName <$> hqname
+    SA.HashQualifiedWithBranchPrefix (BranchAtPath prefix) hqname ->
+      pure . pure $ Path.parentOfName . Path.prefixNameIfRel (Path.AbsolutePath' prefix) <$> hqname
+    SA.ShallowListEntry prefix entry ->
+      pure . pure $ Path.parentOfName . Path.prefixNameIfRel prefix <$> shallowListEntryToHQ' entry
+    SA.SearchResult mpath result -> pure . HQ'.fromHQ $ Path.parentOfName <$> searchResultToHQ mpath result
+    otherNumArg -> Left $ wrongStructuredArgument "a hash or name" otherNumArg
 
 handleRelativeNameSegmentArg :: I.Argument -> Either (P.Pretty CT.ColorText) NameSegment
 handleRelativeNameSegmentArg arg = do
@@ -678,80 +666,74 @@ handleRelativeNameSegmentArg arg = do
 handleNameSegmentArg :: I.Argument -> Either (P.Pretty CT.ColorText) NameSegment
 handleNameSegmentArg arg = do
   case arg of
-    Left txt -> mapLeft P.text $ NameSegment.parseText (Text.pack txt)
+    I.RawArg txt -> mapLeft P.text $ NameSegment.parseText (Text.pack txt)
     -- There are no valid structured args for a single name segment identifier, and there are no commands that
     -- output them as numbered output.
-    Right _ -> Left "Expected a name segment"
+    I.StructuredArg _ -> Left "Expected a name segment"
 
 handleNameArg :: I.Argument -> Either (P.Pretty CT.ColorText) Name
-handleNameArg =
-  either
-    (first P.text . Name.parseTextEither . Text.pack)
-    \case
-      SA.Name name -> pure name
-      SA.NameWithBranchPrefix (BranchAtSCH _) name -> pure name
-      SA.NameWithBranchPrefix (BranchAtPath prefix) name -> pure $ Path.prefixNameIfRel (Path.AbsolutePath' prefix) name
-      SA.HashQualified hqname -> maybe (Left "can’t find a name from the numbered arg") pure $ HQ.toName hqname
-      SA.HashQualifiedWithBranchPrefix (BranchAtSCH _) hqname -> pure $ HQ'.toName hqname
-      SA.HashQualifiedWithBranchPrefix (BranchAtPath prefix) hqname ->
-        pure . Path.prefixNameIfRel (Path.AbsolutePath' prefix) $ HQ'.toName hqname
-      SA.ShallowListEntry prefix entry ->
-        pure . HQ'.toName . fmap (Path.prefixNameIfRel prefix) $ shallowListEntryToHQ' entry
-      SA.SearchResult mpath result ->
-        maybe (Left "can’t find a name from the numbered arg") pure . HQ.toName $ searchResultToHQ mpath result
-      otherNumArg -> Left $ wrongStructuredArgument "a name" otherNumArg
+handleNameArg = \case
+  I.RawArg raw -> first P.text . Name.parseTextEither . Text.pack $ raw
+  I.StructuredArg sa -> case sa of
+    SA.Name name -> pure name
+    SA.NameWithBranchPrefix (BranchAtSCH _) name -> pure name
+    SA.NameWithBranchPrefix (BranchAtPath prefix) name -> pure $ Path.prefixNameIfRel (Path.AbsolutePath' prefix) name
+    SA.HashQualified hqname -> maybe (Left "can’t find a name from the numbered arg") pure $ HQ.toName hqname
+    SA.HashQualifiedWithBranchPrefix (BranchAtSCH _) hqname -> pure $ HQ'.toName hqname
+    SA.HashQualifiedWithBranchPrefix (BranchAtPath prefix) hqname ->
+      pure . Path.prefixNameIfRel (Path.AbsolutePath' prefix) $ HQ'.toName hqname
+    SA.ShallowListEntry prefix entry ->
+      pure . HQ'.toName . fmap (Path.prefixNameIfRel prefix) $ shallowListEntryToHQ' entry
+    SA.SearchResult mpath result ->
+      maybe (Left "can’t find a name from the numbered arg") pure . HQ.toName $ searchResultToHQ mpath result
+    otherNumArg -> Left $ wrongStructuredArgument "a name" otherNumArg
 
 handlePullSourceArg ::
   I.Argument ->
   Either
     (P.Pretty CT.ColorText)
     (ReadRemoteNamespace (These ProjectName ProjectBranchNameOrLatestRelease))
-handlePullSourceArg =
-  either
-    (megaparse (readRemoteNamespaceParser ProjectBranchSpecifier'NameOrLatestRelease) . Text.pack)
-    \case
-      SA.Project project -> pure . RemoteRepo.ReadShare'ProjectBranch $ This project
-      SA.ProjectBranch (ProjectAndBranch project branch) ->
-        pure . RemoteRepo.ReadShare'ProjectBranch . maybe That These project $
-          ProjectBranchNameOrLatestRelease'Name branch
-      otherNumArg -> Left $ wrongStructuredArgument "a source to pull from" otherNumArg
+handlePullSourceArg = \case
+  I.RawArg raw -> megaparse (readRemoteNamespaceParser ProjectBranchSpecifier'NameOrLatestRelease) . Text.pack $ raw
+  I.StructuredArg sa -> case sa of
+    SA.Project project -> pure . RemoteRepo.ReadShare'ProjectBranch $ This project
+    SA.ProjectBranch (ProjectAndBranch project branch) ->
+      pure . RemoteRepo.ReadShare'ProjectBranch . maybe That These project $
+        ProjectBranchNameOrLatestRelease'Name branch
+    otherNumArg -> Left $ wrongStructuredArgument "a source to pull from" otherNumArg
 
 handlePushTargetArg ::
   I.Argument -> Either (P.Pretty CT.ColorText) (These ProjectName ProjectBranchName)
-handlePushTargetArg =
-  either
-    (\str -> maybe (Left $ expectedButActually' "a target to push to" str) pure $ parsePushTarget str)
-    $ \case
-      SA.Project project -> pure $ This project
-      SA.ProjectBranch (ProjectAndBranch project branch) -> pure $ maybe That These project branch
-      otherNumArg -> Left $ wrongStructuredArgument "a target to push to" otherNumArg
+handlePushTargetArg = \case
+  I.RawArg raw -> maybe (Left $ expectedButActually' "a target to push to" raw) pure $ parsePushTarget raw
+  I.StructuredArg sa -> case sa of
+    SA.Project project -> pure $ This project
+    SA.ProjectBranch (ProjectAndBranch project branch) -> pure $ maybe That These project branch
+    otherNumArg -> Left $ wrongStructuredArgument "a target to push to" otherNumArg
 
 handlePushSourceArg :: I.Argument -> Either (P.Pretty CT.ColorText) Input.PushSource
-handlePushSourceArg =
-  either
-    (\str -> maybe (Left $ expectedButActually' "a source to push from" str) pure $ parsePushSource str)
-    \case
-      SA.Project project -> pure . Input.ProjySource $ This project
-      SA.ProjectBranch (ProjectAndBranch project branch) -> pure . Input.ProjySource $ maybe That These project branch
-      otherNumArg -> Left $ wrongStructuredArgument "a source to push from" otherNumArg
+handlePushSourceArg = \case
+  I.RawArg raw -> maybe (Left $ expectedButActually' "a source to push from" raw) pure $ parsePushSource raw
+  I.StructuredArg sa -> case sa of
+    SA.Project project -> pure . Input.ProjySource $ This project
+    SA.ProjectBranch (ProjectAndBranch project branch) -> pure . Input.ProjySource $ maybe That These project branch
+    otherNumArg -> Left $ wrongStructuredArgument "a source to push from" otherNumArg
 
 handleProjectAndBranchNamesArg :: I.Argument -> Either (P.Pretty CT.ColorText) ProjectAndBranchNames
-handleProjectAndBranchNamesArg =
-  either
-    (\str -> first (const $ expectedButActually' "a project or branch" str) . tryInto @ProjectAndBranchNames $ Text.pack str)
-    $ fmap ProjectAndBranchNames'Unambiguous . \case
-      SA.Project project -> pure $ This project
-      SA.ProjectBranch (ProjectAndBranch mproj branch) -> pure $ maybe That These mproj branch
-      otherNumArg -> Left $ wrongStructuredArgument "a project or branch" otherNumArg
+handleProjectAndBranchNamesArg = \case
+  I.RawArg raw -> first (const $ expectedButActually' "a project or branch" raw) . tryInto @ProjectAndBranchNames $ Text.pack raw
+  I.StructuredArg sa -> fmap ProjectAndBranchNames'Unambiguous $ case sa of
+    SA.Project project -> pure $ This project
+    SA.ProjectBranch (ProjectAndBranch mproj branch) -> pure $ maybe That These mproj branch
+    otherNumArg -> Left $ wrongStructuredArgument "a project or branch" otherNumArg
 
 handleOptionalProjectAndBranch :: I.Argument -> Either (P.Pretty CT.ColorText) (ProjectAndBranch (Maybe ProjectName) (Maybe ProjectBranchName))
-handleOptionalProjectAndBranch =
-  either
-    (\str -> fmap intoProjectAndBranch . first (const $ expectedButActually' "a project or branch" str) . tryInto @(These ProjectName ProjectBranchName) $ Text.pack str)
-    $ \case
-      SA.Project project -> pure $ ProjectAndBranch (Just project) Nothing
-      SA.ProjectBranch (ProjectAndBranch mproj branch) -> pure $ ProjectAndBranch mproj (Just branch)
-      otherNumArg -> Left $ wrongStructuredArgument "a project or branch" otherNumArg
+handleOptionalProjectAndBranch = \case
+  I.RawArg raw -> fmap intoProjectAndBranch . first (const $ expectedButActually' "a project or branch" raw) . tryInto @(These ProjectName ProjectBranchName) $ Text.pack raw
+  I.StructuredArg sa -> case sa of
+    SA.Project project -> pure $ ProjectAndBranch (Just project) Nothing
+    SA.ProjectBranch (ProjectAndBranch mproj branch) -> pure $ ProjectAndBranch mproj (Just branch)
+    otherNumArg -> Left $ wrongStructuredArgument "a project or branch" otherNumArg
   where
     intoProjectAndBranch :: These ProjectName ProjectBranchName -> ProjectAndBranch (Maybe ProjectName) (Maybe ProjectBranchName)
     intoProjectAndBranch = \case
@@ -760,38 +742,32 @@ handleOptionalProjectAndBranch =
       These project branch -> ProjectAndBranch (Just project) (Just branch)
 
 handleBranchWithOptionalProject :: I.Argument -> Either (P.Pretty CT.ColorText) (ProjectAndBranch (Maybe ProjectName) ProjectBranchName)
-handleBranchWithOptionalProject =
-  either
-    ( \str ->
-        Text.pack str
-          & tryInto @(These ProjectName ProjectBranchName)
-          & first (const $ expectedButActually' "a project branch" str)
-          >>= \case
-            These project branch -> pure $ ProjectAndBranch (Just project) branch
-            That branch -> pure $ ProjectAndBranch Nothing branch
-            This _project -> Left $ expectedButActually' "a  project branch" str
-    )
-    ( \case
-        SA.ProjectBranch (ProjectAndBranch mproj branch) -> pure $ ProjectAndBranch mproj branch
-        otherNumArg -> Left $ wrongStructuredArgument "a project branch" otherNumArg
-    )
+handleBranchWithOptionalProject = \case
+  I.RawArg raw ->
+    Text.pack raw
+      & tryInto @(These ProjectName ProjectBranchName)
+      & first (const $ expectedButActually' "a project branch" raw)
+      >>= \case
+        These project branch -> pure $ ProjectAndBranch (Just project) branch
+        That branch -> pure $ ProjectAndBranch Nothing branch
+        This _project -> Left $ expectedButActually' "a  project branch" raw
+  I.StructuredArg sa -> case sa of
+    SA.ProjectBranch (ProjectAndBranch mproj branch) -> pure $ ProjectAndBranch mproj branch
+    otherNumArg -> Left $ wrongStructuredArgument "a project branch" otherNumArg
 
 handleBranchWithProject :: I.Argument -> Either (P.Pretty CT.ColorText) (ProjectAndBranch ProjectName ProjectBranchName)
-handleBranchWithProject =
-  either
-    ( \str ->
-        Text.pack str
-          & tryInto @(These ProjectName ProjectBranchName)
-          & first (const $ expectedButActually' "a project branch" str)
-          >>= \case
-            These project branch -> pure $ ProjectAndBranch project branch
-            That _branch -> Left $ expectedButActually' "a project branch" str
-            This _project -> Left $ expectedButActually' "a project branch" str
-    )
-    ( \case
-        SA.ProjectBranch (ProjectAndBranch (Just proj) branch) -> pure $ ProjectAndBranch proj branch
-        otherNumArg -> Left $ wrongStructuredArgument "a project branch" otherNumArg
-    )
+handleBranchWithProject = \case
+  I.RawArg raw ->
+    Text.pack raw
+      & tryInto @(These ProjectName ProjectBranchName)
+      & first (const $ expectedButActually' "a project branch" raw)
+      >>= \case
+        These project branch -> pure $ ProjectAndBranch project branch
+        That _branch -> Left $ expectedButActually' "a project branch" raw
+        This _project -> Left $ expectedButActually' "a project branch" raw
+  I.StructuredArg sa -> case sa of
+    SA.ProjectBranch (ProjectAndBranch (Just proj) branch) -> pure $ ProjectAndBranch proj branch
+    otherNumArg -> Left $ wrongStructuredArgument "a project branch" otherNumArg
 
 mergeBuiltins :: InputPattern
 mergeBuiltins =
@@ -1036,7 +1012,7 @@ textfind allowLib =
         then ("text.find.all", ["grep.all"], "Use `text.find` to exclude `lib` from search.")
         else ("text.find", ["grep"], "Use `text.find.all` to include search of `lib`.")
     parse = \case
-      words -> pure $ Input.TextFindI allowLib (untokenize $ [e | Left e <- words])
+      words -> pure $ Input.TextFindI allowLib (untokenize $ [e | I.RawArg e <- words])
     msg =
       P.lines
         [ P.wrap $
@@ -1350,8 +1326,9 @@ deleteGen suffix queryCompletionArg parseArg target force which =
         $ fmap (Input.DeleteI force which) . traverse parseArg
 
 handleDeleteArg :: I.Argument -> Either (P.Pretty CT.ColorText) (HQ'.HashQualified Name)
-handleDeleteArg =
-  either parseHashQualifiedName' \case
+handleDeleteArg = \case
+  I.RawArg raw -> parseHashQualifiedName' raw
+  I.StructuredArg sa -> case sa of
     SA.Name name -> Right (HQ'.NameOnly name)
     SA.HashQualified (HQ'.fromHQ -> Right name) -> Right name
     SA.ShallowListEntry prefix (ShallowTermEntry entry) ->
@@ -1365,8 +1342,9 @@ handleDeleteArg =
     otherArgType -> Left (wrongStructuredArgument "a term or type name" otherArgType)
 
 handleDeleteTermArg :: I.Argument -> Either (P.Pretty CT.ColorText) (HQ'.HashQualified Name)
-handleDeleteTermArg =
-  either parseHashQualifiedName' \case
+handleDeleteTermArg = \case
+  I.RawArg raw -> parseHashQualifiedName' raw
+  I.StructuredArg sa -> case sa of
     SA.Name name -> Right (HQ'.NameOnly name)
     SA.HashQualified (HQ'.fromHQ -> Right name) -> Right name
     SA.ShallowListEntry prefix (ShallowTermEntry entry) ->
@@ -1376,8 +1354,9 @@ handleDeleteTermArg =
     otherArgType -> Left (wrongStructuredArgument "a term name" otherArgType)
 
 handleDeleteTypeArg :: I.Argument -> Either (P.Pretty CT.ColorText) (HQ'.HashQualified Name)
-handleDeleteTypeArg =
-  either parseHashQualifiedName' \case
+handleDeleteTypeArg = \case
+  I.RawArg raw -> parseHashQualifiedName' raw
+  I.StructuredArg sa -> case sa of
     SA.Name name -> Right (HQ'.NameOnly name)
     SA.HashQualified (HQ'.fromHQ -> Right name) -> Right name
     SA.ShallowListEntry prefix (ShallowTypeEntry entry) ->
@@ -1603,7 +1582,7 @@ cd =
         ]
     )
     \case
-      [Left ".."] -> Right Input.UpI
+      [I.RawArg ".."] -> Right Input.UpI
       [p] -> Input.SwitchBranchI <$> handlePath'Arg p
       args -> wrongArgsLength "exactly one argument" args
 
@@ -1658,7 +1637,7 @@ deleteNamespaceForce =
 
 deleteNamespaceParser :: Input.Insistence -> I.Arguments -> Either (P.Pretty CT.ColorText) Input
 deleteNamespaceParser insistence = \case
-  [Left "."] -> first fromString . pure $ Input.DeleteNamespaceI insistence Nothing
+  [I.RawArg "."] -> first fromString . pure $ Input.DeleteNamespaceI insistence Nothing
   [p] -> Input.DeleteNamespaceI insistence . pure <$> handleSplitArg p
   args -> wrongArgsLength "exactly one argument" args
 

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -126,7 +126,7 @@ getUserInput codebase authHTTPClient pp currentProjectRoot numberedArgs =
                       expandedArgs'
                         <&> requote
                         & unwords
-                when (expandedArgs' /= ws) $ do
+                when (expandedArgs' /= fmap IP.renderCliArg ws) $ do
                   liftIO . Text.putStrLn $ fullPrompt <> Text.pack expandedArgsStr
                 Line.modifyHistory $ Line.addHistoryUnlessConsecutiveDupe expandedArgsStr
                 pure i

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -260,7 +260,6 @@ library
     , random-shuffle
     , raw-strings-qq
     , recover-rtti
-    , regex-tdfa
     , semialign
     , serialise
     , servant

--- a/unison-src/transcripts-using-base/fix-2805.md
+++ b/unison-src/transcripts-using-base/fix-2805.md
@@ -1,23 +1,24 @@
 When running a main function in `ucm` a numeric argument is replaced by the potential last result of a find command:
 
-``` unison
+The workaround for this is to quote the numeric argument instead.
+
+``` unison :hide
 main : '{IO, Exception} Text
 main _ = "Hello " ++ Optional.getOrBug "definitely passed an arg" (List.head !getArgs) ++ "!"
 ```
 
-First we run it with no numbered results in the history, so if number expansion is applied, it should end up calling `main` with zero args, whereas without number expansion, we get a single argument, “1”, passed to it.
+If we quote the arg, it won't expand.
 
 ``` ucm
-> run main 1
+> run main "1"
 
   "Hello 1!"
 ```
 
-Now we set it up so there _are_ numbered results in the history. If number expansion is applied here, we will get an error “`run` can’t accept a numbered argument […]”, and otherwise our expected "1".
+Numeric expansion results in a structured argument, if we pass
+this to `run` we expect an error: “`run` can’t accept a numbered argument […]”
 
-``` ucm
+``` ucm :error
 > find.all isLeft
 > run main 1
-
-  "Hello 1!"
 ```

--- a/unison-src/transcripts-using-base/fix-2805.output.md
+++ b/unison-src/transcripts-using-base/fix-2805.output.md
@@ -1,34 +1,29 @@
 When running a main function in `ucm` a numeric argument is replaced by the potential last result of a find command:
 
-``` unison
+The workaround for this is to quote the numeric argument instead.
+
+``` unison :hide
 main : '{IO, Exception} Text
 main _ = "Hello " ++ Optional.getOrBug "definitely passed an arg" (List.head !getArgs) ++ "!"
 ```
 
-``` ucm :added-by-ucm
-  Loading changes detected in scratch.u.
-
-  + main : '{IO, Exception} Text
-
-  Run `update` to apply these changes to your codebase.
-```
-
-First we run it with no numbered results in the history, so if number expansion is applied, it should end up calling `main` with zero args, whereas without number expansion, we get a single argument, “1”, passed to it.
+If we quote the arg, it won't expand.
 
 ``` ucm
-> run main 1
+> run main "1"
 
   "Hello 1!"
 ```
 
-Now we set it up so there *are* numbered results in the history. If number expansion is applied here, we will get an error “`run` can’t accept a numbered argument \[…\]”, and otherwise our expected "1".
+Numeric expansion results in a structured argument, if we pass
+this to `run` we expect an error: “`run` can’t accept a numbered argument \[…\]”
 
-``` ucm
+``` ucm :error
 > find.all isLeft
 
   1. Either.isLeft : Either a b -> Boolean
 
 > run main 1
 
-  "Hello 1!"
+  Internal error: Expected a String, but got a structured argument instead.
 ```

--- a/unison-src/transcripts/idempotent/input-parsing.md
+++ b/unison-src/transcripts/idempotent/input-parsing.md
@@ -6,18 +6,16 @@ scratch/main> builtins.mergeio
   Done.
 ```
 
-``` unison
+``` unison :hide
 main = do
   getArgs.impl ()
 ```
 
-``` ucm :added-by-ucm
-  Loading changes detected in scratch.u.
-
-  + main : '{IO} Either Failure [Text]
-
-  Run `update` to apply these changes to your codebase.
+``` ucm :hide
+scratch/main> update
 ```
+
+Quoting allows spaces in arguments.
 
 ``` ucm
 scratch/main> run main "all one arg" "contains escaped \" quote" second third
@@ -28,4 +26,85 @@ scratch/main> run main "all one arg" "contains escaped \" quote" second third
     , "second"
     , "third"
     ]
+```
+
+Quoted numbers are not expanded.
+
+``` ucm
+scratch/main> ls
+
+  1. builtin. (840 terms, 121 types)
+  2. main     ('{IO} Either Failure [Text])
+
+scratch/main> run main "1" "2-" "3-4"
+
+  Right ["1", "2-", "3-4"]
+```
+
+## Number expansion
+
+Unquoted numbers are expanded to ranges.
+
+``` unison :hide
+a1 = "a1"
+a2 = "a2"
+a3 = "a3"
+a4 = "a4"
+a5 = "a5"
+a6 = "a6"
+a7 = "a7"
+```
+
+``` ucm :hide
+scratch/numbers> update
+```
+
+``` ucm
+scratch/numbers> ls
+
+  1. a1 (##Text)
+  2. a2 (##Text)
+  3. a3 (##Text)
+  4. a4 (##Text)
+  5. a5 (##Text)
+  6. a6 (##Text)
+  7. a7 (##Text)
+
+scratch/numbers> view 3
+
+  a3 : ##Text
+  a3 = "a3"
+
+scratch/numbers> view -3
+
+  a1 : ##Text
+  a1 = "a1"
+
+  a2 : ##Text
+  a2 = "a2"
+
+  a3 : ##Text
+  a3 = "a3"
+
+scratch/numbers> view 5-
+
+  a5 : ##Text
+  a5 = "a5"
+
+  a6 : ##Text
+  a6 = "a6"
+
+  a7 : ##Text
+  a7 = "a7"
+
+scratch/numbers> view 3-5
+
+  a3 : ##Text
+  a3 = "a3"
+
+  a4 : ##Text
+  a4 = "a4"
+
+  a5 : ##Text
+  a5 = "a5"
 ```


### PR DESCRIPTION
## Overview

* [x] Based on #5968 , merge that first.

Number expansion was done relatively ad-hoc, and it was impossible to pass a number as an argument to `run` since it would always attempt to expand it.

With #5968 the parser is more structured, so now we can actually parse numbered ranges correctly.

* This changes it so quoted numbers are treated as string args and are never expanded.
* I know folks often do patterns like `1-99` or w/e, so I added support for open ranges, e.g. `1-` or `-10`

## Implementation notes

* Replace the Argument type with a proper tagged Union type (this added a lot of noice because everything was written to be very point-free :'( )
* Add a proper parser for numbered ranges, and add a proper tagged union for representing the parsed numeric ranges
* Propagate parsing logic.

## Interesting/controversial decisions

I can change or remove the support for open ranges if desired.

I changed the expected behaviour of the transcript for https://github.com/unisonweb/unison/issues/2805 ;

Personally I think it's quite confusing if the way a command line is parsed is dependent on the previous command.
I changed it to no longer change behaviour based on the numbered args state; but rather if you want to pass a numeric argument you can always quote it to get the desired effect regardless of the state.

## Test coverage

Transcripts

## Loose ends

We could support fully open ranges like `-`, but I left that off for now because `-` is a valid symbol on its own.