### PR TITLE
Make more use of inferred variances during type checking

### DIFF
--- a/parser-typechecker/src/Unison/Typechecker.hs
+++ b/parser-typechecker/src/Unison/Typechecker.hs
@@ -390,7 +390,7 @@ typeDirectedNameResolution ppe oldNotes oldType env = do
           Result (Notes v loc) (Maybe (Context.Suggestion v loc))
         resolve fuzzyNameMatch inferredType (NamedReference fqn foundType replace) =
           -- We found a name that matches or is similar. Check the type matches too.
-          case Context.isSubtype (TypeVar.liftType foundType) (Context.relax inferredType) of
+          case Context.isSubtype (TypeVar.liftType foundType) (Context.relax (variances env) inferredType) of
             Left bug -> Nothing <$ compilerBug bug
             -- Create a suggestion based on name and type similarity.
             Right typeMatches ->

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -55,6 +55,7 @@ import Control.Monad.State
     gets,
     put,
     runStateT,
+    state,
   )
 import Data.Foldable qualified as Foldable
 import Data.Function (on)
@@ -274,14 +275,24 @@ liftTotalM (MT m) = MT $ \ppe pmcSwitch vars datas effects defs env ->
     Left bug -> CompilerBug bug mempty mempty
     Right a -> Success mempty a
 
+checkVarianceWith ::
+  Map Reference [Variance] ->
+  Type v loc ->
+  Maybe [Variance]
+checkVarianceWith vars = \case
+  Type.Ref' r -> Map.lookup r vars
+  Type.Apps' (Type.Ref' r) args ->
+    drop n <$> Map.lookup r vars
+    where
+      n = length args
+  _ -> Nothing
+
 checkVariance :: Type v loc -> M v loc (Maybe [Variance])
 checkVariance ty = MT \_ _ vars _ _ _ env ->
-  Success mempty . (,env) $ case ty of
-    Type.Ref' r -> Map.lookup r vars
-    Type.Apps' (Type.Ref' r) args -> drop n <$> Map.lookup r vars
-      where
-        n = length args
-    _ -> Nothing
+  Success mempty (checkVarianceWith vars ty, env)
+
+getVariances :: M v loc (Map Reference [Variance])
+getVariances = MT \_ _ vars _ _ _ env -> Success mempty (vars, env)
 
 -- Allows modifying the stored notes in a scoped way.
 -- This is based on the `pass` function in e.g. Control.Monad.Writer
@@ -1263,7 +1274,8 @@ synthesizeWanted trm@(Term.Var' v) = do
         -- which variable ot instantiate, so we ought to discard them
         -- early.
         (vs, t) <- ungeneralize' t
-        pure (discardCovariant (Set.fromList vs) t, [])
+        vars <- getVariances
+        pure (discardCovariant vars (Set.fromList vs) t, [])
 synthesizeWanted (Term.Ref' h) =
   compilerCrash $ UnannotatedReference h
 synthesizeWanted (Term.Ann' (Term.Ref' _) t)
@@ -1275,11 +1287,11 @@ synthesizeWanted (Term.Ann' (Term.Ref' _) t)
       t <- existentializeArrows t
       -- See note about ungeneralizing above in the Var case.
       t <- ungeneralize t
-      pure (discard t, [])
+      (,[]) <$> discard t
   | otherwise = compilerCrash $ FreeVarsInTypeAnnotation s
   where
     s = ABT.freeVars t
-    discard ty = discardCovariant fvs ty
+    discard ty = getVariances <&> \vars -> discardCovariant vars fvs ty
       where
         fvs = foldMap p $ ABT.freeVars ty
         p (TypeVar.Existential _ v) = Set.singleton v
@@ -1309,7 +1321,8 @@ synthesizeWanted (Term.LetRecAnnotatedTop' isTop letrec) = do
     e <- annotateLetRecBindings isTop letrec
     synthesize e
   want <- substAndDefaultWanted want ctx2
-  pure (generalizeExistentials ctx2 t, want)
+  vars <- getVariances
+  pure (generalizeExistentials ctx2 vars t, want)
 synthesizeWanted (Term.Handle' h body) = do
   -- To synthesize a handle block, we first synthesize the handler h,
   -- then push its allowed abilities onto the current ambient set when
@@ -1511,7 +1524,8 @@ synthesizeBinding top binding = do
         if top
           then do
             ctx <- retract
-            pure ((generalizeExistentials ctx tb, []), substituteSolved ctx)
+            vars <- getVariances
+            pure ((generalizeExistentials ctx vars tb, []), substituteSolved ctx)
           else do
             ctx <- retract
             -- Note: this is conservative about what we avoid
@@ -1540,7 +1554,8 @@ synthesizeBinding top binding = do
                 (repush, discard) = partitionEithers $ fmap p ctx
             appendContext repush
             markRetained keep
-            let tf = generalizeExistentials discard (applyCtx ctx tb)
+            vars <- getVariances
+            let tf = generalizeExistentials discard vars (applyCtx ctx tb)
             pure ((tf, []), substituteSolved ctx)
 
 getDataConstructorsAtType :: forall v loc. (Ord loc, Var v) => Type v loc -> M v loc (EnumeratedConstructors (TypeVar v loc) v loc)
@@ -1998,8 +2013,10 @@ annotateLetRecBindings isTop letrec =
         pure (bindings, bindingTypes, vlocs)
       -- compute generalized types `gt1, gt2 ...` for each binding `b1, b2...`;
       -- add annotations `v1 : gt1, v2 : gt2 ...` to the context
+      vars <- getVariances
       let bindingArities = Term.arity <$> bindings
-          gen bindingType _arity = generalizeExistentials ctx2 bindingType
+          gen bindingType _arity =
+            generalizeExistentials ctx2 vars bindingType
           bindingTypesGeneralized = zipWith gen bindingTypes bindingArities
           annotations = zipWith3 Ann vs vlocs bindingTypesGeneralized
 
@@ -2177,12 +2194,17 @@ forcedData ty = Type.freeVars ty
 
 -- | Apply the context to the input type, then convert any unsolved existentials
 -- to universals.
-generalizeExistentials :: (Var v, Ord loc) => [Element v loc] -> Type v loc -> Type v loc
-generalizeExistentials ctx ty0 = generalizeP pred ctx ty
+generalizeExistentials ::
+  (Var v, Ord loc) =>
+  [Element v loc] ->
+  Map Reference [Variance] ->
+  Type v loc ->
+  Type v loc
+generalizeExistentials ctx vars ty0 = generalizeP pred ctx ty
   where
     gens = Set.fromList $ mapMaybe (fmap snd . existentialP) ctx
 
-    ty = discardCovariant gens $ applyCtx ctx ty0
+    ty = discardCovariant vars gens $ applyCtx ctx ty0
     fvs = Type.freeVars ty
 
     pred e
@@ -2411,11 +2433,24 @@ defaultAbility _ = pure False
 --
 -- Expects a fully substituted type, so that it is unnecessary to
 -- check if an existential in the type has been solved.
-discardCovariant :: (Var v) => Set v -> Type v loc -> Type v loc
-discardCovariant _ ty | debugType "discardCovariant" ty = undefined
-discardCovariant gens ty =
+discardCovariant ::
+  (Var v) =>
+  Map Reference [Variance] ->
+  Set v ->
+  Type v loc ->
+  Type v loc
+discardCovariant _ _ ty | debugType "discardCovariant" ty = undefined
+discardCovariant vars gens ty =
   ABT.rewriteDown (strip $ keepVarsT True ty) ty
   where
+    keepVarsV pos (Pos, t) = keepVarsT pos t
+    keepVarsV pos (Neg, t) = keepVarsT (not pos) t
+    -- TODO: handle Any if we ever decide to have phantom variance.
+    -- In that case, no variables in a phantom position need to be kept.
+    --
+    -- Below is the invariant case, where all variables need to be kept.
+    keepVarsV _   (_, t) = foldMap exi $ Type.freeVars t
+
     keepVarsT pos (Type.Arrow' i o) =
       keepVarsT (not pos) i <> keepVarsT pos o
     keepVarsT pos (Type.Effect1' e o) =
@@ -2423,6 +2458,10 @@ discardCovariant gens ty =
     keepVarsT pos (Type.Effects' es) = foldMap (keepVarsE pos) es
     keepVarsT pos (Type.ForallNamed' _ t) = keepVarsT pos t
     keepVarsT pos (Type.IntroOuterNamed' _ t) = keepVarsT pos t
+    keepVarsT pos (Type.Apps' f xs)
+      | Just vs <- checkVarianceWith vars f,
+        length vs == length xs =
+          keepVarsT pos f <> foldMap (keepVarsV pos) (zip vs xs)
     keepVarsT _ t = foldMap exi $ Type.freeVars t
 
     exi (TypeVar.Existential _ v) = Set.singleton v
@@ -2466,13 +2505,20 @@ discardCovariant gens ty =
 -- but this is only used for type directed name resolution. A
 -- separate type check must pass if the candidate is allowed, which
 -- will ensure that the location has the right abilities.
-relax :: (Var v) => (Ord loc) => Type v loc -> Type v loc
-relax t = relax' True v t
+relax ::
+  (Var v) =>
+  (Ord loc) =>
+  Map Reference [Variance] ->
+  Type v loc ->
+  Type v loc
+relax vars t = evalState (relax' vars True fv t) fvs
   where
     fvs = foldMap f $ Type.freeVars t
     f (TypeVar.Existential _ v) = Set.singleton v
     f _ = mempty
-    v = ABT.freshIn fvs $ Var.inferAbility
+    fv = state \avoid ->
+      let v = ABT.freshIn avoid $ Var.inferAbility
+      in (v, Set.insert v avoid)
 
 -- The worker for `relax`.
 --
@@ -2490,24 +2536,44 @@ relax t = relax' True v t
 -- type is just `T`. However, it is undesirable to add these variables
 -- when relax' is used during variable instantiation, because it just
 -- adds ability inference ambiguity.
-relax' :: (Var v) => (Ord loc) => Bool -> v -> Type v loc -> Type v loc
-relax' nonArrow v t
-  | Type.Arrow' i o <- t =
-      Type.arrow (ABT.annotation t) i $ relax' nonArrow v o
-  | Type.ForallsNamed' vs b <- t =
-      Type.foralls loc vs $ relax' nonArrow v b
-  | Type.Effect' es r <- t,
-    Type.Arrow' i o <- r =
-      Type.effect loc es . Type.arrow (ABT.annotation t) i $ relax' nonArrow v o
-  | Type.Effect' es r <- t =
-      if any open es then t else Type.effect loc (tv : es) r
-  | nonArrow = Type.effect loc [tv] t
-  | otherwise = t
+relax' ::
+  (Monad f) =>
+  (Var v) =>
+  (Ord loc) =>
+  Map Reference [Variance] ->
+  Bool ->
+  f v ->
+  Type v loc ->
+  f (Type v loc)
+relax' vars nonArrow fv = rebuild True
   where
     open (Type.Var' (TypeVar.Existential {})) = True
     open _ = False
-    loc = ABT.annotation t
-    tv = Type.var loc (TypeVar.Existential B.Blank v)
+    ftv loc = Type.var loc . TypeVar.Existential B.Blank <$> fv
+
+    rebuild top t
+      | Type.Arrow' i o <- t =
+          Type.arrow (ABT.annotation t) i <$> rebuild False o
+      | Type.ForallsNamed' vs b <- t =
+          Type.foralls loc vs <$> rebuild False b
+      | Type.Effect' es r <- t,
+        Type.Arrow' i o <- r =
+          Type.effect loc es . Type.arrow (ABT.annotation t) i <$>
+            rebuild False o
+      | Type.Effect' es r <- t =
+          if any open es
+          then pure t
+          else ftv loc <&> \tv -> Type.effect loc (tv : es) r
+      | Type.App' f x <- t = do
+          f <- rebuild False f
+          x <- case checkVarianceWith vars f of
+            Just (Pos : _) -> rebuild False x
+            _ -> pure x
+          pure $ Type.app loc f x
+      | top, nonArrow = ftv loc <&> \tv -> Type.effect loc [tv] t
+      | otherwise = pure t
+      where
+        loc = ABT.annotation t
 
 -- Adds a mark to the checker context before calling `checkWanted`.
 -- The boolean argument is for exact ability match cases explained in
@@ -2743,8 +2809,9 @@ subtype tx ty = scope (InSubtype tx ty) $ do
     go ctx t (Type.Var' (TypeVar.Existential b v)) -- `InstantiateR`
       | Set.member v (existentials ctx)
           && notMember v (Type.freeVars t) = do
-          e <- extendExistential Var.inferAbility
-          instantiateR (relax' False e t) b v
+          vars <- getVariances
+          t <- relax' vars False (extendExistential Var.inferAbility) t
+          instantiateR t b v
     go _ (Type.Effects' es1) (Type.Effects' es2) =
       void $ subAbilities ((,) Nothing <$> es1) es2
     go _ t t2@(Type.Effects' _) | expand t = subtype (Type.effects (loc t) [t]) t2
@@ -3518,7 +3585,8 @@ synthesizeClosed' abilities term = do
     scope (InSynthesize term) $
       t <$ subAbilities want abilities
   setContext ctx0 -- restore the initial context
-  pure $ generalizeExistentials ctx t
+  vars <- getVariances
+  pure $ generalizeExistentials ctx vars t
 
 -- Check if the given typechecking action succeeds.
 succeeds :: M v loc a -> TotalM v loc Bool

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -2449,7 +2449,7 @@ discardCovariant vars gens ty =
     -- In that case, no variables in a phantom position need to be kept.
     --
     -- Below is the invariant case, where all variables need to be kept.
-    keepVarsV _   (_, t) = foldMap exi $ Type.freeVars t
+    keepVarsV _ (_, t) = foldMap exi $ Type.freeVars t
 
     keepVarsT pos (Type.Arrow' i o) =
       keepVarsT (not pos) i <> keepVarsT pos o
@@ -2518,7 +2518,7 @@ relax vars t = evalState (relax' vars True fv t) fvs
     f _ = mempty
     fv = state \avoid ->
       let v = ABT.freshIn avoid $ Var.inferAbility
-      in (v, Set.insert v avoid)
+       in (v, Set.insert v avoid)
 
 -- The worker for `relax`.
 --
@@ -2558,12 +2558,12 @@ relax' vars nonArrow fv = rebuild True
           Type.foralls loc vs <$> rebuild False b
       | Type.Effect' es r <- t,
         Type.Arrow' i o <- r =
-          Type.effect loc es . Type.arrow (ABT.annotation t) i <$>
-            rebuild False o
+          Type.effect loc es . Type.arrow (ABT.annotation t) i
+            <$> rebuild False o
       | Type.Effect' es r <- t =
           if any open es
-          then pure t
-          else ftv loc <&> \tv -> Type.effect loc (tv : es) r
+            then pure t
+            else ftv loc <&> \tv -> Type.effect loc (tv : es) r
       | Type.App' f x <- t = do
           f <- rebuild False f
           x <- case checkVarianceWith vars f of

--- a/unison-src/transcripts-manual/rewrites.output.md
+++ b/unison-src/transcripts-manual/rewrites.output.md
@@ -139,8 +139,7 @@ After adding to the codebase, here's the rewritten source:
     (i ->{g} o)
     -> Nat
     -> Rewrites
-      ( RewriteTerm Nat Nat,
-        RewriteTerm (i ->{g, g1} o) (i ->{g} o))
+      (RewriteTerm Nat Nat, RewriteTerm (i ->{g} o) (i ->{g} o))
   rule1 f x =
     use Nat +
     @rewrite

--- a/unison-src/transcripts-round-trip/main.output.md
+++ b/unison-src/transcripts-round-trip/main.output.md
@@ -339,7 +339,7 @@ fix_4258 x y z =
 fix_4258_example : ()
 fix_4258_example = fix_4258 1 () 2
 
-fix_4340 : HandlerWebSocket (Nat ->{g, Abort} Text) y z p q
+fix_4340 : HandlerWebSocket (Nat ->{Abort} Text) y z p q
 fix_4340 = HandlerWebSocket cases
   1 -> "hi sdflkj sdlfkjsdflkj sldfkj sldkfj sdf asdlkfjs dlfkj sldfkj sdf"
   _ -> abort
@@ -531,7 +531,7 @@ longlines1 =
         "This has to laksdjf alsdkfj alskdjf asdf be a long enough string to force a line break"
         ())
 
-longlines2 : (Text, '{g} Bytes)
+longlines2 : (Text, 'Bytes)
 longlines2 =
   ( "adsf"
   , do

--- a/unison-src/transcripts-using-base/fix5129.output.md
+++ b/unison-src/transcripts-using-base/fix5129.output.md
@@ -36,7 +36,7 @@ go = do
 
   The check that
 
-      [Unit ->{𝕖75, IO, Exception} Unit]
+      [Unit ->{𝕖73, IO, Exception} Unit]
 
   is a subtype of
 
@@ -81,15 +81,15 @@ fancyTryEval = reraise << catchAll.impl
 
   The check that
 
-      (Unit ->{IO, Exception} 𝕩94) ->{𝕖88, Exception, 𝕖95, IO} 𝕩94
+      (Unit ->{IO, Exception} 𝕩88) ->{𝕖82, Exception, 𝕖89, IO} 𝕩88
 
   is a subtype of
 
-      (Unit ->{g77, IO, Exception} a74) ->{g77, IO, Exception} a74
+      (Unit ->{g71, IO, Exception} a68) ->{g71, IO, Exception} a68
 
   failed because
 
-      {g77}
+      {g71}
 
   is not a subtype of
 

--- a/unison-src/transcripts-using-base/serial-test-05.output.md
+++ b/unison-src/transcripts-using-base/serial-test-05.output.md
@@ -21,7 +21,7 @@ mkTestCase = do
 
   + f          : (Nat, Nat, Nat) -> Nat
   + g          : Map Nat ((Nat, Nat, Nat) ->{g} Nat) ->{g} Text
-  + m          : Map Nat ((Nat, Nat, Nat) ->{g} Nat)
+  + m          : Map Nat ((Nat, Nat, Nat) -> Nat)
   + mkTestCase : '{IO, Exception} ()
 
   Run `update` to apply these changes to your codebase.

--- a/unison-src/transcripts/idempotent/fix2355.md
+++ b/unison-src/transcripts/idempotent/fix2355.md
@@ -30,7 +30,7 @@ example = 'let
 
   The expression in red was inferred to require the ability: 
 
-      {A t25 {𝕖36, 𝕖18}}
+      {A t25 {𝕖35, 𝕖18}}
 
   where `𝕖18` is its overall abilities.
 

--- a/unison-src/transcripts/idempotent/fix4711.md
+++ b/unison-src/transcripts/idempotent/fix4711.md
@@ -13,7 +13,7 @@ thisDoesNotWork = ['(+1)]
 ``` ucm :added-by-ucm
   Loading changes detected in scratch.u.
 
-  + thisDoesNotWork : ['{g} Int]
+  + thisDoesNotWork : ['Int]
   + thisWorks       : 'Int
 
   Run `update` to apply these changes to your codebase.
@@ -46,7 +46,7 @@ Since this is fixed, `thisDoesNotWork` now does work.
 ```
 
 ``` unison :added-by-ucm scratch.u
-thisDoesNotWork : ['{g} Int]
+thisDoesNotWork : ['Int]
 thisDoesNotWork = [do +1]
 
 thisWorks : 'Int

--- a/unison-src/transcripts/idempotent/quad-handlers.md
+++ b/unison-src/transcripts/idempotent/quad-handlers.md
@@ -47,11 +47,11 @@ forget2 k = handle provide 3 k with cases
 
   only needs the abilities:
 
-      {Tell a147}
+      {Tell a138}
 
   but the available abilities are:
 
-      {Tell a147, Ask Nat}
+      {Tell a138, Ask Nat}
 
   The argument:
 
@@ -59,11 +59,11 @@ forget2 k = handle provide 3 k with cases
 
   only needs the abilities:
 
-      {Tell a84}
+      {Tell a80}
 
   but the available abilities are:
 
-      {Tell a84, Ask Nat}
+      {Tell a80, Ask Nat}
 
   To avoid this warning, you can give explicit types to the arguments
   of the recursive call to the handler.

--- a/unison-src/transcripts/idempotent/variance.md
+++ b/unison-src/transcripts/idempotent/variance.md
@@ -1,0 +1,28 @@
+Tests some less trivial variance cases.
+
+``` ucm :hide
+scratch/main> builtins.mergeio
+```
+
+``` unison
+act1 : [(Nat, '{IO} Nat)]
+act1 = [(5, '5)]
+
+act2 : [(Nat, '{Exception} Nat)]
+act2 = [(5, '5)]
+
+act12 = act1 ++ act2
+
+act1or2 = if true then act1 else act2
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  + act1    : [(Nat, '{IO} Nat)]
+  + act12   : [(Nat, '{IO, Exception} Nat)]
+  + act1or2 : [(Nat, '{IO, Exception} Nat)]
+  + act2    : [(Nat, '{Exception} Nat)]
+
+  Run `update` to apply these changes to your codebase.
+```


### PR DESCRIPTION
This PR makes use of variance information in a couple places that weren't originally.

1. When solving a variable, we add slack variables to ability lists that occur in strictly positive position. This helps when matching types across branches in an `if`/`match`, and similar situations. Two ability sets may not be subsets of one another, but may be subsets of a common set.
2. When generalizing types, we discard ability variables that only occur in covariant position. This keeps from accumulating these variables into ability lists that confuse the type checker (when multiple occur in the same list, it becomes unclear which one to solve).

Previously, both these steps only applied to arrow types. Now the inferred variances are used as well.