### PR TITLE
Add libdeps diffs to `branch.diff` output

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/DiffBranch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/DiffBranch.hs
@@ -39,6 +39,7 @@ import Unison.DataDeclaration (Decl, DeclOrBuiltin)
 import Unison.DeclCoherencyCheck (asOneRandomIncoherentDeclReason)
 import Unison.DeclNameLookup (DeclNameLookup)
 import Unison.Merge qualified as Merge
+import Unison.Merge.DiffOp qualified as Merge.DiffOp
 import Unison.Merge.ThreeWay qualified as Merge.ThreeWay
 import Unison.Merge.TwoOrThreeWay qualified as TwoOrThreeWay
 import Unison.Merge.TwoWay qualified as Merge.TwoWay
@@ -186,58 +187,58 @@ handleDiffBranch aliceArg bobArg = do
       hydratedDefns =
         newlyHydratedDefns <> diffblob.hydratedNarrowedDefns
 
-  -- Make a "libdeps diffs" blob suitable for rendering, which merely maps libdep name to its causal hash. `Nothing`
-  -- means the libdep was deleted.
-  let libdepsDiffs :: Merge.ThreeWay (Map NameSegment (Maybe CausalHash))
-      libdepsDiffs =
-        diffblob.libdepsDiffs
-          & fmap
-            ( Map.merge
-                -- If this libdep only exists in the lca, but not alice/bob, that means alice/bob just didn't touch it.
-                -- But the other party did – that's how it exists in the lca blob! So, we still want it in both
-                -- renderings.
-                (Map.mapMissing \_ -> Just)
-                -- If this libdep only exists in alice/bob, not lca, it's clearly an add
-                ( Map.mapMissing \_ -> \case
-                    Merge.DiffOp'Add libdep -> Just (Branch.headHash libdep)
-                    -- these are impossible
-                    Merge.DiffOp'Update _ -> error "expected Add"
-                    Merge.DiffOp'Delete _ -> error "expected Add"
-                )
-                -- If this libdep exists in both lca and alice/bob, it's clearly not an add
-                ( Map.zipWithMatched \_ _ -> \case
-                    Merge.DiffOp'Update libdeps -> Just (Branch.headHash libdeps.new)
-                    Merge.DiffOp'Delete _ -> Nothing
-                    -- impossible
-                    Merge.DiffOp'Add _ -> error "expected Update or Delete"
-                )
-                lcaLibdepsDiff
-            )
-          & Merge.TwoWay.toThreeWay (Map.map Just lcaLibdepsDiff)
-        where
-          -- The LCA libdeps diff is the causal hashes of every libdep updated or deleted by one party
-          lcaLibdepsDiff :: Map NameSegment CausalHash
-          lcaLibdepsDiff =
-            namespaces.lca
-              & view Branch.libdeps_
-              & (`Map.restrictKeys` deletedAndUpdatedLibdepsNames)
-              & Map.map Branch.headHash
-
-          -- Identify the names of the libdeps that were deleted or updated on alice & bob.
-          deletedAndUpdatedLibdepsNames :: Set NameSegment
-          deletedAndUpdatedLibdepsNames =
-            foldMap
-              ( Map.foldMapWithKey \name -> \case
-                  Merge.DiffOp'Add _ -> Set.empty
-                  Merge.DiffOp'Update _ -> Set.singleton name
-                  Merge.DiffOp'Delete _ -> Set.singleton name
-              )
-              diffblob.libdepsDiffs
-
   maybeDifftoolResult <-
     liftIO (lookupEnv "UCM_DIFFTOOL") >>= \case
       Nothing -> pure Nothing
       Just difftool0 -> do
+        -- Make a "libdeps diffs" blob suitable for rendering in files, which merely maps libdep name to its causal
+        -- hash. `Nothing` means the libdep was deleted.
+        let libdepsDiffs :: Merge.ThreeWay (Map NameSegment (Maybe CausalHash))
+            libdepsDiffs =
+              diffblob.libdepsDiffs
+                & fmap
+                  ( Map.merge
+                      -- If this libdep only exists in the lca, but not alice/bob, that means alice/bob just didn't
+                      -- touch it. But the other party did – that's how it exists in the lca blob! So, we still want it
+                      -- in both renderings.
+                      (Map.mapMissing \_ -> Just)
+                      -- If this libdep only exists in alice/bob, not lca, it's clearly an add
+                      ( Map.mapMissing \_ -> \case
+                          Merge.DiffOp'Add libdep -> Just (Branch.headHash libdep)
+                          -- these are impossible
+                          Merge.DiffOp'Update _ -> error "expected Add"
+                          Merge.DiffOp'Delete _ -> error "expected Add"
+                      )
+                      -- If this libdep exists in both lca and alice/bob, it's clearly not an add
+                      ( Map.zipWithMatched \_ _ -> \case
+                          Merge.DiffOp'Update libdeps -> Just (Branch.headHash libdeps.new)
+                          Merge.DiffOp'Delete _ -> Nothing
+                          -- impossible
+                          Merge.DiffOp'Add _ -> error "expected Update or Delete"
+                      )
+                      lcaLibdepsDiff
+                  )
+                & Merge.TwoWay.toThreeWay (Map.map Just lcaLibdepsDiff)
+              where
+                -- The LCA libdeps diff is the causal hashes of every libdep updated or deleted by one party
+                lcaLibdepsDiff :: Map NameSegment CausalHash
+                lcaLibdepsDiff =
+                  namespaces.lca
+                    & view Branch.libdeps_
+                    & (`Map.restrictKeys` deletedAndUpdatedLibdepsNames)
+                    & Map.map Branch.headHash
+
+                -- Identify the names of the libdeps that were deleted or updated on alice & bob.
+                deletedAndUpdatedLibdepsNames :: Set NameSegment
+                deletedAndUpdatedLibdepsNames =
+                  foldMap
+                    ( Map.foldMapWithKey \name -> \case
+                        Merge.DiffOp'Add _ -> Set.empty
+                        Merge.DiffOp'Update _ -> Set.singleton name
+                        Merge.DiffOp'Delete _ -> Set.singleton name
+                    )
+                    diffblob.libdepsDiffs
+
         makeTempFilename <-
           makeMakeTempFilename
 
@@ -366,6 +367,7 @@ handleDiffBranch aliceArg bobArg = do
     Output.ShowBranchDiff
       args
       ((.suffixifiedPPE) . Branch.toPrettyPrintEnvDecl 10 <$> Merge.ThreeWay.forgetLca namespaces)
+      (Map.map (Merge.DiffOp.map Branch.headHash) <$> diffblob.libdepsDiffs)
       diffs
       maybeDifftoolResult
 

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/DiffBranch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/DiffBranch.hs
@@ -5,6 +5,7 @@ where
 
 import Control.Lens (mapped, preview)
 import Control.Monad.Reader (ask)
+import Data.Map.Merge.Strict qualified as Map
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 import Data.Text qualified as Text
@@ -22,6 +23,7 @@ import Unison.Cli.DirectoryUtils (makeMakeTempFilename)
 import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
 import Unison.Cli.MonadUtils qualified as Cli
+import Unison.Cli.Pretty (prettyCausalHash, prettyLibdepName)
 import Unison.Cli.ProjectUtils qualified as ProjectUtils
 import Unison.Cli.UpdateUtils qualified as UpdateUtils
 import Unison.Codebase qualified as Codebase
@@ -39,7 +41,9 @@ import Unison.DeclNameLookup (DeclNameLookup)
 import Unison.Merge qualified as Merge
 import Unison.Merge.ThreeWay qualified as Merge.ThreeWay
 import Unison.Merge.TwoOrThreeWay qualified as TwoOrThreeWay
+import Unison.Merge.TwoWay qualified as Merge.TwoWay
 import Unison.Name (Name)
+import Unison.NameSegment (NameSegment)
 import Unison.NamesUtils qualified as NamesUtils
 import Unison.OrBuiltin (OrBuiltin (..))
 import Unison.Parser.Ann (Ann)
@@ -182,6 +186,54 @@ handleDiffBranch aliceArg bobArg = do
       hydratedDefns =
         newlyHydratedDefns <> diffblob.hydratedNarrowedDefns
 
+  -- Make a "libdeps diffs" blob suitable for rendering, which merely maps libdep name to its causal hash. `Nothing`
+  -- means the libdep was deleted.
+  let libdepsDiffs :: Merge.ThreeWay (Map NameSegment (Maybe CausalHash))
+      libdepsDiffs =
+        diffblob.libdepsDiffs
+          & fmap
+            ( Map.merge
+                -- If this libdep only exists in the lca, but not alice/bob, that means alice/bob just didn't touch it.
+                -- But the other party did – that's how it exists in the lca blob! So, we still want it in both
+                -- renderings.
+                (Map.mapMissing \_ -> Just)
+                -- If this libdep only exists in alice/bob, not lca, it's clearly an add
+                ( Map.mapMissing \_ -> \case
+                    Merge.DiffOp'Add libdep -> Just (Branch.headHash libdep)
+                    -- these are impossible
+                    Merge.DiffOp'Update _ -> error "expected Add"
+                    Merge.DiffOp'Delete _ -> error "expected Add"
+                )
+                -- If this libdep exists in both lca and alice/bob, it's clearly not an add
+                ( Map.zipWithMatched \_ _ -> \case
+                    Merge.DiffOp'Update libdeps -> Just (Branch.headHash libdeps.new)
+                    Merge.DiffOp'Delete _ -> Nothing
+                    -- impossible
+                    Merge.DiffOp'Add _ -> error "expected Update or Delete"
+                )
+                lcaLibdepsDiff
+            )
+          & Merge.TwoWay.toThreeWay (Map.map Just lcaLibdepsDiff)
+        where
+          -- The LCA libdeps diff is the causal hashes of every libdep updated or deleted by one party
+          lcaLibdepsDiff :: Map NameSegment CausalHash
+          lcaLibdepsDiff =
+            namespaces.lca
+              & view Branch.libdeps_
+              & (`Map.restrictKeys` deletedAndUpdatedLibdepsNames)
+              & Map.map Branch.headHash
+
+          -- Identify the names of the libdeps that were deleted or updated on alice & bob.
+          deletedAndUpdatedLibdepsNames :: Set NameSegment
+          deletedAndUpdatedLibdepsNames =
+            foldMap
+              ( Map.foldMapWithKey \name -> \case
+                  Merge.DiffOp'Add _ -> Set.empty
+                  Merge.DiffOp'Update _ -> Set.singleton name
+                  Merge.DiffOp'Delete _ -> Set.singleton name
+              )
+              diffblob.libdepsDiffs
+
   maybeDifftoolResult <-
     liftIO (lookupEnv "UCM_DIFFTOOL") >>= \case
       Nothing -> pure Nothing
@@ -212,7 +264,7 @@ handleDiffBranch aliceArg bobArg = do
         exitCode <-
           liftIO do
             for_
-              ( (,,,,)
+              ( (,,,,,)
                   <$> filenames
                   <*> ( diffblob.declNameLookups
                           & over #lca (PartialDeclNameLookup.toDeclNameLookup Name.unsafeParseText)
@@ -221,11 +273,12 @@ handleDiffBranch aliceArg bobArg = do
                   <*> namespaces
                   <*> diffblob.defns
                   <*> changedBuiltinDefns
+                  <*> libdepsDiffs
               )
-              \(name, declNameLookup, namespace, defns, builtinDefns) ->
+              \(name, declNameLookup, namespace, defns, builtinDefns, libdeps) ->
                 env.writeSource
                   name
-                  (renderUnisonFile declNameLookup namespace defns builtinDefns hydratedDefns)
+                  (renderUnisonFile declNameLookup namespace libdeps defns builtinDefns hydratedDefns)
                   True
             let createProcess = (Process.shell (Text.unpack difftool)) {Process.delegate_ctlc = True}
             Process.withCreateProcess createProcess \_ _ _ -> Process.waitForProcess
@@ -309,13 +362,12 @@ handleDiffBranch aliceArg bobArg = do
               types = (newTypes diff, updatedTypes diff, deletedTypes diff)
             }
 
-  Cli.respond
-    ( Output.ShowBranchDiff
-        args
-        ((.suffixifiedPPE) . Branch.toPrettyPrintEnvDecl 10 <$> Merge.ThreeWay.forgetLca namespaces)
-        diffs
-        maybeDifftoolResult
-    )
+  Cli.respond $
+    Output.ShowBranchDiff
+      args
+      ((.suffixifiedPPE) . Branch.toPrettyPrintEnvDecl 10 <$> Merge.ThreeWay.forgetLca namespaces)
+      diffs
+      maybeDifftoolResult
 
 resolveDiffBranchArg ::
   (forall void. Output -> Sqlite.Transaction void) ->
@@ -337,26 +389,29 @@ mangleDiffBranchArg = \case
   DiffBranchArg'Branch branch -> projectBranchNameToValidProjectBranchNameText branch.branch
   DiffBranchArg'Hash hash -> Text.Builder.text (ShortCausalHash.toText hash)
 
-renderDefinitions ::
-  DefnsF (Map Name) (Pretty ColorText) (Pretty ColorText) ->
-  DefnsF (Map Name) (Pretty ColorText) (Pretty ColorText) ->
-  Pretty ColorText
-renderDefinitions builtinDefns nonBuiltinDefns =
-  zipDefnsWith Map.union Map.union builtinDefns nonBuiltinDefns
-    & (\defns -> Map.toList defns.terms ++ Map.toList defns.types)
-    & sortAlphabeticallyOn fst
-    & foldMap (\(_, defn) -> defn <> Pretty.newline <> Pretty.newline)
-
 renderUnisonFile ::
   (Monoid a, Var v) =>
   DeclNameLookup ->
   Branch0 m ->
+  Map NameSegment (Maybe CausalHash) ->
   UnconflictedLocalDefnsView ->
   DefnsF (Map Name) Text Text ->
   Defns (Map TermReferenceId (Term v a, Type v a)) (Map TypeReferenceId (Decl v a)) ->
   Text
-renderUnisonFile declNameLookup namespace defns builtinDefns hydratedDefns =
-  let builtinDefns1 :: DefnsF (Map Name) (Pretty ColorText) (Pretty ColorText)
+renderUnisonFile declNameLookup namespace libdeps defns builtinDefns hydratedDefns =
+  let renderedLibdeps :: Pretty ColorText
+      renderedLibdeps =
+        libdeps
+          & Map.toList
+          & sortAlphabeticallyOn fst
+          & map
+            ( \case
+                (libdep, Nothing) -> "-- lib." <> prettyLibdepName libdep <> " ="
+                (libdep, Just hash) -> "-- lib." <> prettyLibdepName libdep <> " = " <> prettyCausalHash hash
+            )
+          & Pretty.lines
+
+      builtinDefns1 :: DefnsF (Map Name) (Pretty ColorText) (Pretty ColorText)
       builtinDefns1 =
         let f =
               Map.mapWithKey
@@ -378,4 +433,11 @@ renderUnisonFile declNameLookup namespace defns builtinDefns hydratedDefns =
               & UpdateUtils.nameHydratedRefIds2 defns.defns
               & over (#terms . mapped) snd
           )
-   in Pretty.toPlain 80 (renderDefinitions builtinDefns1 nonBuiltinDefns)
+
+      renderedDefns :: Pretty ColorText
+      renderedDefns =
+        zipDefnsWith Map.union Map.union builtinDefns1 nonBuiltinDefns
+          & (\defns -> Map.toList defns.terms ++ Map.toList defns.types)
+          & sortAlphabeticallyOn fst
+          & foldMap (\(_, defn) -> defn <> Pretty.newline <> Pretty.newline)
+   in Pretty.toPlain 80 (Pretty.sepNonEmpty "\n\n" [renderedLibdeps, renderedDefns])

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -459,6 +459,7 @@ data Output
   | ShowBranchDiff
       !(Merge.TwoWay DiffBranchArg)
       !(Merge.TwoWay PPE.PrettyPrintEnv)
+      !(Merge.TwoWay (Map NameSegment (Merge.DiffOp CausalHash)))
       !( Merge.TwoWay
            ( Defns
                ( Map Name (Type Symbol Ann),

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -96,8 +96,11 @@ import Unison.HashQualifiedPrime qualified as HQ'
 import Unison.LabeledDependency (LabeledDependency)
 import Unison.LabeledDependency qualified as LD
 import Unison.Merge (GUpdated (..), TwoWay (..))
+import Unison.Merge qualified as Merge
+import Unison.Merge.DiffOp qualified as Merge.DiffOp
 import Unison.Name (Name)
 import Unison.Name qualified as Name
+import Unison.NameSegment (NameSegment)
 import Unison.NameSegment qualified as NameSegment
 import Unison.Names (Names (..))
 import Unison.Names qualified as Names
@@ -2390,13 +2393,25 @@ notifyUser dir issueFn = \case
           <> "Please complete the"
           <> (P.group (P.text verb) <> ",")
           <> "then try again."
-  ShowBranchDiff branchArgs ppes diffs _maybeDifftoolResult -> do
-    let isEmpty Defns {terms = (a, b, c), types = (d, e, f)} =
-          Map.null a && Map.null b && Map.null c && Map.null d && Map.null e && Map.null f
+  ShowBranchDiff branchArgs ppes libdepsDiffs diffs _maybeDifftoolResult -> do
+    let isEmpty
+          libdepsDiff
+          Defns
+            { terms = (newTerms, updatedTerms, deletedTerms),
+              types = (newTypes, updatedTypes, deletedTypes)
+            } =
+            Map.null libdepsDiff
+              && Map.null newTerms
+              && Map.null updatedTerms
+              && Map.null deletedTerms
+              && Map.null newTypes
+              && Map.null updatedTypes
+              && Map.null deletedTypes
 
     let showBranchDiff ::
           PPE.PrettyPrintEnv ->
           Input.DiffBranchArg ->
+          Map NameSegment (Merge.DiffOp CausalHash) ->
           ( Defns
               ( Map Name (Type Symbol Ann),
                 Map Name (Type Symbol Ann),
@@ -2408,58 +2423,86 @@ notifyUser dir issueFn = \case
               )
           ) ->
           Pretty
-        showBranchDiff _ _ diff | isEmpty diff = mempty
-        showBranchDiff ppe branchArg diff = do
-          let renderType :: Name -> DeclOrBuiltin Symbol Ann -> Pretty
-              renderType name decl =
-                P.syntaxToColor
-                  (DeclPrinter.prettyDeclOrBuiltinHeader DeclPrinter.RenderUniqueTypeGuids'No (HQ.fromName name) decl)
+        showBranchDiff _ _ libdepsDiff diff | isEmpty libdepsDiff diff = mempty
+        showBranchDiff ppe branchArg libdepsDiff diff = do
+          let colorAdd = P.green . ("+ " <>)
+              colorUpdate = P.yellow . ("~ " <>)
+              colorDelete = P.red . ("- " <>)
+
+          let renderLibdep :: NameSegment -> CausalHash -> Pretty
+              renderLibdep name _hash =
+                prettyName (Name.fromReverseSegments (name NEList.:| [NameSegment.libSegment]))
+
+          let renderLibdeps :: (Pretty -> Pretty) -> [(NameSegment, CausalHash)] -> Pretty
+              renderLibdeps colored libdeps =
+                libdeps
+                  & sortAlphabeticallyOn (view _1)
+                  & map (\(name, hash) -> colored (renderLibdep name hash))
+                  & P.lines
+
+          let renderedNewLibdeps :: Pretty
+              renderedNewLibdeps =
+                libdepsDiff
+                  & Map.toList
+                  & mapMaybe
+                    ( \case
+                        (name, Merge.DiffOp'Add hash) -> Just (name, hash)
+                        _ -> Nothing
+                    )
+                  & renderLibdeps colorAdd
+
+          let renderedUpdatedLibdeps :: Pretty
+              renderedUpdatedLibdeps =
+                libdepsDiff
+                  & Map.toList
+                  & mapMaybe
+                    ( \case
+                        (name, Merge.DiffOp'Update hashes) -> Just (name, hashes.new)
+                        _ -> Nothing
+                    )
+                  & renderLibdeps colorUpdate
+
+          let renderedDeletedLibdeps :: Pretty
+              renderedDeletedLibdeps =
+                libdepsDiff
+                  & Map.toList
+                  & mapMaybe
+                    ( \case
+                        (name, Merge.DiffOp'Delete hash) -> Just (name, hash)
+                        _ -> Nothing
+                    )
+                  & renderLibdeps colorDelete
 
           let renderTypes :: (Pretty -> Pretty) -> Map Name (DeclOrBuiltin Symbol Ann) -> Pretty
               renderTypes colored types =
                 types
                   & Map.toList
                   & sortAlphabeticallyOn (view _1)
-                  & map (\(name, decl) -> colored (renderType name decl))
+                  & map
+                    ( \(name, decl) ->
+                        colored $
+                          P.syntaxToColor $
+                            DeclPrinter.prettyDeclOrBuiltinHeader
+                              DeclPrinter.RenderUniqueTypeGuids'No
+                              (HQ.fromName name)
+                              decl
+                    )
                   & P.lines
-
-          let renderedNewTypes :: Pretty
-              renderedNewTypes =
-                renderTypes (P.green . ("+ " <>)) (view _1 diff.types)
-
-          let renderedUpdatedTypes :: Pretty
-              renderedUpdatedTypes =
-                renderTypes (P.yellow . ("~ " <>)) (view _2 diff.types)
-
-          let renderedDeletedTypes :: Pretty
-              renderedDeletedTypes =
-                renderTypes (P.red . ("- " <>)) (view _3 diff.types)
-
-          let renderTerm :: (Pretty -> Pretty) -> Name -> Type Symbol Ann -> (Pretty, Pretty)
-              renderTerm colored name ty =
-                (colored (prettyNameParens name), ": " <> P.indentNAfterNewline 2 (TypePrinter.pretty ppe ty))
 
           let renderTerms :: (Pretty -> Pretty) -> Map Name (Type Symbol Ann) -> Pretty
               renderTerms colored terms =
                 terms
                   & Map.toList
                   & sortAlphabeticallyOn (view _1)
-                  & map (\(name, ty) -> renderTerm colored name ty)
+                  & map
+                    ( \(name, ty) ->
+                        ( colored (prettyNameParens name),
+                          ": " <> P.indentNAfterNewline 2 (TypePrinter.pretty ppe ty)
+                        )
+                    )
                   & P.align
                   & map P.group
                   & P.lines
-
-          let renderedNewTerms :: Pretty
-              renderedNewTerms =
-                renderTerms (P.green . ("+ " <>)) (view _1 diff.terms)
-
-          let renderedUpdatedTerms :: Pretty
-              renderedUpdatedTerms =
-                renderTerms (P.yellow . ("~ " <>)) (view _2 diff.terms)
-
-          let renderedDeletedTerms :: Pretty
-              renderedDeletedTerms =
-                renderTerms (P.red . ("- " <>)) (view _3 diff.terms)
            in P.sepNonEmpty
                 "\n\n"
                 [ let prettyBranchArg =
@@ -2468,45 +2511,56 @@ notifyUser dir issueFn = \case
                           Input.DiffBranchArg'Hash hash -> prettySCH hash
                    in P.wrap ("Changes on " <> P.group (prettyBranchArg <> ":")),
                   P.linesNonEmpty
-                    [ renderedNewTypes,
-                      renderedUpdatedTypes,
-                      renderedDeletedTypes
+                    [ renderedNewLibdeps,
+                      renderedUpdatedLibdeps,
+                      renderedDeletedLibdeps
                     ],
                   P.linesNonEmpty
-                    [ renderedNewTerms,
-                      renderedUpdatedTerms,
-                      renderedDeletedTerms
+                    [ renderTypes colorAdd (view _1 diff.types),
+                      renderTypes colorUpdate (view _2 diff.types),
+                      renderTypes colorDelete (view _3 diff.types)
+                    ],
+                  P.linesNonEmpty
+                    [ renderTerms colorAdd (view _1 diff.terms),
+                      renderTerms colorUpdate (view _2 diff.terms),
+                      renderTerms colorDelete (view _3 diff.terms)
                     ]
                 ]
 
     pure $
-      if isEmpty diffs.alice && isEmpty diffs.bob
+      if isEmpty libdepsDiffs.alice diffs.alice && isEmpty libdepsDiffs.bob diffs.bob
         then "Those branches are the same."
         else
           P.sepNonEmpty
             "\n\n"
-            [ showBranchDiff ppes.alice branchArgs.alice diffs.alice,
-              showBranchDiff ppes.bob branchArgs.bob diffs.bob,
+            [ showBranchDiff ppes.alice branchArgs.alice libdepsDiffs.alice diffs.alice,
+              showBranchDiff ppes.bob branchArgs.bob libdepsDiffs.bob diffs.bob,
               let existAdds =
                     or
                       [ not (Map.null (view _1 diffs.alice.terms)),
                         not (Map.null (view _1 diffs.alice.types)),
                         not (Map.null (view _1 diffs.bob.terms)),
-                        not (Map.null (view _1 diffs.bob.types))
+                        not (Map.null (view _1 diffs.bob.types)),
+                        any Merge.DiffOp.isAdd libdepsDiffs.alice,
+                        any Merge.DiffOp.isAdd libdepsDiffs.bob
                       ]
                   existUpdates =
                     or
                       [ not (Map.null (view _2 diffs.alice.terms)),
                         not (Map.null (view _2 diffs.alice.types)),
                         not (Map.null (view _2 diffs.bob.terms)),
-                        not (Map.null (view _2 diffs.bob.types))
+                        not (Map.null (view _2 diffs.bob.types)),
+                        any Merge.DiffOp.isUpdate libdepsDiffs.alice,
+                        any Merge.DiffOp.isUpdate libdepsDiffs.bob
                       ]
                   existDeletes =
                     or
                       [ not (Map.null (view _3 diffs.alice.terms)),
                         not (Map.null (view _3 diffs.alice.types)),
                         not (Map.null (view _3 diffs.bob.terms)),
-                        not (Map.null (view _3 diffs.bob.types))
+                        not (Map.null (view _3 diffs.bob.types)),
+                        any Merge.DiffOp.isDelete libdepsDiffs.alice,
+                        any Merge.DiffOp.isDelete libdepsDiffs.bob
                       ]
                in case prettyAddUpdateDeleteLegend existAdds existUpdates existDeletes of
                     Just legend -> legend

--- a/unison-merge/src/Unison/Merge/DiffOp.hs
+++ b/unison-merge/src/Unison/Merge/DiffOp.hs
@@ -1,6 +1,9 @@
 module Unison.Merge.DiffOp
   ( DiffOp (..),
     DiffOp2 (..),
+    isAdd,
+    isDelete,
+    isUpdate,
     Unison.Merge.DiffOp.map,
     Unison.Merge.DiffOp.traverse,
   )
@@ -19,6 +22,24 @@ data DiffOp a
   | DiffOp'Delete !a
   | DiffOp'Update !(Updated a)
   deriving stock (Show)
+
+instance Functor DiffOp where
+  fmap = Unison.Merge.DiffOp.map
+
+isAdd :: DiffOp a -> Bool
+isAdd = \case
+  DiffOp'Add _ -> True
+  _ -> False
+
+isDelete :: DiffOp a -> Bool
+isDelete = \case
+  DiffOp'Delete _ -> True
+  _ -> False
+
+isUpdate :: DiffOp a -> Bool
+isUpdate = \case
+  DiffOp'Update _ -> True
+  _ -> False
 
 map :: (a -> b) -> DiffOp a -> DiffOp b
 map f = \case

--- a/unison-src/transcripts/idempotent/branch-diff.md
+++ b/unison-src/transcripts/idempotent/branch-diff.md
@@ -149,20 +149,22 @@ scratch/main> branch.diff /main /alice
 scratch/main> project.delete scratch
 ```
 
-Currently (and temporarily), `branch.diff` doesn't show changes to `lib.*`.
+`branch.diff` Also shows changes in `lib.*`:
 
 ``` ucm :hide
 scratch/main> builtins.mergeio lib.builtin
 ```
 
 ``` unison
-lib.dep.foo = 17
+lib.foo.foo = 17
+lib.bar.bar = 18
 ```
 
 ``` ucm :added-by-ucm
   Loading changes detected in scratch.u.
 
-  + lib.dep.foo : Nat
+  + lib.bar.bar : Nat
+  + lib.foo.foo : Nat
 
   Run `update` to apply these changes to your codebase.
 ```
@@ -184,15 +186,18 @@ scratch/main> branch alice
 ```
 
 ``` unison
-lib.dep.foo = 18
+lib.foo.foo = 18
+lib.baz.baz = 19
 ```
 
 ``` ucm :added-by-ucm
   Loading changes detected in scratch.u.
 
-  ~ lib.dep.foo : Nat
+  + lib.baz.baz : Nat
+  ~ lib.foo.foo : Nat
+      (also named lib.bar.bar)
 
-  ~ (modified)
+  + (added), ~ (modified)
 
   Run `update` to apply these changes to your codebase.
 ```
@@ -205,9 +210,19 @@ scratch/alice> update
 
   Done.
 
+scratch/alice> delete.namespace lib.bar
+
+  Done.
+
 scratch/alice> branch.diff /main /alice
 
-  Those branches are the same.
+  Changes on /alice:
+
+  + lib.baz
+  ~ lib.foo
+  - lib.bar
+
+  + (added), ~ (modified), - (deleted)
 ```
 
 ``` ucm :hide


### PR DESCRIPTION
## Overview

This PR adds libdeps diffs to `branch.diff`'s output messages and emitted files.

## Test coverage

Output messages are captured by transcript, files passed to difftool were inspected manually