### PR TITLE
fix upgrade fzf behavior

### DIFF
--- a/unison-cli/src/Unison/CommandLine.hs
+++ b/unison-cli/src/Unison/CommandLine.hs
@@ -244,7 +244,6 @@ fzfResolve codebase ppCtx getCurrentBranch InputPattern.Parameters {requiredPara
   argumentResolvers :: [MaybeT (ExceptT FZFResolveFailure IO) (Data.List.NonEmpty.NonEmpty InputPattern.Argument)] <-
     liftA2 (<>) (traverse (maybeFillArg False) requiredParams) case trailingParams of
       InputPattern.Optional _ _ -> pure mempty
-      InputPattern.ZeroPlus p -> pure <$> maybeFillArg True p
       InputPattern.OnePlus p -> pure <$> maybeFillArg True p
   runMaybeT $ foldM (\bs -> ((bs <>) . toList <$>)) [] argumentResolvers
   where

--- a/unison-cli/src/Unison/CommandLine/InputPattern.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPattern.hs
@@ -113,8 +113,6 @@ data TrailingParameters
     Optional [Parameter] (Maybe Parameter)
   | -- | A catch-all that requires at least one value
     OnePlus Parameter
-  | -- | A catch-all that doesn't require a value
-    ZeroPlus Parameter
 
 -- | The `Parameters` for an `InputPattern` are roughly
 --
@@ -146,7 +144,6 @@ foldParamsWithM fn z Parameters {requiredParams, trailingParams} = foldRequiredA
     foldRequiredArgs res = curry \case
       ([], as) -> case trailingParams of
         Optional optParams zeroPlus -> foldOptionalArgs res zeroPlus optParams as
-        ZeroPlus param -> foldCatchallArg res param as
         OnePlus param -> case as of
           [] -> pure $ pure (res, Parameters [] $ OnePlus param)
           a : args -> foldCatchallArg1 res param $ a :| args
@@ -180,7 +177,6 @@ paramInfo Parameters {requiredParams, trailingParams} i =
          in if rem < length optParams
               then pure $ optParams !! rem
               else zeroPlus
-      ZeroPlus arg -> pure arg
       OnePlus arg -> pure arg
 
 -- | `argType` gets called when the user tries to autocomplete an `i`th argument (zero-indexed).
@@ -193,7 +189,6 @@ minArgs :: Parameters -> Int
 minArgs Parameters {requiredParams, trailingParams} =
   length requiredParams + case trailingParams of
     Optional _ _ -> 0
-    ZeroPlus _ -> 0
     OnePlus _ -> 1
 
 maxArgs :: Parameters -> Maybe Int

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -3618,7 +3618,7 @@ upgrade =
       params =
         Parameters
           [("dependency to upgrade", dependencyArg), ("dependency to upgrade to", dependencyArg)]
-          (ZeroPlus ("dependency", dependencyArg)),
+          (Optional [] (Just ("dependency", dependencyArg))),
       help =
         P.wrap $
           "`upgrade old new [old2 new2...]` upgrades library dependency `lib.old` to `lib.new` (and `lib.old2` to `lib.new2`...).",


### PR DESCRIPTION
## Overview

This PR fixes the `upgrade` fzf behavior. On trunk, a zero-argument `upgrade` will keep asking for completions forever, but neither Ctrl+C nor Ctrl+D to stop providing libraries does the right thing.

In this PR, a zero-arg `upgrade` launches FZF twice. If you want to do a multi-library upgrade, you have to type out all of the library names manually, without FZF.

## Implementation notes

I reverted the new `ZeroPlus` "trailing parameter" type that I added when generalizing `upgrade` to take more than 2 arguments. It turns out we already had the trailing parameter type we wanted, called `Optional`, I just misunderstood how it worked.

## Test coverage

I tested this change manually