### PR TITLE
Try to improve information flow down through 'branching' constructs

### DIFF
--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -2681,6 +2681,12 @@ checkWanted _ want e@(Term.Match' scrut cases) t = do
     PatternMatchCoverageCheckAndKindInferenceSwitch'Disabled ->
       pure ()
   pure want
+checkWanted exact want (Term.If' cond t f) ty = do
+  want <-
+    scope InIfCond .
+      checkWanted exact want cond . Type.boolean $ loc cond
+  want <- scope (InIfBody $ loc t) $ checkWanted exact want t ty
+  scope (InIfBody $ loc f) $ checkWanted exact want f ty
 checkWanted _ want e t = do
   (u, wnew) <- synthesize e
   ctx <- getContext

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -2686,8 +2686,10 @@ checkWanted _ want e@(Term.Match' scrut cases) t = do
   pure want
 checkWanted exact want (Term.If' cond t f) ty = do
   want <-
-    scope InIfCond .
-      checkWanted exact want cond . Type.boolean $ loc cond
+    scope InIfCond
+      . checkWanted exact want cond
+      . Type.boolean
+      $ loc cond
   ty <- applyM ty
   want <- scope (InIfBody $ loc t) $ checkWantedScoped bexact want t ty
   ty <- applyM ty
@@ -2698,7 +2700,7 @@ checkWanted exact want (Term.List' es) lty
   | Type.App' (Type.Ref' r) te <- lty,
     r == Type.listRef =
       let f want e = checkWantedScoped bexact want e =<< applyM te
-      in Foldable.foldlM f want es
+       in Foldable.foldlM f want es
   | Type.Var' (TypeVar.Existential _ v) <- lty = do
       ev <- extendExistential v
       let te = existentialp (loc lty) ev

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -2687,6 +2687,16 @@ checkWanted exact want (Term.If' cond t f) ty = do
       checkWanted exact want cond . Type.boolean $ loc cond
   want <- scope (InIfBody $ loc t) $ checkWanted exact want t ty
   scope (InIfBody $ loc f) $ checkWanted exact want f ty
+checkWanted exact want (Term.List' es) lty
+  | Type.App' (Type.Ref' r) te <- lty,
+    r == Type.listRef =
+      Foldable.foldlM (\want e -> checkWanted exact want e te) want es
+  | Type.Var' (TypeVar.Existential _ v) <- lty = do
+      ev <- extendExistential v
+      let te = existentialp (loc lty) ev
+      subtype (Type.app' (Type.ref (loc lty) Type.listRef) te) lty
+      let f want e = checkWanted exact want e =<< applyM te
+      Foldable.foldlM f want es
 checkWanted _ want e t = do
   (u, wnew) <- synthesize e
   ctx <- getContext

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -2685,12 +2685,15 @@ checkWanted exact want (Term.If' cond t f) ty = do
   want <-
     scope InIfCond .
       checkWanted exact want cond . Type.boolean $ loc cond
+  ty <- applyM ty
   want <- scope (InIfBody $ loc t) $ checkWanted exact want t ty
+  ty <- applyM ty
   scope (InIfBody $ loc f) $ checkWanted exact want f ty
 checkWanted exact want (Term.List' es) lty
   | Type.App' (Type.Ref' r) te <- lty,
     r == Type.listRef =
-      Foldable.foldlM (\want e -> checkWanted exact want e te) want es
+      let f want e = checkWanted exact want e =<< applyM te
+      in Foldable.foldlM f want es
   | Type.Var' (TypeVar.Existential _ v) <- lty = do
       ev <- extendExistential v
       let te = existentialp (loc lty) ev

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -2638,13 +2638,16 @@ checkWanted exact want (Term.Lam' boundVarAnn body) (Type.Arrow'' i es o) = do
 checkWanted exact want tm@(Term.Var' _) ty@(Type.Arrow'' i es o) =
   synthesize tm >>= \case
     -- special case to detect quadratic abilities
-    (Type.Arrow'' j fs p, wnew) -> do
+    (ts@(Type.Arrow'' j fs p), wnew) -> do
       ctx <- getContext
-      subtype (apply ctx i) (apply ctx j)
-      ctx <- getContext
-      sub <- subAbilities ((Nothing,) . apply ctx <$> fs) (apply ctx <$> es)
-      ctx <- getContext
-      subtype (apply ctx p) (apply ctx o)
+      sub <- scope (InSubtype ts ty) do
+        -- morally this is a subtype call, but we've expanded it to
+        -- get some better information.
+        subtype (apply ctx i) (apply ctx j)
+        ctx <- getContext
+        sub <- subAbilities ((Nothing,) . apply ctx <$> fs) (apply ctx <$> es)
+        ctx <- getContext
+        sub <$ subtype (apply ctx p) (apply ctx o)
       exactAbilitiesWarning fs es exact sub
       coalesceWanted wnew want
     (u, wnew) -> do
@@ -2686,20 +2689,24 @@ checkWanted exact want (Term.If' cond t f) ty = do
     scope InIfCond .
       checkWanted exact want cond . Type.boolean $ loc cond
   ty <- applyM ty
-  want <- scope (InIfBody $ loc t) $ checkWanted exact want t ty
+  want <- scope (InIfBody $ loc t) $ checkWantedScoped bexact want t ty
   ty <- applyM ty
-  scope (InIfBody $ loc f) $ checkWanted exact want f ty
+  scope (InIfBody $ loc f) $ checkWantedScoped bexact want f ty
+  where
+    bexact = isJust exact
 checkWanted exact want (Term.List' es) lty
   | Type.App' (Type.Ref' r) te <- lty,
     r == Type.listRef =
-      let f want e = checkWanted exact want e =<< applyM te
+      let f want e = checkWantedScoped bexact want e =<< applyM te
       in Foldable.foldlM f want es
   | Type.Var' (TypeVar.Existential _ v) <- lty = do
       ev <- extendExistential v
       let te = existentialp (loc lty) ev
       subtype (Type.app' (Type.ref (loc lty) Type.listRef) te) lty
-      let f want e = checkWanted exact want e =<< applyM te
+      let f want e = checkWantedScoped bexact want e =<< applyM te
       Foldable.foldlM f want es
+  where
+    bexact = isJust exact
 checkWanted _ want e t = do
   (u, wnew) <- synthesize e
   ctx <- getContext

--- a/unison-src/transcripts-using-base/fix5129.output.md
+++ b/unison-src/transcripts-using-base/fix5129.output.md
@@ -30,17 +30,25 @@ go = do
   Loading changes detected in scratch.u.
 
   I found an ability mismatch when checking the expression in red
-      1 | foreach : (a ->{g} ()) -> [a] ->{g} ()
-      .
+      8 | forkIt : '{IO} () ->{IO} ()
+      9 | forkIt e =
+     10 |   _ = IO.forkComp e
+     11 |   ()
+     12 | 
+     13 | thunk : '{IO,Exception} ()
+     14 | thunk = do
+     15 |   raise (Failure (typeLink MiscFailure) "thunk" (Any ()))
+     16 | 
+     17 | go = do
      18 |   foreach forkIt [thunk]
 
   The check that
 
-      [Unit ->{𝕖73, IO, Exception} Unit]
+      Unit ->{IO, Exception} Unit
 
   is a subtype of
 
-      [Unit ->{IO} Unit]
+      Unit ->{IO} Unit
 
   failed because
 


### PR DESCRIPTION
This adds some cases to `checkWanted` that try to improve the flow of type information down through some constructs that could be thought of as branches. The primary one is `if` expressions. Previously the checking of

``` unison
if b then t else f
```

would just be handled like `ifFun b t f`, where `ifFun : Boolean -> a -> a -> a`. But this means that `t` and `f` are synthesized, even in checking mode. Instead, now _checking_ an if statement against `T` will _check_ `t` and `f` against `T`.

Similarly, list literals are now checked against `T` by determining an element type and checking each element against that type. If `T` is of the form `List E`, then the element type is of course `E`. If `T` is a variable, then we make up a new variable, unify `T` with `List e`, then check against `e`.

This allows type information from annotations to successfully flow down through more varieties of expressions, which helps annotations to resolve duplicate ability variable problems in more situations. Previously, annotations on these expressions wouldn't do any good, because they flip over into synthesis mode, which gathers up multiple ability variables and then gets stuck, even if the annotation would prune away most of those variables when pushed through.

One thing to note is that the new `if` checking mode will sometimes reject things that happened to work before. For instance, if you write:

``` unison
thunk : '{IO} ()
thunk = do ()

if x == 0 then id thunk
else if x == 1 then id thunk
else id thunk
```

Then it used to work, and now doesn't. However, the way this used to work is almost an accident. If you instead tried to write:

``` unison
if x == 0 then
  if y == 0 then id thunk
  else id thunk
else id thunk
```

then it _wouldn't_ work in the past, because the order the expression gets inferred in causes the problem. Now both fail, and can be resolved by annotating the `if`.

There are a couple other tweaks to try to maintain error message output. One message changed slightly, but it's essentially the same (just focusing on a subexpression).