### PR TITLE
update macos runners due to deprecation

### DIFF
--- a/.github/workflows/bundle-ucm.yaml
+++ b/.github/workflows/bundle-ucm.yaml
@@ -24,8 +24,8 @@ jobs:
         os: 
           - ubuntu-24.04
           - ubuntu-24.04-arm
-          - macos-13 # intel
-          - macos-14 # apple silicon
+          - macos-15-intel
+          - macos-latest
           - windows-2025
           # - windows-11-arm # 2025-06-17 apparently there's no stack or ghc builds for arm64 windows
     runs-on: ${{matrix.os}}
@@ -105,8 +105,8 @@ jobs:
         os: 
           - ubuntu-24.04
           - ubuntu-24.04-arm
-          - macos-13
-          - macos-14
+          - macos-15-intel
+          - macos-latest
           - windows-2025
           # - windows-11-arm
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,8 +39,8 @@ jobs:
           # While iterating on this file, you can disable one or more of these to speed things up
           - ubuntu-24.04
           - ubuntu-24.04-arm
-          - macos-13
-          - macos-14
+          - macos-15-intel
+          - macos-latest
           - windows-2025
           # - windows-11-arm
     steps:
@@ -210,8 +210,8 @@ jobs:
           # While iterating on this file, you can disable one or more of these to speed things up
           - ubuntu-24.04
           - ubuntu-24.04-arm
-          - macos-13
-          - macos-14
+          - macos-15-intel
+          - macos-latest
           - windows-2025
           # - windows-11-arm
     steps:
@@ -297,8 +297,8 @@ jobs:
           # While iterating on this file, you can disable one or more of these to speed things up
           - ubuntu-24.04
           - ubuntu-24.04-arm
-          - macos-13
-          - macos-14
+          - macos-15-intel
+          - macos-latest
           # - windows-2025 fails! :-\ https://github.com/unisonweb/unison/actions/runs/15706568824/job/44253742036?pr=5765
           # - windows-11-arm
     steps:

--- a/.github/workflows/nix-dev-cache.yaml
+++ b/.github/workflows/nix-dev-cache.yaml
@@ -23,8 +23,8 @@ jobs:
         os:
           # - ubuntu-24.04 disabling this because it's been failing for a while
           # - ubuntu-24.04-arm https://github.com/unisonweb/unison/issues/5789
-          - macos-13
-          - macos-15
+          - macos-15-intel
+          - macos-latest
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: mount Nix store on larger partition

--- a/.github/workflows/tmate.yaml
+++ b/.github/workflows/tmate.yaml
@@ -9,8 +9,8 @@ on:
         options:
         - ubuntu-24.04
         - ubuntu-24.04-arm
-        - macos-13
-        - macos-14
+        - macos-15-intel
+        - macos-latest
         - windows-2022
         - windows-2025
         - windows-11-arm

--- a/.github/workflows/update-transcripts.yaml
+++ b/.github/workflows/update-transcripts.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-13
+          - macos-15-intel
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: unisonweb/actions/stack/cache/restore@main


### PR DESCRIPTION
macos-15-intel is supposedly the last/lts intel runner 
macos-latest is probably gonna be whatever latest arm runner that isn't beta 
macos 26 runner is currently considered beta

probably there's an argument for pinning macos-15 rather than macos-latest, lmk wdyt
