### PR TITLE
don't launch mergetool in transcripts

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Merge2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Merge2.hs
@@ -381,7 +381,7 @@ doMerge info = do
             --                Yes                    Yes                                              Run that cool tool
 
             maybeMergetool <-
-              if not (defnsAreEmpty mergeblob.conflicts.alice)
+              if not env.isTranscriptTest && not (defnsAreEmpty mergeblob.conflicts.alice)
                 then liftIO (lookupEnv "UCM_MERGETOOL")
                 else pure Nothing
 


### PR DESCRIPTION
## Overview

This PR fixes a small oversight – we don't want to spawn a `UCM_MERGETOOL` process in transcripts, even if the env var is set and there are conflicts to render.