### PR TITLE
Print Refs as short hashes in ambiguous hash error

### DIFF
--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -169,6 +169,7 @@ import Unison.Var (Var)
 import Unison.Var qualified as Var
 import Unison.WatchKind qualified as WK
 import Witch (unsafeFrom)
+import Unison.ShortHash qualified as SH
 
 reportBugURL :: Pretty
 reportBugURL = "https://github.com/unisonweb/unison/issues/new"
@@ -1282,7 +1283,7 @@ notifyUser dir issueFn = \case
             <> "is ambiguous."
             <> "Did you mean one of these hashes?",
         "",
-        P.indentN 2 $ P.lines (P.shown <$> Set.toList rs),
+        P.indentN 2 $ P.lines (P.text . SH.toText . Referent.toShortHash <$> Set.toList rs),
         "",
         P.wrap "Try again with a few more hash characters to disambiguate."
       ]

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -132,6 +132,7 @@ import Unison.Server.Backend qualified as Backend
 import Unison.Server.SearchResultPrime qualified as SR'
 import Unison.Share.Sync.Types qualified as Share (CodeserverTransportError (..), GetCausalHashByPathError (..), PullError (..))
 import Unison.Share.Sync.Types qualified as Sync
+import Unison.ShortHash qualified as SH
 import Unison.Symbol (Symbol)
 import Unison.Sync.Types qualified as Share
 import Unison.SyncV2.Types qualified as SyncV2
@@ -169,7 +170,6 @@ import Unison.Var (Var)
 import Unison.Var qualified as Var
 import Unison.WatchKind qualified as WK
 import Witch (unsafeFrom)
-import Unison.ShortHash qualified as SH
 
 reportBugURL :: Pretty
 reportBugURL = "https://github.com/unisonweb/unison/issues/new"


### PR DESCRIPTION
## Overview

Old error message, which just uses Haskell Show instances for References, which isn't ideal because it doesn't show what you actually need to type.

```
@pchiusano/stepwise/main> alias.term #kids8s9hd2 new

  🤔

  The hash #kids8s9hd2 is ambiguous. Did you mean one of these hashes?

    Ref' (ReferenceDerived (Id "kids8s9hd2lo8moik96699cp7a8vt6v5dcksrtrkabf1c6fse1gsnnssrlf4avq5smn4m5vrka3slksdckd218ru8egremqmep3mt78" 0))
    Ref' (ReferenceDerived (Id "kids8s9hd2lo8moik96699cp7a8vt6v5dcksrtrkabf1c6fse1gsnnssrlf4avq5smn4m5vrka3slksdckd218ru8egremqmep3mt78" 1))

  Try again with a few more hash characters to disambiguate.
```

New message, which shows the correct syntax as a shorthash.

```
@pchiusano/stepwise/test> alias.term #kids8s9hd2 newish

  🤔

  The hash #kids8s9hd2 is ambiguous. Did you mean one of these hashes?

    #kids8s9hd2lo8moik96699cp7a8vt6v5dcksrtrkabf1c6fse1gsnnssrlf4avq5smn4m5vrka3slksdckd218ru8egremqmep3mt78
    #kids8s9hd2lo8moik96699cp7a8vt6v5dcksrtrkabf1c6fse1gsnnssrlf4avq5smn4m5vrka3slksdckd218ru8egremqmep3mt78.1

  Try again with a few more hash characters to disambiguate.

```

## Implementation approach and notes

Just swaps the output printer.

## Interesting/controversial decisions

Nah

## Test coverage

Tested manually

## Loose ends

It would be nice if all the ambiguity errors were just numbered outputs, but it looks like we don't have a `returnEarlyNumbered` or w/e so that's a slightly larger change, so I just did the quick thing for now.
