### PR TITLE
Fail hashing if components are ambiguously ordered.

### DIFF
--- a/codebase2/codebase-sqlite-hashing-v2/src/U/Codebase/Term/Hashing.hs
+++ b/codebase2/codebase-sqlite-hashing-v2/src/U/Codebase/Term/Hashing.hs
@@ -5,7 +5,7 @@ import Data.Foldable qualified as Foldable
 import Data.Map qualified as Map
 import U.Codebase.HashTags
 import U.Codebase.Reference qualified as Reference
-import U.Codebase.Sqlite.HashHandle (HashMismatch (..), HashValidationError (..), IncompleteElementOrderingError (..))
+import U.Codebase.Sqlite.HashHandle (HashMismatch (..), HashValidationError (..), HashingFailure (..))
 import U.Codebase.Sqlite.LocalIds qualified as LocalIds
 import U.Codebase.Sqlite.Queries qualified as Q
 import U.Codebase.Sqlite.Symbol qualified as S
@@ -36,7 +36,7 @@ verifyTermFormatHash (ComponentHash hash) (TermFormat.Term (TermFormat.LocallyIn
       & fmap (\(_refId, (v, trm, typ)) -> (v, (H2.v2ToH2Term trm, H2.v2ToH2Type typ, ())))
       & Map.fromList
       & H2.hashTermComponents
-      & mapLeft (const $ HashValidationIncompleteElementOrdering $ IncompleteElementOrderingError $ ComponentHash hash)
+      & mapLeft (const $ HashingFailure $ IncompleteElementOrderingError $ ComponentHash hash)
   r
     & traverse_ \(H2.ReferenceId hash' _, _trm, _typ, _extra) ->
       if hash == hash'

--- a/codebase2/codebase-sqlite-hashing-v2/src/U/Codebase/Term/Hashing.hs
+++ b/codebase2/codebase-sqlite-hashing-v2/src/U/Codebase/Term/Hashing.hs
@@ -5,7 +5,7 @@ import Data.Foldable qualified as Foldable
 import Data.Map qualified as Map
 import U.Codebase.HashTags
 import U.Codebase.Reference qualified as Reference
-import U.Codebase.Sqlite.HashHandle (HashMismatch (..))
+import U.Codebase.Sqlite.HashHandle (HashMismatch (..), HashValidationError (..), IncompleteElementOrderingError (..))
 import U.Codebase.Sqlite.LocalIds qualified as LocalIds
 import U.Codebase.Sqlite.Queries qualified as Q
 import U.Codebase.Sqlite.Symbol qualified as S
@@ -23,23 +23,29 @@ import Unison.Prelude
 import Unison.Symbol qualified as Unison
 import Unison.Var qualified as Var
 
-verifyTermFormatHash :: ComponentHash -> TermFormat.HashTermFormat -> Maybe (HashMismatch)
-verifyTermFormatHash (ComponentHash hash) (TermFormat.Term (TermFormat.LocallyIndexedComponent elements)) =
-  Foldable.toList elements
-    & fmap s2cTermWithType
-    & Reference.component hash
-    & fmap (\((tm, typ), refId) -> (refId, ((mapTermV tm), (mapTypeV typ))))
-    & Map.fromList
-    & C.Term.unhashComponent hash Var.unnamedRef
-    & Map.toList
-    & fmap (\(_refId, (v, trm, typ)) -> (v, (H2.v2ToH2Term trm, H2.v2ToH2Type typ, ())))
-    & Map.fromList
-    & H2.hashTermComponents
-    & altMap \(H2.ReferenceId hash' _, _trm, _typ, _extra) ->
+verifyTermFormatHash :: ComponentHash -> TermFormat.HashTermFormat -> Maybe HashValidationError
+verifyTermFormatHash (ComponentHash hash) (TermFormat.Term (TermFormat.LocallyIndexedComponent elements)) = toMaybe $ do
+  r <-
+    Foldable.toList elements
+      & fmap s2cTermWithType
+      & Reference.component hash
+      & fmap (\((tm, typ), refId) -> (refId, ((mapTermV tm), (mapTypeV typ))))
+      & Map.fromList
+      & C.Term.unhashComponent hash Var.unnamedRef
+      & Map.toList
+      & fmap (\(_refId, (v, trm, typ)) -> (v, (H2.v2ToH2Term trm, H2.v2ToH2Type typ, ())))
+      & Map.fromList
+      & H2.hashTermComponents
+      & mapLeft (const $ HashValidationIncompleteElementOrdering $ IncompleteElementOrderingError $ ComponentHash hash)
+  r
+    & traverse_ \(H2.ReferenceId hash' _, _trm, _typ, _extra) ->
       if hash == hash'
-        then Nothing
-        else Just (HashMismatch hash hash')
+        then pure ()
+        else Left . HashValidationMismatch $ (HashMismatch hash hash')
   where
+    toMaybe = \case
+      Left e -> Just e
+      Right () -> Nothing
     mapTermV ::
       ABT.Term (C.Term.F' text' termRef' typeRef' termLink' typeLink' S.Symbol) S.Symbol a ->
       ABT.Term (C.Term.F' text' termRef' typeRef' termLink' typeLink' Unison.Symbol) Unison.Symbol a

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/HashHandle.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/HashHandle.hs
@@ -35,6 +35,9 @@ data HashingFailure
     IncompleteElementOrderingError ComponentHash
   deriving (Eq, Show, Ord)
 
+-- | We don't expect to encounter these, but if we do we should print a nice message.
+--
+-- In the future we will hopefully prevent this error entirely.
 crashOnHashingFailure :: (HasCallStack) => Either HashingFailure a -> a
 crashOnHashingFailure = \case
   Left hf -> error $ reportBug "E253299" (renderHashingFailure hf)

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/HashHandle.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/HashHandle.hs
@@ -48,9 +48,9 @@ crashOnHashingFailure = \case
             "Hashing failed because cyclic definitions because the definitions could not be completely ordered.",
             "This happens when multiple definitions in a mutually recursive cycle are identical except",
             "for references to other elements in the same cycle.",
-              "If all elements are identical, consider simple recursion instead of mutual recursion,",
+            "If all elements are identical, consider simple recursion instead of mutual recursion,",
             "If mutual recursion is required, you may disambiguate identical definitions by",
-              "adding a dummy comment like:",
+            "adding a dummy comment like:",
             "_ = \"this is the foo definition\""
           ]
 

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/HashHandle.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/HashHandle.hs
@@ -1,6 +1,8 @@
 module U.Codebase.Sqlite.HashHandle
   ( HashHandle (..),
     HashMismatch (..),
+    HashValidationError (..),
+    IncompleteElementOrderingError (..),
     DeclHashingError (..),
   )
 where
@@ -25,6 +27,13 @@ data HashMismatch = HashMismatch
   { expectedHash :: Hash,
     actualHash :: Hash
   }
+
+data IncompleteElementOrderingError = IncompleteElementOrderingError ComponentHash
+  deriving (Eq, Show, Ord)
+
+data HashValidationError
+  = HashValidationMismatch HashMismatch
+  | HashValidationIncompleteElementOrdering IncompleteElementOrderingError
 
 data DeclHashingError
   = DeclHashMismatch HashMismatch
@@ -58,7 +67,7 @@ data HashHandle = HashHandle
     verifyTermFormatHash ::
       ComponentHash ->
       TermFormat.HashTermFormat ->
-      Maybe (HashMismatch),
+      Maybe HashValidationError,
     verifyDeclFormatHash ::
       ComponentHash ->
       DeclFormat.HashDeclFormat ->

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/HashHandle.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/HashHandle.hs
@@ -8,6 +8,7 @@ module U.Codebase.Sqlite.HashHandle
   )
 where
 
+import Control.Exception
 import U.Codebase.Branch.Type (Branch)
 import U.Codebase.BranchV3 (BranchV3)
 import U.Codebase.HashTags
@@ -33,29 +34,33 @@ data HashingFailure
   = -- | two or more component elements can not be completely ordered with respect to one another
     -- https://github.com/unisonweb/unison/issues/2787
     IncompleteElementOrderingError ComponentHash
-  deriving (Eq, Show, Ord)
+  deriving (Eq, Ord)
+  deriving anyclass (Exception)
+
+instance Show HashingFailure where
+  show hf = reportBug "E253299" (renderHashingFailure hf)
+    where
+      renderHashingFailure :: HashingFailure -> String
+      renderHashingFailure = \case
+        IncompleteElementOrderingError h ->
+          unlines
+            [ "Failed to hash the component: " <> show h,
+              "Hashing failed because cyclic definitions because the definitions could not be completely ordered.",
+              "This happens when multiple definitions in a mutually recursive cycle are identical except",
+              "for references to other elements in the same cycle.",
+              "If all elements are identical, consider simple recursion instead of mutual recursion,",
+              "If mutual recursion is required, you may disambiguate identical definitions by",
+              "adding a dummy comment like:",
+              "_ = \"this is the foo definition\""
+            ]
 
 -- | We don't expect to encounter these, but if we do we should print a nice message.
 --
 -- In the future we will hopefully prevent this error entirely.
 crashOnHashingFailure :: (HasCallStack) => Either HashingFailure a -> a
 crashOnHashingFailure = \case
-  Left hf -> error $ reportBug "E253299" (renderHashingFailure hf)
+  Left hf -> throw hf
   Right a -> a
-  where
-    renderHashingFailure :: HashingFailure -> String
-    renderHashingFailure = \case
-      IncompleteElementOrderingError (ComponentHash h) ->
-        unlines
-          [ "Failed to hash the component: " <> show h,
-            "Hashing failed because cyclic definitions because the definitions could not be completely ordered.",
-            "This happens when multiple definitions in a mutually recursive cycle are identical except",
-            "for references to other elements in the same cycle.",
-            "If all elements are identical, consider simple recursion instead of mutual recursion,",
-            "If mutual recursion is required, you may disambiguate identical definitions by",
-            "adding a dummy comment like:",
-            "_ = \"this is the foo definition\""
-          ]
 
 data HashValidationError
   = HashValidationMismatch HashMismatch

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/HashHandle.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/HashHandle.hs
@@ -2,8 +2,9 @@ module U.Codebase.Sqlite.HashHandle
   ( HashHandle (..),
     HashMismatch (..),
     HashValidationError (..),
-    IncompleteElementOrderingError (..),
     DeclHashingError (..),
+    HashingFailure (..),
+    crashOnHashingFailure,
   )
 where
 
@@ -28,12 +29,34 @@ data HashMismatch = HashMismatch
     actualHash :: Hash
   }
 
-data IncompleteElementOrderingError = IncompleteElementOrderingError ComponentHash
+data HashingFailure
+  = -- | two or more component elements can not be completely ordered with respect to one another
+    -- https://github.com/unisonweb/unison/issues/2787
+    IncompleteElementOrderingError ComponentHash
   deriving (Eq, Show, Ord)
+
+crashOnHashingFailure :: (HasCallStack) => Either HashingFailure a -> a
+crashOnHashingFailure = \case
+  Left hf -> error $ reportBug "E253299" (renderHashingFailure hf)
+  Right a -> a
+  where
+    renderHashingFailure :: HashingFailure -> String
+    renderHashingFailure = \case
+      IncompleteElementOrderingError (ComponentHash h) ->
+        unlines
+          [ "Failed to hash the component: " <> show h,
+            "Hashing failed because cyclic definitions because the definitions could not be completely ordered.",
+            "This happens when multiple definitions in a mutually recursive cycle are identical except",
+            "for references to other elements in the same cycle.",
+              "If all elements are identical, consider simple recursion instead of mutual recursion,",
+            "If mutual recursion is required, you may disambiguate identical definitions by",
+              "adding a dummy comment like:",
+            "_ = \"this is the foo definition\""
+          ]
 
 data HashValidationError
   = HashValidationMismatch HashMismatch
-  | HashValidationIncompleteElementOrdering IncompleteElementOrderingError
+  | HashingFailure HashingFailure
 
 data DeclHashingError
   = DeclHashMismatch HashMismatch

--- a/parser-typechecker/src/Unison/Builtin/Terms.hs
+++ b/parser-typechecker/src/Unison/Builtin/Terms.hs
@@ -4,9 +4,7 @@ module Unison.Builtin.Terms
   )
 where
 
-import Data.Map (Map)
 import Data.Map qualified as Map
-import Data.Text (Text)
 import Unison.Builtin.Decls qualified as Decls
 import Unison.ConstructorReference (GConstructorReference (..))
 import Unison.Hashing.V2.Convert qualified as H
@@ -18,6 +16,7 @@ import Unison.Type (Type)
 import Unison.Type qualified as Type
 import Unison.Var (Var)
 import Unison.Var qualified as Var
+import Unison.Prelude
 
 builtinTermsSrc :: a -> [(Symbol, a, Term Symbol a, Type Symbol a)]
 builtinTermsSrc ann =
@@ -39,6 +38,7 @@ v = Var.named
 builtinTermsRef :: Map Symbol Reference.Id
 builtinTermsRef =
   fmap (\(refId, _, _, _) -> refId)
+    . H.crashOnHashingFailure
     . H.hashTermComponents
     . Map.fromList
     . fmap (\(v, _a, tm, tp) -> (v, (tm, tp, ())))

--- a/parser-typechecker/src/Unison/Builtin/Terms.hs
+++ b/parser-typechecker/src/Unison/Builtin/Terms.hs
@@ -8,6 +8,7 @@ import Data.Map qualified as Map
 import Unison.Builtin.Decls qualified as Decls
 import Unison.ConstructorReference (GConstructorReference (..))
 import Unison.Hashing.V2.Convert qualified as H
+import Unison.Prelude
 import Unison.Reference qualified as Reference
 import Unison.Symbol (Symbol)
 import Unison.Term (Term)
@@ -16,7 +17,6 @@ import Unison.Type (Type)
 import Unison.Type qualified as Type
 import Unison.Var (Var)
 import Unison.Var qualified as Var
-import Unison.Prelude
 
 builtinTermsSrc :: a -> [(Symbol, a, Term Symbol a, Type Symbol a)]
 builtinTermsSrc ann =

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations/MigrateSchema1To2.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations/MigrateSchema1To2.hs
@@ -600,6 +600,7 @@ migrateTermComponent getDeclType termBuffer declBuffer oldHash = fmap (either id
           & fmap (\(v, trm, typ) -> (v, (trm, typ, ())))
           & Map.fromList
           & Convert.hashTermComponents
+          & either (\err -> error $ reportBug "E253299" $ "migrateSchema1To2: hashing failed with error: " <> show err) id
           & fmap (\(ref, trm, typ, _) -> (ref, trm, typ))
 
   ifor newTermComponents $ \v (newReferenceId, trm, typ) -> do

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations/MigrateSchema1To2.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations/MigrateSchema1To2.hs
@@ -600,7 +600,7 @@ migrateTermComponent getDeclType termBuffer declBuffer oldHash = fmap (either id
           & fmap (\(v, trm, typ) -> (v, (trm, typ, ())))
           & Map.fromList
           & Convert.hashTermComponents
-          & either (\err -> error $ reportBug "E253299" $ "migrateSchema1To2: hashing failed with error: " <> show err) id
+          & Convert.crashOnHashingFailure
           & fmap (\(ref, trm, typ, _) -> (ref, trm, typ))
 
   ifor newTermComponents $ \v (newReferenceId, trm, typ) -> do

--- a/parser-typechecker/src/Unison/DataDeclaration/Dependencies.hs
+++ b/parser-typechecker/src/Unison/DataDeclaration/Dependencies.hs
@@ -100,7 +100,7 @@ hashFieldAccessors ppe declName vars declRef dd = do
   typecheckedAccessors
     & Map.fromList
     & Hashing.hashTermComponents
-    & either (\err -> error $ reportBug "E253299" $ "hashFieldAccessors: hashing failed with error: " <> show err) id
+    & Hashing.crashOnHashingFailure
     & Map.map Tuple.drop4th
     & Just
   where

--- a/parser-typechecker/src/Unison/DataDeclaration/Dependencies.hs
+++ b/parser-typechecker/src/Unison/DataDeclaration/Dependencies.hs
@@ -100,6 +100,7 @@ hashFieldAccessors ppe declName vars declRef dd = do
   typecheckedAccessors
     & Map.fromList
     & Hashing.hashTermComponents
+    & either (\err -> error $ reportBug "E253299" $ "hashFieldAccessors: hashing failed with error: " <> show err) id
     & Map.map Tuple.drop4th
     & Just
   where

--- a/parser-typechecker/src/Unison/Hashing/V2/Convert.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/Convert.hs
@@ -1,7 +1,7 @@
 -- | Description: Converts V1 types to the V2 hashing types
 module Unison.Hashing.V2.Convert
   ( ResolutionResult,
-    Hashing.HashingFailure(..),
+    Hashing.HashingFailure (..),
     Hashing.crashOnHashingFailure,
     hashBranch0,
     hashCausal,

--- a/parser-typechecker/src/Unison/Hashing/V2/Convert.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/Convert.hs
@@ -65,7 +65,7 @@ hashTermComponents ::
   Map v (Memory.Reference.TermReferenceId, Memory.Term.Term v a, Memory.Type.Type v a, extra)
 hashTermComponents mTerms =
   case h2mTermMap mTerms of
-    (hTerms, constructorTypes) -> h2mTermResult (constructorTypes Map.!) <$> Hashing.hashTermComponents hTerms
+    (hTerms, constructorTypes) -> h2mTermResult (constructorTypes Map.!) <$> (fromRight (error "hashTermComponents encountered unexpected ABT.IncompleteElementOrderingError") $ Hashing.hashTermComponents hTerms)
   where
     h2mTermMap m =
       m

--- a/parser-typechecker/src/Unison/Hashing/V2/Convert.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/Convert.hs
@@ -1,6 +1,8 @@
 -- | Description: Converts V1 types to the V2 hashing types
 module Unison.Hashing.V2.Convert
   ( ResolutionResult,
+    Hashing.HashingFailure(..),
+    Hashing.crashOnHashingFailure,
     hashBranch0,
     hashCausal,
     hashDataDecls,
@@ -62,10 +64,12 @@ hashTermComponents ::
   forall v a extra.
   (Var v) =>
   Map v (Memory.Term.Term v a, Memory.Type.Type v a, extra) ->
-  Map v (Memory.Reference.TermReferenceId, Memory.Term.Term v a, Memory.Type.Type v a, extra)
+  Either Hashing.HashingFailure (Map v (Memory.Reference.TermReferenceId, Memory.Term.Term v a, Memory.Type.Type v a, extra))
 hashTermComponents mTerms =
   case h2mTermMap mTerms of
-    (hTerms, constructorTypes) -> h2mTermResult (constructorTypes Map.!) <$> (fromRight (error "hashTermComponents encountered unexpected ABT.IncompleteElementOrderingError") $ Hashing.hashTermComponents hTerms)
+    (hTerms, constructorTypes) -> do
+      hashedTermComponents <- Hashing.hashTermComponents hTerms
+      pure (h2mTermResult (constructorTypes Map.!) <$> hashedTermComponents)
   where
     h2mTermMap m =
       m

--- a/parser-typechecker/src/Unison/UnisonFile.hs
+++ b/parser-typechecker/src/Unison/UnisonFile.hs
@@ -256,7 +256,7 @@ rewrite leaveAlone rewriteFn uf@(UnisonFileId datas effects _terms watches) =
 
 typecheckedUnisonFile ::
   forall v a.
-  (Var v) =>
+  (Var v, HasCallStack) =>
   Map v (Reference.Id, DataDeclaration v a) ->
   Map v (Reference.Id, EffectDeclaration v a) ->
   [[(v, a, Term v a, Type v a)]] ->
@@ -278,7 +278,7 @@ typecheckedUnisonFile datas effects tlcs watches =
               [(v, Nothing) | (v, _a, _e, _t) <- join tlcs]
                 ++ [(v, Just wk) | (wk, wkTerms) <- watches, (v, _a, _e, _t) <- wkTerms]
           hcs :: Map v (Reference.Id, Term v a, Type v a, a)
-          hcs = Hashing.hashTermComponents $ Map.fromList $ (\(v, a, e, t) -> (v, (e, t, a))) <$> allTerms
+          hcs = Hashing.crashOnHashingFailure $ Hashing.hashTermComponents $ Map.fromList $ (\(v, a, e, t) -> (v, (e, t, a))) <$> allTerms
        in Map.fromList
             [ (v, (a, r, wk, e, t))
               | (v, (r, e, _typ, a)) <- Map.toList hcs,

--- a/unison-cli/package.yaml
+++ b/unison-cli/package.yaml
@@ -86,6 +86,7 @@ library:
     - unison-core
     - unison-core1
     - unison-hash
+    - unison-hashing-v2
     - unison-merge
     - unison-parser-typechecker
     - unison-prelude

--- a/unison-cli/src/Unison/Codebase/Editor/AuthorInfo.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/AuthorInfo.hs
@@ -6,10 +6,9 @@ import Crypto.Random (getRandomBytes)
 import Data.ByteString (unpack)
 import Data.Foldable qualified as Foldable
 import Data.Map qualified as Map
-import Data.Text (Text)
 import Unison.ConstructorReference (GConstructorReference (..))
 import Unison.Hashing.V2.Convert qualified as H
-import Unison.Prelude (MonadIO, Word8)
+import Unison.Prelude
 import Unison.Reference qualified as Reference
 import Unison.Runtime.IOSource qualified as IOSource
 import Unison.Term (Term)
@@ -18,12 +17,11 @@ import Unison.Type (Type)
 import Unison.Type qualified as Type
 import Unison.Var (Var)
 import Unison.Var qualified as Var
-import UnliftIO (liftIO)
 
 data AuthorInfo v a = AuthorInfo
   {guid, author, copyrightHolder :: (Reference.Id, Term v a, Type v a)}
 
-createAuthorInfo :: forall m v a. (MonadIO m) => (Var v) => a -> Text -> m (AuthorInfo v a)
+createAuthorInfo :: forall m v a. (MonadIO m, HasCallStack) => (Var v) => a -> Text -> m (AuthorInfo v a)
 createAuthorInfo a t = createAuthorInfo' . unpack <$> liftIO (getRandomBytes 32)
   where
     createAuthorInfo' :: [Word8] -> AuthorInfo v a
@@ -64,7 +62,7 @@ createAuthorInfo a t = createAuthorInfo' . unpack <$> liftIO (getRandomBytes 32)
       Term v a ->
       (Reference.Id, Term v a)
     hashAndWrangle v typ tm =
-      case Foldable.toList $ H.hashTermComponents (Map.singleton (Var.named v) (tm, typ, ())) of
+      case Foldable.toList . H.crashOnHashingFailure $ H.hashTermComponents (Map.singleton (Var.named v) (tm, typ, ())) of
         [(id, tm, _tp, ())] -> (id, tm)
         _ -> error "hashAndWrangle: Expected a single definition."
     (chType, chTypeRef) = (Type.ref a chTypeRef, IOSource.copyrightHolderRef)

--- a/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
+++ b/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
@@ -133,7 +133,7 @@ withRunner isTest verbosity ucmVersion action = do
                   authenticatedHTTPClient
                   credMan
                   stanzas
-                & catchExceptions
+                  & catchExceptions
   where
     catchExceptions :: forall x. IO (Either Error x) -> IO (Either Error x)
     catchExceptions io =

--- a/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
+++ b/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
@@ -133,7 +133,13 @@ withRunner isTest verbosity ucmVersion action = do
                   authenticatedHTTPClient
                   credMan
                   stanzas
+                & catchExceptions
   where
+    catchExceptions :: forall x. IO (Either Error x) -> IO (Either Error x)
+    catchExceptions io =
+      UnliftIO.tryAny (io >>= UnliftIO.evaluate) >>= \case
+        Left someException -> pure $ Left (Exception someException)
+        Right r -> pure r
     withRuntimes :: (RTI.Runtime Symbol -> RTI.Runtime Symbol -> m a) -> m a
     withRuntimes action =
       RTI.withRuntime False RTI.Persistent ucmVersion \runtime ->
@@ -583,5 +589,6 @@ data Error
   = ParseError (P.ParseErrorBundle Text Void)
   | RunFailure Transcript
   | PortBindingFailure
+  | Exception SomeException
   deriving stock (Show)
   deriving anyclass (Exception)

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -359,7 +359,7 @@ main dir welcome ppIds initialInputs runtime sbRuntime codebase serverBaseUrl uc
                           Left _ -> resultState
                           Right inp -> resultState & #lastInput ?~ inp
                     pure (result, sNext)
-              UnliftIO.race waitForInterrupt (UnliftIO.tryAny (restore step)) >>= \case
+              UnliftIO.race waitForInterrupt (UnliftIO.tryAny (restore step >>= UnliftIO.evaluate)) >>= \case
                 -- SIGINT
                 Left () -> do
                   hPutStrLn stderr "\nAborted."

--- a/unison-cli/src/Unison/Main.hs
+++ b/unison-cli/src/Unison/Main.hs
@@ -551,7 +551,6 @@ runTranscripts' version progName transcriptDir markdownFiles = do
                           ],
                           Transcript.format msg
                         )
-
                       Transcript.Exception someException ->
                         ( [ P.indentN 2 $ "An unexpected exception occurred while running the following file: " <> P.string fileName,
                             "",

--- a/unison-cli/src/Unison/Main.hs
+++ b/unison-cli/src/Unison/Main.hs
@@ -551,6 +551,14 @@ runTranscripts' version progName transcriptDir markdownFiles = do
                           ],
                           Transcript.format msg
                         )
+
+                      Transcript.Exception someException ->
+                        ( [ P.indentN 2 $ "An unexpected exception occurred while running the following file: " <> P.string fileName,
+                            "",
+                            P.indentN 2 (P.text $ tShow someException)
+                          ],
+                          tShow someException
+                        )
                   )
                   (pure . Transcript.format)
                   result

--- a/unison-cli/src/Unison/Main.hs
+++ b/unison-cli/src/Unison/Main.hs
@@ -77,6 +77,7 @@ import Unison.CommandLine.Types qualified as CommandLine
 import Unison.CommandLine.Welcome (CodebaseInitStatus (..))
 import Unison.CommandLine.Welcome qualified as Welcome
 import Unison.Core.Project (ProjectAndBranch (..), ProjectName (..))
+import Unison.Hashing.V2 qualified as ABT
 import Unison.LSP qualified as LSP
 import Unison.LSP.Util.Signal qualified as Signal
 import Unison.MCP qualified as MCP
@@ -107,26 +108,32 @@ main version = do
   -- We've made one exception for `ExitSuccess`, because we've discovered the `lsp` library unhelpfully throws it from a
   -- background thread as part of the default "exit notification handler", with no way to modify the behavior.
   setUncaughtExceptionHandler \exception -> do
-    when (not (isExitSuccess exception)) do
-      let shown = tShow exception
-      let displayed = Text.pack (displayException exception)
-      let indented = Text.unlines . map ("  " <>) . Text.lines
+    if
+      | isExitSuccess exception -> pure ()
+      -- This is a bit of a hack to make hashing failures more user-friendly.
+      -- https://github.com/unisonweb/unison/pull/6007
+      | Just hf <- fromException @ABT.HashingFailure exception -> do
+          Text.hPutStrLn stderr ("\n" <> tShow hf <> "\n")
+      | otherwise -> do
+          let shown = tShow exception
+          let displayed = Text.pack (displayException exception)
+          let indented = Text.unlines . map ("  " <>) . Text.lines
 
-      Text.hPutStrLn stderr . Text.unlines . fold $
-        [ [ "Uh oh, an unexpected exception brought the process down! That should never happen. Please file a bug report.",
-            "",
-            "Here's a stringy rendering of the exception:",
-            "",
-            indented shown
-          ],
-          if shown /= displayed
-            then
-              [ "And here's a different one, in case it's easier to understand:",
+          Text.hPutStrLn stderr . Text.unlines . fold $
+            [ [ "Uh oh, an unexpected exception brought the process down! That should never happen. Please file a bug report.",
                 "",
-                indented displayed
-              ]
-            else []
-        ]
+                "Here's a stringy rendering of the exception:",
+                "",
+                indented shown
+              ],
+              if shown /= displayed
+                then
+                  [ "And here's a different one, in case it's easier to understand:",
+                    "",
+                    indented displayed
+                  ]
+                else []
+            ]
   -- This makes our error messages more safe w/r to concurrency. Without it sometimes the
   -- error messaging from the UCM server and LSP server (both running in separate threads) get
   -- interleaved.

--- a/unison-cli/src/Unison/Share/Sync.hs
+++ b/unison-cli/src/Unison/Share/Sync.hs
@@ -40,6 +40,7 @@ import Servant.Client (BaseUrl)
 import Servant.Client qualified as Servant
 import System.Environment (lookupEnv)
 import U.Codebase.HashTags (CausalHash)
+import U.Codebase.Sqlite.HashHandle qualified as HH
 import U.Codebase.Sqlite.Queries qualified as Q
 import U.Codebase.Sqlite.V2.HashHandle (v2HashHandle)
 import Unison.Auth.HTTPClient (AuthenticatedHttpClient)
@@ -181,7 +182,14 @@ validateEntities entities =
       let entityWithHashes = entity & Share.entityHashes_ %~ Share.hashJWTHash
       case EV.validateEntity hash entityWithHashes of
         Nothing -> pure ()
-        Just err@(Share.EntityHashMismatch et (Share.HashMismatchForEntity {supplied, computed})) ->
+        Just (Left err@(HH.IncompleteElementOrderingError _componentHash)) ->
+          error $
+            "Unexpected incomplete element ordering error during entity validation for hash "
+              <> show hash
+              <> ": "
+              <> show err
+              <> ". This should never happen during normal operation. Please report this as a bug."
+        Just (Right err@(Share.EntityHashMismatch et (Share.HashMismatchForEntity {supplied, computed}))) ->
           let expectedMismatches = case et of
                 Share.TermComponentType -> expectedComponentHashMismatches
                 Share.DeclComponentType -> expectedComponentHashMismatches
@@ -192,7 +200,7 @@ validateEntities entities =
                   | expected == computed -> pure ()
                 _ -> do
                   Left err
-        Just err -> do
+        Just (Right err) -> do
           Left err
 
 -- | Validate entities received from the server unless this flag is set to false.

--- a/unison-cli/src/Unison/Share/Sync.hs
+++ b/unison-cli/src/Unison/Share/Sync.hs
@@ -183,12 +183,7 @@ validateEntities entities =
       case EV.validateEntity hash entityWithHashes of
         Nothing -> pure ()
         Just (Left err@(HH.IncompleteElementOrderingError _componentHash)) ->
-          error $
-            "Unexpected incomplete element ordering error during entity validation for hash "
-              <> show hash
-              <> ": "
-              <> show err
-              <> ". This should never happen during normal operation. Please report this as a bug."
+          HH.crashOnHashingFailure (Left err)
         Just (Right err@(Share.EntityHashMismatch et (Share.HashMismatchForEntity {supplied, computed}))) ->
           let expectedMismatches = case et of
                 Share.TermComponentType -> expectedComponentHashMismatches

--- a/unison-cli/src/Unison/Share/SyncV2.hs
+++ b/unison-cli/src/Unison/Share/SyncV2.hs
@@ -44,6 +44,7 @@ import Servant.Types.SourceT qualified as Servant
 import System.Console.Regions qualified as Console.Regions
 import U.Codebase.HashTags (CausalHash)
 import U.Codebase.Sqlite.DbId (CausalHashId)
+import U.Codebase.Sqlite.HashHandle qualified as HH
 import U.Codebase.Sqlite.Queries qualified as Q
 import U.Codebase.Sqlite.TempEntity (TempEntity)
 import U.Codebase.Sqlite.V2.HashHandle (v2HashHandle)
@@ -214,7 +215,9 @@ batchValidateEntities entities = do
   mismatches <- fmap Vector.catMaybes $ liftIO $ IO.pooledForConcurrently entities \(hash, entity) -> do
     IO.evaluate $ EV.validateTempEntity hash entity
   for_ mismatches \case
-    err@(Share.EntityHashMismatch et (Share.HashMismatchForEntity {supplied, computed})) ->
+    Left err@(HH.IncompleteElementOrderingError _componentHash) ->
+      error $ "Unexpected IncompleteElementOrderingError during sync validation for hash: " <> show err
+    Right err@(Share.EntityHashMismatch et (Share.HashMismatchForEntity {supplied, computed})) ->
       let expectedMismatches = case et of
             Share.TermComponentType -> expectedComponentHashMismatches
             Share.DeclComponentType -> expectedComponentHashMismatches
@@ -225,7 +228,7 @@ batchValidateEntities entities = do
               | expected == computed -> pure ()
             _ -> do
               throwError . SyncError . SyncV2.PullError'DownloadEntities . SyncV2.DownloadEntitiesEntityValidationFailure $ err
-    err -> do
+    Right err -> do
       throwError . SyncError . SyncV2.PullError'DownloadEntities . SyncV2.DownloadEntitiesEntityValidationFailure $ err
 
 -- | Syncs a stream which could send entities in any order.

--- a/unison-cli/src/Unison/Share/SyncV2.hs
+++ b/unison-cli/src/Unison/Share/SyncV2.hs
@@ -216,7 +216,7 @@ batchValidateEntities entities = do
     IO.evaluate $ EV.validateTempEntity hash entity
   for_ mismatches \case
     Left err@(HH.IncompleteElementOrderingError _componentHash) ->
-      error $ "Unexpected IncompleteElementOrderingError during sync validation for hash: " <> show err
+      HH.crashOnHashingFailure (Left err)
     Right err@(Share.EntityHashMismatch et (Share.HashMismatchForEntity {supplied, computed})) ->
       let expectedMismatches = case et of
             Share.TermComponentType -> expectedComponentHashMismatches

--- a/unison-cli/tests/Unison/Test/LSP.hs
+++ b/unison-cli/tests/Unison/Test/LSP.hs
@@ -372,7 +372,7 @@ term = let
       ( "let-rec blocks",
         [here|
 term = let
-  x a = a && y true
+  x a = a && y false
   y b = b && x true
   x true && y true
 |]

--- a/unison-cli/transcripts/Transcripts.hs
+++ b/unison-cli/transcripts/Transcripts.hs
@@ -92,6 +92,12 @@ testBuilder expectFailure replaceOriginal recordFailure inputDir outputDir prelu
               io $ Text.putStrLn errText
               io $ recordFailure (inputDir </> filePath, errText)
               crash $ "Failure in " <> filePath
+          Transcript.Exception someException -> do
+            let errMsg = Text.pack $ "Exception when running " <> filePath <> ": " <> (show someException)
+            io . writeUtf8 outputFile $ errMsg
+            when (not expectFailure) $ do
+              io $ recordFailure (inputDir </> filePath, errMsg)
+              crash (Text.unpack errMsg)
       (filePath, Right out) -> do
         let outputFile = outputDir </> if replaceOriginal then filePath else outputFileForTranscript filePath
         io . createDirectoryIfMissing True $ takeDirectory outputFile

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.38.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -288,6 +288,7 @@ library
     , unison-core
     , unison-core1
     , unison-hash
+    , unison-hashing-v2
     , unison-merge
     , unison-parser-typechecker
     , unison-prelude

--- a/unison-hashing-v2/src/Unison/Hashing/V2.hs
+++ b/unison-hashing-v2/src/Unison/Hashing/V2.hs
@@ -27,6 +27,7 @@ module Unison.Hashing.V2
     Type,
     TypeEdit (..),
     TypeF (..),
+    IncompleteElementOrderingError (..),
     hashClosedTerm,
     hashDecls,
     hashTermComponents,
@@ -40,6 +41,7 @@ module Unison.Hashing.V2
 where
 
 import Unison.Hashing.ContentAddressable (ContentAddressable (..))
+import Unison.Hashing.V2.ABT (IncompleteElementOrderingError (..))
 import Unison.Hashing.V2.Branch (Branch (..), MdValues (..))
 import Unison.Hashing.V2.Causal (Causal (..))
 import Unison.Hashing.V2.DataDeclaration (DataDeclaration (..), Decl, EffectDeclaration (..), Modifier (..), hashDecls)

--- a/unison-hashing-v2/src/Unison/Hashing/V2.hs
+++ b/unison-hashing-v2/src/Unison/Hashing/V2.hs
@@ -27,7 +27,8 @@ module Unison.Hashing.V2
     Type,
     TypeEdit (..),
     TypeF (..),
-    IncompleteElementOrderingError (..),
+    HashingFailure (..),
+    crashOnHashingFailure,
     hashClosedTerm,
     hashDecls,
     hashTermComponents,
@@ -41,7 +42,7 @@ module Unison.Hashing.V2
 where
 
 import Unison.Hashing.ContentAddressable (ContentAddressable (..))
-import Unison.Hashing.V2.ABT (IncompleteElementOrderingError (..))
+import Unison.Hashing.V2.ABT (HashingFailure (..), crashOnHashingFailure)
 import Unison.Hashing.V2.Branch (Branch (..), MdValues (..))
 import Unison.Hashing.V2.Causal (Causal (..))
 import Unison.Hashing.V2.DataDeclaration (DataDeclaration (..), Decl, EffectDeclaration (..), Modifier (..), hashDecls)

--- a/unison-hashing-v2/src/Unison/Hashing/V2/ABT.hs
+++ b/unison-hashing-v2/src/Unison/Hashing/V2/ABT.hs
@@ -34,6 +34,9 @@ data HashingFailure
     IncompleteElementOrderingError
   deriving (Show, Eq, Ord)
 
+-- | We don't expect to encounter these, but if we do we should print a nice message.
+--
+-- In the future we will hopefully prevent this error entirely.
 crashOnHashingFailure :: (HasCallStack) => Either HashingFailure a -> a
 crashOnHashingFailure = \case
   Left hf -> error $ reportBug "E253299" (renderHashingFailure hf)

--- a/unison-hashing-v2/src/Unison/Hashing/V2/ABT.hs
+++ b/unison-hashing-v2/src/Unison/Hashing/V2/ABT.hs
@@ -31,8 +31,9 @@ import Prelude hiding (abs, cycle)
 data HashingFailure
   = -- | two or more component elements can not be completely ordered with respect to one another
     -- https://github.com/unisonweb/unison/issues/2787
-    IncompleteElementOrderingError
-  deriving (Show, Eq, Ord)
+    IncompleteElementOrderingError ([String {- Variable names of component definitions -}])
+  deriving stock (Show, Eq, Ord)
+  deriving anyclass (Exception)
 
 -- | We don't expect to encounter these, but if we do we should print a nice message.
 --
@@ -44,9 +45,10 @@ crashOnHashingFailure = \case
   where
     renderHashingFailure :: HashingFailure -> String
     renderHashingFailure = \case
-      IncompleteElementOrderingError ->
+      IncompleteElementOrderingError names ->
         unlines
-          [ "Hashing failed because cyclic definitions because the definitions could not be completely ordered.",
+          [ "Hashing failed because the following cyclic definitions could not be completely ordered:",
+            "  " ++ intercalate ", " names,
             "This happens when multiple definitions in a mutually recursive cycle are identical except",
             "for references to other elements in the same cycle.",
             "If all elements are identical, consider simple recursion instead of mutual recursion,",
@@ -167,7 +169,7 @@ doHashCycle ::
 doHashCycle env namedTerms = do
   -- Ensure that all of the hashes we use for ordering components are unique;
   -- if not, we have an incomplete ordering of the elements in the cycle
-  when (List.nubOrd hashes /= hashes) $ Left IncompleteElementOrderingError
+  when (List.nubOrd hashes /= hashes) $ Left $ IncompleteElementOrderingError (show <$> names)
   pure $ (map (hash' newEnv) permutedTerms, newEnv)
   where
     names = map fst namedTerms

--- a/unison-hashing-v2/src/Unison/Hashing/V2/ABT.hs
+++ b/unison-hashing-v2/src/Unison/Hashing/V2/ABT.hs
@@ -9,7 +9,8 @@
 
 module Unison.Hashing.V2.ABT
   ( Unison.ABT.Term,
-    IncompleteElementOrderingError (..),
+    HashingFailure (..),
+    crashOnHashingFailure,
     hash,
     hashComponents,
   )
@@ -21,22 +22,43 @@ import Data.List qualified as List (sort)
 import Data.Map qualified as Map
 import Data.Set qualified as Set
 import Unison.ABT
-import Unison.Debug qualified as Debug
 import Unison.Hash (Hash)
 import Unison.Hashing.V2.Tokenizable (Hashable1, hash1)
 import Unison.Hashing.V2.Tokenizable qualified as Hashable
 import Unison.Prelude
 import Prelude hiding (abs, cycle)
 
-data IncompleteElementOrderingError = IncompleteElementOrderingError
+data HashingFailure =
+  -- | two or more component elements can not be completely ordered with respect to one another
+  -- https://github.com/unisonweb/unison/issues/2787
+  IncompleteElementOrderingError
   deriving (Show, Eq, Ord)
+
+crashOnHashingFailure :: (HasCallStack) => Either HashingFailure a -> a
+crashOnHashingFailure = \case
+  Left hf -> error $ reportBug "E253299" (renderHashingFailure hf)
+  Right a -> a
+  where
+    renderHashingFailure :: HashingFailure -> String
+    renderHashingFailure = \case
+      IncompleteElementOrderingError ->
+        unlines
+          [ "Hashing failed because cyclic definitions because the definitions could not be completely ordered.",
+            "This happens when multiple definitions in a mutually recursive cycle are identical except",
+            "for references to other elements in the same cycle.",
+              "If all elements are identical, consider simple recursion instead of mutual recursion,",
+            "If mutual recursion is required, you may disambiguate identical definitions by",
+              "adding a dummy comment like:",
+            "_ = \"this is the foo definition\""
+          ]
+
 
 -- Hash a strongly connected component and sort its definitions into a canonical order.
 hashComponent ::
   forall a f v.
   (Functor f, Hashable1 f, Foldable f, Eq v, Show v, Ord v) =>
   Map.Map v (Term f v a) ->
-  Either IncompleteElementOrderingError (Hash, [(v, Term f v a)])
+  Either HashingFailure (Hash, [(v, Term f v a)])
 hashComponent byName = do
   let ts = Map.toList byName
   -- First, compute a canonical hash ordering of the component, as well as an environment in which we can hash
@@ -69,12 +91,12 @@ hashComponents ::
   (Functor f, Hashable1 f, Foldable f, Eq v, Show v, Var v) =>
   (Hash -> Word64 -> Term f v ()) ->
   Map.Map v (Term f v a) ->
-  Either IncompleteElementOrderingError [(Hash, [(v, Term f v a)])]
+  Either HashingFailure [(Hash, [(v, Term f v a)])]
 hashComponents termFromHash termsByName = do
   let bound = Set.fromList (Map.keys termsByName)
       escapedVars = Set.unions (freeVars <$> Map.elems termsByName) `Set.difference` bound
       sccs = components (Map.toList termsByName)
-      go :: Map v (Term f v ()) -> [[(v, Term f v a)]] -> Either IncompleteElementOrderingError [(Hash, [(v, Term f v a)])]
+      go :: Map v (Term f v ()) -> [[(v, Term f v a)]] -> Either HashingFailure [(Hash, [(v, Term f v a)])]
       go _ [] = pure $ []
       go prevHashes (component : rest) = do
         let sub = substsInheritAnnotation (Map.toList prevHashes)
@@ -127,7 +149,7 @@ hash' env = \case
   Abs'' v t -> hash' (Right v : env) t
   Tm' t -> hash1 (\ts -> (List.sort (map (hash' env) ts), hash' env)) (hash' env) t
   where
-    hashCycle :: [v] -> [Either [v] v] -> [Term f v a] -> Either IncompleteElementOrderingError ([Hash], Term f v a -> Hash)
+    hashCycle :: [v] -> [Either [v] v] -> [Term f v a] -> Either HashingFailure ([Hash], Term f v a -> Hash)
     hashCycle cycle env ts = do
       (ts', env') <- doHashCycle env (zip cycle ts)
       pure (ts', hash' env')
@@ -139,9 +161,10 @@ doHashCycle ::
   (Eq v, Functor f, Hashable1 f, Show v) =>
   [Either [v] v] ->
   [(v, Term f v a)] ->
-  Either IncompleteElementOrderingError ([Hash], [Either [v] v])
+  Either HashingFailure ([Hash], [Either [v] v])
 doHashCycle env namedTerms = do
-  Debug.debugM Debug.Temp "Unison.Hashing.V2.ABT.doHashCycle" (hashes, env, fst <$> namedTerms)
+  -- Ensure that all of the hashes we use for ordering components are unique;
+  -- if not, we have an incomplete ordering of the elements in the cycle
   when (List.nubOrd hashes /= hashes) $ Left IncompleteElementOrderingError
   pure $ (map (hash' newEnv) permutedTerms, newEnv)
   where

--- a/unison-hashing-v2/src/Unison/Hashing/V2/ABT.hs
+++ b/unison-hashing-v2/src/Unison/Hashing/V2/ABT.hs
@@ -153,7 +153,7 @@ hash' env = \case
             ++ show v
             ++ " environment = "
             ++ show env
-  Cycle' vs t -> hash1 (fromRight (error "Encountered ambigous element ordering for component") . hashCycle vs env) undefined t
+  Cycle' vs t -> hash1 (crashOnHashingFailure . hashCycle vs env) undefined t
   Abs'' v t -> hash' (Right v : env) t
   Tm' t -> hash1 (\ts -> (List.sort (map (hash' env) ts), hash' env)) (hash' env) t
   where

--- a/unison-hashing-v2/src/Unison/Hashing/V2/ABT.hs
+++ b/unison-hashing-v2/src/Unison/Hashing/V2/ABT.hs
@@ -7,8 +7,15 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns #-}
 
-module Unison.Hashing.V2.ABT (Unison.ABT.Term, hash, hashComponents) where
+module Unison.Hashing.V2.ABT
+  ( Unison.ABT.Term,
+    IncompleteElementOrderingError (..),
+    hash,
+    hashComponents,
+  )
+where
 
+import Data.Containers.ListUtils qualified as List
 import Data.List hiding (cycle, find)
 import Data.List qualified as List (sort)
 import Data.Map qualified as Map
@@ -20,20 +27,25 @@ import Unison.Hashing.V2.Tokenizable qualified as Hashable
 import Unison.Prelude
 import Prelude hiding (abs, cycle)
 
+data IncompleteElementOrderingError = IncompleteElementOrderingError
+  deriving (Show, Eq, Ord)
+
 -- Hash a strongly connected component and sort its definitions into a canonical order.
 hashComponent ::
   forall a f v.
   (Functor f, Hashable1 f, Foldable f, Eq v, Show v, Ord v) =>
   Map.Map v (Term f v a) ->
-  (Hash, [(v, Term f v a)])
-hashComponent byName =
+  Either IncompleteElementOrderingError (Hash, [(v, Term f v a)])
+hashComponent byName = do
   let ts = Map.toList byName
       -- First, compute a canonical hash ordering of the component, as well as an environment in which we can hash
       -- individual names.
       (hashes, env) = doHashCycle [] ts
-      -- Construct a list of tokens that is shared by all members of the component. They are disambiguated only by their
-      -- name that gets tumbled into the hash.
-      commonTokens :: [Hashable.Token]
+  when (List.nubOrd hashes /= hashes) $ do
+    Left IncompleteElementOrderingError
+  -- Construct a list of tokens that is shared by all members of the component. They are disambiguated only by their
+  -- name that gets tumbled into the hash.
+  let commonTokens :: [Hashable.Token]
       commonTokens = Hashable.Tag 1 : map Hashable.Hashed hashes
       -- Use a helper function that hashes a single term given its name, now that we have an environment in which we can
       -- look the name up, as well as the common tokens.
@@ -47,30 +59,33 @@ hashComponent byName =
           & sortOn fst
           & unzip
       overallHash = Hashable.accumulate (map Hashable.Hashed hashes')
-   in (overallHash, permutedTerms)
+  pure (overallHash, permutedTerms)
 
 -- Group the definitions into strongly connected components and hash
 -- each component. Substitute the hash of each component into subsequent
 -- components (using the `termFromHash` function). Requires that the
 -- overall component has no free variables.
 hashComponents ::
+  forall f v a.
   (Functor f, Hashable1 f, Foldable f, Eq v, Show v, Var v) =>
   (Hash -> Word64 -> Term f v ()) ->
   Map.Map v (Term f v a) ->
-  [(Hash, [(v, Term f v a)])]
-hashComponents termFromHash termsByName =
+  Either IncompleteElementOrderingError [(Hash, [(v, Term f v a)])]
+hashComponents termFromHash termsByName = do
   let bound = Set.fromList (Map.keys termsByName)
       escapedVars = Set.unions (freeVars <$> Map.elems termsByName) `Set.difference` bound
       sccs = components (Map.toList termsByName)
-      go _ [] = []
-      go prevHashes (component : rest) =
+      go :: Map v (Term f v ()) -> [[(v, Term f v a)]] -> Either IncompleteElementOrderingError [(Hash, [(v, Term f v a)])]
+      go _ [] = pure $ []
+      go prevHashes (component : rest) = do
         let sub = substsInheritAnnotation (Map.toList prevHashes)
-            (h, sortedComponent) = hashComponent $ Map.fromList [(v, sub t) | (v, t) <- component]
-            curHashes = Map.fromList [(v, termFromHash h i) | ((v, _), i) <- sortedComponent `zip` [0 ..]]
+        (h, sortedComponent) <- hashComponent $ Map.fromList [(v, sub t) | (v, t) <- component]
+        let curHashes = Map.fromList [(v, termFromHash h i) | ((v, _), i) <- sortedComponent `zip` [0 ..]]
             newHashes = prevHashes `Map.union` curHashes
             newHashesL = Map.toList newHashes
             sortedComponent' = [(v, substsInheritAnnotation newHashesL t) | (v, t) <- sortedComponent]
-         in (h, sortedComponent') : go newHashes rest
+        sortedRest <- go newHashes rest
+        pure $ ((h, sortedComponent') : sortedRest)
    in if Set.null escapedVars
         then go Map.empty sccs
         else

--- a/unison-hashing-v2/src/Unison/Hashing/V2/ABT.hs
+++ b/unison-hashing-v2/src/Unison/Hashing/V2/ABT.hs
@@ -43,13 +43,16 @@ instance Show HashingFailure where
       renderHashingFailure = \case
         IncompleteElementOrderingError names ->
           unlines
-            [ "Hashing failed because the following cyclic definitions could not be completely ordered:",
+            [ "🐞",
+              "",
+              "Sorry, you've encountered a weird situation that we are aware of and are currently working on a fix for.",
+              "I'll explain what happened and how you can work around it.",
+              "",
+              "The following cyclic definitions could not be completely ordered:",
               "  " ++ intercalate ", " names,
-              "This happens when multiple definitions in a mutually recursive cycle are identical except",
-              "for references to other elements in the same cycle.",
-              "If all elements are identical, consider simple recursion instead of mutual recursion,",
-              "If mutual recursion is required, you may disambiguate identical definitions by",
-              "adding a dummy comment like:",
+              "This happens when multiple definitions in a mutually recursive cycle have a very similar structure.",
+              "",
+              "You can work around this by restructuring them to be less similar, e.g. by adding a pure expression to distinguish them, like:",
               "_ = \"this is the foo definition\""
             ]
 

--- a/unison-hashing-v2/src/Unison/Hashing/V2/ABT.hs
+++ b/unison-hashing-v2/src/Unison/Hashing/V2/ABT.hs
@@ -28,10 +28,10 @@ import Unison.Hashing.V2.Tokenizable qualified as Hashable
 import Unison.Prelude
 import Prelude hiding (abs, cycle)
 
-data HashingFailure =
-  -- | two or more component elements can not be completely ordered with respect to one another
-  -- https://github.com/unisonweb/unison/issues/2787
-  IncompleteElementOrderingError
+data HashingFailure
+  = -- | two or more component elements can not be completely ordered with respect to one another
+    -- https://github.com/unisonweb/unison/issues/2787
+    IncompleteElementOrderingError
   deriving (Show, Eq, Ord)
 
 crashOnHashingFailure :: (HasCallStack) => Either HashingFailure a -> a
@@ -46,12 +46,11 @@ crashOnHashingFailure = \case
           [ "Hashing failed because cyclic definitions because the definitions could not be completely ordered.",
             "This happens when multiple definitions in a mutually recursive cycle are identical except",
             "for references to other elements in the same cycle.",
-              "If all elements are identical, consider simple recursion instead of mutual recursion,",
+            "If all elements are identical, consider simple recursion instead of mutual recursion,",
             "If mutual recursion is required, you may disambiguate identical definitions by",
-              "adding a dummy comment like:",
+            "adding a dummy comment like:",
             "_ = \"this is the foo definition\""
           ]
-
 
 -- Hash a strongly connected component and sort its definitions into a canonical order.
 hashComponent ::

--- a/unison-hashing-v2/src/Unison/Hashing/V2/ABT.hs
+++ b/unison-hashing-v2/src/Unison/Hashing/V2/ABT.hs
@@ -16,6 +16,7 @@ module Unison.Hashing.V2.ABT
   )
 where
 
+import Control.Exception (throw)
 import Data.Containers.ListUtils qualified as List
 import Data.List hiding (cycle, find)
 import Data.List qualified as List (sort)
@@ -32,30 +33,33 @@ data HashingFailure
   = -- | two or more component elements can not be completely ordered with respect to one another
     -- https://github.com/unisonweb/unison/issues/2787
     IncompleteElementOrderingError ([String {- Variable names of component definitions -}])
-  deriving stock (Show, Eq, Ord)
+  deriving stock (Eq, Ord)
   deriving anyclass (Exception)
+
+instance Show HashingFailure where
+  show hf = reportBug "E253299" (renderHashingFailure hf)
+    where
+      renderHashingFailure :: HashingFailure -> String
+      renderHashingFailure = \case
+        IncompleteElementOrderingError names ->
+          unlines
+            [ "Hashing failed because the following cyclic definitions could not be completely ordered:",
+              "  " ++ intercalate ", " names,
+              "This happens when multiple definitions in a mutually recursive cycle are identical except",
+              "for references to other elements in the same cycle.",
+              "If all elements are identical, consider simple recursion instead of mutual recursion,",
+              "If mutual recursion is required, you may disambiguate identical definitions by",
+              "adding a dummy comment like:",
+              "_ = \"this is the foo definition\""
+            ]
 
 -- | We don't expect to encounter these, but if we do we should print a nice message.
 --
 -- In the future we will hopefully prevent this error entirely.
 crashOnHashingFailure :: (HasCallStack) => Either HashingFailure a -> a
 crashOnHashingFailure = \case
-  Left hf -> error $ reportBug "E253299" (renderHashingFailure hf)
+  Left hf -> throw hf
   Right a -> a
-  where
-    renderHashingFailure :: HashingFailure -> String
-    renderHashingFailure = \case
-      IncompleteElementOrderingError names ->
-        unlines
-          [ "Hashing failed because the following cyclic definitions could not be completely ordered:",
-            "  " ++ intercalate ", " names,
-            "This happens when multiple definitions in a mutually recursive cycle are identical except",
-            "for references to other elements in the same cycle.",
-            "If all elements are identical, consider simple recursion instead of mutual recursion,",
-            "If mutual recursion is required, you may disambiguate identical definitions by",
-            "adding a dummy comment like:",
-            "_ = \"this is the foo definition\""
-          ]
 
 -- Hash a strongly connected component and sort its definitions into a canonical order.
 hashComponent ::

--- a/unison-hashing-v2/src/Unison/Hashing/V2/ABT.hs
+++ b/unison-hashing-v2/src/Unison/Hashing/V2/ABT.hs
@@ -21,6 +21,7 @@ import Data.List qualified as List (sort)
 import Data.Map qualified as Map
 import Data.Set qualified as Set
 import Unison.ABT
+import Unison.Debug qualified as Debug
 import Unison.Hash (Hash)
 import Unison.Hashing.V2.Tokenizable (Hashable1, hash1)
 import Unison.Hashing.V2.Tokenizable qualified as Hashable
@@ -38,11 +39,9 @@ hashComponent ::
   Either IncompleteElementOrderingError (Hash, [(v, Term f v a)])
 hashComponent byName = do
   let ts = Map.toList byName
-      -- First, compute a canonical hash ordering of the component, as well as an environment in which we can hash
-      -- individual names.
-      (hashes, env) = doHashCycle [] ts
-  when (List.nubOrd hashes /= hashes) $ do
-    Left IncompleteElementOrderingError
+  -- First, compute a canonical hash ordering of the component, as well as an environment in which we can hash
+  -- individual names.
+  (hashes, env) <- doHashCycle [] ts
   -- Construct a list of tokens that is shared by all members of the component. They are disambiguated only by their
   -- name that gets tumbled into the hash.
   let commonTokens :: [Hashable.Token]
@@ -124,14 +123,14 @@ hash' env = \case
             ++ show v
             ++ " environment = "
             ++ show env
-  Cycle' vs t -> hash1 (hashCycle vs env) undefined t
+  Cycle' vs t -> hash1 (fromRight (error "Encountered ambigous element ordering for component") . hashCycle vs env) undefined t
   Abs'' v t -> hash' (Right v : env) t
   Tm' t -> hash1 (\ts -> (List.sort (map (hash' env) ts), hash' env)) (hash' env) t
   where
-    hashCycle :: [v] -> [Either [v] v] -> [Term f v a] -> ([Hash], Term f v a -> Hash)
-    hashCycle cycle env ts =
-      let (ts', env') = doHashCycle env (zip cycle ts)
-       in (ts', hash' env')
+    hashCycle :: [v] -> [Either [v] v] -> [Term f v a] -> Either IncompleteElementOrderingError ([Hash], Term f v a -> Hash)
+    hashCycle cycle env ts = do
+      (ts', env') <- doHashCycle env (zip cycle ts)
+      pure (ts', hash' env')
 
 -- | @doHashCycle env terms@ hashes cycle @terms@ in environment @env@, and returns the canonical ordering of the hashes
 -- of those terms, as well as an updated environment with each of the terms' bindings in the canonical ordering.
@@ -140,16 +139,20 @@ doHashCycle ::
   (Eq v, Functor f, Hashable1 f, Show v) =>
   [Either [v] v] ->
   [(v, Term f v a)] ->
-  ([Hash], [Either [v] v])
-doHashCycle env namedTerms =
-  (map (hash' newEnv) permutedTerms, newEnv)
+  Either IncompleteElementOrderingError ([Hash], [Either [v] v])
+doHashCycle env namedTerms = do
+  Debug.debugM Debug.Temp "Unison.Hashing.V2.ABT.doHashCycle" (hashes, env, fst <$> namedTerms)
+  when (List.nubOrd hashes /= hashes) $ Left IncompleteElementOrderingError
+  pure $ (map (hash' newEnv) permutedTerms, newEnv)
   where
     names = map fst namedTerms
     -- The environment in which we compute the canonical permutation of terms
     permutationEnv = Left names : env
+    hashes = (hash' permutationEnv . snd) <$> namedTerms
     (permutedNames, permutedTerms) =
-      namedTerms
-        & sortOn (hash' permutationEnv . snd)
+      zip namedTerms hashes
+        & sortOn snd
+        & fmap fst
         & unzip
     -- The new environment, which includes the names of all of the terms in the cycle, now that we have computed their
     -- canonical ordering

--- a/unison-hashing-v2/src/Unison/Hashing/V2/DataDeclaration.hs
+++ b/unison-hashing-v2/src/Unison/Hashing/V2/DataDeclaration.hs
@@ -58,7 +58,7 @@ hashDecls0 :: (Eq v, ABT.Var v, Show v) => Map v (DataDeclaration v ()) -> [(v, 
 hashDecls0 decls =
   let abts = toABT <$> decls
       ref r = ABT.tm (Type (Type.TypeRef (ReferenceDerivedId r)))
-      cs = Reference.Util.hashComponents ref abts
+      cs = fromRight (error "hashDecls0 got unexpected IncompleteElementOrderingError") $ Reference.Util.hashComponents ref abts
    in [(v, r) | (v, (r, _)) <- Map.toList cs]
 
 -- | compute the hashes of these user defined types and update any free vars

--- a/unison-hashing-v2/src/Unison/Hashing/V2/DataDeclaration.hs
+++ b/unison-hashing-v2/src/Unison/Hashing/V2/DataDeclaration.hs
@@ -58,7 +58,7 @@ hashDecls0 :: (Eq v, ABT.Var v, Show v) => Map v (DataDeclaration v ()) -> [(v, 
 hashDecls0 decls =
   let abts = toABT <$> decls
       ref r = ABT.tm (Type (Type.TypeRef (ReferenceDerivedId r)))
-      cs = fromRight (error "hashDecls0 got unexpected IncompleteElementOrderingError") $ Reference.Util.hashComponents ref abts
+      cs = ABT.crashOnHashingFailure $ Reference.Util.hashComponents ref abts
    in [(v, r) | (v, (r, _)) <- Map.toList cs]
 
 -- | compute the hashes of these user defined types and update any free vars

--- a/unison-hashing-v2/src/Unison/Hashing/V2/Reference/Util.hs
+++ b/unison-hashing-v2/src/Unison/Hashing/V2/Reference/Util.hs
@@ -15,9 +15,9 @@ hashComponents ::
   (Functor f, Hashable1 f, Foldable f, Eq v, Show v, Var v) =>
   (ReferenceId -> ABT.Term f v ()) ->
   Map v (ABT.Term f v a) ->
-  Map v (ReferenceId, ABT.Term f v a)
-hashComponents embedRef tms =
-  Map.fromList [(v, (r, e)) | ((v, e), r) <- cs]
+  Either ABT.IncompleteElementOrderingError (Map v (ReferenceId, ABT.Term f v a))
+hashComponents embedRef tms = do
+  cs <- Reference.components <$> ABT.hashComponents ref tms
+  pure $ Map.fromList [(v, (r, e)) | ((v, e), r) <- cs]
   where
-    cs = Reference.components $ ABT.hashComponents ref tms
     ref h i = embedRef (ReferenceId h i)

--- a/unison-hashing-v2/src/Unison/Hashing/V2/Reference/Util.hs
+++ b/unison-hashing-v2/src/Unison/Hashing/V2/Reference/Util.hs
@@ -15,7 +15,7 @@ hashComponents ::
   (Functor f, Hashable1 f, Foldable f, Eq v, Show v, Var v) =>
   (ReferenceId -> ABT.Term f v ()) ->
   Map v (ABT.Term f v a) ->
-  Either ABT.IncompleteElementOrderingError (Map v (ReferenceId, ABT.Term f v a))
+  Either ABT.HashingFailure (Map v (ReferenceId, ABT.Term f v a))
 hashComponents embedRef tms = do
   cs <- Reference.components <$> ABT.hashComponents ref tms
   pure $ Map.fromList [(v, (r, e)) | ((v, e), r) <- cs]

--- a/unison-hashing-v2/src/Unison/Hashing/V2/Term.hs
+++ b/unison-hashing-v2/src/Unison/Hashing/V2/Term.hs
@@ -120,7 +120,7 @@ hashTermComponents terms = do
 hashTermComponentsWithoutTypes :: (Var v) => Map v (Term v a) -> Map v (ReferenceId, Term v a)
 hashTermComponentsWithoutTypes terms =
   ReferenceUtil.hashComponents (refId ()) terms
-    & fromRight (error "hashTermComponentsWithoutTypes got unexpected IncompleteElementOrderingError")
+    & ABT.crashOnHashingFailure
 
 hashClosedTerm :: (Var v) => Term v a -> ReferenceId
 hashClosedTerm tm = ReferenceId (ABT.hash tm) 0

--- a/unison-hashing-v2/src/Unison/Hashing/V2/Term.hs
+++ b/unison-hashing-v2/src/Unison/Hashing/V2/Term.hs
@@ -93,7 +93,7 @@ hashTermComponents ::
   forall v a extra.
   (Var v) =>
   Map v (Term v a, Type v a, extra) ->
-  Either ABT.IncompleteElementOrderingError (Map v (ReferenceId, Term v a, Type v a, extra))
+  Either ABT.HashingFailure (Map v (ReferenceId, Term v a, Type v a, extra))
 hashTermComponents terms = do
   hashed <- ReferenceUtil.hashComponents (refId ()) terms'
   pure $ Zip.zipWith keepExtra terms hashed

--- a/unison-hashing-v2/src/Unison/Hashing/V2/Term.hs
+++ b/unison-hashing-v2/src/Unison/Hashing/V2/Term.hs
@@ -93,9 +93,10 @@ hashTermComponents ::
   forall v a extra.
   (Var v) =>
   Map v (Term v a, Type v a, extra) ->
-  Map v (ReferenceId, Term v a, Type v a, extra)
-hashTermComponents terms =
-  Zip.zipWith keepExtra terms (ReferenceUtil.hashComponents (refId ()) terms')
+  Either ABT.IncompleteElementOrderingError (Map v (ReferenceId, Term v a, Type v a, extra))
+hashTermComponents terms = do
+  hashed <- ReferenceUtil.hashComponents (refId ()) terms'
+  pure $ Zip.zipWith keepExtra terms hashed
   where
     terms' :: Map v (Term v a)
     terms' = incorporateType <$> terms
@@ -117,7 +118,9 @@ hashTermComponents terms =
 -- the type that was provided?
 
 hashTermComponentsWithoutTypes :: (Var v) => Map v (Term v a) -> Map v (ReferenceId, Term v a)
-hashTermComponentsWithoutTypes = ReferenceUtil.hashComponents $ refId ()
+hashTermComponentsWithoutTypes terms =
+  ReferenceUtil.hashComponents (refId ()) terms
+    & fromRight (error "hashTermComponentsWithoutTypes got unexpected IncompleteElementOrderingError")
 
 hashClosedTerm :: (Var v) => Term v a -> ReferenceId
 hashClosedTerm tm = ReferenceId (ABT.hash tm) 0

--- a/unison-share-api/src/Unison/Sync/EntityValidation.hs
+++ b/unison-share-api/src/Unison/Sync/EntityValidation.hs
@@ -35,13 +35,13 @@ import Unison.Sync.Types qualified as Share
 
 -- | Note: We currently only validate Namespace hashes.
 -- We should add more validation as more entities are shared.
-validateEntity :: Hash32 -> Share.Entity Text Hash32 Hash32 -> Maybe (Either HH.IncompleteElementOrderingError Share.EntityValidationError)
+validateEntity :: Hash32 -> Share.Entity Text Hash32 Hash32 -> Maybe (Either HH.HashingFailure Share.EntityValidationError)
 validateEntity expectedHash32 entity = do
   validateTempEntity expectedHash32 $ Share.entityToTempEntity id entity
 
 -- | Note: We currently only validate Namespace hashes.
 -- We should add more validation as more entities are shared.
-validateTempEntity :: Hash32 -> TempEntity -> Maybe (Either HH.IncompleteElementOrderingError Share.EntityValidationError)
+validateTempEntity :: Hash32 -> TempEntity -> Maybe (Either HH.HashingFailure Share.EntityValidationError)
 validateTempEntity expectedHash32 tempEntity = do
   case tempEntity of
     Entity.TC (TermFormat.SyncTerm localComp) -> do
@@ -103,14 +103,14 @@ validateBranchFull expectedHash localIds bytes = do
         then Nothing
         else Just $ Share.EntityHashMismatch Share.NamespaceType (mismatch expectedHash (unBranchHash actualHash))
 
-validateTerm :: Hash -> (TermFormat.SyncLocallyIndexedComponent' Text Hash32) -> (Maybe (Either HH.IncompleteElementOrderingError Share.EntityValidationError))
+validateTerm :: Hash -> (TermFormat.SyncLocallyIndexedComponent' Text Hash32) -> (Maybe (Either HH.HashingFailure Share.EntityValidationError))
 validateTerm expectedHash syncLocalComp = do
   case Decode.unsyncTermComponent syncLocalComp of
     Left decodeErr -> Just . Right $ (Share.InvalidByteEncoding (Hash32.fromHash expectedHash) Share.TermComponentType (tShow decodeErr))
     Right localComp -> do
       case HH.verifyTermFormatHash v2HashHandle (ComponentHash expectedHash) (TermFormat.Term localComp) of
         Nothing -> Nothing
-        Just (HH.HashValidationIncompleteElementOrdering incompleteOrdering) -> Just . Left $ incompleteOrdering
+        Just (HH.HashingFailure incompleteOrdering) -> Just . Left $ incompleteOrdering
         Just (HH.HashValidationMismatch (HH.HashMismatch {expectedHash, actualHash})) -> Just . Right $ Share.EntityHashMismatch Share.TermComponentType $ mismatch expectedHash actualHash
 
 validateDecl :: Hash -> (DeclFormat.SyncLocallyIndexedComponent' Text Hash32) -> (Maybe Share.EntityValidationError)

--- a/unison-share-api/src/Unison/Sync/EntityValidation.hs
+++ b/unison-share-api/src/Unison/Sync/EntityValidation.hs
@@ -35,29 +35,29 @@ import Unison.Sync.Types qualified as Share
 
 -- | Note: We currently only validate Namespace hashes.
 -- We should add more validation as more entities are shared.
-validateEntity :: Hash32 -> Share.Entity Text Hash32 Hash32 -> Maybe Share.EntityValidationError
+validateEntity :: Hash32 -> Share.Entity Text Hash32 Hash32 -> Maybe (Either HH.IncompleteElementOrderingError Share.EntityValidationError)
 validateEntity expectedHash32 entity = do
   validateTempEntity expectedHash32 $ Share.entityToTempEntity id entity
 
 -- | Note: We currently only validate Namespace hashes.
 -- We should add more validation as more entities are shared.
-validateTempEntity :: Hash32 -> TempEntity -> Maybe Share.EntityValidationError
+validateTempEntity :: Hash32 -> TempEntity -> Maybe (Either HH.IncompleteElementOrderingError Share.EntityValidationError)
 validateTempEntity expectedHash32 tempEntity = do
   case tempEntity of
     Entity.TC (TermFormat.SyncTerm localComp) -> do
       validateTerm expectedHash localComp
     Entity.DC (DeclFormat.SyncDecl localComp) -> do
-      validateDecl expectedHash localComp
+      Right <$> validateDecl expectedHash localComp
     Entity.N (BranchFormat.SyncDiff {}) -> do
-      Just $ Share.UnsupportedEntityType expectedHash32 Share.NamespaceDiffType
+      Just . Right $ Share.UnsupportedEntityType expectedHash32 Share.NamespaceDiffType
     Entity.N (BranchFormat.SyncFull localIds (BranchFormat.LocalBranchBytes bytes)) -> do
-      validateBranchFull expectedHash localIds bytes
+      Right <$> validateBranchFull expectedHash localIds bytes
     Entity.C CausalFormat.SyncCausalFormat {valueHash, parents} -> do
-      validateCausal expectedHash32 valueHash (toList parents)
+      Right <$> validateCausal expectedHash32 valueHash (toList parents)
     Entity.P (PatchFormat.SyncDiff {}) -> do
-      Just $ Share.UnsupportedEntityType expectedHash32 Share.PatchDiffType
+      Just . Right $ Share.UnsupportedEntityType expectedHash32 Share.PatchDiffType
     Entity.P (PatchFormat.SyncFull localIds bytes) -> do
-      validatePatchFull expectedHash32 localIds bytes
+      Right <$> validatePatchFull expectedHash32 localIds bytes
   where
     expectedHash :: Hash
     expectedHash = Hash32.toHash expectedHash32
@@ -103,14 +103,15 @@ validateBranchFull expectedHash localIds bytes = do
         then Nothing
         else Just $ Share.EntityHashMismatch Share.NamespaceType (mismatch expectedHash (unBranchHash actualHash))
 
-validateTerm :: Hash -> (TermFormat.SyncLocallyIndexedComponent' Text Hash32) -> (Maybe Share.EntityValidationError)
+validateTerm :: Hash -> (TermFormat.SyncLocallyIndexedComponent' Text Hash32) -> (Maybe (Either HH.IncompleteElementOrderingError Share.EntityValidationError))
 validateTerm expectedHash syncLocalComp = do
   case Decode.unsyncTermComponent syncLocalComp of
-    Left decodeErr -> Just (Share.InvalidByteEncoding (Hash32.fromHash expectedHash) Share.TermComponentType (tShow decodeErr))
+    Left decodeErr -> Just . Right $ (Share.InvalidByteEncoding (Hash32.fromHash expectedHash) Share.TermComponentType (tShow decodeErr))
     Right localComp -> do
       case HH.verifyTermFormatHash v2HashHandle (ComponentHash expectedHash) (TermFormat.Term localComp) of
         Nothing -> Nothing
-        Just (HH.HashMismatch {expectedHash, actualHash}) -> Just . Share.EntityHashMismatch Share.TermComponentType $ mismatch expectedHash actualHash
+        Just (HH.HashValidationIncompleteElementOrdering incompleteOrdering) -> Just . Left $ incompleteOrdering
+        Just (HH.HashValidationMismatch (HH.HashMismatch {expectedHash, actualHash})) -> Just . Right $ Share.EntityHashMismatch Share.TermComponentType $ mismatch expectedHash actualHash
 
 validateDecl :: Hash -> (DeclFormat.SyncLocallyIndexedComponent' Text Hash32) -> (Maybe Share.EntityValidationError)
 validateDecl expectedHash syncLocalComp = do

--- a/unison-src/transcripts/errors/incomplete-element-ordering-error.md
+++ b/unison-src/transcripts/errors/incomplete-element-ordering-error.md
@@ -1,0 +1,7 @@
+```unison :error
+foo = do
+  bar ()
+
+bar = do
+  foo ()
+```

--- a/unison-src/transcripts/errors/incomplete-element-ordering-error.output.md
+++ b/unison-src/transcripts/errors/incomplete-element-ordering-error.output.md
@@ -1,0 +1,25 @@
+Exception when running incomplete-element-ordering-error.md: 🐞
+
+Hashing failed because cyclic definitions because the definitions could not be completely ordered.
+This happens when multiple definitions in a mutually recursive cycle are identical except
+for references to other elements in the same cycle.
+If all elements are identical, consider simple recursion instead of mutual recursion,
+If mutual recursion is required, you may disambiguate identical definitions by
+adding a dummy comment like:
+_ = "this is the foo definition"
+
+
+This is a Unison bug and you can report it here:
+
+https://github.com/unisonweb/unison/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+E253299+
+
+Bug reference: E253299
+
+If there's already an issue with this reference, you can give a 👍
+on the issue to let the team know you encountered it, and you can add
+any additional details you know of to the issue.
+
+CallStack (from HasCallStack):
+  error, called at src/Unison/Hashing/V2/ABT.hs:42:14 in unison-hashing-v2-0.0.0-8lPXbJPlm6sDj9SGQtF5JE:Unison.Hashing.V2.ABT
+  crashOnHashingFailure, called at src/Unison/UnisonFile.hs:281:17 in unison-parser-typechecker-0.0.0-E7FuwoDrRadBVo69eIX64V:Unison.UnisonFile
+  typecheckedUnisonFile, called at src/Unison/FileParsers.hs:323:7 in unison-parser-typechecker-0.0.0-E7FuwoDrRadBVo69eIX64V:Unison.FileParsers

--- a/unison-src/transcripts/errors/incomplete-element-ordering-error.output.md
+++ b/unison-src/transcripts/errors/incomplete-element-ordering-error.output.md
@@ -1,11 +1,15 @@
 Exception when running incomplete-element-ordering-error.md: 🐞
 
-Hashing failed because cyclic definitions because the definitions could not be completely ordered.
-This happens when multiple definitions in a mutually recursive cycle are identical except
-for references to other elements in the same cycle.
-If all elements are identical, consider simple recursion instead of mutual recursion,
-If mutual recursion is required, you may disambiguate identical definitions by
-adding a dummy comment like:
+🐞
+
+Sorry, you've encountered a weird situation that we are aware of and are currently working on a fix for.
+I'll explain what happened and how you can work around it.
+
+The following cyclic definitions could not be completely ordered:
+  User "bar", User "foo"
+This happens when multiple definitions in a mutually recursive cycle have a very similar structure.
+
+You can work around this by restructuring them to be less similar, e.g. by adding a pure expression to distinguish them, like:
 _ = "this is the foo definition"
 
 
@@ -18,8 +22,3 @@ Bug reference: E253299
 If there's already an issue with this reference, you can give a 👍
 on the issue to let the team know you encountered it, and you can add
 any additional details you know of to the issue.
-
-CallStack (from HasCallStack):
-  error, called at src/Unison/Hashing/V2/ABT.hs:42:14 in unison-hashing-v2-0.0.0-8lPXbJPlm6sDj9SGQtF5JE:Unison.Hashing.V2.ABT
-  crashOnHashingFailure, called at src/Unison/UnisonFile.hs:281:17 in unison-parser-typechecker-0.0.0-E7FuwoDrRadBVo69eIX64V:Unison.UnisonFile
-  typecheckedUnisonFile, called at src/Unison/FileParsers.hs:323:7 in unison-parser-typechecker-0.0.0-E7FuwoDrRadBVo69eIX64V:Unison.FileParsers

--- a/unison-src/transcripts/idempotent/affine-handlers.md
+++ b/unison-src/transcripts/idempotent/affine-handlers.md
@@ -321,7 +321,7 @@ f m = cases
   n -> g m (drop n 1)
 
 g m = cases
-  0 -> m + 1
+  0 -> m + 2
   n -> f m (drop n 1)
 
 count'extra : Nat -> '{Count} r -> r

--- a/unison-src/transcripts/idempotent/blocks.md
+++ b/unison-src/transcripts/idempotent/blocks.md
@@ -240,7 +240,7 @@ structural ability SpaceAttack where
 
 ex n =
   zap1 planet = launchMissiles planet + zap2 planet
-  zap2 planet = launchMissiles planet + zap1 planet
+  zap2 planet = launchMissiles planet + zap1 planet + 1
   zap1 "pluto"
 ```
 

--- a/unison-src/transcripts/idempotent/edit-namespace.md
+++ b/unison-src/transcripts/idempotent/edit-namespace.md
@@ -7,7 +7,7 @@
 nested.cycle.ping n = n Nat.+ pong n
 
 {{ pong doc }}
-nested.cycle.pong n = n Nat.+ ping n
+nested.cycle.pong n = n Nat.+ ping n + 1
 
 toplevel = "hi"
 
@@ -80,7 +80,7 @@ nested.cycle.ping.doc = {{ ping doc }}
 nested.cycle.pong : Nat -> Nat
 nested.cycle.pong n =
   use Nat +
-  n + nested.cycle.ping n
+  n + nested.cycle.ping n + 1
 
 nested.cycle.pong.doc : Doc2
 nested.cycle.pong.doc = {{ pong doc }}
@@ -120,7 +120,7 @@ nested.cycle.ping.doc = {{ ping doc }}
 nested.cycle.pong : Nat -> Nat
 nested.cycle.pong n =
   use Nat +
-  n + nested.cycle.ping n
+  n + nested.cycle.ping n + 1
 
 nested.cycle.pong.doc : Doc2
 nested.cycle.pong.doc = {{ pong doc }}


### PR DESCRIPTION
## Overview

A temporary measure to prevent components with ambiguous element orderings from propagating through the ecosystem; particularly in Share.

More context on this issue: https://github.com/unisonweb/unison/issues/2787

This doesn't _fix_ the issue, but it does prevent the problematic situation caused by a single hash having multiple semantically different definitions; which would cause completely erroneous behaviour in certain cases.

I analyzed Share and no such definitions are in the ecosystem at the moment, this change should keep it that way.

@aryairani  we'd talked about different approaches for implementing this without making large changes to the codebase;
you seemed hesitant to thread errors all the way through only to (hopefully) remove them later, so instead I inserted calls to `error`, which should have the same effect but with a slightly worse user experience.

Here's what happens if you write a component like this:

```
foo = do bar ()
bar = do foo ()
```

```
Uh oh, an unexpected exception brought the process down! That should never happen. Please file a bug report.

Here's a stringy rendering of the exception:

  🐞

  Hashing failed because cyclic definitions because the definitions could not be completely ordered.
  This happens when multiple definitions in a mutually recursive cycle are identical except
  for references to other elements in the same cycle.
  If all elements are identical, consider simple recursion instead of mutual recursion,
  If mutual recursion is required, you may disambiguate identical definitions by
  adding a dummy comment like:
  _ = "this is the foo definition"


  This is a Unison bug and you can report it here:

  https://github.com/unisonweb/unison/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+E253299+

  Bug reference: E253299

  If there's already an issue with this reference, you can give a 👍
  on the issue to let the team know you encountered it, and you can add
  any additional details you know of to the issue.

  CallStack (from HasCallStack):
    error, called at src/Unison/Hashing/V2/ABT.hs:42:14 in unison-hashing-v2-0.0.0-8lPXbJPlm6sDj9SGQtF5JE:Unison.Hashing.V2.ABT
    crashOnHashingFailure, called at src/Unison/UnisonFile.hs:281:17 in unison-parser-typechecker-0.0.0-E7FuwoDrRadBVo69eIX64V:Unison.UnisonFile
    typecheckedUnisonFile, called at src/Unison/FileParsers.hs:323:7 in unison-parser-typechecker-0.0.0-E7FuwoDrRadBVo69eIX64V:Unison.FileParsers
```

It prevents the user from adding/updating such a component, which accomplishes the goal, but in a bit of a scary way. 

## Implementation approach and notes

* Adds a detection step during component element ordering where we detect if multiple elements have identical ordering-hashes, meaning the element ordering is ambiguous.
* Fail hashing and hash validation if this is detected.

## Interesting/controversial decisions

There's some nuance, we could choose allow components where all elements are identical, since those don't technically cause any problems, but it's somewhat annoying and difficult to  check if this is the case for non-trivial components, and AFAIK there's never a good reason to write such a component since you could just recurse instead.

This also is the first introduction of the idea that hashing a component could _fail_; which is undesirable.
We plan to lift this restriction by introducing a complete ordering of component elements in the future, but it involves implementing a whole new component ordering algorithm. (see #2787 )

## Test coverage

- [x] Tested by running it on every multi-element component on Share.
- [x] Transcript test

## Loose ends

It would be nice to properly resolve this issue by implementing a complete element ordering algorithm.