### PR TITLE
make diff.branch visible and give it a help

### DIFF
--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -2366,7 +2366,7 @@ diffBranch =
   InputPattern
     { patternName = "diff.branch",
       aliases = ["branch.diff"],
-      visibility = I.Hidden,
+      visibility = I.Visible,
       params =
         Parameters
           { requiredParams =
@@ -2382,7 +2382,13 @@ diffBranch =
                   ],
             trailingParams = Optional [] Nothing
           },
-      help = "TODO",
+      help =
+        ( P.column2
+            [ ( "`diff.branch one two`",
+                P.wrap "shows a diff between branches `one` and `two`"
+              )
+            ]
+        ),
       parse = \case
         [branch1, branch2] ->
           Input.DiffBranchI

--- a/unison-src/transcripts/idempotent/help.md
+++ b/unison-src/transcripts/idempotent/help.md
@@ -244,6 +244,10 @@
   deprecated.root-reflog
   `deprecated.root-reflog` lists the changes that have affected the root namespace. This has been deprecated in favor of `reflog` which shows the reflog for the current project.
 
+  diff.branch (or branch.diff)
+  `diff.branch one two` shows a diff between branches `one` and
+                        `two`
+
   diff.namespace
   `diff.namespace before after` shows how the namespace `after`
                                 differs from the namespace


### PR DESCRIPTION
## Overview

This PR marks `diff.branch` as visible in `help` output, and gives it a help string