### PR TITLE
History Comment Sync API

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -4377,7 +4377,7 @@ streamHistoryCommentsForCausal rootCHID action = do
       UNION ALL
       SELECT cp.causal_id
         FROM causal_parent cp
-        JOIN branch_history bh ON cp.parent_causal_id = bh.causal_hash_id
+        JOIN branch_history bh ON cp.parent_id = bh.causal_hash_id
     ) SELECT hc.id
         FROM branch_history bh
         JOIN history_comments hc ON hc.causal_hash_id = bh.causal_hash_id

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -243,6 +243,7 @@ module U.Codebase.Sqlite.Queries
     getLatestCausalComment,
     streamHistoryCommentsForCausal,
     expectHistoryCommentById,
+    expectHistoryCommentIdByHash32,
 
     -- * migrations
     runCreateSql,
@@ -4214,6 +4215,20 @@ getLatestCausalComment causalHashId =
               }
         }
 
+expectHistoryCommentIdByHash32 ::
+  Hash32 -> Transaction HistoryCommentId
+expectHistoryCommentIdByHash32 commentHash = do
+  queryOneCol @HistoryCommentId
+    [sql|
+      SELECT id
+      FROM history_comments
+      WHERE comment_hash_id = (
+        SELECT id
+        FROM hash
+        WHERE base32 = :commentHash
+      )
+    |]
+
 expectHistoryCommentById ::
   HistoryCommentId ->
   Transaction (HistoryComment Time.UTCTime KeyThumbprint Hash32 Hash32, [HistoryCommentRevision Hash32 Time.UTCTime Hash32])
@@ -4368,9 +4383,9 @@ ensurePersonalKeyThumbprintId thumbprint = do
         |]
 
 -- | Stream all the history comments in the history of a branch.
-streamHistoryCommentsForCausal :: CausalHashId -> (Transaction (Maybe HistoryCommentId) -> Transaction r) -> Transaction r
+streamHistoryCommentsForCausal :: CausalHashId -> (Transaction (Maybe (HistoryCommentId, Hash32)) -> Transaction r) -> Transaction r
 streamHistoryCommentsForCausal rootCHID action = do
-  queryStreamCol
+  queryStreamRow
     [sql|
     WITH RECURSIVE branch_history(causal_hash_id) AS(
       SELECT :rootCHID
@@ -4378,8 +4393,9 @@ streamHistoryCommentsForCausal rootCHID action = do
       SELECT cp.causal_id
         FROM causal_parent cp
         JOIN branch_history bh ON cp.parent_id = bh.causal_hash_id
-    ) SELECT hc.id
+    ) SELECT hc.id, comment_hash.base32
         FROM branch_history bh
         JOIN history_comments hc ON hc.causal_hash_id = bh.causal_hash_id
+        JOIN hash AS comment_hash ON comment_hash.id = hc.comment_hash_id
     |]
     action

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -241,6 +241,8 @@ module U.Codebase.Sqlite.Queries
     -- * History Comments
     commentOnCausal,
     getLatestCausalComment,
+    streamHistoryCommentsForCausal,
+    expectHistoryCommentById,
 
     -- * migrations
     runCreateSql,
@@ -4212,6 +4214,51 @@ getLatestCausalComment causalHashId =
               }
         }
 
+expectHistoryCommentById ::
+  HistoryCommentId ->
+  Transaction (HistoryComment Time.UTCTime KeyThumbprint Hash32 Hash32, [HistoryCommentRevision Hash32 Time.UTCTime Hash32])
+expectHistoryCommentById commentId = do
+  comment <-
+    queryOneRow @(Hash32, Hash32, Text, Text, Int64)
+      [sql|
+      SELECT comment_hash.base32, causal_hash.base32, cc.author, kt.thumbprint, cc.created_at_ms
+        FROM history_comments AS cc
+        JOIN hash AS comment_hash ON comment_hash.id = cc.comment_hash_id
+        JOIN hash AS causal_hash ON causal_hash.id = cc.causal_hash_id
+        JOIN key_thumbprints AS kt ON kt.id = cc.author_thumbprint_id
+        WHERE cc.id = :commentId
+    |]
+      <&> \(commentHash, causalHash, author, authorThumbprint, createdAtMs) ->
+        HistoryComment
+          { author,
+            authorThumbprint = KeyThumbprint authorThumbprint,
+            causal = causalHash,
+            createdAt = millisToUTCTime createdAtMs,
+            commentId = commentHash
+          }
+  revisions <-
+    queryListRow
+      @(Hash32, Text, Text, Bool, ByteString, Int64)
+      [sql|
+      SELECT ccrh.base32, ccr.subject, ccr.contents, ccr.hidden, ccr.author_signature, ccr.created_at_ms
+        FROM history_comment_revisions AS ccr
+        JOIN hash AS ccrh ON ccrh.id = ccr.revision_hash_id
+        WHERE ccr.comment_id = :commentId
+        ORDER BY ccr.created_at_ms ASC
+        |]
+      <&> fmap \(revisionHash, subject, content, isHidden, authorSignature, createdAtMs) ->
+        HistoryCommentRevision
+          { subject,
+            content,
+            createdAt = millisToUTCTime createdAtMs,
+            revisionId = revisionHash,
+            isHidden,
+            authorSignature,
+            comment = comment.commentId
+          }
+
+  pure (comment, revisions)
+
 commentOnCausal :: LatestHistoryComment KeyThumbprint CausalHashId HistoryCommentRevisionHash HistoryCommentHash -> Transaction ()
 commentOnCausal
   HistoryCommentRevision
@@ -4319,3 +4366,20 @@ ensurePersonalKeyThumbprintId thumbprint = do
           VALUES (:thumbprintText)
           RETURNING id
         |]
+
+-- | Stream all the history comments in the history of a branch.
+streamHistoryCommentsForCausal :: CausalHashId -> (Transaction (Maybe HistoryCommentId) -> Transaction r) -> Transaction r
+streamHistoryCommentsForCausal rootCHID action = do
+  queryStreamCol
+    [sql|
+    WITH RECURSIVE branch_history(causal_hash_id) AS(
+      SELECT :rootCHID
+      UNION ALL
+      SELECT cp.causal_id
+        FROM causal_parent cp
+        JOIN branch_history bh ON cp.parent_causal_id = bh.causal_hash_id
+    ) SELECT hc.id
+        FROM branch_history bh
+        JOIN history_comments hc ON hc.causal_hash_id = bh.causal_hash_id
+    |]
+    action

--- a/unison-cli/package.yaml
+++ b/unison-cli/package.yaml
@@ -105,6 +105,7 @@ library:
     - vector
     - wai
     - warp
+    - websockets
     - witch
     - witherable
 

--- a/unison-cli/package.yaml
+++ b/unison-cli/package.yaml
@@ -105,7 +105,6 @@ library:
     - vector
     - wai
     - warp
-    - websockets
     - witch
     - witherable
 

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Push.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Push.hs
@@ -411,9 +411,9 @@ executeUploadPlan UploadPlan {remoteBranch, causalHash, afterUploadAction} = do
     (Cli.returnEarly . Output.ShareError) case err0 of
       Share.SyncError err -> ShareErrorUploadEntities err
       Share.TransportError err -> ShareErrorTransport err
+  afterUploadAction
   -- TODO: Unify RepoInfo and BranchRef?
   HC.uploadHistoryComments causalHash codeserverURI (BranchRef remoteTarget)
-  afterUploadAction
   let ProjectAndBranch projectName branchName = remoteBranch
   Cli.respond (ViewOnShare (Share.hardCodedUri, projectName, branchName))
 

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Push.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Push.hs
@@ -45,9 +45,11 @@ import Unison.Project
     prependUserSlugToProjectName,
     projectNameUserSlug,
   )
+import Unison.Server.Types (BranchRef (..))
 import Unison.Share.API.Hash qualified as Share.API
 import Unison.Share.API.Projects qualified as Share.API
 import Unison.Share.Codeserver qualified as Codeserver
+import Unison.Share.HistoryComments qualified as HC
 import Unison.Share.Sync qualified as Share
 import Unison.Share.Sync.Types qualified as Share
 import Unison.Share.Types (codeserverBaseURL)
@@ -390,14 +392,16 @@ data UploadPlan = UploadPlan
 -- Execute an upload plan.
 executeUploadPlan :: UploadPlan -> Cli ()
 executeUploadPlan UploadPlan {remoteBranch, causalHash, afterUploadAction} = do
+  let codeserverURI = Codeserver.defaultCodeserver
+  let remoteTarget = into @Text (ProjectAndBranch (remoteBranch ^. #project) (remoteBranch ^. #branch))
   (uploadResult, numUploaded) <-
     Cli.with withEntitiesUploadedProgressCallback \(uploadedCallback, getNumUploaded) -> do
       uploadResult <-
         Share.uploadEntities
-          (codeserverBaseURL Codeserver.defaultCodeserver)
+          (codeserverBaseURL codeserverURI)
           -- On the wire, the remote branch is encoded as e.g.
           --   { "repo_info": "@unison/base/@arya/topic", ... }
-          (Share.RepoInfo (into @Text (ProjectAndBranch (remoteBranch ^. #project) (remoteBranch ^. #branch))))
+          (Share.RepoInfo remoteTarget)
           (Set.NonEmpty.singleton causalHash)
           uploadedCallback
       numUploaded <- liftIO getNumUploaded
@@ -407,6 +411,8 @@ executeUploadPlan UploadPlan {remoteBranch, causalHash, afterUploadAction} = do
     (Cli.returnEarly . Output.ShareError) case err0 of
       Share.SyncError err -> ShareErrorUploadEntities err
       Share.TransportError err -> ShareErrorTransport err
+  -- TODO: Unify RepoInfo and BranchRef?
+  HC.uploadHistoryComments causalHash codeserverURI (BranchRef remoteTarget)
   afterUploadAction
   let ProjectAndBranch projectName branchName = remoteBranch
   Cli.respond (ViewOnShare (Share.hardCodedUri, projectName, branchName))

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Push.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Push.hs
@@ -45,7 +45,6 @@ import Unison.Project
     prependUserSlugToProjectName,
     projectNameUserSlug,
   )
-import Unison.Server.Types (BranchRef (..))
 import Unison.Share.API.Hash qualified as Share.API
 import Unison.Share.API.Projects qualified as Share.API
 import Unison.Share.Codeserver qualified as Codeserver
@@ -201,6 +200,7 @@ pushProjectBranchToProjectBranch'InferredProject force localProjectAndBranch loc
                   pure
                     UploadPlan
                       { remoteBranch = ProjectAndBranch (remoteBranch ^. #projectName) (remoteBranch ^. #branchName),
+                        remoteHead = Just $ Share.API.hashJWTHash remoteBranch.branchHead,
                         causalHash = localBranchHead,
                         afterUploadAction
                       }
@@ -302,6 +302,7 @@ pushToProjectBranch0 force pushing localBranchHead remoteProjectAndBranch = do
       pure
         UploadPlan
           { remoteBranch = remoteProjectAndBranch,
+            remoteHead = Nothing,
             causalHash = localBranchHead,
             afterUploadAction =
               createBranchAfterUploadAction
@@ -317,6 +318,7 @@ pushToProjectBranch0 force pushing localBranchHead remoteProjectAndBranch = do
           pure
             UploadPlan
               { remoteBranch = remoteProjectAndBranch,
+                remoteHead = Nothing,
                 causalHash = localBranchHead,
                 afterUploadAction =
                   createBranchAfterUploadAction
@@ -332,6 +334,7 @@ pushToProjectBranch0 force pushing localBranchHead remoteProjectAndBranch = do
           pure
             UploadPlan
               { remoteBranch = remoteProjectAndBranch,
+                remoteHead = Just (Share.API.hashJWTHash remoteBranch.branchHead),
                 causalHash = localBranchHead,
                 afterUploadAction
               }
@@ -350,6 +353,7 @@ pushToProjectBranch1 force localProjectAndBranch localBranchHead remoteProjectAn
       pure
         UploadPlan
           { remoteBranch = over #project snd remoteProjectAndBranch,
+            remoteHead = Nothing,
             causalHash = localBranchHead,
             afterUploadAction =
               createBranchAfterUploadAction
@@ -365,6 +369,7 @@ pushToProjectBranch1 force localProjectAndBranch localBranchHead remoteProjectAn
       pure
         UploadPlan
           { remoteBranch = over #project snd remoteProjectAndBranch,
+            remoteHead = Just (Share.API.hashJWTHash remoteBranch.branchHead),
             causalHash = localBranchHead,
             afterUploadAction
           }
@@ -383,6 +388,8 @@ pushToProjectBranch1 force localProjectAndBranch localBranchHead remoteProjectAn
 data UploadPlan = UploadPlan
   { -- The remote branch we are uploading entities for.
     remoteBranch :: ProjectAndBranch ProjectName ProjectBranchName,
+    -- The current head of the remote branch.
+    remoteHead :: Maybe Hash32,
     -- The causal hash to upload.
     causalHash :: Hash32,
     -- The action to call after a successful upload.
@@ -391,29 +398,32 @@ data UploadPlan = UploadPlan
 
 -- Execute an upload plan.
 executeUploadPlan :: UploadPlan -> Cli ()
-executeUploadPlan UploadPlan {remoteBranch, causalHash, afterUploadAction} = do
+executeUploadPlan UploadPlan {remoteBranch, remoteHead, causalHash, afterUploadAction} = do
   let codeserverURI = Codeserver.defaultCodeserver
   let remoteTarget = into @Text (ProjectAndBranch (remoteBranch ^. #project) (remoteBranch ^. #branch))
-  (uploadResult, numUploaded) <-
-    Cli.with withEntitiesUploadedProgressCallback \(uploadedCallback, getNumUploaded) -> do
-      uploadResult <-
-        Share.uploadEntities
-          (codeserverBaseURL codeserverURI)
-          -- On the wire, the remote branch is encoded as e.g.
-          --   { "repo_info": "@unison/base/@arya/topic", ... }
-          (Share.RepoInfo remoteTarget)
-          (Set.NonEmpty.singleton causalHash)
-          uploadedCallback
-      numUploaded <- liftIO getNumUploaded
-      pure (uploadResult, numUploaded)
-  Cli.respond (Output.UploadedEntities numUploaded)
-  uploadResult & onLeft \err0 -> do
-    (Cli.returnEarly . Output.ShareError) case err0 of
-      Share.SyncError err -> ShareErrorUploadEntities err
-      Share.TransportError err -> ShareErrorTransport err
+  case remoteHead of
+    Just remoteHeadHash | remoteHeadHash == causalHash -> do
+      Cli.respond (RemoteProjectBranchIsUpToDate Share.hardCodedUri remoteBranch)
+    _ -> do
+      (uploadResult, numUploaded) <-
+        Cli.with withEntitiesUploadedProgressCallback \(uploadedCallback, getNumUploaded) -> do
+          uploadResult <-
+            Share.uploadEntities
+              (codeserverBaseURL codeserverURI)
+              -- On the wire, the remote branch is encoded as e.g.
+              --   { "repo_info": "@unison/base/@arya/topic", ... }
+              (Share.RepoInfo remoteTarget)
+              (Set.NonEmpty.singleton causalHash)
+              uploadedCallback
+          numUploaded <- liftIO getNumUploaded
+          pure (uploadResult, numUploaded)
+      Cli.respond (Output.UploadedEntities numUploaded)
+      uploadResult & onLeft \err0 -> do
+        (Cli.returnEarly . Output.ShareError) case err0 of
+          Share.SyncError err -> ShareErrorUploadEntities err
+          Share.TransportError err -> ShareErrorTransport err
   afterUploadAction
-  -- TODO: Unify RepoInfo and BranchRef?
-  HC.uploadHistoryComments causalHash codeserverURI (BranchRef remoteTarget)
+  HC.uploadHistoryComments causalHash codeserverURI (Share.RepoInfo remoteTarget)
   let ProjectAndBranch projectName branchName = remoteBranch
   Cli.respond (ViewOnShare (Share.hardCodedUri, projectName, branchName))
 
@@ -505,48 +515,47 @@ makeSetHeadAfterUploadAction ::
 makeSetHeadAfterUploadAction force pushing localBranchHead remoteBranch = do
   let remoteProjectAndBranchNames = ProjectAndBranch remoteBranch.projectName remoteBranch.branchName
 
-  when (localBranchHead == Share.API.hashJWTHash remoteBranch.branchHead) do
-    Cli.respond (RemoteProjectBranchIsUpToDate Share.hardCodedUri remoteProjectAndBranchNames)
-    Cli.returnEarly (ViewOnShare (Share.hardCodedUri, remoteBranch.projectName, remoteBranch.branchName))
-
   when (not force) do
     whenM (Cli.runTransaction (wouldNotBeFastForward localBranchHead remoteBranchHead)) do
       Cli.returnEarly (RemoteProjectBranchHeadMismatch Share.hardCodedUri remoteProjectAndBranchNames)
 
-  pure do
-    let request =
-          Share.API.SetProjectBranchHeadRequest
-            { projectId = unRemoteProjectId (remoteBranch ^. #projectId),
-              branchId = unRemoteProjectBranchId (remoteBranch ^. #branchId),
-              branchOldCausalHash = Just remoteBranchHead,
-              branchNewCausalHash = localBranchHead
-            }
-    let onSuccess =
-          case pushing of
-            PushingLooseCode -> pure ()
-            PushingProjectBranch (ProjectAndBranch localProject localBranch) -> do
-              Cli.runTransaction do
-                Queries.ensureBranchRemoteMapping
-                  (localProject ^. #projectId)
-                  (localBranch ^. #branchId)
-                  (remoteBranch ^. #projectId)
-                  Share.hardCodedUri
-                  (remoteBranch ^. #branchId)
-    Share.setProjectBranchHead request >>= \case
-      Share.SetProjectBranchHeadResponseSuccess -> onSuccess
-      -- Sometimes a different request gets through in between checking the remote head and
-      -- executing the check-and-set push, if it managed to set the head to what we wanted
-      -- then the goal was achieved and we can consider it a success.
-      Share.SetProjectBranchHeadResponseExpectedCausalHashMismatch _expected actual
-        | actual == localBranchHead -> onSuccess
-      Share.SetProjectBranchHeadResponseExpectedCausalHashMismatch _expected _actual ->
-        Cli.returnEarly (RemoteProjectBranchHeadMismatch Share.hardCodedUri remoteProjectAndBranchNames)
-      Share.SetProjectBranchHeadResponseNotFound -> do
-        Cli.returnEarly (Output.RemoteProjectBranchDoesntExist Share.hardCodedUri remoteProjectAndBranchNames)
-      Share.SetProjectBranchHeadResponseDeprecatedReleaseIsImmutable -> do
-        Cli.returnEarly (Output.RemoteProjectReleaseIsDeprecated Share.hardCodedUri remoteProjectAndBranchNames)
-      Share.SetProjectBranchHeadResponsePublishedReleaseIsImmutable -> do
-        Cli.returnEarly (Output.RemoteProjectPublishedReleaseCannotBeChanged Share.hardCodedUri remoteProjectAndBranchNames)
+  if
+    | localBranchHead == Share.API.hashJWTHash remoteBranch.branchHead -> do
+        pure $ pure ()
+    | otherwise -> pure do
+        let request =
+              Share.API.SetProjectBranchHeadRequest
+                { projectId = unRemoteProjectId (remoteBranch ^. #projectId),
+                  branchId = unRemoteProjectBranchId (remoteBranch ^. #branchId),
+                  branchOldCausalHash = Just remoteBranchHead,
+                  branchNewCausalHash = localBranchHead
+                }
+        let onSuccess =
+              case pushing of
+                PushingLooseCode -> pure ()
+                PushingProjectBranch (ProjectAndBranch localProject localBranch) -> do
+                  Cli.runTransaction do
+                    Queries.ensureBranchRemoteMapping
+                      (localProject ^. #projectId)
+                      (localBranch ^. #branchId)
+                      (remoteBranch ^. #projectId)
+                      Share.hardCodedUri
+                      (remoteBranch ^. #branchId)
+        Share.setProjectBranchHead request >>= \case
+          Share.SetProjectBranchHeadResponseSuccess -> onSuccess
+          -- Sometimes a different request gets through in between checking the remote head and
+          -- executing the check-and-set push, if it managed to set the head to what we wanted
+          -- then the goal was achieved and we can consider it a success.
+          Share.SetProjectBranchHeadResponseExpectedCausalHashMismatch _expected actual
+            | actual == localBranchHead -> onSuccess
+          Share.SetProjectBranchHeadResponseExpectedCausalHashMismatch _expected _actual ->
+            Cli.returnEarly (RemoteProjectBranchHeadMismatch Share.hardCodedUri remoteProjectAndBranchNames)
+          Share.SetProjectBranchHeadResponseNotFound -> do
+            Cli.returnEarly (Output.RemoteProjectBranchDoesntExist Share.hardCodedUri remoteProjectAndBranchNames)
+          Share.SetProjectBranchHeadResponseDeprecatedReleaseIsImmutable -> do
+            Cli.returnEarly (Output.RemoteProjectReleaseIsDeprecated Share.hardCodedUri remoteProjectAndBranchNames)
+          Share.SetProjectBranchHeadResponsePublishedReleaseIsImmutable -> do
+            Cli.returnEarly (Output.RemoteProjectPublishedReleaseCannotBeChanged Share.hardCodedUri remoteProjectAndBranchNames)
   where
     remoteBranchHead =
       Share.API.hashJWTHash (remoteBranch ^. #branchHead)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Push.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Push.hs
@@ -423,7 +423,7 @@ executeUploadPlan UploadPlan {remoteBranch, remoteHead, causalHash, afterUploadA
           Share.SyncError err -> ShareErrorUploadEntities err
           Share.TransportError err -> ShareErrorTransport err
   afterUploadAction
-  HC.uploadHistoryComments causalHash codeserverURI (Share.RepoInfo remoteTarget)
+  Cli.time "Uploading History Comments" $ HC.uploadHistoryComments causalHash codeserverURI (Share.RepoInfo remoteTarget)
   let ProjectAndBranch projectName branchName = remoteBranch
   Cli.respond (ViewOnShare (Share.hardCodedUri, projectName, branchName))
 

--- a/unison-cli/src/Unison/Share/HistoryComments.hs
+++ b/unison-cli/src/Unison/Share/HistoryComments.hs
@@ -72,7 +72,7 @@ uploadHistoryComments rootCausalHash32 codeserver repoInfo = do
         let loop = do
               result <- runMaybeT $ do
                 (_commentId, commentHash32) <- MaybeT $ getCommentIds
-                lift . Sqlite.unsafeIO $ atomically $ writeTBMQueue commentHashesToUploadQ commentHash32
+                lift . Sqlite.unsafeIO $ atomically $ writeTBMQueue commentHashesToSendQ commentHash32
               -- Loop till a send fails or we run out of comments
               case result of
                 Just () -> loop
@@ -152,11 +152,13 @@ uploadHistoryComments rootCausalHash32 codeserver repoInfo = do
             isClosed <- atomically $ do
               (newHashes, isClosed) <- flushTBMQueue q
               Any serverClosed <-
-                (NESet.nonEmptySet $ Set.fromList newHashes) & foldMapM \newHashesSet ->
+                (NESet.nonEmptySet $ Set.fromList newHashes) & foldMapM \newHashesSet -> do
+                  Debug.debugM Debug.Temp "Notifying server of comment hashes" newHashesSet
                   Any <$> (send $ Msg $ PossiblyNewHashesChunk newHashesSet)
               pure (isClosed || serverClosed)
             if isClosed
               then do
+                Debug.debugM Debug.Temp "sending DoneSendingHashesChunk" ()
                 -- If the queue is closed, send a DoneCheckingHashesChunk to notify the server we're done.
                 void . atomically $ send (Msg DoneSendingHashesChunk)
               else loop

--- a/unison-cli/src/Unison/Share/HistoryComments.hs
+++ b/unison-cli/src/Unison/Share/HistoryComments.hs
@@ -66,7 +66,7 @@ uploadCommentsClient rootCausalHashId codeserver branchRef = do
       loop
 
   case result of
-    Left _err -> error "handle err"
+    Left err -> error $ "uploadCommentsClient:" <> show err
     Right () -> pure ()
   where
     intoChunk = \case

--- a/unison-cli/src/Unison/Share/HistoryComments.hs
+++ b/unison-cli/src/Unison/Share/HistoryComments.hs
@@ -2,7 +2,6 @@ module Unison.Share.HistoryComments (uploadCommentsClient) where
 
 import Control.Monad.Reader
 import Data.Text qualified as Text
-import Data.Text.Encoding qualified as Text
 import Data.Void
 import Servant.API
 import U.Codebase.Sqlite.DbId (CausalHashId)
@@ -83,7 +82,7 @@ uploadCommentsClient rootCausalHashId codeserver branchRef = do
             Share.HistoryComment
               { author,
                 createdAt,
-                authorThumbprint = Text.encodeUtf8 authorThumbprint,
+                authorThumbprint,
                 Share.causalHash = causal,
                 commentHash
               }

--- a/unison-cli/src/Unison/Share/HistoryComments.hs
+++ b/unison-cli/src/Unison/Share/HistoryComments.hs
@@ -30,15 +30,6 @@ import Unison.Util.Monoid (foldMapM)
 import Unison.Util.Websockets
 import UnliftIO.STM
 
--- type HistoryCommentsAPI = ("ucm" :> "v1" :> "history-comments" :> HistoryCommentsAPI.API)
-
--- downloadCommentsClientM :: BranchRef -> WS.Connection -> Servant.ClientM ()
--- uploadCommentsClientM :: BranchRef -> WS.Connection -> Servant.ClientM ()
--- HistoryCommentsAPI.Routes
---   { uploadHistoryComments = downloadCommentsClientM,
---     downloadHistoryComments = uploadCommentsClientM
---   } = Servant.client historyCommentsAPI
-
 -- | Number of comment chunks that can be queued up in the websockets buffer.
 msgBufferSize :: Int
 msgBufferSize = 20

--- a/unison-cli/src/Unison/Share/HistoryComments.hs
+++ b/unison-cli/src/Unison/Share/HistoryComments.hs
@@ -1,26 +1,28 @@
 module Unison.Share.HistoryComments (uploadCommentsClient) where
 
 import Control.Monad.Reader
-import Data.Proxy (Proxy (..))
-import Data.Text (Text)
 import Data.Text qualified as Text
+import Data.Text.Encoding qualified as Text
 import Data.Void
-import Network.WebSockets qualified as WS
 import Servant.API
-import Servant.Client qualified as Servant
-import Unison.Auth.Tokens (TokenProvider, newTokenProvider)
+import U.Codebase.Sqlite.DbId (CausalHashId)
+import U.Codebase.Sqlite.Queries qualified as Q
+import Unison.Auth.Tokens (newTokenProvider)
 import Unison.Cli.Monad
 import Unison.Cli.Monad qualified as Cli
-import Unison.Server.HistoryComments.API qualified as HistoryCommentsAPI
+import Unison.Codebase qualified as Codebase
+import Unison.HistoryComment qualified as HC
+import Unison.KeyThumbprint (KeyThumbprint (KeyThumbprint))
+import Unison.Prelude
 import Unison.Server.HistoryComments.Types
+import Unison.Server.HistoryComments.Types qualified as Share
 import Unison.Server.Types
 import Unison.Share.Codeserver qualified as Codeserver
+import Unison.Sqlite qualified as Sqlite
 import Unison.Util.Websockets
+import UnliftIO.STM
 
-type HistoryCommentsAPI = ("ucm" :> "v1" :> "history-comments" :> HistoryCommentsAPI.API)
-
-historyCommentsAPI :: Proxy HistoryCommentsAPI
-historyCommentsAPI = Proxy @HistoryCommentsAPI
+-- type HistoryCommentsAPI = ("ucm" :> "v1" :> "history-comments" :> HistoryCommentsAPI.API)
 
 -- downloadCommentsClientM :: BranchRef -> WS.Connection -> Servant.ClientM ()
 -- uploadCommentsClientM :: BranchRef -> WS.Connection -> Servant.ClientM ()
@@ -29,23 +31,80 @@ historyCommentsAPI = Proxy @HistoryCommentsAPI
 --     downloadHistoryComments = uploadCommentsClientM
 --   } = Servant.client historyCommentsAPI
 
+-- | Number of comment chunks that can be queued up in the websockets buffer.
 msgBufferSize :: Int
-msgBufferSize = 100
+msgBufferSize = 20
 
 uploadCommentsClient ::
+  -- | The local branch causal to upload comments for.
+  CausalHashId ->
   -- | The Unison Share URL.
   Codeserver.CodeserverURI ->
-  -- | The branch to download from.
+  -- | The remote branch to upload for.
   BranchRef ->
   Cli ()
-uploadCommentsClient codeserver branchRef = do
+uploadCommentsClient rootCausalHashId codeserver branchRef = do
   Cli.Env {codebase, credentialManager} <- ask
   let path = "/ucm/v1/history-comments/upload?branchRef=" <> Text.unpack (toQueryParam branchRef)
   -- Enable compression
   let tokenProvider = newTokenProvider credentialManager
   result <- liftIO $ withCodeserverWebsocket @IO @(MsgOrError Void HistoryCommentChunk) @Text msgBufferSize codeserver tokenProvider path \Queues {send} -> do
-    error "Send comments"
+    Codebase.runTransaction codebase $ Q.streamHistoryCommentsForCausal rootCausalHashId \getCommentId -> do
+      let loop = do
+            result <- runMaybeT $ do
+              commentId <- MaybeT $ getCommentId
+              (comment, revisions) <- lift $ Q.expectHistoryCommentById commentId
+              success <- lift $ Sqlite.unsafeIO $ atomically $ send (Msg $ intoChunk (Left comment))
+              guard success
+              for_ revisions \revision -> do
+                success <- lift $ Sqlite.unsafeIO $ atomically $ send (Msg $ intoChunk (Right revision))
+                guard success
+            -- Loop till a send fails or we run out of comments
+            case result of
+              Just () -> loop
+              Nothing -> pure ()
+      loop
 
   case result of
     Left _err -> error "handle err"
     Right () -> pure ()
+  where
+    intoChunk = \case
+      Left
+        ( HC.HistoryComment
+            { author,
+              createdAt,
+              authorThumbprint = KeyThumbprint authorThumbprint,
+              causal,
+              commentId = commentHash
+            }
+          ) ->
+          HistoryCommentChunk
+            Share.HistoryComment
+              { author,
+                createdAt,
+                authorThumbprint = Text.encodeUtf8 authorThumbprint,
+                Share.causalHash = causal,
+                commentHash
+              }
+      Right
+        ( HC.HistoryCommentRevision
+            { subject,
+              content,
+              createdAt,
+              comment = commentHash,
+              isHidden,
+              authorSignature,
+              revisionId
+            }
+          ) ->
+          HistoryCommentRevisionChunk
+            Share.HistoryCommentRevision
+              { subject,
+                content,
+                createdAt,
+                isHidden,
+                authorSignature,
+                revisionHash = revisionId,
+                commentHash
+              }

--- a/unison-cli/src/Unison/Share/HistoryComments.hs
+++ b/unison-cli/src/Unison/Share/HistoryComments.hs
@@ -1,15 +1,17 @@
-module Unison.Share.HistoryComments (uploadCommentsClient) where
+module Unison.Share.HistoryComments (uploadHistoryComments) where
 
 import Control.Monad.Reader
 import Data.Text qualified as Text
 import Data.Void
 import Servant.API
-import U.Codebase.Sqlite.DbId (CausalHashId)
+import U.Codebase.HashTags (CausalHash (..))
 import U.Codebase.Sqlite.Queries qualified as Q
 import Unison.Auth.Tokens (newTokenProvider)
 import Unison.Cli.Monad
 import Unison.Cli.Monad qualified as Cli
 import Unison.Codebase qualified as Codebase
+import Unison.Hash32 (Hash32)
+import Unison.Hash32 qualified as Hash32
 import Unison.HistoryComment qualified as HC
 import Unison.KeyThumbprint (KeyThumbprint (KeyThumbprint))
 import Unison.Prelude
@@ -34,35 +36,37 @@ import UnliftIO.STM
 msgBufferSize :: Int
 msgBufferSize = 20
 
-uploadCommentsClient ::
+uploadHistoryComments ::
   -- | The local branch causal to upload comments for.
-  CausalHashId ->
+  Hash32 ->
   -- | The Unison Share URL.
   Codeserver.CodeserverURI ->
   -- | The remote branch to upload for.
   BranchRef ->
   Cli ()
-uploadCommentsClient rootCausalHashId codeserver branchRef = do
+uploadHistoryComments rootCausalHash32 codeserver branchRef = do
   Cli.Env {codebase, credentialManager} <- ask
   let path = "/ucm/v1/history-comments/upload?branchRef=" <> Text.unpack (toQueryParam branchRef)
   -- Enable compression
   let tokenProvider = newTokenProvider credentialManager
   result <- liftIO $ withCodeserverWebsocket @IO @(MsgOrError Void HistoryCommentChunk) @Text msgBufferSize codeserver tokenProvider path \Queues {send} -> do
-    Codebase.runTransaction codebase $ Q.streamHistoryCommentsForCausal rootCausalHashId \getCommentId -> do
-      let loop = do
-            result <- runMaybeT $ do
-              commentId <- MaybeT $ getCommentId
-              (comment, revisions) <- lift $ Q.expectHistoryCommentById commentId
-              success <- lift $ Sqlite.unsafeIO $ atomically $ send (Msg $ intoChunk (Left comment))
-              guard success
-              for_ revisions \revision -> do
-                success <- lift $ Sqlite.unsafeIO $ atomically $ send (Msg $ intoChunk (Right revision))
+    Codebase.runTransaction codebase $ do
+      rootCausalHashId <- Q.expectCausalHashIdByCausalHash $ CausalHash $ Hash32.toHash rootCausalHash32
+      Q.streamHistoryCommentsForCausal rootCausalHashId \getCommentId -> do
+        let loop = do
+              result <- runMaybeT $ do
+                commentId <- MaybeT $ getCommentId
+                (comment, revisions) <- lift $ Q.expectHistoryCommentById commentId
+                success <- lift $ Sqlite.unsafeIO $ atomically $ send (Msg $ intoChunk (Left comment))
                 guard success
-            -- Loop till a send fails or we run out of comments
-            case result of
-              Just () -> loop
-              Nothing -> pure ()
-      loop
+                for_ revisions \revision -> do
+                  success <- lift $ Sqlite.unsafeIO $ atomically $ send (Msg $ intoChunk (Right revision))
+                  guard success
+              -- Loop till a send fails or we run out of comments
+              case result of
+                Just () -> loop
+                Nothing -> pure ()
+        loop
 
   case result of
     Left err -> error $ "uploadCommentsClient:" <> show err

--- a/unison-cli/src/Unison/Share/HistoryComments.hs
+++ b/unison-cli/src/Unison/Share/HistoryComments.hs
@@ -1,0 +1,17 @@
+module Unison.Share.HistoryComments () where
+
+uploadHistoryCommentsImpl :: Codebase IO v a -> BranchRef -> Connection -> WebApp ()
+uploadHistoryCommentsImpl codebase = _
+
+type HistoryCommentsAPI = ("ucm" :> "v1" :> "history-comments" :> HistoryComments.API)
+
+historyCommentsAPI :: Proxy HistoryCommentsAPI
+historyCommentsAPI = Proxy @HistoryCommentsAPI
+
+downloadCommentsClientM :: BranchRef -> Connection -> Servant.ClientM ()
+uploadCommentsClientM :: BranchRef -> Connection -> Servant.ClientM ()
+
+SyncV2.Routes
+  { downloadEntitiesStream = downloadEntitiesStreamClientM,
+    causalDependenciesStream = causalDependenciesStreamClientM
+  } = Servant.client historyCommentsAPI

--- a/unison-cli/src/Unison/Share/HistoryComments.hs
+++ b/unison-cli/src/Unison/Share/HistoryComments.hs
@@ -10,6 +10,7 @@ import Unison.Auth.Tokens (newTokenProvider)
 import Unison.Cli.Monad
 import Unison.Cli.Monad qualified as Cli
 import Unison.Codebase qualified as Codebase
+import Unison.Debug qualified as Debug
 import Unison.Hash32 (Hash32)
 import Unison.Hash32 qualified as Hash32
 import Unison.HistoryComment qualified as HC
@@ -56,6 +57,7 @@ uploadHistoryComments rootCausalHash32 codeserver branchRef = do
         let loop = do
               result <- runMaybeT $ do
                 commentId <- MaybeT $ getCommentId
+                Debug.debugM Debug.Temp "Uploading comment" (show commentId)
                 (comment, revisions) <- lift $ Q.expectHistoryCommentById commentId
                 success <- lift $ Sqlite.unsafeIO $ atomically $ send (Msg $ intoChunk (Left comment))
                 guard success

--- a/unison-cli/src/Unison/Share/HistoryComments.hs
+++ b/unison-cli/src/Unison/Share/HistoryComments.hs
@@ -1,8 +1,14 @@
 module Unison.Share.HistoryComments (uploadHistoryComments) where
 
+import Control.Concurrent.STM.TBMQueue (TBMQueue, closeTBMQueue, newTBMQueueIO, readTBMQueue, writeTBMQueue)
 import Control.Monad.Reader
+import Control.Monad.Trans.Maybe (mapMaybeT)
+import Data.Monoid (Any (..))
+import Data.Set qualified as Set
+import Data.Set.NonEmpty qualified as NESet
 import Data.Text qualified as Text
 import Data.Void
+import Ki qualified
 import Servant.API
 import U.Codebase.HashTags (CausalHash (..))
 import U.Codebase.Sqlite.Queries qualified as Q
@@ -21,6 +27,7 @@ import Unison.Server.HistoryComments.Types qualified as Share
 import Unison.Share.Codeserver qualified as Codeserver
 import Unison.Sqlite qualified as Sqlite
 import Unison.Sync.Types (RepoInfo)
+import Unison.Util.Monoid (foldMapM)
 import Unison.Util.Websockets
 import UnliftIO.STM
 
@@ -50,30 +57,110 @@ uploadHistoryComments rootCausalHash32 codeserver repoInfo = do
   let path = "/ucm/v1/history-comments/upload?branchRef=" <> Text.unpack (toQueryParam repoInfo)
   -- Enable compression
   let tokenProvider = newTokenProvider credentialManager
-  result <- liftIO $ withCodeserverWebsocket @IO @(MsgOrError Void HistoryCommentChunk) @Text msgBufferSize codeserver tokenProvider path \Queues {send} -> do
+  result <- liftIO $ withCodeserverWebsocket @IO @(MsgOrError Void HistoryCommentUploaderChunk) @(MsgOrError Void HistoryCommentDownloaderChunk) msgBufferSize codeserver tokenProvider path \Queues {send, receive} -> Ki.scoped \scope -> do
+    commentHashesToSendQ <- newTBMQueueIO 100
+    commentHashesToUploadQ <- newTBMQueueIO 100
+    -- Is filled when the server notifies us it's done requesting comments
+    doneRequestingCommentsMVar <- newEmptyTMVarIO
+    errMVar <- newEmptyTMVarIO
+    _ <- Ki.fork scope (hashNotifyWorker send commentHashesToSendQ)
+    uploaderThread <- Ki.fork scope (uploaderWorker codebase send commentHashesToUploadQ)
+    _ <- Ki.fork scope (receiverWorker receive commentHashesToUploadQ errMVar doneRequestingCommentsMVar)
     Codebase.runTransaction codebase $ do
       rootCausalHashId <- Q.expectCausalHashIdByCausalHash $ CausalHash $ Hash32.toHash rootCausalHash32
-      Q.streamHistoryCommentsForCausal rootCausalHashId \getCommentId -> do
+      Q.streamHistoryCommentsForCausal rootCausalHashId \getCommentIds -> do
         let loop = do
               result <- runMaybeT $ do
-                commentId <- MaybeT $ getCommentId
-                Debug.debugM Debug.Temp "Uploading comment" (show commentId)
-                (comment, revisions) <- lift $ Q.expectHistoryCommentById commentId
-                success <- lift $ Sqlite.unsafeIO $ atomically $ send (Msg $ intoChunk (Left comment))
-                guard success
-                for_ revisions \revision -> do
-                  success <- lift $ Sqlite.unsafeIO $ atomically $ send (Msg $ intoChunk (Right revision))
-                  guard success
+                (_commentId, commentHash32) <- MaybeT $ getCommentIds
+                lift . Sqlite.unsafeIO $ atomically $ writeTBMQueue commentHashesToUploadQ commentHash32
               -- Loop till a send fails or we run out of comments
               case result of
                 Just () -> loop
                 Nothing -> pure ()
         loop
-
+    -- Close the hashes queue to signal we don't have any more, then wait for the notifier to finish
+    atomically $ closeTBMQueue commentHashesToSendQ
+    -- Once the comment Hash queue is closed, eventually we'll send a DoneSendingHashesChunk message,
+    -- the server will respond with a DoneCheckingHashesChunk message after it's made all necessary
+    -- requests.
+    --
+    -- Then we can close the comment upload hash queue to signal we won't get any more upload requests.
+    atomically $ readTMVar doneRequestingCommentsMVar >> closeTBMQueue commentHashesToUploadQ
+    -- Now we just have to wait for the uploader to finish sending all the comments we have queued up.
+    -- Once we've uploaded everything we can safely exit and the connection will be closed.
+    atomically $ Ki.await uploaderThread
   case result of
     Left err -> error $ "uploadCommentsClient:" <> show err
     Right ((), _leftovers {- Messages sent by server after we finished. -}) -> pure ()
   where
+    -- Read all available values from a TBMQueue, returning them and whether the queue is closed.
+    flushTBMQueue :: TBMQueue a -> STM ([a], Bool)
+    flushTBMQueue q = do
+      optional (readTBMQueue q) >>= \case
+        -- No values available
+        Nothing -> empty
+        Just Nothing -> do
+          -- Queue closed
+          pure ([], True)
+        Just (Just v) -> do
+          (vs, closed) <- flushTBMQueue q <|> pure ([], False)
+          pure (v : vs, closed)
+    uploaderWorker ::
+      Codebase.Codebase IO v a ->
+      ( MsgOrError err HistoryCommentUploaderChunk ->
+        STM Bool
+      ) ->
+      TBMQueue Hash32 ->
+      IO ()
+    uploaderWorker codebase send uploadCommentQueue = do
+      let loop = do
+            commentHash <- MaybeT $ atomically (readTBMQueue uploadCommentQueue)
+            Debug.debugM Debug.Temp "Uploading comment" commentHash
+            mapMaybeT (Codebase.runTransaction codebase) $ do
+              commentId <- lift $ Q.expectHistoryCommentIdByHash32 commentHash
+              (comment, revisions) <- lift $ Q.expectHistoryCommentById commentId
+              success <- lift $ Sqlite.unsafeIO $ atomically $ send (Msg $ intoChunk (Left comment))
+              guard success
+              for_ revisions \revision -> do
+                success <- lift $ Sqlite.unsafeIO $ atomically $ send (Msg $ intoChunk (Right revision))
+                guard success
+            loop
+      void . runMaybeT $ loop
+
+    receiverWorker :: STM (Maybe (MsgOrError Void HistoryCommentDownloaderChunk)) -> TBMQueue Hash32 -> TMVar Text -> TMVar () -> IO ()
+    receiverWorker receive toUploadQ errMVar doneRequestingCommentsMVar = do
+      let loop = do
+            msgOrError <- atomically receive
+            case msgOrError of
+              -- Channel closed, shut down
+              Nothing -> pure ()
+              Just (Msg msg) -> case msg of
+                DoneCheckingHashesChunk -> do
+                  -- Notify that the server is done requesting comments
+                  atomically $ putTMVar doneRequestingCommentsMVar ()
+                  loop
+                RequestCommentsChunk comments -> do
+                  atomically $ for_ comments $ writeTBMQueue toUploadQ
+                  loop
+              Just (DeserialiseFailure msg) -> do
+                atomically $ putTMVar errMVar $ "uploadHistoryComments: deserialisation failure: " <> msg
+      loop
+
+    hashNotifyWorker :: (MsgOrError Void HistoryCommentUploaderChunk -> STM Bool) -> TBMQueue Hash32 -> IO ()
+    hashNotifyWorker send q = do
+      let loop = do
+            isClosed <- atomically $ do
+              (newHashes, isClosed) <- flushTBMQueue q
+              Any serverClosed <-
+                (NESet.nonEmptySet $ Set.fromList newHashes) & foldMapM \newHashesSet ->
+                  Any <$> (send $ Msg $ PossiblyNewHashesChunk newHashesSet)
+              pure (isClosed || serverClosed)
+            if isClosed
+              then do
+                -- If the queue is closed, send a DoneCheckingHashesChunk to notify the server we're done.
+                void . atomically $ send (Msg DoneSendingHashesChunk)
+              else loop
+      loop
     intoChunk = \case
       Left
         ( HC.HistoryComment

--- a/unison-cli/src/Unison/Share/HistoryComments.hs
+++ b/unison-cli/src/Unison/Share/HistoryComments.hs
@@ -2,7 +2,9 @@ module Unison.Share.HistoryComments (uploadCommentsClient) where
 
 import Control.Monad.Reader
 import Data.Proxy (Proxy (..))
+import Data.Text (Text)
 import Data.Text qualified as Text
+import Data.Void
 import Network.WebSockets qualified as WS
 import Servant.API
 import Servant.Client qualified as Servant
@@ -41,7 +43,7 @@ uploadCommentsClient codeserver branchRef = do
   let path = "/ucm/v1/history-comments/upload?branchRef=" <> Text.unpack (toQueryParam branchRef)
   -- Enable compression
   let tokenProvider = newTokenProvider credentialManager
-  result <- liftIO $ withCodeserverWebsocket @IO @HistoryCommentChunk @() msgBufferSize codeserver tokenProvider path \Queues {send, receive} -> do
+  result <- liftIO $ withCodeserverWebsocket @IO @(MsgOrError Void HistoryCommentChunk) @Text msgBufferSize codeserver tokenProvider path \Queues {send} -> do
     error "Send comments"
 
   case result of

--- a/unison-cli/src/Unison/Share/HistoryComments.hs
+++ b/unison-cli/src/Unison/Share/HistoryComments.hs
@@ -18,9 +18,9 @@ import Unison.KeyThumbprint (KeyThumbprint (KeyThumbprint))
 import Unison.Prelude
 import Unison.Server.HistoryComments.Types
 import Unison.Server.HistoryComments.Types qualified as Share
-import Unison.Server.Types
 import Unison.Share.Codeserver qualified as Codeserver
 import Unison.Sqlite qualified as Sqlite
+import Unison.Sync.Types (RepoInfo)
 import Unison.Util.Websockets
 import UnliftIO.STM
 
@@ -43,11 +43,11 @@ uploadHistoryComments ::
   -- | The Unison Share URL.
   Codeserver.CodeserverURI ->
   -- | The remote branch to upload for.
-  BranchRef ->
+  RepoInfo ->
   Cli ()
-uploadHistoryComments rootCausalHash32 codeserver branchRef = do
+uploadHistoryComments rootCausalHash32 codeserver repoInfo = do
   Cli.Env {codebase, credentialManager} <- ask
-  let path = "/ucm/v1/history-comments/upload?branchRef=" <> Text.unpack (toQueryParam branchRef)
+  let path = "/ucm/v1/history-comments/upload?branchRef=" <> Text.unpack (toQueryParam repoInfo)
   -- Enable compression
   let tokenProvider = newTokenProvider credentialManager
   result <- liftIO $ withCodeserverWebsocket @IO @(MsgOrError Void HistoryCommentChunk) @Text msgBufferSize codeserver tokenProvider path \Queues {send} -> do

--- a/unison-cli/src/Unison/Share/HistoryComments.hs
+++ b/unison-cli/src/Unison/Share/HistoryComments.hs
@@ -3,8 +3,6 @@ module Unison.Share.HistoryComments (uploadCommentsClient) where
 import Control.Monad.Reader
 import Data.Proxy (Proxy (..))
 import Data.Text qualified as Text
-import Unison.Auth.Tokens (newTokenProvider, TokenProvider)
-import Data.Proxy (Proxy)
 import Network.WebSockets qualified as WS
 import Servant.API
 import Servant.Client qualified as Servant

--- a/unison-cli/src/Unison/Share/HistoryComments.hs
+++ b/unison-cli/src/Unison/Share/HistoryComments.hs
@@ -1,201 +1,49 @@
-module Unison.Share.HistoryComments () where
+module Unison.Share.HistoryComments (uploadCommentsClient) where
 
-import Unison.Auth.Tokens (newTokenProvider, TokenProvider)
-import Data.Proxy (Proxy)
+import Control.Monad.Reader
+import Data.Proxy (Proxy (..))
+import Data.Text qualified as Text
 import Network.WebSockets qualified as WS
 import Servant.API
 import Servant.Client qualified as Servant
+import Unison.Auth.Tokens (TokenProvider, newTokenProvider)
 import Unison.Cli.Monad
 import Unison.Cli.Monad qualified as Cli
 import Unison.Server.HistoryComments.API qualified as HistoryCommentsAPI
+import Unison.Server.HistoryComments.Types
 import Unison.Server.Types
 import Unison.Share.Codeserver qualified as Codeserver
+import Unison.Util.Websockets
 
 type HistoryCommentsAPI = ("ucm" :> "v1" :> "history-comments" :> HistoryCommentsAPI.API)
 
 historyCommentsAPI :: Proxy HistoryCommentsAPI
 historyCommentsAPI = Proxy @HistoryCommentsAPI
 
-downloadCommentsClientM :: BranchRef -> WS.Connection -> Servant.ClientM ()
-uploadCommentsClientM :: BranchRef -> WS.Connection -> Servant.ClientM ()
-HistoryCommentsAPI.Routes
-  { uploadHistoryComments = downloadCommentsClientM,
-    downloadHistoryComments = uploadCommentsClientM
-  } = Servant.client historyCommentsAPI
+-- downloadCommentsClientM :: BranchRef -> WS.Connection -> Servant.ClientM ()
+-- uploadCommentsClientM :: BranchRef -> WS.Connection -> Servant.ClientM ()
+-- HistoryCommentsAPI.Routes
+--   { uploadHistoryComments = downloadCommentsClientM,
+--     downloadHistoryComments = uploadCommentsClientM
+--   } = Servant.client historyCommentsAPI
 
-uploadHistoryCommentsImpl ::
+msgBufferSize :: Int
+msgBufferSize = 100
+
+uploadCommentsClient ::
   -- | The Unison Share URL.
   Codeserver.CodeserverURI ->
   -- | The branch to download from.
   BranchRef ->
   Cli ()
-uploadHistoryCommentsImpl codeserver branchRef = do
+uploadCommentsClient codeserver branchRef = do
   Cli.Env {codebase, credentialManager} <- ask
-  let host = Codeserver.codeserverRegName codeserver
-  let syncV3Path = "/ucm/v1/history-comments/upload"
+  let path = "/ucm/v1/history-comments/upload?branchRef=" <> Text.unpack (toQueryParam branchRef)
   -- Enable compression
-  let connectionOptions = WS.defaultConnectionOptions {WS.connectionCompressionOptions = WS.PermessageDeflateCompression WS.defaultPermessageDeflate}
-  let tokenProvider = Creds.newTokenProvider credentialManager
-  headers <-
-    (liftIO (tokenProvider (codeserverIdFromCodeserverURI codeserver))) <&> \case
-      Left {} -> []
-      Right token -> [("Authorization", "Bearer " <> Text.encodeUtf8 token)]
-  let runner = case Codeserver.codeserverScheme codeserver of
-        Codeserver.Https ->
-          let tlsPort = 443
-              port = maybe tlsPort fromIntegral $ (Codeserver.codeserverPort) codeserver
-           in Wuss.runSecureClientWith host port
-        Codeserver.Http ->
-          let tlsPort = 443 :: Int
-              port = maybe tlsPort id $ (Codeserver.codeserverPort) codeserver
-           in WS.runClientWith host port
-  Debug.debugLogM Debug.Temp "Obtaining Connection"
-  liftIO $ withSocketsDo $ (runner syncV3Path connectionOptions headers) \conn -> do
-    Debug.debugLogM Debug.Temp "Obtained Connection"
-    withQueues inputBuffer outputBuffer conn $ \queues@Queues {send} -> do
-      Debug.debugLogM Debug.Temp "Obtained Queues"
-      let initMsg =
-            InitMsg
-              { initMsgClientVersion = syncV3ClientVersion,
-                initMsgBranchRef = branchRef,
-                initMsgRootCausal = hashJwt,
-                initMsgRequestedDepth = Nothing
-              }
-      Debug.debugLogM Debug.Temp "Sending init message"
-      atomically $ send $ Msg $ ReceiverInitStream initMsg
-      Debug.debugLogM Debug.Temp "Init message sent"
-      pendingRequestsVar <- newTVarIO (Set.singleton (CausalEntity, rootCausalHash))
-      yetToRequestVar <- newTVarIO Set.empty
-      toIngestQueue <- newTBQueueIO transactionBatchSize
-      let initState =
-            SyncState
-              { pendingRequestsVar,
-                yetToRequestVar,
-                toIngestQueue,
-                rootCausalHash
-              }
+  let tokenProvider = newTokenProvider credentialManager
+  result <- liftIO $ withCodeserverWebsocket @IO @HistoryCommentChunk @() msgBufferSize codeserver tokenProvider path \Queues {send, receive} -> do
+    error "Send comments"
 
-      liftIO (doSync codebase initState queues) >>= \case
-        -- TODO: proper error handling
-        Left err -> error $ show err
-        Right () -> pure ()
-      Debug.debugLogM Debug.Temp "!Done sync, flushing temp entities"
-      causalId <- liftIO $ flushTemp codebase (Share.hashJWTHash hashJwt)
-      pure $ Right (Sync.hash32ToCausalHash rootCausalHash, causalId)
-
-data SyncState = SyncState
-  { pendingRequestsVar :: TVar (Set (EntityKind, Hash32)),
-    yetToRequestVar :: TVar (Set (EntityKind, Hash32)),
-    toIngestQueue :: TBQueue (Entity Hash32 Text),
-    rootCausalHash :: Hash32
-  }
-
--- | Given a stream that's already been initialized, receive entities and issue requests as needed.
-doSync :: Codebase IO v a -> SyncState -> Queues (MsgOrError SyncError (FromReceiverMessage Share.HashJWT Hash32)) (MsgOrError SyncError (FromEmitterMessage Hash32 Text)) -> IO (Either SyncError ())
-doSync codebase SyncState {pendingRequestsVar, yetToRequestVar, toIngestQueue, rootCausalHash} (Queues {send, receive, shutdown, connectionClosed}) = Ki.scoped \scope -> do
-  errorVar <- newEmptyTMVarIO
-  let onErr err = do
-        atomically $ putTMVar errorVar err
-        shutdown
-  _ <- Ki.fork scope (receiverWorker onErr)
-  _ <- Ki.fork scope (requesterWorker onErr)
-  _ <- Ki.fork scope (ingestionWorker onErr)
-  let finished = do
-        pending <- readTVar pendingRequestsVar
-        yetToReq <- readTVar yetToRequestVar
-        guard $ Set.null pending && Set.null yetToReq
-
-  Debug.debugLogM Debug.Temp "Awaiting completion"
-  result <-
-    atomically $
-      (Right <$> finished)
-        <|> (Right <$> Ki.awaitAll scope)
-        <|> (Left . Left <$> readTMVar errorVar)
-        <|> (Left . Right <$> connectionClosed)
-
-  Debug.debugM Debug.Temp "End result" result
   case result of
-    Left (Left syncErr) -> pure $ Left syncErr
-    Left (Right mayConnErr) -> case mayConnErr of
-      Nothing -> pure $ Right ()
-      Just connErr -> pure $ Left $ ConnectionError (tShow connErr)
-    Right () -> pure $ Right ()
-  where
-    receiverWorker :: (SyncError -> IO ()) -> IO ()
-    receiverWorker onErr = do
-      Debug.debugLogM Debug.Temp "Receiver waiting for message"
-      atomically receive >>= \case
-        Msg (EmitterEntityMsg entity) -> do
-          atomically $ do
-            writeTBQueue toIngestQueue entity
-          receiverWorker onErr
-        Err err -> onErr err
-    requesterWorker :: (SyncError -> IO ()) -> IO ()
-    requesterWorker _onErr = forever do
-      Debug.debugLogM Debug.Temp "Requester waiting to send requests"
-      atomically $ do
-        requests <- readTVar yetToRequestVar
-        guard $ not (Set.null requests)
-        writeTVar yetToRequestVar Set.empty
-        modifyTVar' pendingRequestsVar (Set.union requests)
-        send $ Msg $ ReceiverEntityRequest $ EntityRequestMsg (Set.toList requests)
-
-    ingestionWorker :: (SyncError -> IO ()) -> IO ()
-    ingestionWorker _onErr = forever do
-      Debug.debugLogM Debug.Temp "Ingestion waiting for entities"
-      newEntities <- atomically $ do
-        flushTBQueue toIngestQueue
-      Codebase.runTransaction codebase $ do
-        -- TODO: do hash validation based on shouldValidate
-        for_ newEntities $ \(Entity {entityKind, entityHash, entityDepth, entityData = CBOR.CBORBytes entityBytes}) -> do
-          Q.insertTempEntitySyncV3 rootCausalHash (tShow entityKind) entityHash (unEntityDepth entityDepth) entityBytes
-
-      tempEntities <- case for newEntities (CBOR.deserialiseOrFailCBORBytes . entityData) of
-        -- TODO: proper error handling
-        Left err -> error $ show err
-        Right tempEntities -> pure tempEntities
-      let allDeps = foldMap tempEntityDependencies tempEntities
-      -- TODO: double-check whether it's okay to have this as a separate atomic block.
-      alreadyRequestedEntities <- atomically $ do
-        pending <- readTVar pendingRequestsVar
-        reqs <- readTVar yetToRequestVar
-        pure $ Set.union pending reqs
-      let unrequestedDeps = Set.difference allDeps alreadyRequestedEntities
-      missingDeps <-
-        (Set.toList unrequestedDeps) & filterA \(_depKind, depHash) -> do
-          Codebase.runTransaction codebase (Q.entityLocationSyncV3 depHash) <&> \case
-            Nothing -> True
-            _ -> False
-      let newlyInserted =
-            newEntities
-              <&> (entityKind &&& entityHash)
-              & Set.fromList
-      -- Request any deps we're missing which also haven't already been requested
-      atomically $ do
-        pending <- readTVar pendingRequestsVar
-        let missingDepsSet = Set.fromList missingDeps
-        let unRequestedDeps = Set.difference missingDepsSet pending
-        modifyTVar' yetToRequestVar (Set.union unRequestedDeps)
-        modifyTVar' pendingRequestsVar (\pending -> Set.difference pending newlyInserted)
-
-flushTemp :: Codebase IO v a -> Hash32 -> IO CausalHashId
-flushTemp codebase rootCausalHash = do
-  Codebase.runTransaction codebase $ do
-    Q.streamTempEntitiesSyncV3 rootCausalHash \next ->
-      do
-        let loop = do
-              next >>= \case
-                Nothing -> pure ()
-                Just (hash, tempEntityBytes) ->
-                  do
-                    Debug.debugLogM Debug.Temp $ "Flushing temp entity: " <> show hash
-                    tempEntity <- case CBOR.deserialiseOrFailCBORBytes (CBOR.CBORBytes tempEntityBytes) of
-                      -- TODO: proper error handling
-                      Left err -> error $ show err
-                      Right tempEntity -> pure tempEntity
-                    Debug.debugLogM Debug.Temp $ "Saving in main" <> show hash
-                    void $ Q.saveTempEntityInMain v2HashHandle hash tempEntity
-                    loop
-        loop
-    Debug.debugLogM Debug.Temp "Flushed temp entities, getting causal hash id"
-    Q.expectCausalHashIdByCausalHash (Sync.hash32ToCausalHash rootCausalHash)
+    Left _err -> error "handle err"
+    Right () -> pure ()

--- a/unison-cli/src/Unison/Share/HistoryComments.hs
+++ b/unison-cli/src/Unison/Share/HistoryComments.hs
@@ -16,7 +16,6 @@ import Unison.Auth.Tokens (newTokenProvider)
 import Unison.Cli.Monad
 import Unison.Cli.Monad qualified as Cli
 import Unison.Codebase qualified as Codebase
-import Unison.Debug qualified as Debug
 import Unison.Hash32 (Hash32)
 import Unison.Hash32 qualified as Hash32
 import Unison.HistoryComment qualified as HC
@@ -115,7 +114,6 @@ uploadHistoryComments rootCausalHash32 codeserver repoInfo = do
     uploaderWorker codebase send uploadCommentQueue = do
       let loop = do
             commentHash <- MaybeT $ atomically (readTBMQueue uploadCommentQueue)
-            Debug.debugM Debug.Temp "Uploading comment" commentHash
             mapMaybeT (Codebase.runTransaction codebase) $ do
               commentId <- lift $ Q.expectHistoryCommentIdByHash32 commentHash
               (comment, revisions) <- lift $ Q.expectHistoryCommentById commentId
@@ -153,12 +151,10 @@ uploadHistoryComments rootCausalHash32 codeserver repoInfo = do
               (newHashes, isClosed) <- flushTBMQueue q
               Any serverClosed <-
                 (NESet.nonEmptySet $ Set.fromList newHashes) & foldMapM \newHashesSet -> do
-                  Debug.debugM Debug.Temp "Notifying server of comment hashes" newHashesSet
                   Any <$> (send $ Msg $ PossiblyNewHashesChunk newHashesSet)
               pure (isClosed || serverClosed)
             if isClosed
               then do
-                Debug.debugM Debug.Temp "sending DoneSendingHashesChunk" ()
                 -- If the queue is closed, send a DoneCheckingHashesChunk to notify the server we're done.
                 void . atomically $ send (Msg DoneSendingHashesChunk)
               else loop

--- a/unison-cli/src/Unison/Share/HistoryComments.hs
+++ b/unison-cli/src/Unison/Share/HistoryComments.hs
@@ -1,17 +1,201 @@
 module Unison.Share.HistoryComments () where
 
-uploadHistoryCommentsImpl :: Codebase IO v a -> BranchRef -> Connection -> WebApp ()
-uploadHistoryCommentsImpl codebase = _
+import Unison.Auth.Tokens (newTokenProvider, TokenProvider)
+import Data.Proxy (Proxy)
+import Network.WebSockets qualified as WS
+import Servant.API
+import Servant.Client qualified as Servant
+import Unison.Cli.Monad
+import Unison.Cli.Monad qualified as Cli
+import Unison.Server.HistoryComments.API qualified as HistoryCommentsAPI
+import Unison.Server.Types
+import Unison.Share.Codeserver qualified as Codeserver
 
-type HistoryCommentsAPI = ("ucm" :> "v1" :> "history-comments" :> HistoryComments.API)
+type HistoryCommentsAPI = ("ucm" :> "v1" :> "history-comments" :> HistoryCommentsAPI.API)
 
 historyCommentsAPI :: Proxy HistoryCommentsAPI
 historyCommentsAPI = Proxy @HistoryCommentsAPI
 
-downloadCommentsClientM :: BranchRef -> Connection -> Servant.ClientM ()
-uploadCommentsClientM :: BranchRef -> Connection -> Servant.ClientM ()
-
-SyncV2.Routes
-  { downloadEntitiesStream = downloadEntitiesStreamClientM,
-    causalDependenciesStream = causalDependenciesStreamClientM
+downloadCommentsClientM :: BranchRef -> WS.Connection -> Servant.ClientM ()
+uploadCommentsClientM :: BranchRef -> WS.Connection -> Servant.ClientM ()
+HistoryCommentsAPI.Routes
+  { uploadHistoryComments = downloadCommentsClientM,
+    downloadHistoryComments = uploadCommentsClientM
   } = Servant.client historyCommentsAPI
+
+uploadHistoryCommentsImpl ::
+  -- | The Unison Share URL.
+  Codeserver.CodeserverURI ->
+  -- | The branch to download from.
+  BranchRef ->
+  Cli ()
+uploadHistoryCommentsImpl codeserver branchRef = do
+  Cli.Env {codebase, credentialManager} <- ask
+  let host = Codeserver.codeserverRegName codeserver
+  let syncV3Path = "/ucm/v1/history-comments/upload"
+  -- Enable compression
+  let connectionOptions = WS.defaultConnectionOptions {WS.connectionCompressionOptions = WS.PermessageDeflateCompression WS.defaultPermessageDeflate}
+  let tokenProvider = Creds.newTokenProvider credentialManager
+  headers <-
+    (liftIO (tokenProvider (codeserverIdFromCodeserverURI codeserver))) <&> \case
+      Left {} -> []
+      Right token -> [("Authorization", "Bearer " <> Text.encodeUtf8 token)]
+  let runner = case Codeserver.codeserverScheme codeserver of
+        Codeserver.Https ->
+          let tlsPort = 443
+              port = maybe tlsPort fromIntegral $ (Codeserver.codeserverPort) codeserver
+           in Wuss.runSecureClientWith host port
+        Codeserver.Http ->
+          let tlsPort = 443 :: Int
+              port = maybe tlsPort id $ (Codeserver.codeserverPort) codeserver
+           in WS.runClientWith host port
+  Debug.debugLogM Debug.Temp "Obtaining Connection"
+  liftIO $ withSocketsDo $ (runner syncV3Path connectionOptions headers) \conn -> do
+    Debug.debugLogM Debug.Temp "Obtained Connection"
+    withQueues inputBuffer outputBuffer conn $ \queues@Queues {send} -> do
+      Debug.debugLogM Debug.Temp "Obtained Queues"
+      let initMsg =
+            InitMsg
+              { initMsgClientVersion = syncV3ClientVersion,
+                initMsgBranchRef = branchRef,
+                initMsgRootCausal = hashJwt,
+                initMsgRequestedDepth = Nothing
+              }
+      Debug.debugLogM Debug.Temp "Sending init message"
+      atomically $ send $ Msg $ ReceiverInitStream initMsg
+      Debug.debugLogM Debug.Temp "Init message sent"
+      pendingRequestsVar <- newTVarIO (Set.singleton (CausalEntity, rootCausalHash))
+      yetToRequestVar <- newTVarIO Set.empty
+      toIngestQueue <- newTBQueueIO transactionBatchSize
+      let initState =
+            SyncState
+              { pendingRequestsVar,
+                yetToRequestVar,
+                toIngestQueue,
+                rootCausalHash
+              }
+
+      liftIO (doSync codebase initState queues) >>= \case
+        -- TODO: proper error handling
+        Left err -> error $ show err
+        Right () -> pure ()
+      Debug.debugLogM Debug.Temp "!Done sync, flushing temp entities"
+      causalId <- liftIO $ flushTemp codebase (Share.hashJWTHash hashJwt)
+      pure $ Right (Sync.hash32ToCausalHash rootCausalHash, causalId)
+
+data SyncState = SyncState
+  { pendingRequestsVar :: TVar (Set (EntityKind, Hash32)),
+    yetToRequestVar :: TVar (Set (EntityKind, Hash32)),
+    toIngestQueue :: TBQueue (Entity Hash32 Text),
+    rootCausalHash :: Hash32
+  }
+
+-- | Given a stream that's already been initialized, receive entities and issue requests as needed.
+doSync :: Codebase IO v a -> SyncState -> Queues (MsgOrError SyncError (FromReceiverMessage Share.HashJWT Hash32)) (MsgOrError SyncError (FromEmitterMessage Hash32 Text)) -> IO (Either SyncError ())
+doSync codebase SyncState {pendingRequestsVar, yetToRequestVar, toIngestQueue, rootCausalHash} (Queues {send, receive, shutdown, connectionClosed}) = Ki.scoped \scope -> do
+  errorVar <- newEmptyTMVarIO
+  let onErr err = do
+        atomically $ putTMVar errorVar err
+        shutdown
+  _ <- Ki.fork scope (receiverWorker onErr)
+  _ <- Ki.fork scope (requesterWorker onErr)
+  _ <- Ki.fork scope (ingestionWorker onErr)
+  let finished = do
+        pending <- readTVar pendingRequestsVar
+        yetToReq <- readTVar yetToRequestVar
+        guard $ Set.null pending && Set.null yetToReq
+
+  Debug.debugLogM Debug.Temp "Awaiting completion"
+  result <-
+    atomically $
+      (Right <$> finished)
+        <|> (Right <$> Ki.awaitAll scope)
+        <|> (Left . Left <$> readTMVar errorVar)
+        <|> (Left . Right <$> connectionClosed)
+
+  Debug.debugM Debug.Temp "End result" result
+  case result of
+    Left (Left syncErr) -> pure $ Left syncErr
+    Left (Right mayConnErr) -> case mayConnErr of
+      Nothing -> pure $ Right ()
+      Just connErr -> pure $ Left $ ConnectionError (tShow connErr)
+    Right () -> pure $ Right ()
+  where
+    receiverWorker :: (SyncError -> IO ()) -> IO ()
+    receiverWorker onErr = do
+      Debug.debugLogM Debug.Temp "Receiver waiting for message"
+      atomically receive >>= \case
+        Msg (EmitterEntityMsg entity) -> do
+          atomically $ do
+            writeTBQueue toIngestQueue entity
+          receiverWorker onErr
+        Err err -> onErr err
+    requesterWorker :: (SyncError -> IO ()) -> IO ()
+    requesterWorker _onErr = forever do
+      Debug.debugLogM Debug.Temp "Requester waiting to send requests"
+      atomically $ do
+        requests <- readTVar yetToRequestVar
+        guard $ not (Set.null requests)
+        writeTVar yetToRequestVar Set.empty
+        modifyTVar' pendingRequestsVar (Set.union requests)
+        send $ Msg $ ReceiverEntityRequest $ EntityRequestMsg (Set.toList requests)
+
+    ingestionWorker :: (SyncError -> IO ()) -> IO ()
+    ingestionWorker _onErr = forever do
+      Debug.debugLogM Debug.Temp "Ingestion waiting for entities"
+      newEntities <- atomically $ do
+        flushTBQueue toIngestQueue
+      Codebase.runTransaction codebase $ do
+        -- TODO: do hash validation based on shouldValidate
+        for_ newEntities $ \(Entity {entityKind, entityHash, entityDepth, entityData = CBOR.CBORBytes entityBytes}) -> do
+          Q.insertTempEntitySyncV3 rootCausalHash (tShow entityKind) entityHash (unEntityDepth entityDepth) entityBytes
+
+      tempEntities <- case for newEntities (CBOR.deserialiseOrFailCBORBytes . entityData) of
+        -- TODO: proper error handling
+        Left err -> error $ show err
+        Right tempEntities -> pure tempEntities
+      let allDeps = foldMap tempEntityDependencies tempEntities
+      -- TODO: double-check whether it's okay to have this as a separate atomic block.
+      alreadyRequestedEntities <- atomically $ do
+        pending <- readTVar pendingRequestsVar
+        reqs <- readTVar yetToRequestVar
+        pure $ Set.union pending reqs
+      let unrequestedDeps = Set.difference allDeps alreadyRequestedEntities
+      missingDeps <-
+        (Set.toList unrequestedDeps) & filterA \(_depKind, depHash) -> do
+          Codebase.runTransaction codebase (Q.entityLocationSyncV3 depHash) <&> \case
+            Nothing -> True
+            _ -> False
+      let newlyInserted =
+            newEntities
+              <&> (entityKind &&& entityHash)
+              & Set.fromList
+      -- Request any deps we're missing which also haven't already been requested
+      atomically $ do
+        pending <- readTVar pendingRequestsVar
+        let missingDepsSet = Set.fromList missingDeps
+        let unRequestedDeps = Set.difference missingDepsSet pending
+        modifyTVar' yetToRequestVar (Set.union unRequestedDeps)
+        modifyTVar' pendingRequestsVar (\pending -> Set.difference pending newlyInserted)
+
+flushTemp :: Codebase IO v a -> Hash32 -> IO CausalHashId
+flushTemp codebase rootCausalHash = do
+  Codebase.runTransaction codebase $ do
+    Q.streamTempEntitiesSyncV3 rootCausalHash \next ->
+      do
+        let loop = do
+              next >>= \case
+                Nothing -> pure ()
+                Just (hash, tempEntityBytes) ->
+                  do
+                    Debug.debugLogM Debug.Temp $ "Flushing temp entity: " <> show hash
+                    tempEntity <- case CBOR.deserialiseOrFailCBORBytes (CBOR.CBORBytes tempEntityBytes) of
+                      -- TODO: proper error handling
+                      Left err -> error $ show err
+                      Right tempEntity -> pure tempEntity
+                    Debug.debugLogM Debug.Temp $ "Saving in main" <> show hash
+                    void $ Q.saveTempEntityInMain v2HashHandle hash tempEntity
+                    loop
+        loop
+    Debug.debugLogM Debug.Temp "Flushed temp entities, getting causal hash id"
+    Q.expectCausalHashIdByCausalHash (Sync.hash32ToCausalHash rootCausalHash)

--- a/unison-cli/src/Unison/Share/HistoryComments.hs
+++ b/unison-cli/src/Unison/Share/HistoryComments.hs
@@ -67,11 +67,10 @@ uploadHistoryComments rootCausalHash32 codeserver branchRef = do
                 Just () -> loop
                 Nothing -> pure ()
         loop
-    void . liftIO . atomically . send $ Msg HistoryCommentSyncDone
 
   case result of
     Left err -> error $ "uploadCommentsClient:" <> show err
-    Right () -> pure ()
+    Right ((), _leftovers {- Messages sent by server after we finished. -}) -> pure ()
   where
     intoChunk = \case
       Left

--- a/unison-cli/src/Unison/Share/HistoryComments.hs
+++ b/unison-cli/src/Unison/Share/HistoryComments.hs
@@ -47,7 +47,7 @@ uploadHistoryComments rootCausalHash32 codeserver repoInfo = do
   let path = "/ucm/v1/history-comments/upload?branchRef=" <> Text.unpack (toQueryParam repoInfo)
   -- Enable compression
   let tokenProvider = newTokenProvider credentialManager
-  result <- liftIO $ withCodeserverWebsocket @IO @(MsgOrError Void HistoryCommentUploaderChunk) @(MsgOrError Void HistoryCommentDownloaderChunk) msgBufferSize codeserver tokenProvider path \Queues {send, receive} -> Ki.scoped \scope -> do
+  result <- liftIO $ withCodeserverWebsocket @IO @(MsgOrError Void HistoryCommentUploaderChunk) @(MsgOrError UploadCommentsResponse HistoryCommentDownloaderChunk) msgBufferSize codeserver tokenProvider path \Queues {send, receive} -> Ki.scoped \scope -> do
     commentHashesToSendQ <- newTBMQueueIO 100
     commentHashesToUploadQ <- newTBMQueueIO 100
     -- Is filled when the server notifies us it's done requesting comments
@@ -116,7 +116,7 @@ uploadHistoryComments rootCausalHash32 codeserver repoInfo = do
             loop
       void . runMaybeT $ loop
 
-    receiverWorker :: STM (Maybe (MsgOrError Void HistoryCommentDownloaderChunk)) -> TBMQueue Hash32 -> TMVar Text -> TMVar () -> IO ()
+    receiverWorker :: STM (Maybe (MsgOrError UploadCommentsResponse HistoryCommentDownloaderChunk)) -> TBMQueue Hash32 -> TMVar Text -> TMVar () -> IO ()
     receiverWorker receive toUploadQ errMVar doneRequestingCommentsMVar = do
       let loop = do
             msgOrError <- atomically receive
@@ -133,6 +133,8 @@ uploadHistoryComments rootCausalHash32 codeserver repoInfo = do
                   loop
               Just (DeserialiseFailure msg) -> do
                 atomically $ putTMVar errMVar $ "uploadHistoryComments: deserialisation failure: " <> msg
+              Just (UserErr err) -> do
+                atomically $ putTMVar errMVar $ "uploadHistoryComments: server error: " <> tShow err
       loop
 
     hashNotifyWorker :: (MsgOrError Void HistoryCommentUploaderChunk -> STM Bool) -> TBMQueue Hash32 -> IO ()

--- a/unison-cli/src/Unison/Share/HistoryComments.hs
+++ b/unison-cli/src/Unison/Share/HistoryComments.hs
@@ -67,6 +67,7 @@ uploadHistoryComments rootCausalHash32 codeserver branchRef = do
                 Just () -> loop
                 Nothing -> pure ()
         loop
+    void . liftIO . atomically . send $ Msg HistoryCommentSyncDone
 
   case result of
     Left err -> error $ "uploadCommentsClient:" <> show err

--- a/unison-cli/src/Unison/Share/HistoryComments.hs
+++ b/unison-cli/src/Unison/Share/HistoryComments.hs
@@ -1,10 +1,10 @@
 module Unison.Share.HistoryComments () where
 
-import Unison.Auth.Tokens (newTokenProvider, TokenProvider)
 import Data.Proxy (Proxy)
 import Network.WebSockets qualified as WS
 import Servant.API
 import Servant.Client qualified as Servant
+import Unison.Auth.Tokens (TokenProvider, newTokenProvider)
 import Unison.Cli.Monad
 import Unison.Cli.Monad qualified as Cli
 import Unison.Server.HistoryComments.API qualified as HistoryCommentsAPI

--- a/unison-cli/src/Unison/Share/SyncV2.hs
+++ b/unison-cli/src/Unison/Share/SyncV2.hs
@@ -15,11 +15,9 @@ import Control.Concurrent.STM.TBMQueue qualified as STM
 import Control.Lens
 import Control.Monad.Except
 import Control.Monad.Reader (ask)
-import Control.Monad.ST (ST, stToIO)
 import Control.Monad.State
 import Data.Attoparsec.ByteString qualified as A
 import Data.Attoparsec.ByteString.Char8 qualified as A8
-import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BL
 import Data.Conduit.Attoparsec qualified as C
 import Data.Conduit.Combinators qualified as C
@@ -65,9 +63,10 @@ import Unison.Sync.Types qualified as Share
 import Unison.Sync.Types qualified as Sync
 import Unison.SyncV2.API (Routes (downloadEntitiesStream))
 import Unison.SyncV2.API qualified as SyncV2
-import Unison.SyncV2.Types (CBORBytes, CBORStream, DependencyType (..))
+import Unison.SyncV2.Types (DependencyType (..))
 import Unison.SyncV2.Types qualified as SyncV2
 import Unison.Util.Monoid qualified as Monoid
+import Unison.Util.Servant.CBOR
 import Unison.Util.Servant.CBOR qualified as CBOR
 import Unison.Util.Timing qualified as Timing
 import UnliftIO qualified
@@ -131,7 +130,7 @@ syncFromFile shouldValidate syncFilePath = do
     runExceptT do
       mapExceptT liftIO $ Timing.time "File Sync" $ do
         header <- mapExceptT C.runResourceT $ do
-          let stream = C.sourceFile syncFilePath C..| C.ungzip C..| decodeUnframedEntities
+          let stream = C.transPipe (withExceptT cborStreamingErrorToSyncError) (C.sourceFile syncFilePath C..| C.ungzip C..| decodeUnframedEntities)
           (header, rest) <- initializeStream (setTotal progressCounters) stream
           streamIntoCodebase progressCounters shouldValidate codebase header rest
           pure header
@@ -434,54 +433,6 @@ _decodeFramedEntity bs = do
     Left err -> throwError . SyncError . SyncV2.PullError'Sync $ SyncV2.SyncErrorDeserializationFailure err
     Right chunk -> pure chunk
 
--- | Unpacks a stream of tightly-packed CBOR entities without any framing/separators.
-decodeUnframedEntities :: forall a. (CBOR.Serialise a) => Stream ByteString a
-decodeUnframedEntities = C.transPipe (mapExceptT (lift . stToIO)) $ do
-  C.await >>= \case
-    Nothing -> pure ()
-    Just bs -> do
-      d <- newDecoder
-      loop bs d
-  where
-    newDecoder :: ConduitT ByteString a (ExceptT SyncErr (ST s)) (Maybe ByteString -> ST s (CBOR.IDecode s a))
-    newDecoder = do
-      (lift . lift) CBOR.deserialiseIncremental >>= \case
-        CBOR.Done _ _ _ -> throwError . SyncError . SyncV2.PullError'Sync $ SyncV2.SyncErrorStreamFailure "Invalid initial decoder"
-        CBOR.Fail _ _ err -> throwError . SyncError . SyncV2.PullError'Sync $ SyncV2.SyncErrorDeserializationFailure err
-        CBOR.Partial k -> pure k
-    loop :: ByteString -> (Maybe ByteString -> ST s (CBOR.IDecode s a)) -> ConduitT ByteString a (ExceptT SyncErr (ST s)) ()
-    loop bs k = do
-      (lift . lift) (k (Just bs)) >>= \case
-        CBOR.Fail _ _ err -> throwError . SyncError . SyncV2.PullError'Sync $ SyncV2.SyncErrorDeserializationFailure err
-        CBOR.Partial k' -> do
-          -- We need more input, try to get some
-          nextBS <- C.await
-          case nextBS of
-            Nothing -> do
-              -- No more input, try to finish up the decoder.
-              (lift . lift) (k' Nothing) >>= \case
-                CBOR.Done _ _ a -> C.yield a
-                CBOR.Fail _ _ err -> throwError . SyncError . SyncV2.PullError'Sync $ SyncV2.SyncErrorDeserializationFailure err
-                CBOR.Partial _ -> throwError . SyncError . SyncV2.PullError'Sync $ SyncV2.SyncErrorStreamFailure "Unexpected end of input"
-            Just bs' ->
-              -- Have some input, keep going.
-              loop bs' k'
-        CBOR.Done rem _ a -> do
-          C.yield a
-          if BS.null rem
-            then do
-              -- If we had no leftovers, we can check if there's any input left.
-              C.await >>= \case
-                Nothing -> pure ()
-                Just bs'' -> do
-                  -- If we have input left, start up a new decoder.
-                  k <- newDecoder
-                  loop bs'' k
-            else do
-              -- We have leftovers, start a new decoder and use those.
-              k <- newDecoder
-              loop rem k
-
 ------------------------------------------------------------------------------------------------------------------------
 -- Servant stuff
 
@@ -506,11 +457,14 @@ withConduit clientEnv callback clientM = do
       Left err -> pure . Left . TransportError $ (handleClientError clientEnv err)
       Right sourceT -> do
         conduit <- liftIO $ Servant.fromSourceIO sourceT
-        (runInIO . runExceptT $ callback (conduit C..| unpackCBORBytesStream))
+        (runInIO . runExceptT $ callback (conduit C..| C.transPipe (withExceptT cborStreamingErrorToSyncError) unpackCBORBytesStream))
 
-unpackCBORBytesStream :: (CBOR.Serialise a) => Stream (CBORStream a) a
-unpackCBORBytesStream =
-  C.map (BL.toStrict . coerce @_ @BL.ByteString) C..| decodeUnframedEntities
+cborStreamingErrorToSyncError :: CBOR.CBORStreamError -> SyncErr
+cborStreamingErrorToSyncError =
+  \case
+    CBORStreamDeserializationError err -> SyncError . SyncV2.PullError'Sync $ SyncV2.SyncErrorDeserializationFailure err
+    CBORStreamInitializationError msg -> SyncError . SyncV2.PullError'Sync $ SyncV2.SyncErrorStreamFailure msg
+    CBORStreamUnexpectedEndOfInput -> SyncError . SyncV2.PullError'Sync $ SyncV2.SyncErrorStreamFailure "Unexpected end of input"
 
 handleClientError :: Servant.ClientEnv -> Servant.ClientError -> CodeserverTransportError
 handleClientError clientEnv err =

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -310,7 +310,6 @@ library
     , vector
     , wai
     , warp
-    , websockets
     , witch
     , witherable
   default-language: Haskell2010

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -310,6 +310,7 @@ library
     , vector
     , wai
     , warp
+    , websockets
     , witch
     , witherable
   default-language: Haskell2010

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -170,6 +170,7 @@ library
       Unison.MCP.Wrapper
       Unison.Share.Codeserver
       Unison.Share.ExpectedHashMismatches
+      Unison.Share.HistoryComments
       Unison.Share.Sync
       Unison.Share.Sync.Types
       Unison.Share.SyncV2

--- a/unison-share-api/package.yaml
+++ b/unison-share-api/package.yaml
@@ -32,6 +32,7 @@ library:
     - lucid
     - memory
     - mtl
+    - network
     - nonempty-containers
     - openapi3
     - regex-tdfa
@@ -71,6 +72,7 @@ library:
     - websockets
     - wai-cors
     - warp
+    - wuss
     - yaml
 
 tests:

--- a/unison-share-api/package.yaml
+++ b/unison-share-api/package.yaml
@@ -40,6 +40,7 @@ library:
     - servant-docs
     - servant-openapi3
     - servant-server
+    - servant-websockets
     - text
     - time
     - transformers

--- a/unison-share-api/package.yaml
+++ b/unison-share-api/package.yaml
@@ -27,6 +27,7 @@ library:
     - hs-mcp
     - http-media
     - http-types
+    - ki-unlifted
     - lens
     - lucid
     - memory
@@ -65,6 +66,7 @@ library:
     - utf8-string
     - vector
     - wai
+    - websockets
     - wai-cors
     - warp
     - yaml

--- a/unison-share-api/package.yaml
+++ b/unison-share-api/package.yaml
@@ -41,6 +41,7 @@ library:
     - servant-openapi3
     - servant-server
     - servant-websockets
+    - stm-chans
     - text
     - time
     - transformers

--- a/unison-share-api/package.yaml
+++ b/unison-share-api/package.yaml
@@ -39,6 +39,7 @@ library:
     - servant-openapi3
     - servant-server
     - text
+    - time
     - transformers
     - unison-codebase
     - unison-codebase-sqlite

--- a/unison-share-api/package.yaml
+++ b/unison-share-api/package.yaml
@@ -17,6 +17,7 @@ library:
     - bytestring
     - cborg
     - containers
+    - conduit
     - Diff
     - directory
     - errors

--- a/unison-share-api/src/Unison/Server/HistoryComments/API.hs
+++ b/unison-share-api/src/Unison/Server/HistoryComments/API.hs
@@ -6,7 +6,7 @@ import Data.Proxy
 import GHC.Generics (Generic)
 import Servant.API
 import Servant.API.WebSocket
-import Unison.Server.Types (RequiredQueryParam, BranchRef)
+import Unison.Server.Types (BranchRef, RequiredQueryParam)
 
 api :: Proxy API
 api = Proxy

--- a/unison-share-api/src/Unison/Server/HistoryComments/API.hs
+++ b/unison-share-api/src/Unison/Server/HistoryComments/API.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE DataKinds #-}
+
+module Unison.Server.HistoryComments.API (api, API, Routes (..)) where
+
+import Data.Proxy
+import GHC.Generics (Generic)
+import Servant.API
+import Unison.Server.HistoryComments.Types
+import Unison.SyncV2.Types
+import Unison.Util.Servant.CBOR (CBOR)
+
+api :: Proxy API
+api = Proxy
+
+type API = NamedRoutes Routes
+
+type DownloadCommentsStream =
+  -- | The causal hash the client needs. The server should provide it and all of its dependencies
+  ReqBody '[CBOR, JSON] DownloadCommentsRequest
+    :> StreamPost NoFraming OctetStream (SourceIO (CBORStream HistoryCommentChunk))
+
+type UploadCommentsStream =
+  StreamBody NoFraming OctetStream (SourceIO (CBORStream HistoryCommentChunk))
+    :> Post '[JSON] UploadCommentsResponse
+
+data Routes mode = Routes
+  { uploadComments :: mode :- "history-comments" :> "upload" :> UploadCommentsStream,
+    downloadComments :: mode :- "history-comments" :> "download" :> DownloadCommentsStream
+  }
+  deriving stock (Generic)

--- a/unison-share-api/src/Unison/Server/HistoryComments/API.hs
+++ b/unison-share-api/src/Unison/Server/HistoryComments/API.hs
@@ -6,6 +6,7 @@ import Data.Proxy
 import GHC.Generics (Generic)
 import Servant.API
 import Servant.API.WebSocket
+import Unison.Server.Types (RequiredQueryParam, BranchRef)
 
 api :: Proxy API
 api = Proxy
@@ -14,7 +15,9 @@ type API = NamedRoutes Routes
 
 type DownloadCommentsStream = WebSocket
 
-type UploadCommentsStream = WebSocket
+type UploadCommentsStream =
+  RequiredQueryParam "branchRef" BranchRef
+    :> WebSocket
 
 data Routes mode = Routes
   { uploadHistoryComments :: mode :- "history-comments" :> "upload" :> UploadCommentsStream,

--- a/unison-share-api/src/Unison/Server/HistoryComments/API.hs
+++ b/unison-share-api/src/Unison/Server/HistoryComments/API.hs
@@ -24,7 +24,7 @@ type UploadCommentsStream =
     :> Post '[JSON] UploadCommentsResponse
 
 data Routes mode = Routes
-  { uploadComments :: mode :- "history-comments" :> "upload" :> UploadCommentsStream,
-    downloadComments :: mode :- "history-comments" :> "download" :> DownloadCommentsStream
+  { uploadHistoryComments :: mode :- "history-comments" :> "upload" :> UploadCommentsStream,
+    downloadHistoryComments :: mode :- "history-comments" :> "download" :> DownloadCommentsStream
   }
   deriving stock (Generic)

--- a/unison-share-api/src/Unison/Server/HistoryComments/API.hs
+++ b/unison-share-api/src/Unison/Server/HistoryComments/API.hs
@@ -5,23 +5,16 @@ module Unison.Server.HistoryComments.API (api, API, Routes (..)) where
 import Data.Proxy
 import GHC.Generics (Generic)
 import Servant.API
-import Unison.Server.HistoryComments.Types
-import Unison.SyncV2.Types
-import Unison.Util.Servant.CBOR (CBOR)
+import Servant.API.WebSocket
 
 api :: Proxy API
 api = Proxy
 
 type API = NamedRoutes Routes
 
-type DownloadCommentsStream =
-  -- | The causal hash the client needs. The server should provide it and all of its dependencies
-  ReqBody '[CBOR, JSON] DownloadCommentsRequest
-    :> StreamPost NoFraming OctetStream (SourceIO (CBORStream HistoryCommentChunk))
+type DownloadCommentsStream = WebSocket
 
-type UploadCommentsStream =
-  StreamBody NoFraming OctetStream (SourceIO (CBORStream HistoryCommentChunk))
-    :> Post '[JSON] UploadCommentsResponse
+type UploadCommentsStream = WebSocket
 
 data Routes mode = Routes
   { uploadHistoryComments :: mode :- "history-comments" :> "upload" :> UploadCommentsStream,

--- a/unison-share-api/src/Unison/Server/HistoryComments/API.hs
+++ b/unison-share-api/src/Unison/Server/HistoryComments/API.hs
@@ -20,7 +20,7 @@ type UploadCommentsStream =
     :> WebSocket
 
 data Routes mode = Routes
-  { uploadHistoryComments :: mode :- "history-comments" :> "upload" :> UploadCommentsStream,
-    downloadHistoryComments :: mode :- "history-comments" :> "download" :> DownloadCommentsStream
+  { uploadHistoryComments :: mode :- "upload" :> UploadCommentsStream,
+    downloadHistoryComments :: mode :- "download" :> DownloadCommentsStream
   }
   deriving stock (Generic)

--- a/unison-share-api/src/Unison/Server/HistoryComments/Types.hs
+++ b/unison-share-api/src/Unison/Server/HistoryComments/Types.hs
@@ -59,17 +59,20 @@ data HistoryCommentRevision = HistoryCommentRevision
     createdAt :: UTCTime,
     isHidden :: Bool,
     authorSignature :: ByteString,
-    revisionHash :: Hash32
+    revisionHash :: Hash32,
+    commentHash :: Hash32
   }
 
 instance Serialise HistoryCommentRevision where
-  encode (HistoryCommentRevision {subject, content, createdAt, isHidden, authorSignature, revisionHash}) =
+  encode (HistoryCommentRevision {subject, content, createdAt, isHidden, authorSignature, revisionHash, commentHash}) =
     encode subject
       <> encode content
       <> encode createdAt
       <> encode isHidden
       <> encode authorSignature
       <> encode revisionHash
+      <> encode commentHash
+
   decode = do
     subject <- decode
     content <- decode
@@ -77,7 +80,8 @@ instance Serialise HistoryCommentRevision where
     isHidden <- decode
     authorSignature <- decode
     revisionHash <- decode
-    pure HistoryCommentRevision {subject, content, createdAt, isHidden, authorSignature, revisionHash}
+    commentHash <- decode
+    pure HistoryCommentRevision {subject, content, createdAt, isHidden, authorSignature, revisionHash, commentHash}
 
 data HistoryCommentChunk
   = HistoryCommentChunk HistoryComment

--- a/unison-share-api/src/Unison/Server/HistoryComments/Types.hs
+++ b/unison-share-api/src/Unison/Server/HistoryComments/Types.hs
@@ -104,7 +104,6 @@ data HistoryCommentChunk
   | HistoryCommentRevisionChunk HistoryCommentRevision
   | -- Generic error chunk
     HistoryCommentErrorChunk Text
-  | HistoryCommentSyncDone
 
 instance Serialise HistoryCommentChunk where
   encode = \case
@@ -117,32 +116,27 @@ instance Serialise HistoryCommentChunk where
     HistoryCommentErrorChunk errMsg ->
       encode HistoryCommentErrorTag
         <> encode errMsg
-    HistoryCommentSyncDone -> encode HistoryCommentSyncDoneTag
   decode = do
     tag <- decode :: Decoder s HistoryCommentChunkTag
     case tag of
       HistoryCommentTag -> HistoryCommentChunk <$> decode
       HistoryCommentRevisionTag -> HistoryCommentRevisionChunk <$> decode
       HistoryCommentErrorTag -> HistoryCommentErrorChunk <$> decode
-      HistoryCommentSyncDoneTag -> pure HistoryCommentSyncDone
 
 data HistoryCommentChunkTag
   = HistoryCommentTag
   | HistoryCommentRevisionTag
   | HistoryCommentErrorTag
-  | HistoryCommentSyncDoneTag
 
 instance Serialise HistoryCommentChunkTag where
   encode = \case
     HistoryCommentTag -> encode (0 :: Word8)
     HistoryCommentRevisionTag -> encode (1 :: Word8)
     HistoryCommentErrorTag -> encode (2 :: Word8)
-    HistoryCommentSyncDoneTag -> encode (3 :: Word8)
   decode = do
     tag <- decode :: Decoder s Word8
     case tag of
       0 -> pure HistoryCommentTag
       1 -> pure HistoryCommentRevisionTag
       2 -> pure HistoryCommentErrorTag
-      3 -> pure HistoryCommentSyncDoneTag
       _ -> fail "Invalid HistoryCommentChunkTag"

--- a/unison-share-api/src/Unison/Server/HistoryComments/Types.hs
+++ b/unison-share-api/src/Unison/Server/HistoryComments/Types.hs
@@ -30,6 +30,22 @@ data UploadCommentsResponse
   | UploadCommentsNotAuthorized BranchRef
   | UploadCommentsGenericFailure Text
 
+instance Serialise UploadCommentsResponse where
+  encode = \case
+    UploadCommentsProjectBranchNotFound br ->
+      encode (0 :: Word8) <> encode br
+    UploadCommentsNotAuthorized br ->
+      encode (1 :: Word8) <> encode br
+    UploadCommentsGenericFailure errMsg ->
+      encode (2 :: Word8) <> encode errMsg
+  decode = do
+    tag <- decode :: Decoder s Word8
+    case tag of
+      0 -> UploadCommentsProjectBranchNotFound <$> decode
+      1 -> UploadCommentsNotAuthorized <$> decode
+      2 -> UploadCommentsGenericFailure <$> decode
+      _ -> fail "Invalid UploadCommentsResponse tag"
+
 data HistoryComment = HistoryComment
   { author :: Text,
     createdAt :: UTCTime,

--- a/unison-share-api/src/Unison/Server/HistoryComments/Types.hs
+++ b/unison-share-api/src/Unison/Server/HistoryComments/Types.hs
@@ -25,7 +25,10 @@ data DownloadCommentsRequest = DownloadCommentsRequest
     since :: UTCTime
   }
 
-data UploadCommentsResponse = UploadCommentsResponse
+data UploadCommentsResponse
+  = UploadCommentsProjectBranchNotFound BranchRef
+  | UploadCommentsNotAuthorized BranchRef
+  | UploadCommentsGenericFailure Text
 
 data HistoryComment = HistoryComment
   { author :: Text,

--- a/unison-share-api/src/Unison/Server/HistoryComments/Types.hs
+++ b/unison-share-api/src/Unison/Server/HistoryComments/Types.hs
@@ -13,8 +13,7 @@ import Codec.Serialise.Class (Serialise (..))
 import Data.ByteString (ByteString)
 import Data.Text (Text)
 import Data.Time (UTCTime)
-import Data.Word (Word64)
-import GHC.Word (Word8)
+import Data.Word (Word8)
 import Unison.Hash32 (Hash32)
 import Unison.Server.Orphans ()
 import Unison.Server.Types
@@ -58,7 +57,7 @@ data HistoryCommentRevision
     createdAt :: UTCTime,
     isHidden :: Bool,
     authorSignature :: ByteString,
-    revisionHash :: Word64
+    revisionHash :: Hash32
   }
 
 instance Serialise HistoryCommentRevision where

--- a/unison-share-api/src/Unison/Server/HistoryComments/Types.hs
+++ b/unison-share-api/src/Unison/Server/HistoryComments/Types.hs
@@ -24,11 +24,13 @@ data DownloadCommentsRequest = DownloadCommentsRequest
     branchRef :: BranchRef,
     since :: UTCTime
   }
+  deriving (Show, Eq)
 
 data UploadCommentsResponse
   = UploadCommentsProjectBranchNotFound BranchRef
   | UploadCommentsNotAuthorized BranchRef
   | UploadCommentsGenericFailure Text
+  deriving (Show, Eq)
 
 instance Serialise UploadCommentsResponse where
   encode = \case
@@ -53,6 +55,7 @@ data HistoryComment = HistoryComment
     causalHash :: Hash32,
     commentHash :: Hash32
   }
+  deriving (Show, Eq)
 
 instance Serialise HistoryComment where
   encode (HistoryComment {author, createdAt, authorThumbprint, causalHash, commentHash}) =
@@ -78,6 +81,7 @@ data HistoryCommentRevision = HistoryCommentRevision
     revisionHash :: Hash32,
     commentHash :: Hash32
   }
+  deriving (Show, Eq)
 
 instance Serialise HistoryCommentRevision where
   encode (HistoryCommentRevision {subject, content, createdAt, isHidden, authorSignature, revisionHash, commentHash}) =
@@ -104,6 +108,7 @@ data HistoryCommentChunk
   | HistoryCommentRevisionChunk HistoryCommentRevision
   | -- Generic error chunk
     HistoryCommentErrorChunk Text
+  deriving (Show, Eq)
 
 instance Serialise HistoryCommentChunk where
   encode = \case
@@ -127,6 +132,7 @@ data HistoryCommentChunkTag
   = HistoryCommentTag
   | HistoryCommentRevisionTag
   | HistoryCommentErrorTag
+  deriving (Show, Eq)
 
 instance Serialise HistoryCommentChunkTag where
   encode = \case

--- a/unison-share-api/src/Unison/Server/HistoryComments/Types.hs
+++ b/unison-share-api/src/Unison/Server/HistoryComments/Types.hs
@@ -33,7 +33,7 @@ data UploadCommentsResponse
 data HistoryComment = HistoryComment
   { author :: Text,
     createdAt :: UTCTime,
-    authorThumbprint :: ByteString,
+    authorThumbprint :: Text,
     causalHash :: Hash32,
     commentHash :: Hash32
   }

--- a/unison-share-api/src/Unison/Server/HistoryComments/Types.hs
+++ b/unison-share-api/src/Unison/Server/HistoryComments/Types.hs
@@ -1,0 +1,119 @@
+module Unison.Server.HistoryComments.Types
+  ( DownloadCommentsRequest (..),
+    UploadCommentsResponse (..),
+    HistoryCommentChunk (..),
+  )
+where
+
+import Codec.CBOR.Decoding
+import Codec.Serialise (Serialise)
+import Codec.Serialise.Class (Serialise (..))
+import Data.ByteString (ByteString)
+import Data.Text (Text)
+import Data.Time (UTCTime)
+import Data.Word (Word64)
+import GHC.Word (Word8)
+import Unison.Hash32 (Hash32)
+import Unison.Server.Orphans ()
+import Unison.Server.Types
+import Unison.Share.API.Hash (HashJWT)
+
+data DownloadCommentsRequest = DownloadCommentsRequest
+  { causalHash :: HashJWT,
+    branchRef :: BranchRef,
+    since :: UTCTime
+  }
+
+data UploadCommentsResponse = UploadCommentsResponse
+
+data HistoryComment = HistoryComment
+  { author :: Text,
+    createdAt :: UTCTime,
+    authorThumbprint :: ByteString,
+    causalHash :: Hash32,
+    commentHash :: Hash32
+  }
+
+instance Serialise HistoryComment where
+  encode (HistoryComment {author, createdAt, authorThumbprint, causalHash, commentHash}) =
+    encode author
+      <> encode createdAt
+      <> encode authorThumbprint
+      <> encode causalHash
+      <> encode commentHash
+  decode = do
+    author <- decode
+    createdAt <- decode
+    authorThumbprint <- decode
+    causalHash <- decode
+    commentHash <- decode
+    pure HistoryComment {author, createdAt, authorThumbprint, causalHash, commentHash}
+
+data HistoryCommentRevision
+  = HistoryCommentRevision
+  { subject :: Text,
+    content :: Text,
+    createdAt :: UTCTime,
+    isHidden :: Bool,
+    authorSignature :: ByteString,
+    revisionHash :: Word64
+  }
+
+instance Serialise HistoryCommentRevision where
+  encode (HistoryCommentRevision {subject, content, createdAt, isHidden, authorSignature, revisionHash}) =
+    encode subject
+      <> encode content
+      <> encode createdAt
+      <> encode isHidden
+      <> encode authorSignature
+      <> encode revisionHash
+  decode = do
+    subject <- decode
+    content <- decode
+    createdAt <- decode
+    isHidden <- decode
+    authorSignature <- decode
+    revisionHash <- decode
+    pure HistoryCommentRevision {subject, content, createdAt, isHidden, authorSignature, revisionHash}
+
+data HistoryCommentChunk
+  = HistoryCommentChunk HistoryComment
+  | HistoryCommentRevisionChunk HistoryCommentRevision
+  | -- Generic error chunk
+    HistoryCommentErrorChunk Text
+
+instance Serialise HistoryCommentChunk where
+  encode = \case
+    HistoryCommentChunk comment ->
+      encode HistoryCommentTag
+        <> encode comment
+    HistoryCommentRevisionChunk revision ->
+      encode HistoryCommentRevisionTag
+        <> encode revision
+    HistoryCommentErrorChunk errMsg ->
+      encode HistoryCommentErrorTag
+        <> encode errMsg
+  decode = do
+    tag <- decode :: Decoder s HistoryCommentChunkTag
+    case tag of
+      HistoryCommentTag -> HistoryCommentChunk <$> decode
+      HistoryCommentRevisionTag -> HistoryCommentRevisionChunk <$> decode
+      HistoryCommentErrorTag -> HistoryCommentErrorChunk <$> decode
+
+data HistoryCommentChunkTag
+  = HistoryCommentTag
+  | HistoryCommentRevisionTag
+  | HistoryCommentErrorTag
+
+instance Serialise HistoryCommentChunkTag where
+  encode = \case
+    HistoryCommentTag -> encode (0 :: Word8)
+    HistoryCommentRevisionTag -> encode (1 :: Word8)
+    HistoryCommentErrorTag -> encode (2 :: Word8)
+  decode = do
+    tag <- decode :: Decoder s Word8
+    case tag of
+      0 -> pure HistoryCommentTag
+      1 -> pure HistoryCommentRevisionTag
+      2 -> pure HistoryCommentErrorTag
+      _ -> fail "Invalid HistoryCommentChunkTag"

--- a/unison-share-api/src/Unison/Server/HistoryComments/Types.hs
+++ b/unison-share-api/src/Unison/Server/HistoryComments/Types.hs
@@ -50,8 +50,7 @@ instance Serialise HistoryComment where
     commentHash <- decode
     pure HistoryComment {author, createdAt, authorThumbprint, causalHash, commentHash}
 
-data HistoryCommentRevision
-  = HistoryCommentRevision
+data HistoryCommentRevision = HistoryCommentRevision
   { subject :: Text,
     content :: Text,
     createdAt :: UTCTime,

--- a/unison-share-api/src/Unison/Server/HistoryComments/Types.hs
+++ b/unison-share-api/src/Unison/Server/HistoryComments/Types.hs
@@ -2,6 +2,8 @@ module Unison.Server.HistoryComments.Types
   ( DownloadCommentsRequest (..),
     UploadCommentsResponse (..),
     HistoryCommentChunk (..),
+    HistoryComment (..),
+    HistoryCommentRevision (..),
   )
 where
 

--- a/unison-share-api/src/Unison/Server/HistoryComments/Types.hs
+++ b/unison-share-api/src/Unison/Server/HistoryComments/Types.hs
@@ -104,6 +104,7 @@ data HistoryCommentChunk
   | HistoryCommentRevisionChunk HistoryCommentRevision
   | -- Generic error chunk
     HistoryCommentErrorChunk Text
+  | HistoryCommentSyncDone
 
 instance Serialise HistoryCommentChunk where
   encode = \case
@@ -116,27 +117,32 @@ instance Serialise HistoryCommentChunk where
     HistoryCommentErrorChunk errMsg ->
       encode HistoryCommentErrorTag
         <> encode errMsg
+    HistoryCommentSyncDone -> encode HistoryCommentSyncDoneTag
   decode = do
     tag <- decode :: Decoder s HistoryCommentChunkTag
     case tag of
       HistoryCommentTag -> HistoryCommentChunk <$> decode
       HistoryCommentRevisionTag -> HistoryCommentRevisionChunk <$> decode
       HistoryCommentErrorTag -> HistoryCommentErrorChunk <$> decode
+      HistoryCommentSyncDoneTag -> pure HistoryCommentSyncDone
 
 data HistoryCommentChunkTag
   = HistoryCommentTag
   | HistoryCommentRevisionTag
   | HistoryCommentErrorTag
+  | HistoryCommentSyncDoneTag
 
 instance Serialise HistoryCommentChunkTag where
   encode = \case
     HistoryCommentTag -> encode (0 :: Word8)
     HistoryCommentRevisionTag -> encode (1 :: Word8)
     HistoryCommentErrorTag -> encode (2 :: Word8)
+    HistoryCommentSyncDoneTag -> encode (3 :: Word8)
   decode = do
     tag <- decode :: Decoder s Word8
     case tag of
       0 -> pure HistoryCommentTag
       1 -> pure HistoryCommentRevisionTag
       2 -> pure HistoryCommentErrorTag
+      3 -> pure HistoryCommentSyncDoneTag
       _ -> fail "Invalid HistoryCommentChunkTag"

--- a/unison-share-api/src/Unison/Server/HistoryComments/Types.hs
+++ b/unison-share-api/src/Unison/Server/HistoryComments/Types.hs
@@ -1,7 +1,8 @@
 module Unison.Server.HistoryComments.Types
   ( DownloadCommentsRequest (..),
     UploadCommentsResponse (..),
-    HistoryCommentChunk (..),
+    HistoryCommentUploaderChunk (..),
+    HistoryCommentDownloaderChunk (..),
     HistoryComment (..),
     HistoryCommentRevision (..),
   )
@@ -11,6 +12,8 @@ import Codec.CBOR.Decoding
 import Codec.Serialise (Serialise)
 import Codec.Serialise.Class (Serialise (..))
 import Data.ByteString (ByteString)
+import Data.Set.NonEmpty (NESet)
+import Data.Set.NonEmpty qualified as NESet
 import Data.Text (Text)
 import Data.Time (UTCTime)
 import Data.Word (Word8)
@@ -103,46 +106,98 @@ instance Serialise HistoryCommentRevision where
     commentHash <- decode
     pure HistoryCommentRevision {subject, content, createdAt, isHidden, authorSignature, revisionHash, commentHash}
 
-data HistoryCommentChunk
-  = HistoryCommentChunk HistoryComment
-  | HistoryCommentRevisionChunk HistoryCommentRevision
-  | -- Generic error chunk
-    HistoryCommentErrorChunk Text
+data HistoryCommentDownloaderChunkTag
+  = RequestCommentsTag
+  | DoneCheckingHashesTag
+  deriving (Show, Eq, Enum, Bounded)
+
+instance Serialise HistoryCommentDownloaderChunkTag where
+  encode = \case
+    RequestCommentsTag -> encode (0 :: Word8)
+    DoneCheckingHashesTag -> encode (1 :: Word8)
+
+  decode = do
+    tag <- decodeWord8
+    case tag of
+      0 -> pure RequestCommentsTag
+      1 -> pure DoneCheckingHashesTag
+      _ -> fail $ "Unknown HistoryCommentDownloaderChunkTag: " ++ show tag
+
+data HistoryCommentDownloaderChunk
+  = -- Request the comments we're missing.
+    RequestCommentsChunk (NESet Hash32)
+  | -- We've checked all provided hashes (and received DoneSendingHashesChunk from the uploader), and have issued all the Requests we need.
+    DoneCheckingHashesChunk
   deriving (Show, Eq)
 
-instance Serialise HistoryCommentChunk where
+instance Serialise HistoryCommentDownloaderChunk where
   encode = \case
+    RequestCommentsChunk hashSet ->
+      encode RequestCommentsTag
+        <> encode (NESet.toSet hashSet)
+    DoneCheckingHashesChunk ->
+      encode DoneCheckingHashesTag
+  decode = do
+    tag <- decode :: Decoder s HistoryCommentDownloaderChunkTag
+    case tag of
+      RequestCommentsTag -> do
+        mayHashSet <- NESet.nonEmptySet <$> decode
+        case mayHashSet of
+          Just hashSet -> pure $ RequestCommentsChunk hashSet
+          Nothing -> fail "HistoryCommentRequestComments: unexpected empty set"
+      DoneCheckingHashesTag -> pure DoneCheckingHashesChunk
+
+data HistoryCommentUploaderChunk
+  = -- Tell the other side about some comment hashes that it may wish to request.
+    PossiblyNewHashesChunk (NESet Hash32)
+  | DoneSendingHashesChunk
+  | HistoryCommentChunk HistoryComment
+  | HistoryCommentRevisionChunk HistoryCommentRevision
+  deriving (Show, Eq)
+
+instance Serialise HistoryCommentUploaderChunk where
+  encode = \case
+    PossiblyNewHashesChunk hashSet ->
+      encode PossiblyNewHashesTag
+        <> encode (NESet.toSet hashSet)
+    DoneSendingHashesChunk ->
+      encode DoneSendingHashesTag
     HistoryCommentChunk comment ->
       encode HistoryCommentTag
         <> encode comment
     HistoryCommentRevisionChunk revision ->
       encode HistoryCommentRevisionTag
         <> encode revision
-    HistoryCommentErrorChunk errMsg ->
-      encode HistoryCommentErrorTag
-        <> encode errMsg
   decode = do
     tag <- decode :: Decoder s HistoryCommentChunkTag
     case tag of
+      PossiblyNewHashesTag -> do
+        mayHashSet <- NESet.nonEmptySet <$> decode
+        case mayHashSet of
+          Just hashSet -> pure $ PossiblyNewHashesChunk hashSet
+          Nothing -> fail "HistoryCommentPossiblyNewHashes: unexpected empty set"
+      DoneSendingHashesTag -> pure DoneSendingHashesChunk
       HistoryCommentTag -> HistoryCommentChunk <$> decode
       HistoryCommentRevisionTag -> HistoryCommentRevisionChunk <$> decode
-      HistoryCommentErrorTag -> HistoryCommentErrorChunk <$> decode
 
 data HistoryCommentChunkTag
-  = HistoryCommentTag
+  = PossiblyNewHashesTag
+  | DoneSendingHashesTag
+  | HistoryCommentTag
   | HistoryCommentRevisionTag
-  | HistoryCommentErrorTag
   deriving (Show, Eq)
 
 instance Serialise HistoryCommentChunkTag where
   encode = \case
-    HistoryCommentTag -> encode (0 :: Word8)
-    HistoryCommentRevisionTag -> encode (1 :: Word8)
-    HistoryCommentErrorTag -> encode (2 :: Word8)
+    PossiblyNewHashesTag -> encode (0 :: Word8)
+    DoneSendingHashesTag -> encode (1 :: Word8)
+    HistoryCommentTag -> encode (2 :: Word8)
+    HistoryCommentRevisionTag -> encode (3 :: Word8)
   decode = do
     tag <- decode :: Decoder s Word8
     case tag of
-      0 -> pure HistoryCommentTag
-      1 -> pure HistoryCommentRevisionTag
-      2 -> pure HistoryCommentErrorTag
+      0 -> pure PossiblyNewHashesTag
+      1 -> pure DoneSendingHashesTag
+      2 -> pure HistoryCommentTag
+      3 -> pure HistoryCommentRevisionTag
       _ -> fail "Invalid HistoryCommentChunkTag"

--- a/unison-share-api/src/Unison/Server/Types.hs
+++ b/unison-share-api/src/Unison/Server/Types.hs
@@ -907,7 +907,7 @@ instance FromJSON TermOrTypeTag where
       Right tag -> pure tag
 
 newtype BranchRef = BranchRef {unBranchRef :: Text}
-  deriving (Serialise, Eq, Show, Ord, ToJSON, FromJSON) via Text
+  deriving (Serialise, Eq, Show, Ord, ToJSON, FromJSON, ToHttpApiData) via Text
 
 instance From (ProjectAndBranch ProjectName ProjectBranchName) BranchRef where
   from pab = BranchRef $ from pab

--- a/unison-share-api/src/Unison/Server/Types.hs
+++ b/unison-share-api/src/Unison/Server/Types.hs
@@ -907,7 +907,7 @@ instance FromJSON TermOrTypeTag where
       Right tag -> pure tag
 
 newtype BranchRef = BranchRef {unBranchRef :: Text}
-  deriving (Serialise, Eq, Show, Ord, ToJSON, FromJSON, ToHttpApiData) via Text
+  deriving (Serialise, Eq, Show, Ord, ToJSON, FromJSON, ToHttpApiData, FromHttpApiData) via Text
 
 instance From (ProjectAndBranch ProjectName ProjectBranchName) BranchRef where
   from pab = BranchRef $ from pab

--- a/unison-share-api/src/Unison/Server/Types.hs
+++ b/unison-share-api/src/Unison/Server/Types.hs
@@ -4,7 +4,9 @@
 module Unison.Server.Types where
 
 -- Types common to endpoints --
-import Control.Lens hiding ((.=))
+
+import Codec.Serialise
+import Control.Lens hiding (from, (.=))
 import Data.Aeson
 import Data.Aeson qualified as Aeson
 import Data.Bifoldable (Bifoldable (..))
@@ -903,3 +905,9 @@ instance FromJSON TermOrTypeTag where
     case parseQueryParam txt of
       Left err -> fail $ Text.unpack err
       Right tag -> pure tag
+
+newtype BranchRef = BranchRef {unBranchRef :: Text}
+  deriving (Serialise, Eq, Show, Ord, ToJSON, FromJSON) via Text
+
+instance From (ProjectAndBranch ProjectName ProjectBranchName) BranchRef where
+  from pab = BranchRef $ from pab

--- a/unison-share-api/src/Unison/Sync/Types.hs
+++ b/unison-share-api/src/Unison/Sync/Types.hs
@@ -73,6 +73,7 @@ import Data.Set qualified as Set
 import Data.Set.NonEmpty (NESet)
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
+import Servant (FromHttpApiData, ToHttpApiData)
 import U.Codebase.Sqlite.Branch.Format (LocalBranchBytes (..))
 import Unison.Hash32 (Hash32)
 import Unison.Hash32.Orphans.Aeson ()
@@ -95,7 +96,7 @@ instance FromJSON Base64Bytes where
     either fail (pure . Base64Bytes) $ convertFromBase Base64 (Text.encodeUtf8 txt)
 
 newtype RepoInfo = RepoInfo {unRepoInfo :: Text}
-  deriving newtype (Show, Eq, Ord, ToJSON, FromJSON)
+  deriving newtype (Show, Eq, Ord, ToJSON, FromJSON, ToHttpApiData, FromHttpApiData)
   deriving (Serialise) via Text
 
 data Path = Path

--- a/unison-share-api/src/Unison/SyncV2/Types.hs
+++ b/unison-share-api/src/Unison/SyncV2/Types.hs
@@ -38,19 +38,12 @@ import Data.Text qualified as Text
 import Data.Word (Word16, Word64)
 import U.Codebase.HashTags (CausalHash)
 import U.Codebase.Sqlite.TempEntity (TempEntity)
-import Unison.Core.Project (ProjectAndBranch (..), ProjectBranchName, ProjectName)
 import Unison.Hash32 (Hash32)
-import Unison.Prelude (From (..))
 import Unison.Server.Orphans ()
+import Unison.Server.Types
 import Unison.Share.API.Hash (HashJWT)
 import Unison.Sync.Types qualified as SyncV1
 import Unison.Util.Servant.CBOR
-
-newtype BranchRef = BranchRef {unBranchRef :: Text}
-  deriving (Serialise, Eq, Show, Ord, ToJSON, FromJSON) via Text
-
-instance From (ProjectAndBranch ProjectName ProjectBranchName) BranchRef where
-  from pab = BranchRef $ from pab
 
 data GetCausalHashErrorTag
   = GetCausalHashNoReadPermissionTag

--- a/unison-share-api/src/Unison/Util/Servant/CBOR.hs
+++ b/unison-share-api/src/Unison/Util/Servant/CBOR.hs
@@ -6,22 +6,31 @@ module Unison.Util.Servant.CBOR
     UnknownCBORBytes,
     CBORBytes (..),
     CBORStream (..),
+    unpackCBORBytesStream,
     deserialiseOrFailCBORBytes,
     serialiseCBORBytes,
     decodeCBORBytes,
     decodeUnknownCBORBytes,
     serialiseUnknownCBORBytes,
+    CBORStreamError (..),
+    decodeUnframedEntities,
   )
 where
 
 import Codec.CBOR.Read (DeserialiseFailure (..))
 import Codec.Serialise (Serialise, deserialiseOrFail, serialise)
 import Codec.Serialise qualified as CBOR
-import Codec.Serialise.Decoding qualified as CBOR
+import Codec.Serialise.Decoding qualified as CBORDecode
+import Conduit
+import Control.Monad.Except
+import Control.Monad.ST (ST, stToIO)
+import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BL
+import Data.Conduit.Combinators qualified as Conduit
 import Data.List.NonEmpty qualified as NonEmpty
 import Network.HTTP.Media.MediaType qualified as MediaType
 import Servant
+import Unison.Prelude
 
 -- | Content-type for encoding and decoding objects as their CBOR representations
 data CBOR
@@ -70,10 +79,10 @@ newtype CBORBytes t = CBORBytes BL.ByteString
 deserialiseOrFailCBORBytes :: (Serialise t) => CBORBytes t -> Either CBOR.DeserialiseFailure t
 deserialiseOrFailCBORBytes (CBORBytes bs) = CBOR.deserialiseOrFail bs
 
-decodeCBORBytes :: (Serialise t) => CBORBytes t -> CBOR.Decoder s t
+decodeCBORBytes :: (Serialise t) => CBORBytes t -> CBORDecode.Decoder s t
 decodeCBORBytes (CBORBytes bs) = decodeUnknownCBORBytes (CBORBytes bs)
 
-decodeUnknownCBORBytes :: (Serialise t) => UnknownCBORBytes -> CBOR.Decoder s t
+decodeUnknownCBORBytes :: (Serialise t) => UnknownCBORBytes -> CBORDecode.Decoder s t
 decodeUnknownCBORBytes (CBORBytes bs) = case deserialiseOrFailCBORBytes (CBORBytes bs) of
   Left err -> fail (show err)
   Right t -> pure t
@@ -98,3 +107,61 @@ instance MimeRender OctetStream (CBORStream a) where
 
 instance MimeUnrender OctetStream (CBORStream a) where
   mimeUnrender Proxy bs = Right (CBORStream bs)
+
+unpackCBORBytesStream :: (CBOR.Serialise o, MonadIO m) => ConduitT (CBORStream o) o (ExceptT CBORStreamError m) ()
+unpackCBORBytesStream =
+  Conduit.map (BL.toStrict . coerce @_ @BL.ByteString) Conduit..| decodeUnframedEntities
+
+data CBORStreamError
+  = CBORStreamDeserializationError CBOR.DeserialiseFailure
+  | CBORStreamInitializationError Text
+  | CBORStreamUnexpectedEndOfInput
+  deriving (Eq, Show)
+
+-- | Unpacks a stream of tightly-packed CBOR entities without any framing/separators.
+decodeUnframedEntities :: forall a m. (MonadIO m) => (CBOR.Serialise a) => ConduitT BS.ByteString a (ExceptT CBORStreamError m) ()
+decodeUnframedEntities = Conduit.transPipe (mapExceptT (liftIO . stToIO)) $ do
+  Conduit.await >>= \case
+    Nothing -> pure ()
+    Just bs -> do
+      d <- newDecoder
+      loop bs d
+  where
+    newDecoder :: ConduitT BS.ByteString a (ExceptT CBORStreamError (ST s)) (Maybe BS.ByteString -> ST s (CBOR.IDecode s a))
+    newDecoder = do
+      (lift . lift) CBOR.deserialiseIncremental >>= \case
+        CBOR.Done _ _ _ -> throwError $ CBORStreamInitializationError "Decoder unexpectedly finished immediately"
+        CBOR.Fail _ _ err -> throwError $ CBORStreamDeserializationError err
+        CBOR.Partial k -> pure k
+    loop :: BS.ByteString -> (Maybe BS.ByteString -> ST s (CBOR.IDecode s a)) -> ConduitT BS.ByteString a (ExceptT CBORStreamError (ST s)) ()
+    loop bs k = do
+      (lift . lift) (k (Just bs)) >>= \case
+        CBOR.Fail _ _ err -> throwError $ CBORStreamDeserializationError err
+        CBOR.Partial k' -> do
+          -- We need more input, try to get some
+          nextBS <- Conduit.await
+          case nextBS of
+            Nothing -> do
+              -- No more input, try to finish up the decoder.
+              (lift . lift) (k' Nothing) >>= \case
+                CBOR.Done _ _ a -> Conduit.yield a
+                CBOR.Fail _ _ err -> throwError $ CBORStreamDeserializationError err
+                CBOR.Partial _ -> throwError CBORStreamUnexpectedEndOfInput
+            Just bs' ->
+              -- Have some input, keep going.
+              loop bs' k'
+        CBOR.Done rem _ a -> do
+          Conduit.yield a
+          if BS.null rem
+            then do
+              -- If we had no leftovers, we can check if there's any input left.
+              Conduit.await >>= \case
+                Nothing -> pure ()
+                Just bs'' -> do
+                  -- If we have input left, start up a new decoder.
+                  k <- newDecoder
+                  loop bs'' k
+            else do
+              -- We have leftovers, start a new decoder and use those.
+              k <- newDecoder
+              loop rem k

--- a/unison-share-api/src/Unison/Util/Websockets.hs
+++ b/unison-share-api/src/Unison/Util/Websockets.hs
@@ -126,7 +126,8 @@ withQueues inputBuffer outputBuffer conn action = Ki.scoped $ \scope -> do
               Just Nothing -> pure ([], True)
               -- Got a message, keep flushing
               Just (Just outMsg) -> do
-                first (outMsg :) <$> flushQ
+                (outMsgs, isClosed) <- flushQ <|> pure ([], False)
+                pure (outMsg : outMsgs, isClosed)
       (outMsgs, isClosed) <- atomically $ flushQ
       liftIO $ sendBinaryDatas conn outMsgs
       when (not isClosed) $ sendWorker q
@@ -169,9 +170,9 @@ withCodeserverWebsocket msgBufferSize codeserver tokenProvider codeserverPath ac
 
 -- | Type used for websocket messages that can either be a message or an error.
 data MsgOrError err a
-  = Msg a
-  | UserErr err
-  | DeserialiseFailure Text
+  = Msg !a
+  | UserErr !err
+  | DeserialiseFailure !Text
   deriving (Show, Eq, Ord)
 
 -- | Roundtrip test:

--- a/unison-share-api/src/Unison/Util/Websockets.hs
+++ b/unison-share-api/src/Unison/Util/Websockets.hs
@@ -54,7 +54,7 @@ withQueues inputBuffer outputBuffer conn action = Ki.scoped $ \scope -> do
   let queues = Queues {receive, send}
 
   _ <- Ki.fork scope $ recvWorker connectionClosedMVar receiveQ
-  _ <- Ki.fork scope $ sendWorker sendQ
+  sendWorkerThread <- Ki.fork scope $ sendWorker sendQ
   let waitConnectionError = atomically do
         mayErr <- readTMVar connectionClosedMVar
         case mayErr of
@@ -67,6 +67,11 @@ withQueues inputBuffer outputBuffer conn action = Ki.scoped $ \scope -> do
     Right result -> do
       -- The action completed, we need to close the connection gracefully
       -- and drain any remaining messages.
+      atomically $ do
+        -- Close the send queue, then wait for all messages to be sent before we close.
+        closeTBMQueue sendQ
+      atomically $ Ki.await sendWorkerThread
+      -- Now we can close and drain any remaining messages.
       msgs <- selfClose receiveQ
       pure $ Right (result, msgs)
   where
@@ -74,7 +79,7 @@ withQueues inputBuffer outputBuffer conn action = Ki.scoped $ \scope -> do
     selfClose :: (TBMQueue o) -> m [o]
     selfClose receiveQ = do
       -- We've requested to close the connection.
-      Debug.debugLogM Debug.Temp "Client requested close, sending close message"
+      Debug.debugLogM Debug.Temp "We've requested close, sending close message"
       liftIO $ sendClose conn ("Done" :: Text)
       let drainMessages :: m [o]
           drainMessages = do
@@ -97,7 +102,7 @@ withQueues inputBuffer outputBuffer conn action = Ki.scoped $ \scope -> do
           CloseRequest {} -> do
             -- The other side requested a close, we close the recv channel to indicate
             -- we won't receive any more messages.
-            Debug.debugM Debug.Temp "Server requested close" ()
+            Debug.debugM Debug.Temp "Other side requested close" ()
             atomically $ do
               closeTBMQueue q
 

--- a/unison-share-api/src/Unison/Util/Websockets.hs
+++ b/unison-share-api/src/Unison/Util/Websockets.hs
@@ -29,9 +29,9 @@ import Wuss qualified
 
 -- | Allows interfacing with a websocket as a pair of bounded queues.
 data Queues i o = Queues
-  { -- Receive from the client. Returns Nothing if the connection is closed.
+  { -- Receive from the other side. Returns Nothing if the connection is closed.
     receive :: STM (Maybe o),
-    -- Send to the client. Returns False if the connection is closed.
+    -- Send to the other side. Returns False if the connection is closed.
     send :: i -> STM Bool
   }
 
@@ -42,7 +42,7 @@ instance Profunctor Queues where
         send = send . f
       }
 
-withQueues :: forall i o m a. (MonadUnliftIO m, WebSocketsData i, WebSocketsData o) => Int -> Int -> Connection -> (Queues i o -> m a) -> m (Either ConnectionException a)
+withQueues :: forall i o m a. (MonadUnliftIO m, WebSocketsData i, WebSocketsData o) => Int -> Int -> Connection -> (Queues i o -> m a) -> m (Either ConnectionException (a, [o {- Any leftover messages received from the other side after we've indicated we want to shut down. -}]))
 withQueues inputBuffer outputBuffer conn action = Ki.scoped $ \scope -> do
   receiveQ <- liftIO $ newTBMQueueIO inputBuffer
   sendQ <- liftIO $ newTBMQueueIO outputBuffer
@@ -53,77 +53,81 @@ withQueues inputBuffer outputBuffer conn action = Ki.scoped $ \scope -> do
         isClosedTBMQueue sendQ
   let queues = Queues {receive, send}
 
-  let triggerClose :: forall n. (MonadIO n) => (Maybe ConnectionException) -> n ()
-      triggerClose mayErr = do
-        newlyClosed <- atomically $ do
-          newlyClosed <- tryPutTMVar connectionClosedMVar mayErr
-          when newlyClosed $ do
-            -- Close the queues to signal to workers to stop.
-            closeTBMQueue receiveQ
-            closeTBMQueue sendQ
-          pure newlyClosed
-
-        when newlyClosed $ do
-          -- If we closed due to a connection error, we don't need to send a close.
-          -- If we're shutting down normally, we send a close message.
-          case mayErr of
-            Nothing -> do
-              Debug.debugM Debug.Temp "Sending close message" ()
-              liftIO $ sendClose conn ("Server is shutting down" :: Text)
-              Debug.debugM Debug.Temp "Waiting for server to shut down" ()
-              -- TODO: maybe wait for the close to complete?
-              _ <- liftIO $ atomically receive
-              pure ()
-            _ -> pure ()
-  _ <- Ki.fork scope $ recvWorker triggerClose receiveQ
-  _ <- Ki.fork scope $ sendWorker triggerClose sendQ
+  _ <- Ki.fork scope $ recvWorker connectionClosedMVar receiveQ
+  _ <- Ki.fork scope $ sendWorker sendQ
   let waitConnectionError = atomically do
         mayErr <- readTMVar connectionClosedMVar
         case mayErr of
           Nothing -> empty
           Just err -> pure err
-  result <- race waitConnectionError (action queues)
-  -- Ensure the connection is closed when done.
-  liftIO $ triggerClose Nothing
-  pure result
+  race waitConnectionError (action queues) >>= \case
+    Left err -> do
+      -- An error occurred, return it.
+      pure (Left err)
+    Right result -> do
+      -- The action completed, we need to close the connection gracefully
+      -- and drain any remaining messages.
+      msgs <- selfClose receiveQ
+      pure $ Right (result, msgs)
   where
-    recvWorker :: (Maybe ConnectionException -> m ()) -> TBMQueue o -> m ()
-    recvWorker triggerClose q = UnliftIO.handle (handler triggerClose) $ do
+    -- Shut down the connection gracefully, returning any remaining messages.
+    selfClose :: (TBMQueue o) -> m [o]
+    selfClose receiveQ = do
+      -- We've requested to close the connection.
+      Debug.debugLogM Debug.Temp "Client requested close, sending close message"
+      liftIO $ sendClose conn ("Done" :: Text)
+      let drainMessages :: m [o]
+          drainMessages = do
+            -- Read messages until the queue is closed, which indicates the other side has also closed their connection.
+            atomically (readTBMQueue receiveQ) >>= \case
+              Nothing -> pure []
+              Just msg -> do
+                rest <- drainMessages
+                pure (msg : rest)
+      drainMessages
+
+    recvWorker :: (TMVar (Maybe ConnectionException)) -> TBMQueue o -> m ()
+    recvWorker errMVar q = UnliftIO.handle handler $ do
       msg <- liftIO $ receiveData conn
       atomically $ writeTBMQueue q msg
-      recvWorker triggerClose q
+      recvWorker errMVar q
+      where
+        handler :: ConnectionException -> m ()
+        handler = \case
+          CloseRequest {} -> do
+            -- The other side requested a close, we close the recv channel to indicate
+            -- we won't receive any more messages.
+            Debug.debugM Debug.Temp "Server requested close" ()
+            atomically $ do
+              closeTBMQueue q
 
-    handler :: (Maybe ConnectionException -> m ()) -> ConnectionException -> m ()
-    handler triggerClose = \case
-      CloseRequest {} -> do
-        -- The client requested a close, we can just close normally.
-        triggerClose Nothing
-      -- Other cases are exceptional
-      err -> triggerClose (Just err)
+          -- Other cases are exceptional, set the error var
+          err -> do
+            Debug.debugM Debug.Temp "ConnectionException in recvWorker" (show err)
+            atomically $ do
+              void $ tryPutTMVar errMVar (Just err)
+            pure ()
 
-    sendWorker :: (Maybe ConnectionException -> m ()) -> TBMQueue i -> m ()
-    sendWorker triggerClose q = UnliftIO.handle (handler triggerClose) $ do
-      let flushQ = do
-            xs <- many $ do
-              readTBMQueue q >>= \case
-                Nothing -> empty
-                Just outMsg -> pure outMsg
-            isClosedTBMQueue q >>= \case
-              True -> pure (Left xs)
-              False -> do
-                pure (Right xs)
-      outMsgs <- atomically $ flushQ
-      case outMsgs of
-        Left msgs ->
-          liftIO $ sendBinaryDatas conn msgs
-        Right msgs -> do
-          liftIO $ sendBinaryDatas conn msgs
-          sendWorker triggerClose q
+    sendWorker :: TBMQueue i -> m ()
+    sendWorker q = do
+      let flushQ :: STM ([i], Bool)
+          flushQ = do
+            optional (readTBMQueue q) >>= \case
+              -- No messages, but queue is still open
+              Nothing -> empty
+              -- Queue is closed
+              Just Nothing -> pure ([], True)
+              -- Got a message, keep flushing
+              Just (Just outMsg) -> do
+                first (outMsg :) <$> flushQ
+      (outMsgs, isClosed) <- atomically $ flushQ
+      liftIO $ sendBinaryDatas conn outMsgs
+      when (not isClosed) $ sendWorker q
 
 -- | Connect a websocket to the codeserver at the given URI.
 -- The action will be called with a 'Queues' to send and receive messages,
 -- when the action completes, the websocket connection will be closed.
-withCodeserverWebsocket :: forall m i o r e. (MonadUnliftIO m, WebSocketsData i, WebSocketsData o) => Int -> CodeserverURI -> (CodeserverId -> IO (Either e Text)) -> String -> (Queues i o -> m r) -> m (Either ConnectionException r)
+withCodeserverWebsocket :: forall m i o r e. (MonadUnliftIO m, WebSocketsData i, WebSocketsData o) => Int -> CodeserverURI -> (CodeserverId -> IO (Either e Text)) -> String -> (Queues i o -> m r) -> m (Either ConnectionException (r, [o {- Any leftover messages received from the server after we've indicated we want to shut down. -}]))
 withCodeserverWebsocket msgBufferSize codeserver tokenProvider codeserverPath action = do
   let host = codeserverRegName codeserver
   let connectionOptions = WS.defaultConnectionOptions {WS.connectionCompressionOptions = WS.PermessageDeflateCompression WS.defaultPermessageDeflate}

--- a/unison-share-api/src/Unison/Util/Websockets.hs
+++ b/unison-share-api/src/Unison/Util/Websockets.hs
@@ -20,23 +20,17 @@ data Queues i o = Queues
   { -- Receive from the client
     receive :: STM o,
     -- Send to the client
-    send :: i -> STM (),
-    shutdown :: IO (),
-    -- This succeeds with a 'Just' value if the connection was closed due to an exception,
-    -- 'Nothing' if it was closed normally, or retries if the connection is still open.
-    connectionClosed :: STM (Maybe ConnectionException)
+    send :: i -> STM ()
   }
 
 instance Profunctor Queues where
-  dimap f g (Queues {receive, send, shutdown, connectionClosed}) =
+  dimap f g (Queues {receive, send}) =
     Queues
       { receive = g <$> receive,
-        send = send . f,
-        shutdown,
-        connectionClosed
+        send = send . f
       }
 
-withQueues :: forall i o m a. (MonadUnliftIO m, WebSocketsData i, WebSocketsData o) => Natural -> Natural -> Connection -> (Queues i o -> m a) -> m a
+withQueues :: forall i o m a. (MonadUnliftIO m, WebSocketsData i, WebSocketsData o) => Natural -> Natural -> Connection -> (Queues i o -> m a) -> m (Either ConnectionException a)
 withQueues inputBuffer outputBuffer conn action = Ki.scoped $ \scope -> do
   receiveQ <- liftIO $ newTBQueueIO inputBuffer
   sendQ <- liftIO $ newTBQueueIO outputBuffer
@@ -55,13 +49,18 @@ withQueues inputBuffer outputBuffer conn action = Ki.scoped $ \scope -> do
             Nothing -> liftIO $ sendClose conn ("Server is shutting down" :: Text)
             _ -> pure ()
 
-  let queues = Queues {receive, send, shutdown = (triggerClose Nothing), connectionClosed = readTMVar connectionClosedMVar}
+  let queues = Queues {receive, send}
   _ <- Ki.fork scope $ recvWorker triggerClose receiveQ
   _ <- Ki.fork scope $ sendWorker triggerClose sendQ
-  r <- action queues
+  let waitConnectionError = atomically do
+        mayErr <- readTMVar connectionClosedMVar
+        case mayErr of
+          Nothing -> empty
+          Just err -> pure err
+  result <- race waitConnectionError (action queues)
   -- Ensure the connection is closed when done.
   liftIO $ triggerClose Nothing
-  pure r
+  pure result
   where
     recvWorker :: (Maybe ConnectionException -> m ()) -> TBQueue o -> m ()
     recvWorker triggerClose q = UnliftIO.handle (handler triggerClose) $ do

--- a/unison-share-api/src/Unison/Util/Websockets.hs
+++ b/unison-share-api/src/Unison/Util/Websockets.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE KindSignatures #-}
+
+module Unison.Util.Websockets
+  ( withQueues,
+    Queues (..),
+  )
+where
+
+import Control.Applicative
+import Control.Lens (Profunctor (..))
+import Control.Monad
+import Data.Text (Text)
+import GHC.Natural
+import Ki.Unlifted qualified as Ki
+import Network.WebSockets
+import UnliftIO
+
+-- | Allows interfacing with a websocket as a pair of bounded queues.
+data Queues i o = Queues
+  { -- Receive from the client
+    receive :: STM o,
+    -- Send to the client
+    send :: i -> STM (),
+    shutdown :: IO (),
+    -- This succeeds with a 'Just' value if the connection was closed due to an exception,
+    -- 'Nothing' if it was closed normally, or retries if the connection is still open.
+    connectionClosed :: STM (Maybe ConnectionException)
+  }
+
+instance Profunctor Queues where
+  dimap f g (Queues {receive, send, shutdown, connectionClosed}) =
+    Queues
+      { receive = g <$> receive,
+        send = send . f,
+        shutdown,
+        connectionClosed
+      }
+
+withQueues :: forall i o m a. (MonadUnliftIO m, WebSocketsData i, WebSocketsData o) => Natural -> Natural -> Connection -> (Queues i o -> m a) -> m a
+withQueues inputBuffer outputBuffer conn action = Ki.scoped $ \scope -> do
+  receiveQ <- liftIO $ newTBQueueIO inputBuffer
+  sendQ <- liftIO $ newTBQueueIO outputBuffer
+  connectionClosedMVar <- liftIO $ newEmptyTMVarIO
+  let receive = do readTBQueue receiveQ
+  let send msg = writeTBQueue sendQ msg
+
+  let triggerClose :: forall n. (MonadIO n) => (Maybe ConnectionException) -> n ()
+      triggerClose mayErr = do
+        newlyClosed <- atomically $ do
+          tryPutTMVar connectionClosedMVar mayErr
+        when newlyClosed $ do
+          -- If we closed due to a connection error, we don't need to send a close.
+          -- If we're shutting down normally, we send a close message.
+          case mayErr of
+            Nothing -> liftIO $ sendClose conn ("Server is shutting down" :: Text)
+            _ -> pure ()
+
+  let queues = Queues {receive, send, shutdown = (triggerClose Nothing), connectionClosed = readTMVar connectionClosedMVar}
+  _ <- Ki.fork scope $ recvWorker triggerClose receiveQ
+  _ <- Ki.fork scope $ sendWorker triggerClose sendQ
+  r <- action queues
+  -- Ensure the connection is closed when done.
+  liftIO $ triggerClose Nothing
+  pure r
+  where
+    recvWorker :: (Maybe ConnectionException -> m ()) -> TBQueue o -> m ()
+    recvWorker triggerClose q = UnliftIO.handle (handler triggerClose) $ do
+      msg <- liftIO $ receiveData conn
+      atomically $ writeTBQueue q msg
+      recvWorker triggerClose q
+
+    handler :: (Maybe ConnectionException -> m ()) -> ConnectionException -> m ()
+    handler triggerClose = \case
+      CloseRequest {} -> do
+        -- The client requested a close, we can just close normally.
+        triggerClose Nothing
+      -- Other cases are exceptional
+      err -> triggerClose (Just err)
+
+    sendWorker :: (Maybe ConnectionException -> m ()) -> TBQueue i -> m ()
+    sendWorker triggerClose q = UnliftIO.handle (handler triggerClose) $ do
+      outMsgs <- atomically $ some $ readTBQueue q
+      liftIO $ sendBinaryDatas conn outMsgs
+      sendWorker triggerClose q
+

--- a/unison-share-api/src/Unison/Util/Websockets.hs
+++ b/unison-share-api/src/Unison/Util/Websockets.hs
@@ -82,4 +82,3 @@ withQueues inputBuffer outputBuffer conn action = Ki.scoped $ \scope -> do
       outMsgs <- atomically $ some $ readTBQueue q
       liftIO $ sendBinaryDatas conn outMsgs
       sendWorker triggerClose q
-

--- a/unison-share-api/src/Unison/Util/Websockets.hs
+++ b/unison-share-api/src/Unison/Util/Websockets.hs
@@ -21,7 +21,6 @@ import Ki.Unlifted qualified as Ki
 import Network.Socket
 import Network.WebSockets
 import Network.WebSockets qualified as WS
-import Unison.Debug qualified as Debug
 import Unison.Prelude
 import Unison.Share.Types
 import UnliftIO
@@ -59,7 +58,6 @@ withQueues inputBuffer outputBuffer conn action = Ki.scoped $ \scope -> do
         readTMVar connectionClosedMVar
   race waitConnectionError (action queues) >>= \case
     Left err -> do
-      Debug.debugM Debug.Temp "Connection error occurred, shutting down websocket" (show err)
       -- An error occurred, return it.
       pure (Left err)
     Right result -> do
@@ -77,7 +75,6 @@ withQueues inputBuffer outputBuffer conn action = Ki.scoped $ \scope -> do
     selfClose :: (TBMQueue o) -> m [o]
     selfClose receiveQ = do
       -- We've requested to close the connection.
-      Debug.debugLogM Debug.Temp "We've requested close, sending close message"
       liftIO $ sendClose conn ("Done" :: Text)
       let drainMessages :: m [o]
           drainMessages = do
@@ -102,14 +99,12 @@ withQueues inputBuffer outputBuffer conn action = Ki.scoped $ \scope -> do
           CloseRequest {} -> do
             -- The other side requested a close, we close the recv channel to indicate
             -- we won't receive any more messages.
-            Debug.debugM Debug.Temp "Other side requested close" ()
             atomically $ do
               closeTBMQueue q
             pure True
 
           -- Other cases are exceptional, set the error var
           err -> do
-            Debug.debugM Debug.Temp "ConnectionException in recvWorker" (show err)
             atomically $ do
               void $ tryPutTMVar errMVar err
             pure True
@@ -161,9 +156,7 @@ withCodeserverWebsocket msgBufferSize codeserver tokenProvider codeserverPath ac
                 print $ "Connecting to codeserver via WS: " <> show (fixedHost, port, codeserverPath, headers)
                 WS.runClientWith fixedHost port path opts headers action
   toIO <- askRunInIO
-  Debug.debugM Debug.Temp "withCodeserverWebsocket:" (host, codeserverPath)
   liftIO $ withSocketsDo $ (wsRunner codeserverPath connectionOptions headers) \conn -> do
-    Debug.debugM Debug.Temp "CONNECTED to websocket" (host, codeserverPath)
     withQueues msgBufferSize msgBufferSize conn $ \queues -> do
       toIO $ action queues
 

--- a/unison-share-api/src/Unison/Util/Websockets.hs
+++ b/unison-share-api/src/Unison/Util/Websockets.hs
@@ -21,6 +21,7 @@ import Ki.Unlifted qualified as Ki
 import Network.Socket
 import Network.WebSockets
 import Network.WebSockets qualified as WS
+import Unison.Debug qualified as Debug
 import Unison.Prelude
 import Unison.Share.Types
 import UnliftIO
@@ -120,22 +121,33 @@ withQueues inputBuffer outputBuffer conn action = Ki.scoped $ \scope -> do
 withCodeserverWebsocket :: forall m i o r e. (MonadUnliftIO m, WebSocketsData i, WebSocketsData o) => Int -> CodeserverURI -> (CodeserverId -> IO (Either e Text)) -> String -> (Queues i o -> m r) -> m (Either ConnectionException r)
 withCodeserverWebsocket msgBufferSize codeserver tokenProvider codeserverPath action = do
   let host = codeserverRegName codeserver
-  let connectionOptions = WS.defaultConnectionOptions {WS.connectionCompressionOptions = WS.PermessageDeflateCompression WS.defaultPermessageDeflate}
+  let connectionOptions = WS.defaultConnectionOptions -- {WS.connectionCompressionOptions = WS.PermessageDeflateCompression WS.defaultPermessageDeflate}
   headers <-
     (liftIO (tokenProvider (codeserverIdFromCodeserverURI codeserver))) <&> \case
       Left {} -> []
       Right token -> [("Authorization", "Bearer " <> Text.encodeUtf8 token)]
-  let wsRunner = case codeserverScheme codeserver of
+
+  let wsRunner path opts headers action = case codeserverScheme codeserver of
         Https ->
           let tlsPort = 443
               port = maybe tlsPort fromIntegral $ (codeserverPort) codeserver
-           in Wuss.runSecureClientWith host port
+           in do
+                print $ "Connecting to codeserver via WSS: " <> show (host, port, codeserverPath, headers)
+                Wuss.runSecureClientWith host port path opts headers action
         Http ->
-          let tlsPort = 443 :: Int
-              port = maybe tlsPort id $ (codeserverPort) codeserver
-           in WS.runClientWith host port
+          let defaultPort = 80 :: Int
+              port = maybe defaultPort id $ codeserverPort codeserver
+              fixedHost = case host of
+                -- The haskell ws client has issues with "localhost"
+                "localhost" -> "127.0.0.1"
+                _ -> host
+           in do
+                print $ "Connecting to codeserver via WS: " <> show (fixedHost, port, codeserverPath, headers)
+                WS.runClientWith fixedHost port path opts headers action
   toIO <- askRunInIO
+  Debug.debugM Debug.Temp "withCodeserverWebsocket:" (host, codeserverPath)
   liftIO $ withSocketsDo $ (wsRunner codeserverPath connectionOptions headers) \conn -> do
+    Debug.debugM Debug.Temp "CONNECTED to websocket" (host, codeserverPath)
     withQueues msgBufferSize msgBufferSize conn $ \queues -> do
       toIO $ action queues
 

--- a/unison-share-api/src/Unison/Util/Websockets.hs
+++ b/unison-share-api/src/Unison/Util/Websockets.hs
@@ -9,10 +9,12 @@ module Unison.Util.Websockets
   )
 where
 
+import Codec.Serialise qualified as CBOR
 import Control.Applicative
 import Control.Concurrent.STM.TBMQueue
 import Control.Lens (Profunctor (..))
 import Control.Monad
+import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
 import Ki.Unlifted qualified as Ki
 import Network.Socket
@@ -139,7 +141,8 @@ withCodeserverWebsocket msgBufferSize codeserver tokenProvider codeserverPath ac
 -- | Type used for websocket messages that can either be a message or an error.
 data MsgOrError err a
   = Msg a
-  | Err err
+  | UserErr err
+  | DeserialiseFailure Text
   deriving (Show, Eq, Ord)
 
 -- | Roundtrip test:
@@ -151,30 +154,37 @@ data MsgOrError err a
 instance (CBOR.Serialise a, CBOR.Serialise err) => CBOR.Serialise (MsgOrError err a) where
   encode = \case
     Msg a -> CBOR.encode (0 :: Int) <> CBOR.encode a
-    Err e -> CBOR.encode (1 :: Int) <> CBOR.encode e
+    UserErr e -> CBOR.encode (1 :: Int) <> CBOR.encode e
+    DeserialiseFailure msg -> CBOR.encode (2 :: Int) <> CBOR.encode msg
 
   decode = do
     tag <- CBOR.decode @Int
     case tag of
       0 -> Msg <$> CBOR.decode
-      1 -> Err <$> CBOR.decode
+      1 -> UserErr <$> CBOR.decode
+      2 -> DeserialiseFailure <$> CBOR.decode
       _ -> fail $ "Unknown MsgOrError tag: " <> show tag
 
 -- | Roundtrip test:
 -- >>> import qualified Network.WebSockets as WS
--- >>> let msgVal = Msg "test" :: MsgOrError SyncError Text
+-- >>> let msgVal = Msg "test" :: MsgOrError Text Text
 -- >>> WS.fromLazyByteString (WS.toLazyByteString msgVal) == msgVal
 -- True
--- >>> let errVal = Err (InitializationError "init error") :: MsgOrError SyncError Text
+-- >>> let errVal = UserErr "whoops" :: MsgOrError Text Text
+-- >>> WS.fromLazyByteString (WS.toLazyByteString errVal) == errVal
+-- True
+--
+-- >>> let errVal = DeserialiseFailure "whoops" :: MsgOrError Text Text
 -- >>> WS.fromLazyByteString (WS.toLazyByteString errVal) == errVal
 -- True
 -- >>> let dataMsg = WS.Binary (WS.toLazyByteString msgVal)
 -- >>> WS.fromDataMessage dataMsg == msgVal
 -- True
-instance (Serialise msg) => WebSocketsData (MsgOrError (Either DeserialiseFailure e) msg) where
+instance (CBOR.Serialise msg, CBOR.Serialise e) => WebSocketsData (MsgOrError e msg) where
   fromLazyByteString bytes =
-    CBOR.deserialiseOrFail bytes
-      & either (\err -> Err . EncodingFailure $ "Error decoding CBOR message from bytes: " <> tShow err) id
+    case CBOR.deserialiseOrFail bytes of
+      Left err -> DeserialiseFailure (Text.pack (show err))
+      Right msg -> msg
 
   toLazyByteString = CBOR.serialise
 

--- a/unison-share-api/src/Unison/Util/Websockets.hs
+++ b/unison-share-api/src/Unison/Util/Websockets.hs
@@ -3,6 +3,7 @@
 module Unison.Util.Websockets
   ( withQueues,
     Queues (..),
+    withCodeserverWebsocket,
   )
 where
 
@@ -10,10 +11,15 @@ import Control.Applicative
 import Control.Concurrent.STM.TBMQueue
 import Control.Lens (Profunctor (..))
 import Control.Monad
-import Data.Text (Text)
+import Data.Text.Encoding qualified as Text
 import Ki.Unlifted qualified as Ki
+import Network.Socket
 import Network.WebSockets
+import Network.WebSockets qualified as WS
+import Unison.Prelude
+import Unison.Share.Types
 import UnliftIO
+import Wuss qualified
 
 -- | Allows interfacing with a websocket as a pair of bounded queues.
 data Queues i o = Queues
@@ -102,3 +108,28 @@ withQueues inputBuffer outputBuffer conn action = Ki.scoped $ \scope -> do
         Right msgs -> do
           liftIO $ sendBinaryDatas conn msgs
           sendWorker triggerClose q
+
+-- | Connect a websocket to the codeserver at the given URI.
+-- The action will be called with a 'Queues' to send and receive messages,
+-- when the action completes, the websocket connection will be closed.
+withCodeserverWebsocket :: (MonadUnliftIO m, WebSocketsData i, WebSocketsData o) => Int -> CodeserverURI -> (CodeserverId -> IO (Either e Text)) -> String -> (Queues i o -> m r) -> m (Either ConnectionException r)
+withCodeserverWebsocket msgBufferSize codeserver tokenProvider codeserverPath action = do
+  let host = codeserverRegName codeserver
+  let connectionOptions = WS.defaultConnectionOptions {WS.connectionCompressionOptions = WS.PermessageDeflateCompression WS.defaultPermessageDeflate}
+  headers <-
+    (liftIO (tokenProvider (codeserverIdFromCodeserverURI codeserver))) <&> \case
+      Left {} -> []
+      Right token -> [("Authorization", "Bearer " <> Text.encodeUtf8 token)]
+  let wsRunner = case codeserverScheme codeserver of
+        Https ->
+          let tlsPort = 443
+              port = maybe tlsPort fromIntegral $ (codeserverPort) codeserver
+           in Wuss.runSecureClientWith host port
+        Http ->
+          let tlsPort = 443 :: Int
+              port = maybe tlsPort id $ (codeserverPort) codeserver
+           in WS.runClientWith host port
+  toIO <- askRunInIO
+  liftIO $ withSocketsDo $ (wsRunner codeserverPath connectionOptions headers) \conn -> do
+    withQueues msgBufferSize msgBufferSize conn $ \queues -> do
+      toIO $ action queues

--- a/unison-share-api/src/Unison/Util/Websockets.hs
+++ b/unison-share-api/src/Unison/Util/Websockets.hs
@@ -91,13 +91,14 @@ withQueues inputBuffer outputBuffer conn action = Ki.scoped $ \scope -> do
 
     recvWorker :: (TMVar ConnectionException) -> TBMQueue o -> m ()
     recvWorker errMVar q = do
-      UnliftIO.handle handler $ do
+      closed <- UnliftIO.handle handler $ do
         msg <- liftIO $ receiveData conn
         Debug.debugM Debug.Temp "Received message from websocket" ()
         atomically $ writeTBMQueue q msg
-      recvWorker errMVar q
+        pure False
+      when (not closed) $ recvWorker errMVar q
       where
-        handler :: ConnectionException -> m ()
+        handler :: ConnectionException -> m Bool
         handler = \case
           CloseRequest {} -> do
             -- The other side requested a close, we close the recv channel to indicate
@@ -105,13 +106,14 @@ withQueues inputBuffer outputBuffer conn action = Ki.scoped $ \scope -> do
             Debug.debugM Debug.Temp "Other side requested close" ()
             atomically $ do
               closeTBMQueue q
+            pure True
 
           -- Other cases are exceptional, set the error var
           err -> do
             Debug.debugM Debug.Temp "ConnectionException in recvWorker" (show err)
             atomically $ do
               void $ tryPutTMVar errMVar err
-            pure ()
+            pure True
 
     sendWorker :: TBMQueue i -> m ()
     sendWorker q = do

--- a/unison-share-api/src/Unison/Util/Websockets.hs
+++ b/unison-share-api/src/Unison/Util/Websockets.hs
@@ -56,12 +56,10 @@ withQueues inputBuffer outputBuffer conn action = Ki.scoped $ \scope -> do
   _ <- Ki.fork scope $ recvWorker connectionClosedMVar receiveQ
   sendWorkerThread <- Ki.fork scope $ sendWorker sendQ
   let waitConnectionError = atomically do
-        mayErr <- readTMVar connectionClosedMVar
-        case mayErr of
-          Nothing -> empty
-          Just err -> pure err
+        readTMVar connectionClosedMVar
   race waitConnectionError (action queues) >>= \case
     Left err -> do
+      Debug.debugM Debug.Temp "Connection error occurred, shutting down websocket" (show err)
       -- An error occurred, return it.
       pure (Left err)
     Right result -> do
@@ -91,10 +89,12 @@ withQueues inputBuffer outputBuffer conn action = Ki.scoped $ \scope -> do
                 pure (msg : rest)
       drainMessages
 
-    recvWorker :: (TMVar (Maybe ConnectionException)) -> TBMQueue o -> m ()
-    recvWorker errMVar q = UnliftIO.handle handler $ do
-      msg <- liftIO $ receiveData conn
-      atomically $ writeTBMQueue q msg
+    recvWorker :: (TMVar ConnectionException) -> TBMQueue o -> m ()
+    recvWorker errMVar q = do
+      UnliftIO.handle handler $ do
+        msg <- liftIO $ receiveData conn
+        Debug.debugM Debug.Temp "Received message from websocket" ()
+        atomically $ writeTBMQueue q msg
       recvWorker errMVar q
       where
         handler :: ConnectionException -> m ()
@@ -110,7 +110,7 @@ withQueues inputBuffer outputBuffer conn action = Ki.scoped $ \scope -> do
           err -> do
             Debug.debugM Debug.Temp "ConnectionException in recvWorker" (show err)
             atomically $ do
-              void $ tryPutTMVar errMVar (Just err)
+              void $ tryPutTMVar errMVar err
             pure ()
 
     sendWorker :: TBMQueue i -> m ()

--- a/unison-share-api/src/Unison/Util/Websockets.hs
+++ b/unison-share-api/src/Unison/Util/Websockets.hs
@@ -93,7 +93,6 @@ withQueues inputBuffer outputBuffer conn action = Ki.scoped $ \scope -> do
     recvWorker errMVar q = do
       closed <- UnliftIO.handle handler $ do
         msg <- liftIO $ receiveData conn
-        Debug.debugM Debug.Temp "Received message from websocket" ()
         atomically $ writeTBMQueue q msg
         pure False
       when (not closed) $ recvWorker errMVar q

--- a/unison-share-api/src/Unison/Util/Websockets.hs
+++ b/unison-share-api/src/Unison/Util/Websockets.hs
@@ -5,6 +5,7 @@
 module Unison.Util.Websockets
   ( withQueues,
     Queues (..),
+    MsgOrError (..),
     withCodeserverWebsocket,
   )
 where

--- a/unison-share-api/src/Unison/Util/Websockets.hs
+++ b/unison-share-api/src/Unison/Util/Websockets.hs
@@ -1,4 +1,6 @@
+{-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Unison.Util.Websockets
   ( withQueues,
@@ -112,7 +114,7 @@ withQueues inputBuffer outputBuffer conn action = Ki.scoped $ \scope -> do
 -- | Connect a websocket to the codeserver at the given URI.
 -- The action will be called with a 'Queues' to send and receive messages,
 -- when the action completes, the websocket connection will be closed.
-withCodeserverWebsocket :: (MonadUnliftIO m, WebSocketsData i, WebSocketsData o) => Int -> CodeserverURI -> (CodeserverId -> IO (Either e Text)) -> String -> (Queues i o -> m r) -> m (Either ConnectionException r)
+withCodeserverWebsocket :: forall m i o r e. (MonadUnliftIO m, WebSocketsData i, WebSocketsData o) => Int -> CodeserverURI -> (CodeserverId -> IO (Either e Text)) -> String -> (Queues i o -> m r) -> m (Either ConnectionException r)
 withCodeserverWebsocket msgBufferSize codeserver tokenProvider codeserverPath action = do
   let host = codeserverRegName codeserver
   let connectionOptions = WS.defaultConnectionOptions {WS.connectionCompressionOptions = WS.PermessageDeflateCompression WS.defaultPermessageDeflate}

--- a/unison-share-api/src/Unison/Util/Websockets.hs
+++ b/unison-share-api/src/Unison/Util/Websockets.hs
@@ -7,41 +7,49 @@ module Unison.Util.Websockets
 where
 
 import Control.Applicative
+import Control.Concurrent.STM.TBMQueue
 import Control.Lens (Profunctor (..))
 import Control.Monad
 import Data.Text (Text)
-import GHC.Natural
 import Ki.Unlifted qualified as Ki
 import Network.WebSockets
 import UnliftIO
 
 -- | Allows interfacing with a websocket as a pair of bounded queues.
 data Queues i o = Queues
-  { -- Receive from the client
-    receive :: STM o,
-    -- Send to the client
-    send :: i -> STM ()
+  { -- Receive from the client. Returns Nothing if the connection is closed.
+    receive :: STM (Maybe o),
+    -- Send to the client. Returns False if the connection is closed.
+    send :: i -> STM Bool
   }
 
 instance Profunctor Queues where
   dimap f g (Queues {receive, send}) =
     Queues
-      { receive = g <$> receive,
+      { receive = fmap g <$> receive,
         send = send . f
       }
 
-withQueues :: forall i o m a. (MonadUnliftIO m, WebSocketsData i, WebSocketsData o) => Natural -> Natural -> Connection -> (Queues i o -> m a) -> m (Either ConnectionException a)
+withQueues :: forall i o m a. (MonadUnliftIO m, WebSocketsData i, WebSocketsData o) => Int -> Int -> Connection -> (Queues i o -> m a) -> m (Either ConnectionException a)
 withQueues inputBuffer outputBuffer conn action = Ki.scoped $ \scope -> do
-  receiveQ <- liftIO $ newTBQueueIO inputBuffer
-  sendQ <- liftIO $ newTBQueueIO outputBuffer
+  receiveQ <- liftIO $ newTBMQueueIO inputBuffer
+  sendQ <- liftIO $ newTBMQueueIO outputBuffer
   connectionClosedMVar <- liftIO $ newEmptyTMVarIO
-  let receive = do readTBQueue receiveQ
-  let send msg = writeTBQueue sendQ msg
+  let receive = do readTBMQueue receiveQ
+  let send msg = do
+        writeTBMQueue sendQ msg
+        isClosedTBMQueue sendQ
 
   let triggerClose :: forall n. (MonadIO n) => (Maybe ConnectionException) -> n ()
       triggerClose mayErr = do
         newlyClosed <- atomically $ do
-          tryPutTMVar connectionClosedMVar mayErr
+          newlyClosed <- tryPutTMVar connectionClosedMVar mayErr
+          when newlyClosed $ do
+            -- Close the queues to signal to workers to stop.
+            closeTBMQueue receiveQ
+            closeTBMQueue sendQ
+          pure newlyClosed
+
         when newlyClosed $ do
           -- If we closed due to a connection error, we don't need to send a close.
           -- If we're shutting down normally, we send a close message.
@@ -62,10 +70,10 @@ withQueues inputBuffer outputBuffer conn action = Ki.scoped $ \scope -> do
   liftIO $ triggerClose Nothing
   pure result
   where
-    recvWorker :: (Maybe ConnectionException -> m ()) -> TBQueue o -> m ()
+    recvWorker :: (Maybe ConnectionException -> m ()) -> TBMQueue o -> m ()
     recvWorker triggerClose q = UnliftIO.handle (handler triggerClose) $ do
       msg <- liftIO $ receiveData conn
-      atomically $ writeTBQueue q msg
+      atomically $ writeTBMQueue q msg
       recvWorker triggerClose q
 
     handler :: (Maybe ConnectionException -> m ()) -> ConnectionException -> m ()
@@ -76,8 +84,21 @@ withQueues inputBuffer outputBuffer conn action = Ki.scoped $ \scope -> do
       -- Other cases are exceptional
       err -> triggerClose (Just err)
 
-    sendWorker :: (Maybe ConnectionException -> m ()) -> TBQueue i -> m ()
+    sendWorker :: (Maybe ConnectionException -> m ()) -> TBMQueue i -> m ()
     sendWorker triggerClose q = UnliftIO.handle (handler triggerClose) $ do
-      outMsgs <- atomically $ some $ readTBQueue q
-      liftIO $ sendBinaryDatas conn outMsgs
-      sendWorker triggerClose q
+      let flushQ = do
+            xs <- many $ do
+              readTBMQueue q >>= \case
+                Nothing -> empty
+                Just outMsg -> pure outMsg
+            isClosedTBMQueue q >>= \case
+              True -> pure (Left xs)
+              False -> do
+                pure (Right xs)
+      outMsgs <- atomically $ flushQ
+      case outMsgs of
+        Left msgs ->
+          liftIO $ sendBinaryDatas conn msgs
+        Right msgs -> do
+          liftIO $ sendBinaryDatas conn msgs
+          sendWorker triggerClose q

--- a/unison-share-api/src/Unison/Util/Websockets.hs
+++ b/unison-share-api/src/Unison/Util/Websockets.hs
@@ -51,6 +51,7 @@ withQueues inputBuffer outputBuffer conn action = Ki.scoped $ \scope -> do
   let send msg = do
         writeTBMQueue sendQ msg
         isClosedTBMQueue sendQ
+  let queues = Queues {receive, send}
 
   let triggerClose :: forall n. (MonadIO n) => (Maybe ConnectionException) -> n ()
       triggerClose mayErr = do
@@ -66,10 +67,14 @@ withQueues inputBuffer outputBuffer conn action = Ki.scoped $ \scope -> do
           -- If we closed due to a connection error, we don't need to send a close.
           -- If we're shutting down normally, we send a close message.
           case mayErr of
-            Nothing -> liftIO $ sendClose conn ("Server is shutting down" :: Text)
+            Nothing -> do
+              Debug.debugM Debug.Temp "Sending close message" ()
+              liftIO $ sendClose conn ("Server is shutting down" :: Text)
+              Debug.debugM Debug.Temp "Waiting for server to shut down" ()
+              -- TODO: maybe wait for the close to complete?
+              _ <- liftIO $ atomically receive
+              pure ()
             _ -> pure ()
-
-  let queues = Queues {receive, send}
   _ <- Ki.fork scope $ recvWorker triggerClose receiveQ
   _ <- Ki.fork scope $ sendWorker triggerClose sendQ
   let waitConnectionError = atomically do
@@ -121,7 +126,7 @@ withQueues inputBuffer outputBuffer conn action = Ki.scoped $ \scope -> do
 withCodeserverWebsocket :: forall m i o r e. (MonadUnliftIO m, WebSocketsData i, WebSocketsData o) => Int -> CodeserverURI -> (CodeserverId -> IO (Either e Text)) -> String -> (Queues i o -> m r) -> m (Either ConnectionException r)
 withCodeserverWebsocket msgBufferSize codeserver tokenProvider codeserverPath action = do
   let host = codeserverRegName codeserver
-  let connectionOptions = WS.defaultConnectionOptions -- {WS.connectionCompressionOptions = WS.PermessageDeflateCompression WS.defaultPermessageDeflate}
+  let connectionOptions = WS.defaultConnectionOptions {WS.connectionCompressionOptions = WS.PermessageDeflateCompression WS.defaultPermessageDeflate}
   headers <-
     (liftIO (tokenProvider (codeserverIdFromCodeserverURI codeserver))) <&> \case
       Left {} -> []

--- a/unison-share-api/unison-share-api.cabal
+++ b/unison-share-api/unison-share-api.cabal
@@ -55,6 +55,7 @@ library
       Unison.SyncV2.Types
       Unison.Util.Find
       Unison.Util.Servant.CBOR
+      Unison.Util.Websockets
   hs-source-dirs:
       src
   default-extensions:
@@ -108,6 +109,7 @@ library
     , hs-mcp
     , http-media
     , http-types
+    , ki-unlifted
     , lens
     , lucid
     , memory
@@ -148,6 +150,7 @@ library
     , wai
     , wai-cors
     , warp
+    , websockets
     , yaml
   default-language: Haskell2010
 

--- a/unison-share-api/unison-share-api.cabal
+++ b/unison-share-api/unison-share-api.cabal
@@ -123,6 +123,7 @@ library
     , servant-openapi3
     , servant-server
     , servant-websockets
+    , stm-chans
     , text
     , time
     , transformers

--- a/unison-share-api/unison-share-api.cabal
+++ b/unison-share-api/unison-share-api.cabal
@@ -98,6 +98,7 @@ library
     , bytes
     , bytestring
     , cborg
+    , conduit
     , containers
     , directory
     , errors

--- a/unison-share-api/unison-share-api.cabal
+++ b/unison-share-api/unison-share-api.cabal
@@ -114,6 +114,7 @@ library
     , lucid
     , memory
     , mtl
+    , network
     , nonempty-containers
     , openapi3
     , regex-tdfa
@@ -153,6 +154,7 @@ library
     , wai-cors
     , warp
     , websockets
+    , wuss
     , yaml
   default-language: Haskell2010
 

--- a/unison-share-api/unison-share-api.cabal
+++ b/unison-share-api/unison-share-api.cabal
@@ -25,6 +25,8 @@ library
       Unison.Server.Doc.Markdown.Render
       Unison.Server.Doc.Markdown.Types
       Unison.Server.Errors
+      Unison.Server.HistoryComments.API
+      Unison.Server.HistoryComments.Types
       Unison.Server.Local
       Unison.Server.Local.Definitions
       Unison.Server.Local.Endpoints.Current
@@ -118,6 +120,7 @@ library
     , servant-openapi3
     , servant-server
     , text
+    , time
     , transformers
     , unison-codebase
     , unison-codebase-sqlite

--- a/unison-share-api/unison-share-api.cabal
+++ b/unison-share-api/unison-share-api.cabal
@@ -122,6 +122,7 @@ library
     , servant-docs
     , servant-openapi3
     , servant-server
+    , servant-websockets
     , text
     , time
     , transformers

--- a/weeder.toml
+++ b/weeder.toml
@@ -78,6 +78,9 @@ roots = [
     '''^Unison\.Auth\.Types\.codeserverIdFromURIAuth$''',
     '''^Unison\.Auth\.Types\.codeserverIdFromCodeserverURI$''',
     '''^Unison\.Auth\.Types\.codeserverBaseURL$''',
+    '''^Unison\.Server\.HistoryComments\.API.api$''',
+    '''^Unison\.Server\.HistoryComments\.API.API$''',
+    '''^Unison\.Server\.HistoryComments\.API.Routes$''',
 
     ## Entries below here have been grandfathered in and should be reviewed.
     '''^U\.Codebase\.Branch\.Type\.hoist$''',


### PR DESCRIPTION
## Overview

* Adds comment syncing to the `push` process

## Implementation approach and notes

* Uses websockets bi-directional channel interactive sync process
* Adds a lot of websocket utilities which are also useful to SyncV3 :)
* UCM scans the full causal history and collects comment hashes, sends them to the server, the server reports back which hashes its missing, which UCM then uploads.

## Interesting/controversial decisions

The algorithm here is pretty naive, the "correct" way to sync something like this is to make comments part of the main causal merkle-tree (and affect hashing); but a redo of code hashing is out-of-scope;

There are smarter ways to do this sync even without integrating comments into the history; 
one particular option would be to tag each branch with not just its causal root, but also the root of a Merkle Search Tree which contains all the comments it knows about which are reachable from that causal root. MSTs are a useful data type for efficiently doing unions of arbitrary sets across distributed clients like this.

Since most cases are likely to be small here, we'll ship with this simple version in the hopes it lasts us for a while, and we can integrate the more complex and efficient version later.

Comment sync is quite likely to be dwarfed by code-sync in the majority of cases.

## Test coverage

- [x] Manual testing
- [x] Transcripts on the Share side.