### PR TITLE
fixup hpack file for unison-dynlib

### DIFF
--- a/lib/unison-dynlib/package.yaml
+++ b/lib/unison-dynlib/package.yaml
@@ -1,6 +1,7 @@
 name: unison-dynlib
 github: unisonweb/unison
 copyright: Copyright (C) 2025 Unison Computing, PBC and contributors
+license: MIT
 
 ghc-options: -Wall -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
 
@@ -8,6 +9,8 @@ dependencies:
   - base
 
 library:
+  exposed-modules:
+    - Unison.Runtime.FFI.DLL
   when:
     - condition: false
       other-modules: Paths_unison_hash

--- a/lib/unison-dynlib/unison-dynlib.cabal
+++ b/lib/unison-dynlib/unison-dynlib.cabal
@@ -1,5 +1,9 @@
 cabal-version: 1.12
 
+-- This file has been generated from package.yaml by hpack version 0.36.0.
+--
+-- see: https://github.com/sol/hpack
+
 name:           unison-dynlib
 version:        0.0.0
 homepage:       https://github.com/unisonweb/unison#readme
@@ -14,51 +18,48 @@ source-repository head
 
 library
   exposed-modules:
-    Unison.Runtime.FFI.DLL
-
+      Unison.Runtime.FFI.DLL
+  other-modules:
+      Paths_unison_dynlib
+  default-extensions:
+      ApplicativeDo
+      BangPatterns
+      BlockArguments
+      DeriveAnyClass
+      DeriveFunctor
+      DeriveGeneric
+      DeriveTraversable
+      DerivingStrategies
+      DerivingVia
+      DoAndIfThenElse
+      DuplicateRecordFields
+      FlexibleContexts
+      FlexibleInstances
+      GeneralizedNewtypeDeriving
+      ImportQualifiedPost
+      LambdaCase
+      MultiParamTypeClasses
+      NamedFieldPuns
+      OverloadedStrings
+      PatternSynonyms
+      RankNTypes
+      ScopedTypeVariables
+      StandaloneDeriving
+      TupleSections
+      TypeApplications
+      TypeFamilies
+      ViewPatterns
+  ghc-options: -Wall -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
   build-depends:
       base
-
-  ghc-options: -Wall -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
-
-  if os(windows)
-    build-depends:
-      Win32
-    hs-source-dirs:
-      src-win32
-
-  if !os(windows)
-    build-depends:
-      unix
-    hs-source-dirs:
-      src-unix
-
   default-language: Haskell2010
-  default-extensions:
-    ApplicativeDo
-    BangPatterns
-    BlockArguments
-    DeriveAnyClass
-    DeriveFunctor
-    DeriveGeneric
-    DeriveTraversable
-    DerivingStrategies
-    DerivingVia
-    DoAndIfThenElse
-    DuplicateRecordFields
-    FlexibleContexts
-    FlexibleInstances
-    GeneralizedNewtypeDeriving
-    ImportQualifiedPost
-    LambdaCase
-    MultiParamTypeClasses
-    NamedFieldPuns
-    OverloadedStrings
-    PatternSynonyms
-    RankNTypes
-    ScopedTypeVariables
-    StandaloneDeriving
-    TupleSections
-    TypeApplications
-    TypeFamilies
-    ViewPatterns
+  if os(windows)
+    hs-source-dirs:
+        src-win32
+    build-depends:
+        Win32
+  if !os(windows)
+    hs-source-dirs:
+        src-unix
+    build-depends:
+        unix

--- a/unison-runtime/unison-runtime.cabal
+++ b/unison-runtime/unison-runtime.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -81,8 +81,6 @@ library
       Unison.Runtime.Vector
   hs-source-dirs:
       src
-  c-sources:
-      cbits/i2d.c
   default-extensions:
       ApplicativeDo
       BangPatterns
@@ -114,6 +112,8 @@ library
       TypeFamilies
       ViewPatterns
   ghc-options: -fmax-worker-args=100 -Wall -funbox-strict-fields -O2
+  c-sources:
+      cbits/i2d.c
   build-depends:
       asn1-encoding
     , asn1-types


### PR DESCRIPTION
Fixes this warning
```
unison/lib/unison-dynlib/unison-dynlib.cabal was modified manually.
Ignoring unison/lib/unison-dynlib/package.yaml in favor of the Cabal file.
If you want to use the package.yaml file instead of the Cabal file,
then please delete the Cabal file.
```
from https://unisoncomputing.slack.com/archives/C03HW54CYP4/p1764083771136229