### PR TITLE
canonicalize libnames for synhashing

### DIFF
--- a/lib/unison-util-relation/src/Unison/Util/Relation.hs
+++ b/lib/unison-util-relation/src/Unison/Util/Relation.hs
@@ -715,9 +715,17 @@ mapRanMonotonic f Relation {domain, range} =
 fromMap :: (Ord a, Ord b) => Map a b -> Relation a b
 fromMap = fromList . Map.toList
 
-fromMultimap :: (Ord a, Ord b) => Map a (Set b) -> Relation a b
-fromMultimap m =
-  foldl' (\r (a, bs) -> insertManyRan a bs r) empty $ Map.toList m
+fromMultimap :: forall a b. (Ord a, Ord b) => Map a (Set b) -> Relation a b
+fromMultimap domain =
+  Relation {domain, range}
+  where
+    range :: Map b (Set a)
+    range =
+      Map.foldlWithKey' step Map.empty domain
+
+    step :: Map b (Set a) -> a -> Set b -> Map b (Set a)
+    step acc a bs =
+      Map.unionWith Set.union (Map.fromSet (const (Set.singleton a)) bs) acc
 
 toMultimap :: Relation a b -> Map a (Set b)
 toMultimap = domain

--- a/unison-cli/src/Unison/Cli/NamesUtils.hs
+++ b/unison-cli/src/Unison/Cli/NamesUtils.hs
@@ -11,7 +11,7 @@ import Unison.Cli.Monad (Cli)
 import Unison.Cli.MonadUtils qualified as Cli
 import Unison.Codebase.Branch qualified as Branch
 import Unison.Codebase.Branch.Names qualified as Branch
-import Unison.Names (Names)
+import Unison.Names (Names (..))
 
 -- | Produce a 'Names' object which contains names for the current branch.
 currentNames :: Cli Names

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/DebugSynhashTerm.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/DebugSynhashTerm.hs
@@ -17,6 +17,7 @@ import Unison.Codebase.Branch.Names qualified as Branch
 import Unison.Codebase.Editor.Output (Output (..))
 import Unison.Hash (Hash)
 import Unison.Hashable qualified as Hashable
+import Unison.Merge.Diffblob qualified as Diffblob
 import Unison.Merge.Synhash (hashBuiltinTermTokens, hashDerivedTermTokens)
 import Unison.Name (Name)
 import Unison.Names qualified as Names
@@ -33,7 +34,9 @@ handleDebugSynhashTerm :: Name -> Cli ()
 handleDebugSynhashTerm name = do
   namespace <- Cli.getCurrentBranch0
   let names = Branch.toNames namespace
-  let pped = PPED.makePPED (PPE.hqNamer 10 names) (PPE.suffixifyByHash names)
+  let pped =
+        let names1 = Diffblob.canonicalizeNamesForSynhashing names
+         in PPED.makePPED (PPE.namer names1) (PPE.suffixifyByHash names1)
 
   for_ (Names.refTermsNamed names name) \ref -> do
     maybeTokens <-

--- a/unison-merge/src/Unison/Merge/Diffblob.hs
+++ b/unison-merge/src/Unison/Merge/Diffblob.hs
@@ -4,14 +4,18 @@ module Unison.Merge.Diffblob
     makeFastForwardDiffblob,
     DiffblobLog (..),
     emptyDiffblobLog,
+    canonicalizeNamesForSynhashing,
   )
 where
 
 import Control.Lens.Fold (folded)
+import Data.Char qualified as Char
 import Data.List qualified as List
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 import Data.Set.Lens (setOf)
+import Data.Text qualified as Text
+import GHC.Base qualified as List.NonEmpty
 import Unison.DataDeclaration (Decl)
 import Unison.DataDeclaration.Dependencies qualified as Decl
 import Unison.DeclNameLookup (DeclNameLookup)
@@ -34,8 +38,11 @@ import Unison.Merge.Unconflicts (Unconflicts)
 import Unison.Merge.Updated (GUpdated (..), Updated)
 import Unison.Merge.Updated qualified as Updated
 import Unison.Name (Name)
+import Unison.Name qualified as Name
 import Unison.NameSegment (NameSegment)
-import Unison.Names (Names)
+import Unison.NameSegment qualified as NameSegment
+import Unison.NameSegment.Internal qualified as NameSegment
+import Unison.Names (Names (..))
 import Unison.NamesUtils qualified as NamesUtils
 import Unison.Parser.Ann (Ann)
 import Unison.PartialDeclNameLookup (PartialDeclNameLookup)
@@ -58,6 +65,8 @@ import Unison.Type qualified as Type
 import Unison.UnconflictedLocalDefnsView (UnconflictedLocalDefnsView (..))
 import Unison.Util.BiMultimap qualified as BiMultimap
 import Unison.Util.Defns (Defns (..), DefnsF, DefnsF2, DefnsF3, zipDefnsWith)
+import Unison.Util.Relation (Relation)
+import Unison.Util.Relation qualified as Relation
 
 data Diffblob libdep = Diffblob
   { conflicts :: TwoWay (DefnsF (Map Name) TermReference TypeReference),
@@ -402,7 +411,9 @@ makeSynhashedNarrowedDefns toTerm allNames declNameLookups defns hydratedDefns =
 
     ppeds :: ThreeWay PrettyPrintEnvDecl
     ppeds =
-      allNames <&> \names -> PPED.makePPED (PPE.namer names) (PPE.suffixifyByHash names)
+      allNames <&> \names ->
+        let names1 = canonicalizeNamesForSynhashing names
+         in PPED.makePPED (PPE.namer names1) (PPE.suffixifyByHash names1)
 
     ppe :: PrettyPrintEnv
     ppe =
@@ -422,7 +433,12 @@ makeSynhashedNarrowedDefnsForFastForward toTerm allNames declNameLookups defns h
   where
     ppeds :: Updated PrettyPrintEnvDecl
     ppeds =
-      Updated.map (\names -> PPED.makePPED (PPE.namer names) (PPE.suffixifyByHash names)) allNames
+      Updated.map
+        ( \names ->
+            let names1 = canonicalizeNamesForSynhashing names
+             in PPED.makePPED (PPE.namer names1) (PPE.suffixifyByHash names1)
+        )
+        allNames
 
     ppe :: PrettyPrintEnv
     ppe =
@@ -443,3 +459,57 @@ toLabeledDependencies defns =
     ( defns.types & foldMap \(ref, decl) ->
         Decl.labeledDeclDependenciesIncludingSelfAndFieldAccessors (Reference.DerivedId ref) decl
     )
+
+canonicalizeNamesForSynhashing :: Names -> Names
+canonicalizeNamesForSynhashing names =
+  Names (canonicalizeNames1 names.terms) (canonicalizeNames1 names.types)
+
+canonicalizeNames1 :: forall ref. (Ord ref) => Relation Name ref -> Relation Name ref
+canonicalizeNames1 =
+  Relation.fromMultimap . Map.foldlWithKey' f Map.empty . Relation.domain
+  where
+    f :: Map Name (Set ref) -> Name -> Set ref -> Map Name (Set ref)
+    f acc name refs =
+      Map.insertWith Set.union (canonicalizeName name) refs acc
+
+canonicalizeName :: Name -> Name
+canonicalizeName name =
+  case Name.segments name of
+    NameSegment.LibSegment List.NonEmpty.:| (asCanonicalizedLibname -> Just libname) : segments ->
+      Name.fromSegments (NameSegment.libSegment List.NonEmpty.:| libname : segments)
+    _ -> name
+
+-- Canonicalize a libname for the purpose of syntactic hashing.
+--
+-- Currently, we only perform one canonicalization - stripping a suffix that looks like a mangled semver, e.g. "_1_2_3".
+-- We could additionally (first) try to strip a suffix like "__2" (two underscores), which we add sometimes when a
+-- preferred name isn't available. This is just a hack that we perform to make it more likely that we classify things
+-- that are *probably* true propagated updates as such.
+asCanonicalizedLibname :: NameSegment -> Maybe NameSegment
+asCanonicalizedLibname =
+  fmap NameSegment.NameSegment . asCanonicalizedLibname1 . NameSegment.toUnescapedText
+
+-- >>> asCanonicalizedLibname1 "unison_base_1_0_0"
+-- Just "unison_base"
+--
+-- >>> asCanonicalizedLibname1 "foo"
+-- Nothing
+asCanonicalizedLibname1 :: Text -> Maybe Text
+asCanonicalizedLibname1 =
+  removeNumberFromEnd
+    >=> removeUnderscoreFromEnd
+    >=> removeNumberFromEnd
+    >=> removeUnderscoreFromEnd
+    >=> removeNumberFromEnd
+    >=> removeUnderscoreFromEnd
+  where
+    removeNumberFromEnd :: Text -> Maybe Text
+    removeNumberFromEnd s =
+      case runIdentity (Text.spanEndM (Identity . Char.isDigit) s) of
+        (s1, n) | not (Text.null n) -> Just s1
+        _ -> Nothing
+
+    removeUnderscoreFromEnd :: Text -> Maybe Text
+    removeUnderscoreFromEnd s
+      | Text.takeEnd 1 s == "_" = Just (Text.dropEnd 1 s)
+      | otherwise = Nothing

--- a/unison-src/transcripts/idempotent/branch-diff.md
+++ b/unison-src/transcripts/idempotent/branch-diff.md
@@ -300,3 +300,77 @@ scratch/topic> branch.diff /topic /main
 ``` ucm :hide
 scratch/main> project.delete scratch
 ```
+
+Libdep names are canonicalized, so differences in libdeps often register as propagated changes, not actual changes.
+
+``` ucm :hide
+scratch/main> builtins.mergeio lib.builtin
+```
+
+``` unison
+lib.dep_1_0_0.thing = 17
+foo = thing + thing
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  + foo                 : Nat
+  + lib.dep_1_0_0.thing : Nat
+
+  Run `update` to apply these changes to your codebase.
+```
+
+``` ucm
+scratch/main> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+
+scratch/main> branch topic
+
+  Done. I've created the topic branch based off of main.
+
+  Tip: To merge your work back into the main branch, first
+       `switch /main` then `merge /topic`.
+```
+
+``` unison
+lib.dep_2_0_0.thing = 18
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  + lib.dep_2_0_0.thing : Nat
+
+  Run `update` to apply these changes to your codebase.
+```
+
+``` ucm
+scratch/topic> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+
+scratch/topic> upgrade dep_1_0_0 dep_2_0_0
+
+  I upgraded dep_1_0_0 to dep_2_0_0.
+
+scratch/topic> diff.branch /main /topic
+
+  Changes on /topic:
+
+  + lib.dep_2_0_0
+  - lib.dep_1_0_0
+
+  + (added), - (deleted)
+```
+
+``` ucm :hide
+scratch/main> project.delete scratch
+```


### PR DESCRIPTION
## Overview

This PR implements a simple "canonicalize names" step before synhashing (for diff / merge calculations). The intention is to make changes to library dependencies (i.e. upgrades) register as propagated updates.

The existing (trunk) implementation of synhashing, omitting a couple minor details, considers two terms synhash-equal if they render the same (without suffixification).

That mostly works, but not for when one branch swaps out one library for another whilst also changing the library's name (e.g. `lib.base_1_0_0` -> `lib.base_2_0_0`).

In this PR, we simply form a canonicalization step (for the pretty-print environment used in synhashing) for names of the form `lib.*_X_Y_Z.*`, where `X`, `Y`, and `Z` are numbers. For example, `lib.base_1_0_0.data.List.map` gets canonicalized to `lib.base.data.List.map`. This matches how we mangle released libraries with semantic version numbers.

## Test coverage

I added a transcript to `branch.diff.md` to demonstrate that we don't classify library upgrades as propagated updates, when the library names fit the `_X_Y_Z` mold. I also inspected synhashes manually at the command line.

## Loose ends

We'll want to bump Share too, so it can perform the same canonicalization when producing diffs