### PR TITLE
Fix typo in init command help message

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -94,3 +94,4 @@ The format for this list: name, GitHub handle
 * Erik Schnetter (@eschnett)
 * Régis Kuckaertz (@regiskuckaertz)
 * Emil Petersen (@leetemil)
+* Lars Wilhelmsen (@larsw)

--- a/unison-cli/src/ArgParse.hs
+++ b/unison-cli/src/ArgParse.hs
@@ -186,7 +186,7 @@ initCommand :: Mod CommandFields Command
 initCommand = command "init" (info initParser (progDesc initHelp))
   where
     initHelp =
-      "This command is has been removed. Use --codebase-create instead to create a codebase in the specified directory when starting the UCM."
+      "This command has been removed. Use --codebase-create instead to create a codebase in the specified directory when starting the UCM."
 
 runDesc :: String -> String -> String
 runDesc cmd location =


### PR DESCRIPTION
Removed an extraneous "is" from the text.

