### PR TITLE
pretty-print symboly binders with surrounding parens

### DIFF
--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -653,7 +653,7 @@ pretty0
 
       isDelay (Delay' _) = True
       isDelay _ = False
-      varList = intercalateMap PP.softbreak (PP.text . Var.name)
+      varList = intercalateMap PP.softbreak prettyBinder
 
       nonForcePred :: Term3 v PrintAnnotation -> Bool
       nonForcePred = \case
@@ -1071,20 +1071,20 @@ prettyBinding0' a@AmbientContext {imports = im, docContext = doc} v term =
               x : y : _ ->
                 PP.sep
                   " "
-                  [ fmt S.Var $ PP.text (Var.name x),
+                  [ fmt S.Var $ prettyBinder x,
                     styleHashQualified'' (fmt $ S.HashQualifier v) $ elideFQN im v,
-                    fmt S.Var $ PP.text (Var.name y)
+                    fmt S.Var $ prettyBinder y
                   ]
               [x] ->
                 PP.sep
                   " "
                   [ renderName v,
-                    fmt S.Var $ PP.text (Var.name x)
+                    fmt S.Var $ prettyBinder x
                   ]
               _ -> l "error"
           | null vs = renderName v
           | otherwise = renderName v `PP.hang` args vs
-        args = PP.spacedMap $ fmt S.Var . PP.text . Var.name
+        args = PP.spacedMap $ fmt S.Var . prettyBinder
         renderName n =
           let n' = elideFQN im n
            in parenIfInfix n' NonInfix $ styleHashQualified'' (fmt $ S.HashQualifier n') n'
@@ -2356,6 +2356,13 @@ avoidShadowing tm (PrettyPrintEnv terms types) =
     tweak _ p = p
     varToName :: (Var v) => v -> [Name]
     varToName = toList . Name.parseText . Var.name . Var.reset
+
+prettyBinder :: (IsString s, Var v) => v -> Pretty s
+prettyBinder var =
+  let text = Var.name var
+   in case Name.parseText text of
+        Just name | Name.isSymboly name -> "(" <> PP.text text <> ")"
+        _ -> PP.text text
 
 isLeaf :: Term2 vt at ap v a -> Bool
 isLeaf (Var' {}) = True

--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -653,8 +653,7 @@ pretty0
 
       isDelay (Delay' _) = True
       isDelay _ = False
-      sepList' f sep xs = fold . intersperse sep <$> traverse f xs
-      varList = runIdentity . sepList' (Identity . PP.text . Var.name) PP.softbreak
+      varList = intercalateMap PP.softbreak (PP.text . Var.name)
 
       nonForcePred :: Term3 v PrintAnnotation -> Bool
       nonForcePred = \case

--- a/unison-src/transcripts/idempotent/fix-5317.md
+++ b/unison-src/transcripts/idempotent/fix-5317.md
@@ -1,0 +1,41 @@
+This transcript demonstrates a fix to \#5317. Previously, both of these terms would print without parens surrounding the binder.
+
+``` ucm
+scratch/main> builtins.merge lib.builtin
+
+  Done.
+```
+
+``` unison
+foo : a -> Nat
+foo (+) = 17
+
+bar : Nat
+bar = ((+) -> 17) ()
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  + bar : Nat
+  + foo : a -> Nat
+
+  Run `update` to apply these changes to your codebase.
+```
+
+``` ucm
+scratch/main> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+
+scratch/main> view foo bar
+
+  bar : Nat
+  bar = ((+) -> 17) ()
+
+  foo : a -> Nat
+  foo (+) = 17
+```

--- a/unison-src/transcripts/pretty-print-libraries.output.md
+++ b/unison-src/transcripts/pretty-print-libraries.output.md
@@ -73623,8 +73623,8 @@ test.laws.associativity.doc =
   returned by `gen`, `f x (f y z)` is equal to `f (f x y) z`.
   
   For example, if `f` is {Nat.+}, then {{
-  docExample 4 do x + y z -> x + (y + z) }} is equal to
-  {{ docExample 4 do + x y z -> x + y + z }}.
+  docExample 4 do x (+) y z -> x + (y + z) }} is equal to
+  {{ docExample 4 do (+) x y z -> x + y + z }}.
   }}
 
 test.laws.commutativity :


### PR DESCRIPTION
## Overview

Fixes #5317

## Test coverage

I've added a transcript that demonstrates the fix

## Loose ends

In investigating this issue, I discovered that we are also willing to generate symboly type variables (when a user doesn't supply a type sig) that we can't then parse back.

Example type signature:

```
foo : forall +. + -> +
```

That seems related to this issue, though probably not as likely to actually happen.

FWIW, I'm not sure we should have ever even allowed symboly binders, but that ship has probably sailed