### PR TITLE
Only check for incomplete element orderings on top-level-bindings

### DIFF
--- a/codebase2/codebase/U/Codebase/Term.hs
+++ b/codebase2/codebase/U/Codebase/Term.hs
@@ -51,8 +51,6 @@ type F vt =
     TypeLink
     vt
 
-type IsTop = Bool
-
 -- | Generalized version.  We could generalize further to allow sharing within
 --  terms.
 data F' text termRef typeRef termLink typeLink vt a

--- a/codebase2/codebase/U/Codebase/Term.hs
+++ b/codebase2/codebase/U/Codebase/Term.hs
@@ -51,6 +51,8 @@ type F vt =
     TypeLink
     vt
 
+type IsTop = Bool
+
 -- | Generalized version.  We could generalize further to allow sharing within
 --  terms.
 data F' text termRef typeRef termLink typeLink vt a

--- a/unison-hashing-v2/src/Unison/Hashing/V2/ABT.hs
+++ b/unison-hashing-v2/src/Unison/Hashing/V2/ABT.hs
@@ -17,9 +17,10 @@ module Unison.Hashing.V2.ABT
 where
 
 import Control.Exception (throw)
-import Data.Containers.ListUtils qualified as List
 import Data.List hiding (cycle, find)
 import Data.List qualified as List (sort)
+import Data.List.NonEmpty (NonEmpty)
+import Data.List.NonEmpty qualified as NEL
 import Data.Map qualified as Map
 import Data.Set qualified as Set
 import Unison.ABT
@@ -32,7 +33,7 @@ import Prelude hiding (abs, cycle)
 data HashingFailure
   = -- | two or more component elements can not be completely ordered with respect to one another
     -- https://github.com/unisonweb/unison/issues/2787
-    IncompleteElementOrderingError ([String {- Variable names of component definitions -}])
+    IncompleteElementOrderingError (NonEmpty (NonEmpty String {- Each list is a set of structurally equivalent component elements -}))
   deriving stock (Eq, Ord)
   deriving anyclass (Exception)
 
@@ -41,15 +42,20 @@ instance Show HashingFailure where
     where
       renderHashingFailure :: HashingFailure -> String
       renderHashingFailure = \case
-        IncompleteElementOrderingError names ->
+        IncompleteElementOrderingError equivalenceSets ->
           unlines
             [ "🐞",
               "",
               "Sorry, you've encountered a weird situation that we are aware of and are currently working on a fix for.",
               "I'll explain what happened and how you can work around it.",
               "",
-              "The following cyclic definitions could not be completely ordered:",
-              "  " ++ intercalate ", " names,
+              "The following cyclic definition sets could not be completely ordered:",
+              toList equivalenceSets
+                <&> ( \vs ->
+                        "  * " <> intercalate ", " (toList vs)
+                    )
+                & unlines,
+              "",
               "This happens when multiple definitions in a mutually recursive cycle have a very similar structure.",
               "",
               "You can work around this by restructuring them to be less similar, e.g. by adding a pure expression to distinguish them, like:",
@@ -163,6 +169,8 @@ hash' env = \case
   where
     hashCycle :: [v] -> [Either [v] v] -> [Term f v a] -> Either HashingFailure ([Hash], Term f v a -> Hash)
     hashCycle cycle env ts = do
+      -- isTop is always false when called via `hash'`, we only set it to True
+      -- when calling from `hashComponent`
       let isTop = False
       (ts', env') <- doHashCycle isTop env (zip cycle ts)
       pure (ts', hash' env')
@@ -179,13 +187,24 @@ doHashCycle ::
 doHashCycle isTop env namedTerms = do
   -- Ensure that all of the hashes we use for ordering components are unique;
   -- if not, we have an incomplete ordering of the elements in the cycle
-  when (isTop && List.nubOrd hashes /= hashes) $ Left $ IncompleteElementOrderingError (show <$> names)
+  when isTop $ do
+    -- Error if there are any structurally equivalent elements
+    for_ structurallyEquivalentElements \vs -> do
+      -- Sort them so they're deterministic in transcripts
+      let sortedVars =
+            vs
+              <&> (NEL.sort . fmap show)
+              & NEL.sort
+      Left $ IncompleteElementOrderingError sortedVars
   pure $ (map (hash' newEnv) permutedTerms, newEnv)
   where
     names = map fst namedTerms
     -- The environment in which we compute the canonical permutation of terms
     permutationEnv = Left names : env
-    hashes = (hash' permutationEnv . snd) <$> namedTerms
+    namedHashes :: [(v, Hash)]
+    namedHashes = second (hash' permutationEnv) <$> namedTerms
+    hashes :: [Hash]
+    hashes = snd <$> namedHashes
     (permutedNames, permutedTerms) =
       zip namedTerms hashes
         & sortOn snd
@@ -194,3 +213,11 @@ doHashCycle isTop env namedTerms = do
     -- The new environment, which includes the names of all of the terms in the cycle, now that we have computed their
     -- canonical ordering
     newEnv = map Right permutedNames ++ env
+    structurallyEquivalentElements :: Maybe (NonEmpty (NonEmpty v))
+    structurallyEquivalentElements =
+      namedHashes
+        <&> (\(v, h) -> (h, [v]))
+        & Map.fromListWith (<>)
+        & mapMaybe (\xs -> guard (length xs > 1) *> NEL.nonEmpty xs)
+        & Map.elems
+        & NEL.nonEmpty

--- a/unison-hashing-v2/src/Unison/Hashing/V2/ABT.hs
+++ b/unison-hashing-v2/src/Unison/Hashing/V2/ABT.hs
@@ -74,7 +74,8 @@ hashComponent byName = do
   let ts = Map.toList byName
   -- First, compute a canonical hash ordering of the component, as well as an environment in which we can hash
   -- individual names.
-  (hashes, env) <- doHashCycle [] ts
+  let isTop = True
+  (hashes, env) <- doHashCycle isTop [] ts
   -- Construct a list of tokens that is shared by all members of the component. They are disambiguated only by their
   -- name that gets tumbled into the hash.
   let commonTokens :: [Hashable.Token]
@@ -156,13 +157,14 @@ hash' env = \case
             ++ show v
             ++ " environment = "
             ++ show env
-  Cycle' vs t -> hash1 (crashOnHashingFailure . hashCycle vs env) undefined t
+  Cycle' vs t -> hash1 (\ts -> crashOnHashingFailure $ hashCycle vs env ts) undefined t
   Abs'' v t -> hash' (Right v : env) t
   Tm' t -> hash1 (\ts -> (List.sort (map (hash' env) ts), hash' env)) (hash' env) t
   where
     hashCycle :: [v] -> [Either [v] v] -> [Term f v a] -> Either HashingFailure ([Hash], Term f v a -> Hash)
     hashCycle cycle env ts = do
-      (ts', env') <- doHashCycle env (zip cycle ts)
+      let isTop = False
+      (ts', env') <- doHashCycle isTop env (zip cycle ts)
       pure (ts', hash' env')
 
 -- | @doHashCycle env terms@ hashes cycle @terms@ in environment @env@, and returns the canonical ordering of the hashes
@@ -170,13 +172,14 @@ hash' env = \case
 doHashCycle ::
   forall a f v.
   (Eq v, Functor f, Hashable1 f, Show v) =>
+  Bool ->
   [Either [v] v] ->
   [(v, Term f v a)] ->
   Either HashingFailure ([Hash], [Either [v] v])
-doHashCycle env namedTerms = do
+doHashCycle isTop env namedTerms = do
   -- Ensure that all of the hashes we use for ordering components are unique;
   -- if not, we have an incomplete ordering of the elements in the cycle
-  when (List.nubOrd hashes /= hashes) $ Left $ IncompleteElementOrderingError (show <$> names)
+  when (isTop && List.nubOrd hashes /= hashes) $ Left $ IncompleteElementOrderingError (show <$> names)
   pure $ (map (hash' newEnv) permutedTerms, newEnv)
   where
     names = map fst namedTerms

--- a/unison-hashing-v2/src/Unison/Hashing/V2/DataDeclaration.hs
+++ b/unison-hashing-v2/src/Unison/Hashing/V2/DataDeclaration.hs
@@ -121,6 +121,7 @@ instance Hashable1 F where
               let (hashes, hash') = hashCycle bindings
                in [tag 1] ++ map hashed hashes ++ [hashed $ hash' body]
             Constructors cs ->
+              -- Should constructors be considered top-level?
               let (hashes, _) = hashCycle cs
                in tag 2 : map hashed hashes
             Modified m t ->

--- a/unison-src/transcripts/errors/incomplete-data-element-ordering-error.md
+++ b/unison-src/transcripts/errors/incomplete-data-element-ordering-error.md
@@ -1,0 +1,16 @@
+```ucm
+scratch/main> builtins.merge
+```
+
+These should error, this is because each element in the cycle is identical to one another except for the internal references.
+
+We can't allow these terms into the codebase because in certain cases there are multiple valid distinct components which
+would receive the same hash.
+
+```unison
+structural type CycleA =
+  OneA Int CycleB
+
+structural type CycleB =
+  OneB Int CycleA
+```

--- a/unison-src/transcripts/errors/incomplete-data-element-ordering-error.output.md
+++ b/unison-src/transcripts/errors/incomplete-data-element-ordering-error.output.md
@@ -1,0 +1,24 @@
+Exception when running incomplete-data-element-ordering-error.md: 🐞
+
+🐞
+
+Sorry, you've encountered a weird situation that we are aware of and are currently working on a fix for.
+I'll explain what happened and how you can work around it.
+
+The following cyclic definitions could not be completely ordered:
+  User "CycleA", User "CycleB"
+This happens when multiple definitions in a mutually recursive cycle have a very similar structure.
+
+You can work around this by restructuring them to be less similar, e.g. by adding a pure expression to distinguish them, like:
+_ = "this is the foo definition"
+
+
+This is a Unison bug and you can report it here:
+
+https://github.com/unisonweb/unison/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+E253299+
+
+Bug reference: E253299
+
+If there's already an issue with this reference, you can give a 👍
+on the issue to let the team know you encountered it, and you can add
+any additional details you know of to the issue.

--- a/unison-src/transcripts/errors/incomplete-data-element-ordering-error.output.md
+++ b/unison-src/transcripts/errors/incomplete-data-element-ordering-error.output.md
@@ -5,8 +5,10 @@ Exception when running incomplete-data-element-ordering-error.md: 🐞
 Sorry, you've encountered a weird situation that we are aware of and are currently working on a fix for.
 I'll explain what happened and how you can work around it.
 
-The following cyclic definitions could not be completely ordered:
-  User "CycleA", User "CycleB"
+The following cyclic definition sets could not be completely ordered:
+  * User "CycleA", User "CycleB"
+
+
 This happens when multiple definitions in a mutually recursive cycle have a very similar structure.
 
 You can work around this by restructuring them to be less similar, e.g. by adding a pure expression to distinguish them, like:

--- a/unison-src/transcripts/errors/incomplete-element-ordering-error.md
+++ b/unison-src/transcripts/errors/incomplete-element-ordering-error.md
@@ -1,9 +1,0 @@
-These should error.
-
-```unison :error
-foo = do
-  bar ()
-
-bar = do
-  foo ()
-```

--- a/unison-src/transcripts/errors/incomplete-element-ordering-error.md
+++ b/unison-src/transcripts/errors/incomplete-element-ordering-error.md
@@ -1,3 +1,5 @@
+These should error.
+
 ```unison :error
 foo = do
   bar ()

--- a/unison-src/transcripts/errors/incomplete-term-element-ordering-error.md
+++ b/unison-src/transcripts/errors/incomplete-term-element-ordering-error.md
@@ -1,0 +1,12 @@
+These should error, this is because each term element is identical to one another except for the internal references.
+
+We can't allow these terms into the codebase because in certain cases there are multiple valid distinct components which
+would receive the same hash.
+
+```unison :error
+foo = do
+  bar ()
+
+bar = do
+  foo ()
+```

--- a/unison-src/transcripts/errors/incomplete-term-element-ordering-error.output.md
+++ b/unison-src/transcripts/errors/incomplete-term-element-ordering-error.output.md
@@ -1,4 +1,4 @@
-Exception when running incomplete-element-ordering-error.md: 🐞
+Exception when running incomplete-term-element-ordering-error.md: 🐞
 
 🐞
 

--- a/unison-src/transcripts/errors/incomplete-term-element-ordering-error.output.md
+++ b/unison-src/transcripts/errors/incomplete-term-element-ordering-error.output.md
@@ -5,8 +5,10 @@ Exception when running incomplete-term-element-ordering-error.md: 🐞
 Sorry, you've encountered a weird situation that we are aware of and are currently working on a fix for.
 I'll explain what happened and how you can work around it.
 
-The following cyclic definitions could not be completely ordered:
-  User "bar", User "foo"
+The following cyclic definition sets could not be completely ordered:
+  * User "bar", User "foo"
+
+
 This happens when multiple definitions in a mutually recursive cycle have a very similar structure.
 
 You can work around this by restructuring them to be less similar, e.g. by adding a pure expression to distinguish them, like:

--- a/unison-src/transcripts/idempotent/internal-incomplete-element-ordering.md
+++ b/unison-src/transcripts/idempotent/internal-incomplete-element-ordering.md
@@ -1,7 +1,8 @@
-```ucm
+``` ucm
 scratch/main> builtins.merge
-```
 
+  Done.
+```
 
 This creates a cycle of structurally equivalent elements, which have an ambiguous ordering.
 
@@ -10,9 +11,17 @@ On top level components this is an error, but we don't want to error on letrecs 
 See `unison-src/transcripts/errors/incomplete-element-ordering.md` for
 examples which should trigger failures.
 
-```unison
+``` unison
 foo =
   x = do 1 + y()
   y = do 1 + x()
   x ()
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  + foo : Nat
+
+  Run `update` to apply these changes to your codebase.
 ```

--- a/unison-src/transcripts/idempotent/internal-incomplete-element-ordering.md
+++ b/unison-src/transcripts/idempotent/internal-incomplete-element-ordering.md
@@ -1,0 +1,13 @@
+This creates a cycle of structurally equivalent elements, which have an ambiguous ordering.
+
+On top level components this is an error, but we don't want to error on letrecs which are internal to a definition.
+
+See `unison-src/transcripts/errors/incomplete-element-ordering.md` for
+examples which should trigger failures.
+
+```unison
+foo =
+  x = do 1 + y()
+  y = do 1 + x()
+  x ()
+```

--- a/unison-src/transcripts/idempotent/internal-incomplete-element-ordering.md
+++ b/unison-src/transcripts/idempotent/internal-incomplete-element-ordering.md
@@ -1,3 +1,8 @@
+```ucm
+scratch/main> builtins.merge
+```
+
+
 This creates a cycle of structurally equivalent elements, which have an ambiguous ordering.
 
 On top level components this is an error, but we don't want to error on letrecs which are internal to a definition.


### PR DESCRIPTION
## Overview

in https://github.com/unisonweb/unison/pull/6007 I introduced checks to prevent creation of certain classes of problematic components for which there were multiple possible components for the same hash;

However in doing so, it also triggered failures where valid definitions contained structurally equivalent letrec-bindings

This change makes it so we only trigger the error on top-level bindings, not internal let-recs.

See https://www.notion.so/unisonweb/Cycle-Hashing-Issue-2bf5fbdd830d80c8b2ffe821c0f8638a?showMoveTo=true&saveParent=true for some more internal notes on the issue.

## Implementation approach and notes

The original plan was to use `IsTop` from the ABT Term Functor to determine whether we were hashing the top-level cycle, however this didn't work in all cases because the V2 Term Functor doesn't have an IsTop, and adding one would affect the serialization format which is no good;

Instead I added an argument to `doHashCycle` for `isTop`, and set it to true on the initial call to `hashComponents` and False when we recurse. 

I'm not 100% positive of the behaviour here, but it does seem to be working as expected in tests.

## Test coverage

* Added a new transcript for testing that we _don't_ fail on internal cycles
* Left existing transcript which asserts that we _do_ fail on top-level cycles (when structurally equivalent)
* Added a transcript testing that we _do_ fail on structurally equivalent elements within structural data type cycles