### PR TITLE
Add FQN to syntax text

### DIFF
--- a/lib/unison-pretty-printer/src/Unison/Util/ColorText.hs
+++ b/lib/unison-pretty-printer/src/Unison/Util/ColorText.hs
@@ -179,8 +179,8 @@ defaultColors = \case
   ST.BooleanLiteral -> Nothing
   ST.Blank -> Nothing
   ST.Var -> Nothing
-  ST.TypeReference _ -> Nothing
-  ST.TermReference _ -> Nothing
+  ST.TypeReference {} -> Nothing
+  ST.TermReference {} -> Nothing
   ST.Op _ -> Nothing
   ST.Unit -> Nothing
   ST.AbilityBraces -> Just HiPurple

--- a/lib/unison-pretty-printer/src/Unison/Util/SyntaxText.hs
+++ b/lib/unison-pretty-printer/src/Unison/Util/SyntaxText.hs
@@ -18,8 +18,8 @@ data Element r
   | BooleanLiteral
   | Blank
   | Var
-  | TypeReference r
-  | TermReference (Referent' r)
+  | TypeReference (Maybe Name {- fqn, if it has one -}) r
+  | TermReference (Maybe Name {- fqn, if it has one -}) (Referent' r)
   | Op SeqOp
   | AbilityBraces
   | -- let|handle|in|where|match|with|cases|->|if|then|else|and|or

--- a/parser-typechecker/src/Unison/PrettyPrintEnv.hs
+++ b/parser-typechecker/src/Unison/PrettyPrintEnv.hs
@@ -3,7 +3,9 @@ module Unison.PrettyPrintEnv
     patterns,
     patternName,
     terms,
+    termFQN,
     types,
+    typeFQN,
     allTermNames,
     allTypeNames,
     termName,
@@ -57,6 +59,12 @@ terms ppe = fmap snd . listToMaybe . termNames ppe
 
 types :: PrettyPrintEnv -> Reference -> Maybe (HQ'.HashQualified Name)
 types ppe = fmap snd . listToMaybe . typeNames ppe
+
+termFQN :: PrettyPrintEnv -> Referent -> Maybe Name
+termFQN ppe = fmap (HQ'.toName . fst) . listToMaybe . termNames ppe
+
+typeFQN :: PrettyPrintEnv -> Reference -> Maybe Name
+typeFQN ppe = fmap (HQ'.toName . fst) . listToMaybe . typeNames ppe
 
 termNameOrHashOnly :: PrettyPrintEnv -> Referent -> HQ.HashQualified Name
 termNameOrHashOnly ppe r = maybe (HQ.fromReferent r) HQ'.toHQ $ terms ppe r

--- a/parser-typechecker/src/Unison/Syntax/DeclPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/DeclPrinter.hs
@@ -112,7 +112,7 @@ prettyPattern ::
   Pretty SyntaxText
 prettyPattern env ctorType namespace ref =
   styleHashQualified''
-    (fmt (S.TermReference conRef))
+    (fmt (S.TermReference (PPE.termFQN env conRef) conRef))
     ( let strip =
             case HQ.toName namespace of
               Nothing -> id
@@ -164,9 +164,9 @@ prettyDataDecl (PrettyPrintEnvDecl unsuffixifiedPPE suffixifiedPPE) guid r name 
                 (fmt S.DelimiterChar "," <> " " `P.orElse` "\n      ")
                 (field <$> zip fieldNames (init ts))
               <> fmt S.DelimiterChar " }"
-    field (fname, typ) =
+    field (fname, typ) = do
       P.group $
-        fmt (S.TypeReference r) (prettyName fname)
+        fmt (S.TypeReference (PPE.typeFQN suffixifiedPPE r) r) (prettyName fname)
           <> fmt S.TypeAscriptionColon " :"
             `P.hang` runPretty suffixifiedPPE (TypePrinter.prettyRaw Map.empty (-1) typ)
     header = prettyDataHeader guid name dd <> fmt S.DelimiterChar (" = " `P.orElse` "\n  = ")

--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -234,19 +234,19 @@ pretty0
           Ref' r -> do
             env <- ask
             let name = elideFQN im $ PrettyPrintEnv.termName env.ppe (Referent.Ref r)
-            pure . parenIfInfix name ic $ styleHashQualified'' (fmt $ S.TermReference (Referent.Ref r)) name
+            pure . parenIfInfix name ic $ styleHashQualified'' (fmt $ S.TermReference (PrettyPrintEnv.termFQN env.ppe (Referent.Ref r)) (Referent.Ref r)) name
           TermLink' r -> do
             env <- ask
             let name = elideFQN im $ PrettyPrintEnv.termName env.ppe r
             pure . paren (p >= Application) $
               fmt S.LinkKeyword "termLink "
-                <> parenIfInfix name ic (styleHashQualified'' (fmt $ S.TermReference r) name)
+                <> parenIfInfix name ic (styleHashQualified'' (fmt $ S.TermReference (PrettyPrintEnv.termFQN env.ppe r) r) name)
           TypeLink' r -> do
             env <- ask
             let name = elideFQN im $ PrettyPrintEnv.typeName env.ppe r
             pure . paren (p >= Application) $
               fmt S.LinkKeyword "typeLink "
-                <> parenIfInfix name ic (styleHashQualified'' (fmt $ S.TypeReference r) name)
+                <> parenIfInfix name ic (styleHashQualified'' (fmt $ S.TypeReference (PrettyPrintEnv.typeFQN env.ppe r) r) name)
           Ann' tm t -> do
             tm' <- pretty0 (ac Application Normal im doc) tm
             tp' <- TypePrinter.pretty0 im 0 t
@@ -289,12 +289,12 @@ pretty0
             env <- ask
             let name = elideFQN im $ PrettyPrintEnv.termName env.ppe conRef
                 conRef = Referent.Con ref CT.Data
-            pure $ styleHashQualified'' (fmt $ S.TermReference conRef) name
+            pure $ styleHashQualified'' (fmt $ S.TermReference (PrettyPrintEnv.termFQN env.ppe conRef) conRef) name
           Request' ref -> do
             env <- ask
             let name = elideFQN im $ PrettyPrintEnv.termName env.ppe conRef
                 conRef = Referent.Con ref CT.Effect
-            pure $ styleHashQualified'' (fmt $ S.TermReference conRef) name
+            pure $ styleHashQualified'' (fmt $ S.TermReference (PrettyPrintEnv.termFQN env.ppe conRef) conRef) name
           Handle' h body -> do
             pb <- pretty0 (ac Annotation Block im doc) body
             ph <- pretty0 (ac Annotation Block im doc) h
@@ -340,7 +340,8 @@ pretty0
             pure . paren (p > Control) $
               fmt S.ControlKeyword "do" `hang` PP.lines (uses <> [PP.indentNAfterNewline indent px])
           List' xs -> do
-            let listLink p = fmt (S.TypeReference Type.listRef) p
+            env <- ask
+            let listLink p = fmt (S.TypeReference (PrettyPrintEnv.typeFQN env.ppe Type.listRef) Type.listRef) p
             let comma = listLink ", " `PP.orElse` ("\n" <> listLink ", ")
             pelems <- traverse (fmap (PP.indentNAfterNewline 2) . pretty0 (ac Annotation Normal im doc)) xs
             let open = listLink "[" `PP.orElse` listLink "[ "
@@ -543,13 +544,14 @@ pretty0
                 let conRef = DD.pairCtorRef
                 env <- ask
                 let name = elideFQN im (PrettyPrintEnv.termName env.ppe conRef)
-                let pair = parenIfInfix name ic $ styleHashQualified'' (fmt (S.TermReference conRef)) name
+                let pair = parenIfInfix name ic $ styleHashQualified'' (fmt (S.TermReference (PrettyPrintEnv.termFQN env.ppe conRef) conRef)) name
                 x' <- pretty0 (ac Application Normal im doc) x
                 pure . paren (p >= Application) $
                   pair
-                    `PP.hang` PP.spaced [x', fmt (S.TermReference DD.unitCtorRef) "()"]
+                    `PP.hang` PP.spaced [x', fmt (S.TermReference (PrettyPrintEnv.termFQN env.ppe DD.unitCtorRef) DD.unitCtorRef) "()"]
               (TupleTerm' xs, _) -> do
-                let tupleLink p = fmt (S.TypeReference DD.pairRef) p
+                env <- ask
+                let tupleLink p = fmt (S.TypeReference (PrettyPrintEnv.typeFQN env.ppe DD.pairRef) DD.pairRef) p
                 let comma = tupleLink ", " `PP.orElse` ("\n" <> tupleLink ", ")
                 pelems <- traverse (fmap (PP.indentNAfterNewline 2) . goNormal Annotation) xs
                 let clist = PP.sep comma pelems
@@ -744,7 +746,7 @@ prettyPattern n c@AmbientContext {imports = im} p vs patt = case patt of
         let (pats_printed, tail_vs) = patterns Bottom vs pats
          in (PP.parenthesizeCommas pats_printed, tail_vs)
   Pattern.Constructor _ ref [] ->
-    (styleHashQualified'' (fmt $ S.TermReference conRef) name, vs)
+    (styleHashQualified'' (fmt $ S.TermReference (PrettyPrintEnv.termFQN n conRef) conRef) name, vs)
     where
       name = elideFQN im $ PrettyPrintEnv.termName n conRef
       conRef = Referent.Con ref CT.Data
@@ -753,7 +755,7 @@ prettyPattern n c@AmbientContext {imports = im} p vs patt = case patt of
         name = elideFQN im $ PrettyPrintEnv.termName n conRef
         conRef = Referent.Con ref CT.Data
      in ( paren (p >= Application) $
-            styleHashQualified'' (fmt $ S.TermReference conRef) name
+            styleHashQualified'' (fmt $ S.TermReference (PrettyPrintEnv.termFQN n conRef) conRef) name
               `PP.hang` pats_printed,
           tail_vs
         )
@@ -774,7 +776,7 @@ prettyPattern n c@AmbientContext {imports = im} p vs patt = case patt of
      in ( PP.group
             ( PP.sep " " . PP.nonEmpty $
                 [ fmt S.DelimiterChar "{",
-                  styleHashQualified'' (fmt (S.TermReference conRef)) name,
+                  styleHashQualified'' (fmt (S.TermReference (PrettyPrintEnv.termFQN n conRef) conRef)) name,
                   pats_printed,
                   fmt S.ControlKeyword "->",
                   k_pat_printed,
@@ -1121,9 +1123,9 @@ prettyDoc n im term =
     go (DD.DocJoin segs) = foldMap go segs
     go (DD.DocBlob txt) = PP.paragraphyText (escaped txt)
     go (DD.DocLink (DD.LinkTerm (TermLink' r))) =
-      curlyRef . fmt (S.TermReference r) $ fmtTerm r
+      curlyRef . fmt (S.TermReference (PrettyPrintEnv.termFQN n r) r) $ fmtTerm r
     go (DD.DocLink (DD.LinkType (TypeLink' r))) =
-      curlyRef $ fmt S.DocKeyword (l "type ") <> fmt (S.TypeReference r) (fmtType r)
+      curlyRef $ fmt S.DocKeyword (l "type ") <> fmt (S.TypeReference (PrettyPrintEnv.typeFQN n r) r) (fmtType r)
     go (DD.DocSource (DD.LinkTerm (TermLink' r))) =
       atKeyword "source" $ fmtTerm r
     go (DD.DocSource (DD.LinkType (TypeLink' r))) =
@@ -2060,8 +2062,8 @@ prettyDoc2 ac tm = do
         tm -> bail tm
         where
           im = imports ac
-          tyName r = styleHashQualified'' (fmt $ S.TypeReference r) . elideFQN im $ PrettyPrintEnv.typeName env.ppe r
-          tmName r = styleHashQualified'' (fmt $ S.TermReference r) . elideFQN im $ PrettyPrintEnv.termName env.ppe r
+          tyName r = styleHashQualified'' (fmt $ S.TypeReference (PrettyPrintEnv.typeFQN env.ppe r) r) . elideFQN im $ PrettyPrintEnv.typeName env.ppe r
+          tmName r = styleHashQualified'' (fmt $ S.TermReference (PrettyPrintEnv.termFQN env.ppe r) r) . elideFQN im $ PrettyPrintEnv.termName env.ppe r
           rec = go hdr
           sepBlankline = intercalateMapM "\n\n" rec
   case tm of

--- a/parser-typechecker/src/Unison/Syntax/TypePrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TypePrinter.hs
@@ -99,7 +99,7 @@ prettyRaw im p tp = go im p tp
       -- Would be nice to use a different SyntaxHighlights color if the reference is an ability.
       Ref' r -> do
         env <- ask
-        pure $ styleHashQualified'' (fmt $ S.TypeReference r) $ elideFQN im (PrettyPrintEnv.typeName env.ppe r)
+        pure $ styleHashQualified'' (fmt $ S.TypeReference (PrettyPrintEnv.typeFQN env.ppe r) r) $ elideFQN im (PrettyPrintEnv.typeName env.ppe r)
       Cycle' _ _ -> pure $ fromString "bug: TypeParser does not currently emit Cycle"
       Abs' _ -> pure $ fromString "bug: TypeParser does not currently emit Abs"
       Ann' _ _ -> pure $ fromString "bug: TypeParser does not currently emit Ann"
@@ -205,7 +205,7 @@ prettySignaturesST ppe ts =
   PP.align . runPretty ppe $ traverse (\(r, hq, typ) -> (name r hq,) <$> sig typ) ts
   where
     name r hq =
-      styleHashQualified'' (fmt $ S.TermReference r) hq
+      styleHashQualified'' (fmt $ S.TermReference (PrettyPrintEnv.termFQN ppe r) r) hq
     sig typ = do
       t <- pretty0 Map.empty (-1) typ
       let col = fmt S.TypeAscriptionColon ": "

--- a/unison-cli/src/Unison/CommandLine/DisplayValues.hs
+++ b/unison-cli/src/Unison/CommandLine/DisplayValues.hs
@@ -345,13 +345,13 @@ displayDoc pped terms typeOf evaluated types = go
 termName :: PPE.PrettyPrintEnv -> Referent -> Pretty
 termName ppe r =
   P.syntaxToColor $
-    NP.styleHashQualified'' (NP.fmt $ S.TermReference r) name
+    NP.styleHashQualified'' (NP.fmt $ S.TermReference (PPE.termFQN ppe r) r) name
   where
     name = PPE.termName ppe r
 
 typeName :: PPE.PrettyPrintEnv -> Reference -> Pretty
 typeName ppe r =
   P.syntaxToColor $
-    NP.styleHashQualified'' (NP.fmt $ S.TypeReference r) name
+    NP.styleHashQualified'' (NP.fmt $ S.TypeReference (PPE.typeFQN ppe r) r) name
   where
     name = PPE.typeName ppe r

--- a/unison-share-api/src/Unison/Server/Backend/DefinitionDiff.hs
+++ b/unison-share-api/src/Unison/Server/Backend/DefinitionDiff.hs
@@ -176,10 +176,10 @@ semanticLinewiseDiff (AnnotatedText lhs) (AnnotatedText rhs) =
         where
           elementHash :: Syntax.Element -> Maybe Syntax.UnisonHash
           elementHash = \case
-            Syntax.TypeReference hash -> Just hash
-            Syntax.TermReference hash -> Just hash
-            Syntax.DataConstructorReference hash -> Just hash
-            Syntax.AbilityConstructorReference hash -> Just hash
+            Syntax.TypeReference _fqn hash -> Just hash
+            Syntax.TermReference _fqn hash -> Just hash
+            Syntax.DataConstructorReference _fqn hash -> Just hash
+            Syntax.AbilityConstructorReference _fqn hash -> Just hash
             _ -> Nothing
 
     -- Collapse subsequent chunks of the same kind of diff into one chunk.

--- a/unison-share-api/src/Unison/Server/Doc.hs
+++ b/unison-share-api/src/Unison/Server/Doc.hs
@@ -193,9 +193,9 @@ renderDoc pped doc = renderSpecial <$> doc
       ELink ref ->
         let ppe = PPE.suffixifiedPPE pped
             tm :: Referent -> P.Pretty SSyntaxText
-            tm r = (NP.styleHashQualified'' (NP.fmt (S.TermReference r)) . PPE.termName ppe) r
+            tm r = (NP.styleHashQualified'' (NP.fmt (S.TermReference (PPE.termFQN ppe r) r)) . PPE.termName ppe) r
             ty :: Reference -> P.Pretty SSyntaxText
-            ty r = (NP.styleHashQualified'' (NP.fmt (S.TypeReference r)) . PPE.typeName ppe) r
+            ty r = (NP.styleHashQualified'' (NP.fmt (S.TypeReference (PPE.typeFQN ppe r) r)) . PPE.typeName ppe) r
          in Link $ case ref of
               Left trm -> source trm
               Right ld -> case ld of
@@ -232,7 +232,7 @@ renderDoc pped doc = renderSpecial <$> doc
           BuiltinDecl r ->
             let name =
                   formatPretty
-                    . NP.styleHashQualified (NP.fmt (S.TypeReference r))
+                    . NP.styleHashQualified (NP.fmt (S.TypeReference (PPE.typeFQN suffixifiedPPE r) r))
                     . PPE.typeName suffixifiedPPE
                     $ r
              in [Type (Reference.toText r, DO.BuiltinObject name)]

--- a/unison-share-api/src/Unison/Server/Syntax.hs
+++ b/unison-share-api/src/Unison/Server/Syntax.hs
@@ -22,7 +22,7 @@ import Unison.Reference (Reference)
 import Unison.Reference qualified as Reference
 import Unison.Referent qualified as Referent
 import Unison.Syntax.HashQualified qualified as HashQualified (toText)
-import Unison.Syntax.Name qualified as Name (unsafeParseText)
+import Unison.Syntax.Name qualified as Name
 import Unison.Syntax.NameSegment qualified as NameSegment (toEscapedText)
 import Unison.Util.AnnotatedText
   ( AnnotatedText (..),
@@ -78,8 +78,8 @@ convertElement = \case
   SyntaxText.BooleanLiteral -> BooleanLiteral
   SyntaxText.Blank -> Blank
   SyntaxText.Var -> Var
-  SyntaxText.TermReference r -> TermReference $ Referent.toText r
-  SyntaxText.TypeReference r -> TypeReference $ Reference.toText r
+  SyntaxText.TermReference fqn r -> TermReference (Name.toText <$> fqn) (Referent.toText r)
+  SyntaxText.TypeReference fqn r -> TypeReference (Name.toText <$> fqn) (Reference.toText r)
   SyntaxText.Op s -> Op s
   SyntaxText.AbilityBraces -> AbilityBraces
   SyntaxText.ControlKeyword -> ControlKeyword
@@ -105,6 +105,9 @@ type UnisonHash = Text
 
 type HashQualifiedName = Text
 
+-- Fully qualified name, without a hash.
+type FQN = Text
+
 -- | The elements of the Unison grammar, for syntax highlighting purposes
 data Element
   = NumericLiteral
@@ -114,10 +117,10 @@ data Element
   | BooleanLiteral
   | Blank
   | Var
-  | TypeReference UnisonHash
-  | DataConstructorReference UnisonHash
-  | AbilityConstructorReference UnisonHash
-  | TermReference UnisonHash
+  | TypeReference (Maybe FQN) UnisonHash
+  | DataConstructorReference (Maybe FQN) UnisonHash
+  | AbilityConstructorReference (Maybe FQN) UnisonHash
+  | TermReference (Maybe FQN) UnisonHash
   | Op SeqOp
   | -- | Constructor Are these even used?
     -- | Request
@@ -162,11 +165,11 @@ instance ToJSON Element where
     BooleanLiteral -> object ["tag" .= String "BooleanLiteral"]
     Blank -> object ["tag" .= String "Blank"]
     Var -> object ["tag" .= String "Var"]
-    TypeReference r -> object ["tag" .= String "TypeReference", "contents" .= r]
-    DataConstructorReference r ->
-      object ["tag" .= String "DataConstructorReference", "contents" .= r]
-    AbilityConstructorReference r -> object ["tag" .= String "AbilityConstructorReference", "contents" .= r]
-    TermReference r -> object ["tag" .= String "TermReference", "contents" .= r]
+    TypeReference fqn r -> object ["tag" .= String "TypeReference", "contents" .= r, "fqn" .= fqn]
+    DataConstructorReference fqn r ->
+      object ["tag" .= String "DataConstructorReference", "contents" .= r, "fqn" .= fqn]
+    AbilityConstructorReference fqn r -> object ["tag" .= String "AbilityConstructorReference", "contents" .= r, "fqn" .= fqn]
+    TermReference fqn r -> object ["tag" .= String "TermReference", "contents" .= r, "fqn" .= fqn]
     Op s -> object ["tag" .= String "Op", "contents" .= s]
     AbilityBraces -> object ["tag" .= String "AbilityBraces"]
     ControlKeyword -> object ["tag" .= String "ControlKeyword"]
@@ -199,10 +202,10 @@ instance FromJSON Element where
       "BooleanLiteral" -> pure BooleanLiteral
       "Blank" -> pure Blank
       "Var" -> pure Var
-      "TypeReference" -> TypeReference <$> obj .: "contents"
-      "DataConstructorReference" -> DataConstructorReference <$> obj .: "contents"
-      "AbilityConstructorReference" -> AbilityConstructorReference <$> obj .: "contents"
-      "TermReference" -> TermReference <$> obj .: "contents"
+      "TypeReference" -> TypeReference <$> obj .:? "fqn" <*> obj .: "contents"
+      "DataConstructorReference" -> DataConstructorReference <$> obj .:? "fqn" <*> obj .: "contents"
+      "AbilityConstructorReference" -> AbilityConstructorReference <$> obj .:? "fqn" <*> obj .: "contents"
+      "TermReference" -> TermReference <$> obj .:? "fqn" <*> obj .: "contents"
       "Op" -> Op <$> obj .: "contents"
       "AbilityBraces" -> pure AbilityBraces
       "ControlKeyword" -> pure ControlKeyword
@@ -238,8 +241,8 @@ reference :: SyntaxSegment -> Maybe UnisonHash
 reference (Segment _ el) =
   let reference' el' =
         case el' of
-          TermReference r -> Just r
-          TypeReference r -> Just r
+          TermReference _fqn r -> Just r
+          TypeReference _fqn r -> Just r
           HashQualifier r -> Just r
           _ -> Nothing
    in el >>= reference'
@@ -278,13 +281,13 @@ segmentToHtml (Segment sText element) =
 
       ref =
         case el of
-          TypeReference h ->
+          TypeReference _fqn h ->
             Just (h, "type")
-          TermReference h ->
+          TermReference _fqn h ->
             Just (h, "term")
-          AbilityConstructorReference h ->
+          AbilityConstructorReference _fqn h ->
             Just (h, "ability-constructor")
-          DataConstructorReference h ->
+          DataConstructorReference _fqn h ->
             Just (h, "data-constructor")
           _ ->
             Nothing

--- a/unison-src/transcripts/idempotent/api-dependencies.md
+++ b/unison-src/transcripts/idempotent/api-dependencies.md
@@ -119,6 +119,7 @@ RESPONSE:
                           {
                               "annotation": {
                                   "contents": "##Nat",
+                                  "fqn": "builtin.Nat",
                                   "tag": "TypeReference"
                               },
                               "segment": "builtin.Nat"
@@ -140,6 +141,7 @@ RESPONSE:
                           {
                               "annotation": {
                                   "contents": "##Nat",
+                                  "fqn": "builtin.Nat",
                                   "tag": "TypeReference"
                               },
                               "segment": "builtin.Nat"
@@ -161,6 +163,7 @@ RESPONSE:
                           {
                               "annotation": {
                                   "contents": "##Nat",
+                                  "fqn": "builtin.Nat",
                                   "tag": "TypeReference"
                               },
                               "segment": "builtin.Nat"
@@ -184,6 +187,7 @@ RESPONSE:
                           {
                               "annotation": {
                                   "contents": "##Nat",
+                                  "fqn": "builtin.Nat",
                                   "tag": "TypeReference"
                               },
                               "segment": "builtin.Nat"
@@ -239,6 +243,7 @@ RESPONSE:
                           {
                               "annotation": {
                                   "contents": "##Nat",
+                                  "fqn": "builtin.Nat",
                                   "tag": "TypeReference"
                               },
                               "segment": "builtin.Nat"
@@ -260,6 +265,7 @@ RESPONSE:
                           {
                               "annotation": {
                                   "contents": "##Nat",
+                                  "fqn": "builtin.Nat",
                                   "tag": "TypeReference"
                               },
                               "segment": "builtin.Nat"
@@ -281,6 +287,7 @@ RESPONSE:
                           {
                               "annotation": {
                                   "contents": "##Nat",
+                                  "fqn": "builtin.Nat",
                                   "tag": "TypeReference"
                               },
                               "segment": "builtin.Nat"
@@ -304,6 +311,7 @@ RESPONSE:
                           {
                               "annotation": {
                                   "contents": "##Nat",
+                                  "fqn": "builtin.Nat",
                                   "tag": "TypeReference"
                               },
                               "segment": "builtin.Nat"

--- a/unison-src/transcripts/idempotent/api-dependents.md
+++ b/unison-src/transcripts/idempotent/api-dependents.md
@@ -37,6 +37,7 @@ RESPONSE:
                           {
                               "annotation": {
                                   "contents": "#0qbc2dfom7m4pputtdojo849g2mp5kkr00kvsvjktb07tcmo1jql53bg73bqiib35vja4a7059rcet0raf7jsh4d8vg5582ibinpqj8",
+                                  "fqn": "MyType",
                                   "tag": "TypeReference"
                               },
                               "segment": "MyType"
@@ -60,6 +61,7 @@ RESPONSE:
                           {
                               "annotation": {
                                   "contents": "##Nat",
+                                  "fqn": "builtin.Nat",
                                   "tag": "TypeReference"
                               },
                               "segment": "builtin.Nat"
@@ -93,6 +95,7 @@ RESPONSE:
                           {
                               "annotation": {
                                   "contents": "##Nat",
+                                  "fqn": "builtin.Nat",
                                   "tag": "TypeReference"
                               },
                               "segment": "builtin.Nat"
@@ -126,6 +129,7 @@ RESPONSE:
                           {
                               "annotation": {
                                   "contents": "##Nat",
+                                  "fqn": "builtin.Nat",
                                   "tag": "TypeReference"
                               },
                               "segment": "builtin.Nat"
@@ -149,6 +153,7 @@ RESPONSE:
                           {
                               "annotation": {
                                   "contents": "##Nat",
+                                  "fqn": "builtin.Nat",
                                   "tag": "TypeReference"
                               },
                               "segment": "builtin.Nat"
@@ -195,6 +200,7 @@ RESPONSE:
                           {
                               "annotation": {
                                   "contents": "#0qbc2dfom7m4pputtdojo849g2mp5kkr00kvsvjktb07tcmo1jql53bg73bqiib35vja4a7059rcet0raf7jsh4d8vg5582ibinpqj8",
+                                  "fqn": "MyType",
                                   "tag": "TypeReference"
                               },
                               "segment": "MyType"
@@ -218,6 +224,7 @@ RESPONSE:
                           {
                               "annotation": {
                                   "contents": "##Nat",
+                                  "fqn": "builtin.Nat",
                                   "tag": "TypeReference"
                               },
                               "segment": "builtin.Nat"

--- a/unison-src/transcripts/idempotent/api-doc-rendering.md
+++ b/unison-src/transcripts/idempotent/api-doc-rendering.md
@@ -167,6 +167,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "##Nat",
+                          "fqn": "builtin.Nat",
                           "tag": "TypeReference"
                       },
                       "segment": "Nat"
@@ -194,6 +195,7 @@ RESPONSE:
                       {
                           "annotation": {
                               "contents": "##Nat",
+                              "fqn": "builtin.Nat",
                               "tag": "TypeReference"
                           },
                           "segment": "Nat"
@@ -276,6 +278,7 @@ RESPONSE:
                                                                   {
                                                                       "annotation": {
                                                                           "contents": "#k5gpql9cbdfau6lf1aja24joc3sfctvjor8esu8bemn0in3l148otb0t3vebgqrt6qml302h62bbfeftg65gec1v8ouin5m6v2969d8",
+                                                                          "fqn": "otherTerm",
                                                                           "tag": "TermReference"
                                                                       },
                                                                       "segment": "otherTerm"
@@ -304,6 +307,7 @@ RESPONSE:
                                                                   {
                                                                       "annotation": {
                                                                           "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg",
+                                                                          "fqn": "Maybe",
                                                                           "tag": "TypeReference"
                                                                       },
                                                                       "segment": "Maybe"
@@ -343,6 +347,7 @@ RESPONSE:
                                                                                       {
                                                                                           "annotation": {
                                                                                               "contents": "#qkhkl0n238s1eqibd1ecb8605sqj1m4hpoaag177cu572otqlaf1u28c8suuuqgljdtthsjtr07rv04np05o6oa27ml9105k7uas0t8",
+                                                                                              "fqn": "term",
                                                                                               "tag": "TermReference"
                                                                                           },
                                                                                           "segment": "term"
@@ -360,6 +365,7 @@ RESPONSE:
                                                                                       {
                                                                                           "annotation": {
                                                                                               "contents": "##Nat",
+                                                                                              "fqn": "builtin.Nat",
                                                                                               "tag": "TypeReference"
                                                                                           },
                                                                                           "segment": "Nat"
@@ -386,6 +392,7 @@ RESPONSE:
                                                                                       {
                                                                                           "annotation": {
                                                                                               "contents": "##Nat",
+                                                                                              "fqn": "builtin.Nat",
                                                                                               "tag": "TypeReference"
                                                                                           },
                                                                                           "segment": "Nat"
@@ -454,6 +461,7 @@ RESPONSE:
                                                                       {
                                                                           "annotation": {
                                                                               "contents": "#qkhkl0n238s1eqibd1ecb8605sqj1m4hpoaag177cu572otqlaf1u28c8suuuqgljdtthsjtr07rv04np05o6oa27ml9105k7uas0t8",
+                                                                              "fqn": "term",
                                                                               "tag": "TermReference"
                                                                           },
                                                                           "segment": "term"
@@ -471,6 +479,7 @@ RESPONSE:
                                                                       {
                                                                           "annotation": {
                                                                               "contents": "##Nat",
+                                                                              "fqn": "builtin.Nat",
                                                                               "tag": "TypeReference"
                                                                           },
                                                                           "segment": "Nat"
@@ -588,6 +597,7 @@ RESPONSE:
                                                                   {
                                                                       "annotation": {
                                                                           "contents": "##Nat.+",
+                                                                          "fqn": "builtin.Nat.+",
                                                                           "tag": "TermReference"
                                                                       },
                                                                       "segment": "Nat.+"

--- a/unison-src/transcripts/idempotent/api-getDefinition.md
+++ b/unison-src/transcripts/idempotent/api-getDefinition.md
@@ -38,6 +38,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "##Nat",
+                          "fqn": "lib.builtins.Nat",
                           "tag": "TypeReference"
                       },
                       "segment": "Nat"
@@ -65,6 +66,7 @@ RESPONSE:
                       {
                           "annotation": {
                               "contents": "##Nat",
+                              "fqn": "lib.builtins.Nat",
                               "tag": "TypeReference"
                           },
                           "segment": "Nat"
@@ -135,6 +137,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "##Nat",
+                          "fqn": "lib.builtins.Nat",
                           "tag": "TypeReference"
                       },
                       "segment": "Nat"
@@ -162,6 +165,7 @@ RESPONSE:
                       {
                           "annotation": {
                               "contents": "##Nat",
+                              "fqn": "lib.builtins.Nat",
                               "tag": "TypeReference"
                           },
                           "segment": "Nat"
@@ -249,6 +253,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "##Text",
+                          "fqn": "lib.builtins.Text",
                           "tag": "TypeReference"
                       },
                       "segment": "Text"
@@ -276,6 +281,7 @@ RESPONSE:
                       {
                           "annotation": {
                               "contents": "##Text",
+                              "fqn": "lib.builtins.Text",
                               "tag": "TypeReference"
                           },
                           "segment": "Text"
@@ -371,6 +377,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "#ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0",
+                          "fqn": "lib.builtins.Doc2",
                           "tag": "TypeReference"
                       },
                       "segment": "Doc2"
@@ -398,6 +405,7 @@ RESPONSE:
                       {
                           "annotation": {
                               "contents": "#ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0",
+                              "fqn": "lib.builtins.Doc2",
                               "tag": "TypeReference"
                           },
                           "segment": "Doc2"

--- a/unison-src/transcripts/idempotent/api-summaries.md
+++ b/unison-src/transcripts/idempotent/api-summaries.md
@@ -45,6 +45,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "##Nat",
+                      "fqn": "Nat",
                       "tag": "TypeReference"
                   },
                   "segment": "Nat"
@@ -66,6 +67,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "##Nat",
+                      "fqn": "Nat",
                       "tag": "TypeReference"
                   },
                   "segment": "Nat"
@@ -87,6 +89,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "#ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0",
+                      "fqn": "builtin.Doc2",
                       "tag": "TypeReference"
                   },
                   "segment": "Doc2"
@@ -114,6 +117,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "#aql7qk3iud6vs4cvu43aimopoosgk0fnipibdkc3so13adencmibgfn0u5c01r0adei55nkl3ttsjhl8gbj7tr4gnpj63g64ftbq6s0",
+                      "fqn": "builtin.Test.Result",
                       "tag": "TypeReference"
                   },
                   "segment": "Result"
@@ -141,6 +145,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "##Text",
+                      "fqn": "builtin.Text",
                       "tag": "TypeReference"
                   },
                   "segment": "Text"
@@ -162,6 +167,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "##Text",
+                      "fqn": "builtin.Text",
                       "tag": "TypeReference"
                   },
                   "segment": "Text"
@@ -183,6 +189,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "##Nat",
+                      "fqn": "Nat",
                       "tag": "TypeReference"
                   },
                   "segment": "Nat"
@@ -204,6 +211,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "#altimqs66j3dh94dpab5pg7j5adjrndq61n803j7fg0v0ohdiut6or66bu1fiongpd45s5euiuo8ru47b928aqv8osln1ikdeg05hq0",
+                      "fqn": "Thing",
                       "tag": "TypeReference"
                   },
                   "segment": "Thing"
@@ -225,6 +233,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "##Text",
+                      "fqn": "builtin.Text",
                       "tag": "TypeReference"
                   },
                   "segment": "Text"
@@ -246,6 +255,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "##Text",
+                      "fqn": "builtin.Text",
                       "tag": "TypeReference"
                   },
                   "segment": "Text"
@@ -267,6 +277,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "##Text",
+                      "fqn": "builtin.Text",
                       "tag": "TypeReference"
                   },
                   "segment": "Text"
@@ -288,6 +299,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "##Text",
+                      "fqn": "builtin.Text",
                       "tag": "TypeReference"
                   },
                   "segment": "Text"
@@ -309,6 +321,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "##Text",
+                      "fqn": "builtin.Text",
                       "tag": "TypeReference"
                   },
                   "segment": "Text"
@@ -330,6 +343,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "##Text",
+                      "fqn": "builtin.Text",
                       "tag": "TypeReference"
                   },
                   "segment": "Text"
@@ -351,6 +365,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "##Text",
+                      "fqn": "builtin.Text",
                       "tag": "TypeReference"
                   },
                   "segment": "Text"
@@ -372,6 +387,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "##Text",
+                      "fqn": "builtin.Text",
                       "tag": "TypeReference"
                   },
                   "segment": "Text"
@@ -393,6 +409,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "##Text",
+                      "fqn": "builtin.Text",
                       "tag": "TypeReference"
                   },
                   "segment": "Text"
@@ -414,6 +431,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "##Text",
+                      "fqn": "builtin.Text",
                       "tag": "TypeReference"
                   },
                   "segment": "Text"
@@ -435,6 +453,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "##Text",
+                      "fqn": "builtin.Text",
                       "tag": "TypeReference"
                   },
                   "segment": "Text"
@@ -456,6 +475,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "##Text",
+                      "fqn": "builtin.Text",
                       "tag": "TypeReference"
                   },
                   "segment": "Text"
@@ -477,6 +497,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "##Text",
+                      "fqn": "builtin.Text",
                       "tag": "TypeReference"
                   },
                   "segment": "Text"
@@ -498,6 +519,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "##Text",
+                      "fqn": "builtin.Text",
                       "tag": "TypeReference"
                   },
                   "segment": "Text"
@@ -519,6 +541,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "##Text",
+                      "fqn": "builtin.Text",
                       "tag": "TypeReference"
                   },
                   "segment": "Text"
@@ -540,6 +563,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "##Text",
+                      "fqn": "builtin.Text",
                       "tag": "TypeReference"
                   },
                   "segment": "Text"
@@ -561,6 +585,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "##Text",
+                      "fqn": "builtin.Text",
                       "tag": "TypeReference"
                   },
                   "segment": "Text"
@@ -582,6 +607,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "##Text",
+                      "fqn": "builtin.Text",
                       "tag": "TypeReference"
                   },
                   "segment": "Text"
@@ -603,6 +629,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "##Handle",
+                      "fqn": "builtin.io2.Handle",
                       "tag": "TypeReference"
                   },
                   "segment": "Handle"
@@ -624,6 +651,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "##Bytes",
+                      "fqn": "builtin.Bytes",
                       "tag": "TypeReference"
                   },
                   "segment": "Bytes"
@@ -647,6 +675,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "##IO",
+                      "fqn": "builtin.io2.IO",
                       "tag": "TypeReference"
                   },
                   "segment": "IO"
@@ -664,6 +693,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "#0o7mf021foma9acqdaibmlh1jidlijq08uf7f5se9tssttqs546pfunjpk6s31mqoq8s2o1natede8hkk6he45l95fibglidikt44v8",
+                      "fqn": "builtin.Either",
                       "tag": "TypeReference"
                   },
                   "segment": "Either"
@@ -675,6 +705,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "#r29dja8j9dmjjp45trccchaata8eo1h6d6haar1eai74pq1jt4m7u3ldhlq79f7phfo57eq4bau39vqotl2h63k7ff1m5sj5o9ajuf8",
+                      "fqn": "builtin.io2.Failure",
                       "tag": "TypeReference"
                   },
                   "segment": "Failure"

--- a/unison-src/transcripts/idempotent/definition-diff-api.md
+++ b/unison-src/transcripts/idempotent/definition-diff-api.md
@@ -155,6 +155,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "##Nat",
+                                          "fqn": "lib.builtins.Nat",
                                           "tag": "TypeReference"
                                       },
                                       "segment": "Nat"
@@ -287,6 +288,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "##Nat.+",
+                                          "fqn": "lib.builtins.Nat.+",
                                           "tag": "TermReference"
                                       },
                                       "segment": "+"
@@ -338,6 +340,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "##Nat",
+                                          "fqn": "lib.builtins.Nat",
                                           "tag": "TypeReference"
                                       },
                                       "segment": "Nat"
@@ -470,6 +473,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "##Nat.+",
+                                          "fqn": "lib.builtins.Nat.+",
                                           "tag": "TermReference"
                                       },
                                       "segment": "+"
@@ -506,6 +510,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "##Nat",
+                      "fqn": "lib.builtins.Nat",
                       "tag": "TypeReference"
                   },
                   "segment": "Nat"
@@ -533,6 +538,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "##Nat",
+                          "fqn": "lib.builtins.Nat",
                           "tag": "TypeReference"
                       },
                       "segment": "Nat"
@@ -636,6 +642,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "##Nat.+",
+                          "fqn": "lib.builtins.Nat.+",
                           "tag": "TermReference"
                       },
                       "segment": "+"
@@ -666,6 +673,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "##Nat",
+                      "fqn": "lib.builtins.Nat",
                       "tag": "TypeReference"
                   },
                   "segment": "Nat"
@@ -693,6 +701,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "##Nat",
+                          "fqn": "lib.builtins.Nat",
                           "tag": "TypeReference"
                       },
                       "segment": "Nat"
@@ -796,6 +805,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "##Nat.+",
+                          "fqn": "lib.builtins.Nat.+",
                           "tag": "TermReference"
                       },
                       "segment": "+"
@@ -858,6 +868,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "##Nat",
+                                          "fqn": "lib.builtins.Nat",
                                           "tag": "TypeReference"
                                       },
                                       "segment": "Nat"
@@ -943,6 +954,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro",
+                                          "fqn": "Stream",
                                           "tag": "TypeReference"
                                       },
                                       "segment": "Stream"
@@ -970,6 +982,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg",
+                                          "fqn": "lib.builtins.Optional",
                                           "tag": "TypeReference"
                                       },
                                       "segment": "Optional"
@@ -1153,6 +1166,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro#a0",
+                                          "fqn": "Stream.emit",
                                           "tag": "TermReference"
                                       },
                                       "segment": "emit"
@@ -1253,6 +1267,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "##Nat.>",
+                                          "fqn": "lib.builtins.Nat.>",
                                           "tag": "TermReference"
                                       },
                                       "segment": ">"
@@ -1307,6 +1322,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro#a0",
+                                          "fqn": "Stream.emit",
                                           "tag": "TermReference"
                                       },
                                       "segment": "emit"
@@ -1422,6 +1438,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "##Nat.drop",
+                                          "fqn": "lib.builtins.Nat.-",
                                           "tag": "TermReference"
                                       },
                                       "segment": "-"
@@ -1482,6 +1499,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d1",
+                                          "fqn": "lib.builtins.Optional.None",
                                           "tag": "TermReference"
                                       },
                                       "segment": "None"
@@ -1547,6 +1565,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d0",
+                                          "fqn": "lib.builtins.Optional.Some",
                                           "tag": "TermReference"
                                       },
                                       "segment": "Some"
@@ -1659,6 +1678,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "##Nat",
+                                          "fqn": "lib.builtins.Nat",
                                           "tag": "TypeReference"
                                       },
                                       "segment": "Nat"
@@ -1744,6 +1764,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro",
+                                          "fqn": "Stream",
                                           "tag": "TypeReference"
                                       },
                                       "segment": "Stream"
@@ -1771,6 +1792,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg",
+                                          "fqn": "lib.builtins.Optional",
                                           "tag": "TypeReference"
                                       },
                                       "segment": "Optional"
@@ -1954,6 +1976,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro#a0",
+                                          "fqn": "Stream.emit",
                                           "tag": "TermReference"
                                       },
                                       "segment": "emit"
@@ -2033,6 +2056,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro#a0",
+                                          "fqn": "Stream.emit",
                                           "tag": "TermReference"
                                       },
                                       "segment": "emit"
@@ -2097,6 +2121,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "##Nat.>",
+                                          "fqn": "lib.builtins.Nat.>",
                                           "tag": "TermReference"
                                       },
                                       "segment": ">"
@@ -2191,6 +2216,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "##Nat.drop",
+                                          "fqn": "lib.builtins.Nat.-",
                                           "tag": "TermReference"
                                       },
                                       "segment": "-"
@@ -2238,6 +2264,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d1",
+                                          "fqn": "lib.builtins.Optional.None",
                                           "tag": "TermReference"
                                       },
                                       "segment": "None"
@@ -2309,6 +2336,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d0",
+                                          "fqn": "lib.builtins.Optional.Some",
                                           "tag": "TermReference"
                                       },
                                       "segment": "Some"
@@ -2365,6 +2393,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "##Nat.>",
+                                          "fqn": "lib.builtins.Nat.>",
                                           "tag": "TermReference"
                                       },
                                       "segment": ">"
@@ -2474,6 +2503,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "##Nat.drop",
+                                          "fqn": "lib.builtins.Nat.-",
                                           "tag": "TermReference"
                                       },
                                       "segment": "-"
@@ -2511,6 +2541,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d1",
+                                          "fqn": "lib.builtins.Optional.None",
                                           "tag": "TermReference"
                                       },
                                       "segment": "None"
@@ -2532,6 +2563,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "##Nat",
+                      "fqn": "lib.builtins.Nat",
                       "tag": "TypeReference"
                   },
                   "segment": "Nat"
@@ -2617,6 +2649,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro",
+                      "fqn": "Stream",
                       "tag": "TypeReference"
                   },
                   "segment": "Stream"
@@ -2644,6 +2677,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg",
+                      "fqn": "lib.builtins.Optional",
                       "tag": "TypeReference"
                   },
                   "segment": "Optional"
@@ -2681,6 +2715,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "##Nat",
+                          "fqn": "lib.builtins.Nat",
                           "tag": "TypeReference"
                       },
                       "segment": "Nat"
@@ -2766,6 +2801,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro",
+                          "fqn": "Stream",
                           "tag": "TypeReference"
                       },
                       "segment": "Stream"
@@ -2793,6 +2829,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg",
+                          "fqn": "lib.builtins.Optional",
                           "tag": "TypeReference"
                       },
                       "segment": "Optional"
@@ -2952,6 +2989,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro#a0",
+                          "fqn": "Stream.emit",
                           "tag": "TermReference"
                       },
                       "segment": "emit"
@@ -3025,6 +3063,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro#a0",
+                          "fqn": "Stream.emit",
                           "tag": "TermReference"
                       },
                       "segment": "emit"
@@ -3078,6 +3117,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "##Nat.>",
+                          "fqn": "lib.builtins.Nat.>",
                           "tag": "TermReference"
                       },
                       "segment": ">"
@@ -3167,6 +3207,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "##Nat.drop",
+                          "fqn": "lib.builtins.Nat.-",
                           "tag": "TermReference"
                       },
                       "segment": "-"
@@ -3204,6 +3245,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d1",
+                          "fqn": "lib.builtins.Optional.None",
                           "tag": "TermReference"
                       },
                       "segment": "None"
@@ -3263,6 +3305,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d0",
+                          "fqn": "lib.builtins.Optional.Some",
                           "tag": "TermReference"
                       },
                       "segment": "Some"
@@ -3308,6 +3351,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "##Nat.>",
+                          "fqn": "lib.builtins.Nat.>",
                           "tag": "TermReference"
                       },
                       "segment": ">"
@@ -3397,6 +3441,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "##Nat.drop",
+                          "fqn": "lib.builtins.Nat.-",
                           "tag": "TermReference"
                       },
                       "segment": "-"
@@ -3434,6 +3479,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d1",
+                          "fqn": "lib.builtins.Optional.None",
                           "tag": "TermReference"
                       },
                       "segment": "None"
@@ -3454,6 +3500,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "##Nat",
+                      "fqn": "lib.builtins.Nat",
                       "tag": "TypeReference"
                   },
                   "segment": "Nat"
@@ -3539,6 +3586,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro",
+                      "fqn": "Stream",
                       "tag": "TypeReference"
                   },
                   "segment": "Stream"
@@ -3566,6 +3614,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg",
+                      "fqn": "lib.builtins.Optional",
                       "tag": "TypeReference"
                   },
                   "segment": "Optional"
@@ -3603,6 +3652,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "##Nat",
+                          "fqn": "lib.builtins.Nat",
                           "tag": "TypeReference"
                       },
                       "segment": "Nat"
@@ -3688,6 +3738,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro",
+                          "fqn": "Stream",
                           "tag": "TypeReference"
                       },
                       "segment": "Stream"
@@ -3715,6 +3766,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg",
+                          "fqn": "lib.builtins.Optional",
                           "tag": "TypeReference"
                       },
                       "segment": "Optional"
@@ -3874,6 +3926,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro#a0",
+                          "fqn": "Stream.emit",
                           "tag": "TermReference"
                       },
                       "segment": "emit"
@@ -3963,6 +4016,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "##Nat.>",
+                          "fqn": "lib.builtins.Nat.>",
                           "tag": "TermReference"
                       },
                       "segment": ">"
@@ -4006,6 +4060,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "#b035k0tpdv9jbs80ig29hujmv9kpkubda6or4320o5g7aj7edsudislnp2uovntgu5b0e6a18p0p7j8r2hcpr20blls7am8nll6t2ro#a0",
+                          "fqn": "Stream.emit",
                           "tag": "TermReference"
                       },
                       "segment": "emit"
@@ -4105,6 +4160,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "##Nat.drop",
+                          "fqn": "lib.builtins.Nat.-",
                           "tag": "TermReference"
                       },
                       "segment": "-"
@@ -4154,6 +4210,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d1",
+                          "fqn": "lib.builtins.Optional.None",
                           "tag": "TermReference"
                       },
                       "segment": "None"
@@ -4213,6 +4270,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#d0",
+                          "fqn": "lib.builtins.Optional.Some",
                           "tag": "TermReference"
                       },
                       "segment": "Some"
@@ -4355,6 +4413,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "##Nat",
+                                          "fqn": "lib.builtins.Nat",
                                           "tag": "TypeReference"
                                       },
                                       "segment": "Nat"
@@ -4389,6 +4448,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "#ttjui80dbufvf3vgaddmcr065dpgl0rtp68i5cdht6tq4t2vk3i2vg60hi77rug368qijgijf8oui27te7o5oq0t0osm6dg65c080i0",
+                                          "fqn": "id",
                                           "tag": "TermReference"
                                       },
                                       "segment": "id"
@@ -4500,6 +4560,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "##Nat",
+                                          "fqn": "lib.builtins.Nat",
                                           "tag": "TypeReference"
                                       },
                                       "segment": "Nat"
@@ -4559,6 +4620,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "#ttjui80dbufvf3vgaddmcr065dpgl0rtp68i5cdht6tq4t2vk3i2vg60hi77rug368qijgijf8oui27te7o5oq0t0osm6dg65c080i0",
+                                          "fqn": "id",
                                           "tag": "TermReference"
                                       },
                                       "segment": "id"
@@ -4595,6 +4657,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                                          "fqn": "lib.builtins.Tuple",
                                           "tag": "TypeReference"
                                       },
                                       "segment": "("
@@ -4618,6 +4681,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                                          "fqn": "lib.builtins.Tuple",
                                           "tag": "TypeReference"
                                       },
                                       "segment": ", "
@@ -4625,6 +4689,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                                          "fqn": "lib.builtins.Tuple",
                                           "tag": "TypeReference"
                                       },
                                       "segment": "("
@@ -4632,6 +4697,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                                          "fqn": "lib.builtins.Tuple",
                                           "tag": "TypeReference"
                                       },
                                       "segment": ")"
@@ -4639,6 +4705,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                                          "fqn": "lib.builtins.Tuple",
                                           "tag": "TypeReference"
                                       },
                                       "segment": ")"
@@ -4690,6 +4757,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "##Nat",
+                      "fqn": "lib.builtins.Nat",
                       "tag": "TypeReference"
                   },
                   "segment": "Nat"
@@ -4761,6 +4829,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "##Nat",
+                          "fqn": "lib.builtins.Nat",
                           "tag": "TypeReference"
                       },
                       "segment": "Nat"
@@ -4809,6 +4878,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "#ttjui80dbufvf3vgaddmcr065dpgl0rtp68i5cdht6tq4t2vk3i2vg60hi77rug368qijgijf8oui27te7o5oq0t0osm6dg65c080i0",
+                          "fqn": "id",
                           "tag": "TermReference"
                       },
                       "segment": "id"
@@ -4840,6 +4910,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                          "fqn": "lib.builtins.Tuple",
                           "tag": "TypeReference"
                       },
                       "segment": "("
@@ -4853,6 +4924,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                          "fqn": "lib.builtins.Tuple",
                           "tag": "TypeReference"
                       },
                       "segment": ", "
@@ -4860,6 +4932,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                          "fqn": "lib.builtins.Tuple",
                           "tag": "TypeReference"
                       },
                       "segment": "("
@@ -4867,6 +4940,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                          "fqn": "lib.builtins.Tuple",
                           "tag": "TypeReference"
                       },
                       "segment": ")"
@@ -4874,6 +4948,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "#2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8",
+                          "fqn": "lib.builtins.Tuple",
                           "tag": "TypeReference"
                       },
                       "segment": ")"
@@ -4920,6 +4995,7 @@ RESPONSE:
               {
                   "annotation": {
                       "contents": "##Nat",
+                      "fqn": "lib.builtins.Nat",
                       "tag": "TypeReference"
                   },
                   "segment": "Nat"
@@ -4967,6 +5043,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "##Nat",
+                          "fqn": "lib.builtins.Nat",
                           "tag": "TypeReference"
                       },
                       "segment": "Nat"
@@ -4995,6 +5072,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "#ttjui80dbufvf3vgaddmcr065dpgl0rtp68i5cdht6tq4t2vk3i2vg60hi77rug368qijgijf8oui27te7o5oq0t0osm6dg65c080i0",
+                          "fqn": "id",
                           "tag": "TermReference"
                       },
                       "segment": "id"
@@ -5092,11 +5170,13 @@ RESPONSE:
                               "diffTag": "annotationChange",
                               "fromAnnotation": {
                                   "contents": "#m5hlrmkn9a3kuqabta2e9qs934em1qmkotpsh9tjvta2u86nuesbjbk2k2sprbdiljq7uqibp49vku4gfpg2u60ceiv8net1f0bu2n8#d0",
+                                  "fqn": "Type.Type",
                                   "tag": "TermReference"
                               },
                               "segment": "Type",
                               "toAnnotation": {
                                   "contents": "#uik7pl3klg4u2obtf2fattdaeldui46ohmsi0knpp5hu8tn4d5o8vp570qgh7esgap0pmq9cfrh9dfg1r8qa7qh33g45a3tric24o20#d0",
+                                  "fqn": "Type.Type",
                                   "tag": "TermReference"
                               }
                           },
@@ -5115,6 +5195,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "##Nat",
+                                          "fqn": "lib.builtins.Nat",
                                           "tag": "TypeReference"
                                       },
                                       "segment": "Nat"
@@ -5180,11 +5261,13 @@ RESPONSE:
                               "diffTag": "annotationChange",
                               "fromAnnotation": {
                                   "contents": "#uik7pl3klg4u2obtf2fattdaeldui46ohmsi0knpp5hu8tn4d5o8vp570qgh7esgap0pmq9cfrh9dfg1r8qa7qh33g45a3tric24o20#d0",
+                                  "fqn": "Type.Type",
                                   "tag": "TermReference"
                               },
                               "segment": "Type",
                               "toAnnotation": {
                                   "contents": "#m5hlrmkn9a3kuqabta2e9qs934em1qmkotpsh9tjvta2u86nuesbjbk2k2sprbdiljq7uqibp49vku4gfpg2u60ceiv8net1f0bu2n8#d0",
+                                  "fqn": "Type.Type",
                                   "tag": "TermReference"
                               }
                           },
@@ -5213,6 +5296,7 @@ RESPONSE:
                                   {
                                       "annotation": {
                                           "contents": "##Text",
+                                          "fqn": "lib.builtins.Text",
                                           "tag": "TypeReference"
                                       },
                                       "segment": "Text"
@@ -5268,6 +5352,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "#uik7pl3klg4u2obtf2fattdaeldui46ohmsi0knpp5hu8tn4d5o8vp570qgh7esgap0pmq9cfrh9dfg1r8qa7qh33g45a3tric24o20#d0",
+                          "fqn": "Type.Type",
                           "tag": "TermReference"
                       },
                       "segment": "Type"
@@ -5289,6 +5374,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "##Text",
+                          "fqn": "lib.builtins.Text",
                           "tag": "TypeReference"
                       },
                       "segment": "Text"
@@ -5333,6 +5419,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "#m5hlrmkn9a3kuqabta2e9qs934em1qmkotpsh9tjvta2u86nuesbjbk2k2sprbdiljq7uqibp49vku4gfpg2u60ceiv8net1f0bu2n8#d0",
+                          "fqn": "Type.Type",
                           "tag": "TermReference"
                       },
                       "segment": "Type"
@@ -5344,6 +5431,7 @@ RESPONSE:
                   {
                       "annotation": {
                           "contents": "##Nat",
+                          "fqn": "lib.builtins.Nat",
                           "tag": "TypeReference"
                       },
                       "segment": "Nat"


### PR DESCRIPTION
## Overview

[Internal ticket](https://linear.app/unison/issue/SHA-210/add-the-fully-qualified-name-to-references-in-syntax)

Adds the fully-qualified-name to the rendered syntax text JSON.

* This is helpful for including in things like the hover-help; but also lets us generate correct hyper-links by name, not just by hash.
* Linking by name is typically faster (due to implementation reasons) and it's a better UX to have the name in the URL rather than a hash. 
* It also guarantees that the name we render actually matches the name the user clicked on (in cases where there are multiple names for a hash).
* It also allows us to know when a given hash is in a specific library by name alone, which Share can use to avoid needing to crawl through libs to find it.
* It's also less prone to breakage when linking to branch heads _without_ a pinned causal hash. If the causal hash _is_ pinned, then it uniquely identifies a given term.

## Implementation approach and notes

Just adds a new `fqn` key to the JSON for `TypeReference, DataConstructorReference, AbilityConstructorReference, TermReference` syntax text elements.  It's a little awkward it's not in `contents` or w/e, but can't do that and still be back-compatible. It's fine as is IMO
This value will be null if a given hash doesn't have a name in scope. Possibly also when using old cached syntax texts; but we can choose to clear the old caches if desired.

## Test coverage

* Updated the output of the api transcripts.