### PR TITLE
Prevent hash failure errors in runtime

### DIFF
--- a/codebase2/codebase-sqlite-hashing-v2/src/U/Codebase/Term/Hashing.hs
+++ b/codebase2/codebase-sqlite-hashing-v2/src/U/Codebase/Term/Hashing.hs
@@ -37,7 +37,7 @@ verifyTermFormatHash (ComponentHash hash) (TermFormat.Term (TermFormat.LocallyIn
       & Map.fromList
       & H2.hashTermComponents
       -- Convert HashingWarnings to HashValidationErrors
-      & first (\errs -> errs $> (HashingFailure ( IncompleteElementOrderingError ( ComponentHash hash))))
+      & first (\errs -> errs $> (HashingFailure (IncompleteElementOrderingError (ComponentHash hash))))
   r
     & traverse_ \(H2.ReferenceId hash' _, _trm, _typ, _extra) ->
       if hash == hash'
@@ -46,7 +46,7 @@ verifyTermFormatHash (ComponentHash hash) (TermFormat.Term (TermFormat.LocallyIn
   where
     toMaybe = \case
       ([], ()) -> Nothing
-      (e:_es, ()) -> Just e
+      (e : _es, ()) -> Just e
     mapTermV ::
       ABT.Term (C.Term.F' text' termRef' typeRef' termLink' typeLink' S.Symbol) S.Symbol a ->
       ABT.Term (C.Term.F' text' termRef' typeRef' termLink' typeLink' Unison.Symbol) Unison.Symbol a

--- a/codebase2/codebase-sqlite-hashing-v2/src/U/Codebase/Term/Hashing.hs
+++ b/codebase2/codebase-sqlite-hashing-v2/src/U/Codebase/Term/Hashing.hs
@@ -36,16 +36,17 @@ verifyTermFormatHash (ComponentHash hash) (TermFormat.Term (TermFormat.LocallyIn
       & fmap (\(_refId, (v, trm, typ)) -> (v, (H2.v2ToH2Term trm, H2.v2ToH2Type typ, ())))
       & Map.fromList
       & H2.hashTermComponents
-      & mapLeft (const $ HashingFailure $ IncompleteElementOrderingError $ ComponentHash hash)
+      -- Convert HashingWarnings to HashValidationErrors
+      & first (\errs -> errs $> (HashingFailure ( IncompleteElementOrderingError ( ComponentHash hash))))
   r
     & traverse_ \(H2.ReferenceId hash' _, _trm, _typ, _extra) ->
       if hash == hash'
         then pure ()
-        else Left . HashValidationMismatch $ (HashMismatch hash hash')
+        else ([HashValidationMismatch $ (HashMismatch hash hash')], ())
   where
     toMaybe = \case
-      Left e -> Just e
-      Right () -> Nothing
+      ([], ()) -> Nothing
+      (e:_es, ()) -> Just e
     mapTermV ::
       ABT.Term (C.Term.F' text' termRef' typeRef' termLink' typeLink' S.Symbol) S.Symbol a ->
       ABT.Term (C.Term.F' text' termRef' typeRef' termLink' typeLink' Unison.Symbol) Unison.Symbol a

--- a/parser-typechecker/src/Unison/Builtin/Terms.hs
+++ b/parser-typechecker/src/Unison/Builtin/Terms.hs
@@ -38,7 +38,7 @@ v = Var.named
 builtinTermsRef :: Map Symbol Reference.Id
 builtinTermsRef =
   fmap (\(refId, _, _, _) -> refId)
-    . H.crashOnHashingFailure
+    . H.crashOnHashingWarning
     . H.hashTermComponents
     . Map.fromList
     . fmap (\(v, _a, tm, tp) -> (v, (tm, tp, ())))

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations/MigrateSchema1To2.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations/MigrateSchema1To2.hs
@@ -600,7 +600,7 @@ migrateTermComponent getDeclType termBuffer declBuffer oldHash = fmap (either id
           & fmap (\(v, trm, typ) -> (v, (trm, typ, ())))
           & Map.fromList
           & Convert.hashTermComponents
-          & Convert.crashOnHashingFailure
+          & Convert.crashOnHashingWarning
           & fmap (\(ref, trm, typ, _) -> (ref, trm, typ))
 
   ifor newTermComponents $ \v (newReferenceId, trm, typ) -> do

--- a/parser-typechecker/src/Unison/DataDeclaration/Dependencies.hs
+++ b/parser-typechecker/src/Unison/DataDeclaration/Dependencies.hs
@@ -100,7 +100,7 @@ hashFieldAccessors ppe declName vars declRef dd = do
   typecheckedAccessors
     & Map.fromList
     & Hashing.hashTermComponents
-    & Hashing.crashOnHashingFailure
+    & Hashing.crashOnHashingWarning
     & Map.map Tuple.drop4th
     & Just
   where

--- a/parser-typechecker/src/Unison/Hashing/V2/Convert.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/Convert.hs
@@ -1,7 +1,7 @@
 -- | Description: Converts V1 types to the V2 hashing types
 module Unison.Hashing.V2.Convert
   ( ResolutionResult,
-    Hashing.HashingFailure (..),
+    Hashing.HashingWarning (..),
     Hashing.crashOnHashingFailure,
     hashBranch0,
     hashCausal,
@@ -64,7 +64,7 @@ hashTermComponents ::
   forall v a extra.
   (Var v) =>
   Map v (Memory.Term.Term v a, Memory.Type.Type v a, extra) ->
-  Either Hashing.HashingFailure (Map v (Memory.Reference.TermReferenceId, Memory.Term.Term v a, Memory.Type.Type v a, extra))
+  ([Hashing.HashingWarning], (Map v (Memory.Reference.TermReferenceId, Memory.Term.Term v a, Memory.Type.Type v a, extra)))
 hashTermComponents mTerms =
   case h2mTermMap mTerms of
     (hTerms, constructorTypes) -> do
@@ -91,10 +91,12 @@ hashTermComponentsWithoutTypes ::
   forall v a.
   (Var v) =>
   Map v (Memory.Term.Term v a) ->
-  Map v (Memory.Reference.TermReferenceId, Memory.Term.Term v a)
+  ([Hashing.HashingWarning], Map v (Memory.Reference.TermReferenceId, Memory.Term.Term v a))
 hashTermComponentsWithoutTypes mTerms =
   case Writer.runWriter (traverse m2hTerm mTerms) of
-    (hTerms, constructorTypes) -> h2mTermResult (constructorTypes Map.!) <$> Hashing.hashTermComponentsWithoutTypes hTerms
+    (hTerms, constructorTypes) -> do
+      hashed <- Hashing.hashTermComponentsWithoutTypes hTerms
+      pure (h2mTermResult (constructorTypes Map.!) <$> hashed)
   where
     h2mTermResult ::
       (Ord v) =>

--- a/parser-typechecker/src/Unison/Hashing/V2/Convert.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/Convert.hs
@@ -2,7 +2,7 @@
 module Unison.Hashing.V2.Convert
   ( ResolutionResult,
     Hashing.HashingWarning (..),
-    Hashing.crashOnHashingFailure,
+    Hashing.crashOnHashingWarning,
     hashBranch0,
     hashCausal,
     hashDataDecls,

--- a/parser-typechecker/src/Unison/UnisonFile.hs
+++ b/parser-typechecker/src/Unison/UnisonFile.hs
@@ -278,7 +278,7 @@ typecheckedUnisonFile datas effects tlcs watches =
               [(v, Nothing) | (v, _a, _e, _t) <- join tlcs]
                 ++ [(v, Just wk) | (wk, wkTerms) <- watches, (v, _a, _e, _t) <- wkTerms]
           hcs :: Map v (Reference.Id, Term v a, Type v a, a)
-          hcs = Hashing.crashOnHashingFailure $ Hashing.hashTermComponents $ Map.fromList $ (\(v, a, e, t) -> (v, (e, t, a))) <$> allTerms
+          hcs = Hashing.crashOnHashingWarning $ Hashing.hashTermComponents $ Map.fromList $ (\(v, a, e, t) -> (v, (e, t, a))) <$> allTerms
        in Map.fromList
             [ (v, (a, r, wk, e, t))
               | (v, (r, e, _typ, a)) <- Map.toList hcs,

--- a/unison-cli/src/Unison/Codebase/Editor/AuthorInfo.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/AuthorInfo.hs
@@ -62,7 +62,7 @@ createAuthorInfo a t = createAuthorInfo' . unpack <$> liftIO (getRandomBytes 32)
       Term v a ->
       (Reference.Id, Term v a)
     hashAndWrangle v typ tm =
-      case Foldable.toList . H.crashOnHashingFailure $ H.hashTermComponents (Map.singleton (Var.named v) (tm, typ, ())) of
+      case Foldable.toList . H.crashOnHashingWarning $ H.hashTermComponents (Map.singleton (Var.named v) (tm, typ, ())) of
         [(id, tm, _tp, ())] -> (id, tm)
         _ -> error "hashAndWrangle: Expected a single definition."
     (chType, chTypeRef) = (Type.ref a chTypeRef, IOSource.copyrightHolderRef)

--- a/unison-cli/src/Unison/Main.hs
+++ b/unison-cli/src/Unison/Main.hs
@@ -112,7 +112,7 @@ main version = do
       | isExitSuccess exception -> pure ()
       -- This is a bit of a hack to make hashing failures more user-friendly.
       -- https://github.com/unisonweb/unison/pull/6007
-      | Just hf <- fromException @ABT.HashingFailure exception -> do
+      | Just hf <- fromException @ABT.HashingWarning exception -> do
           Text.hPutStrLn stderr ("\n" <> tShow hf <> "\n")
       | otherwise -> do
           let shown = tShow exception

--- a/unison-hashing-v2/src/Unison/Hashing/V2.hs
+++ b/unison-hashing-v2/src/Unison/Hashing/V2.hs
@@ -28,7 +28,7 @@ module Unison.Hashing.V2
     TypeEdit (..),
     TypeF (..),
     HashingWarning (..),
-    crashOnHashingFailure,
+    crashOnHashingWarning,
     hashClosedTerm,
     hashDecls,
     hashTermComponents,
@@ -42,7 +42,7 @@ module Unison.Hashing.V2
 where
 
 import Unison.Hashing.ContentAddressable (ContentAddressable (..))
-import Unison.Hashing.V2.ABT (HashingWarning (..), crashOnHashingFailure)
+import Unison.Hashing.V2.ABT (HashingWarning (..), crashOnHashingWarning)
 import Unison.Hashing.V2.Branch (Branch (..), MdValues (..))
 import Unison.Hashing.V2.Causal (Causal (..))
 import Unison.Hashing.V2.DataDeclaration (DataDeclaration (..), Decl, EffectDeclaration (..), Modifier (..), hashDecls)

--- a/unison-hashing-v2/src/Unison/Hashing/V2.hs
+++ b/unison-hashing-v2/src/Unison/Hashing/V2.hs
@@ -27,7 +27,7 @@ module Unison.Hashing.V2
     Type,
     TypeEdit (..),
     TypeF (..),
-    HashingFailure (..),
+    HashingWarning (..),
     crashOnHashingFailure,
     hashClosedTerm,
     hashDecls,
@@ -42,7 +42,7 @@ module Unison.Hashing.V2
 where
 
 import Unison.Hashing.ContentAddressable (ContentAddressable (..))
-import Unison.Hashing.V2.ABT (HashingFailure (..), crashOnHashingFailure)
+import Unison.Hashing.V2.ABT (HashingWarning (..), crashOnHashingFailure)
 import Unison.Hashing.V2.Branch (Branch (..), MdValues (..))
 import Unison.Hashing.V2.Causal (Causal (..))
 import Unison.Hashing.V2.DataDeclaration (DataDeclaration (..), Decl, EffectDeclaration (..), Modifier (..), hashDecls)

--- a/unison-hashing-v2/src/Unison/Hashing/V2/ABT.hs
+++ b/unison-hashing-v2/src/Unison/Hashing/V2/ABT.hs
@@ -10,7 +10,7 @@
 module Unison.Hashing.V2.ABT
   ( Unison.ABT.Term,
     HashingWarning (..),
-    crashOnHashingFailure,
+    crashOnHashingWarning,
     hash,
     hashComponents,
   )
@@ -65,8 +65,8 @@ instance Show HashingWarning where
 -- | Crash if hashing produced any warnings.
 --
 -- In the future we will hopefully prevent this error entirely.
-crashOnHashingFailure :: (HasCallStack) => ([HashingWarning], a) -> a
-crashOnHashingFailure = \case
+crashOnHashingWarning :: (HasCallStack) => ([HashingWarning], a) -> a
+crashOnHashingWarning = \case
   ([], a) -> a
   (hf : _, _) -> throw hf
 

--- a/unison-hashing-v2/src/Unison/Hashing/V2/ABT.hs
+++ b/unison-hashing-v2/src/Unison/Hashing/V2/ABT.hs
@@ -9,7 +9,7 @@
 
 module Unison.Hashing.V2.ABT
   ( Unison.ABT.Term,
-    HashingFailure (..),
+    HashingWarning (..),
     crashOnHashingFailure,
     hash,
     hashComponents,
@@ -30,17 +30,17 @@ import Unison.Hashing.V2.Tokenizable qualified as Hashable
 import Unison.Prelude
 import Prelude hiding (abs, cycle)
 
-data HashingFailure
+data HashingWarning
   = -- | two or more component elements can not be completely ordered with respect to one another
     -- https://github.com/unisonweb/unison/issues/2787
     IncompleteElementOrderingError (NonEmpty (NonEmpty String {- Each list is a set of structurally equivalent component elements -}))
   deriving stock (Eq, Ord)
   deriving anyclass (Exception)
 
-instance Show HashingFailure where
+instance Show HashingWarning where
   show hf = reportBug "E253299" (renderHashingFailure hf)
     where
-      renderHashingFailure :: HashingFailure -> String
+      renderHashingFailure :: HashingWarning -> String
       renderHashingFailure = \case
         IncompleteElementOrderingError equivalenceSets ->
           unlines
@@ -62,26 +62,25 @@ instance Show HashingFailure where
               "_ = \"this is the foo definition\""
             ]
 
--- | We don't expect to encounter these, but if we do we should print a nice message.
+-- | Crash if hashing produced any warnings.
 --
 -- In the future we will hopefully prevent this error entirely.
-crashOnHashingFailure :: (HasCallStack) => Either HashingFailure a -> a
+crashOnHashingFailure :: (HasCallStack) => ([HashingWarning], a) -> a
 crashOnHashingFailure = \case
-  Left hf -> throw hf
-  Right a -> a
+  ([], a) -> a
+  (hf : _, _) -> throw hf
 
 -- Hash a strongly connected component and sort its definitions into a canonical order.
 hashComponent ::
   forall a f v.
   (Functor f, Hashable1 f, Foldable f, Eq v, Show v, Ord v) =>
   Map.Map v (Term f v a) ->
-  Either HashingFailure (Hash, [(v, Term f v a)])
+  ([HashingWarning], (Hash, [(v, Term f v a)]))
 hashComponent byName = do
   let ts = Map.toList byName
   -- First, compute a canonical hash ordering of the component, as well as an environment in which we can hash
   -- individual names.
-  let isTop = True
-  (hashes, env) <- doHashCycle isTop [] ts
+  (hashes, env) <- doHashCycle [] ts
   -- Construct a list of tokens that is shared by all members of the component. They are disambiguated only by their
   -- name that gets tumbled into the hash.
   let commonTokens :: [Hashable.Token]
@@ -109,12 +108,12 @@ hashComponents ::
   (Functor f, Hashable1 f, Foldable f, Eq v, Show v, Var v) =>
   (Hash -> Word64 -> Term f v ()) ->
   Map.Map v (Term f v a) ->
-  Either HashingFailure [(Hash, [(v, Term f v a)])]
+  ([HashingWarning], [(Hash, [(v, Term f v a)])])
 hashComponents termFromHash termsByName = do
   let bound = Set.fromList (Map.keys termsByName)
       escapedVars = Set.unions (freeVars <$> Map.elems termsByName) `Set.difference` bound
       sccs = components (Map.toList termsByName)
-      go :: Map v (Term f v ()) -> [[(v, Term f v a)]] -> Either HashingFailure [(Hash, [(v, Term f v a)])]
+      go :: Map v (Term f v ()) -> [[(v, Term f v a)]] -> ([HashingWarning], [(Hash, [(v, Term f v a)])])
       go _ [] = pure $ []
       go prevHashes (component : rest) = do
         let sub = substsInheritAnnotation (Map.toList prevHashes)
@@ -163,39 +162,34 @@ hash' env = \case
             ++ show v
             ++ " environment = "
             ++ show env
-  Cycle' vs t -> hash1 (\ts -> crashOnHashingFailure $ hashCycle vs env ts) undefined t
+  Cycle' vs t -> hash1 (hashCycle vs env) undefined t
   Abs'' v t -> hash' (Right v : env) t
   Tm' t -> hash1 (\ts -> (List.sort (map (hash' env) ts), hash' env)) (hash' env) t
   where
-    hashCycle :: [v] -> [Either [v] v] -> [Term f v a] -> Either HashingFailure ([Hash], Term f v a -> Hash)
-    hashCycle cycle env ts = do
-      -- isTop is always false when called via `hash'`, we only set it to True
-      -- when calling from `hashComponent`
-      let isTop = False
-      (ts', env') <- doHashCycle isTop env (zip cycle ts)
-      pure (ts', hash' env')
+    hashCycle :: [v] -> [Either [v] v] -> [Term f v a] -> (([Hash], Term f v a -> Hash))
+    hashCycle cycle env ts =
+      -- We ignore incomplete element ordering warnings when calling in from hash';
+      -- we don't want to error on that when hashing internal let-bindings.
+      let (_warnings, (ts', env')) = doHashCycle env (zip cycle ts)
+       in (ts', hash' env')
 
 -- | @doHashCycle env terms@ hashes cycle @terms@ in environment @env@, and returns the canonical ordering of the hashes
 -- of those terms, as well as an updated environment with each of the terms' bindings in the canonical ordering.
 doHashCycle ::
   forall a f v.
   (Eq v, Functor f, Hashable1 f, Show v) =>
-  Bool ->
   [Either [v] v] ->
   [(v, Term f v a)] ->
-  Either HashingFailure ([Hash], [Either [v] v])
-doHashCycle isTop env namedTerms = do
+  -- Hashing always succeeds even if it generates warnings.
+  ([HashingWarning], ([Hash], [Either [v] v]))
+doHashCycle env namedTerms = do
   -- Ensure that all of the hashes we use for ordering components are unique;
-  -- if not, we have an incomplete ordering of the elements in the cycle
-  when isTop $ do
-    -- Error if there are any structurally equivalent elements
-    for_ structurallyEquivalentElements \vs -> do
-      -- Sort them so they're deterministic in transcripts
-      let sortedVars =
-            vs
-              <&> (NEL.sort . fmap show)
-              & NEL.sort
-      Left $ IncompleteElementOrderingError sortedVars
+  -- if not, we have an incomplete ordering of the elements in the cycle.
+  -- Report a warning if there are any structurally equivalent elements,
+  -- the caller can choose what to do with the warning.
+  for_ structurallyEquivalentElements \vs ->
+    -- Accumulate errors using the tuple monad.
+    ([IncompleteElementOrderingError (vs <&> (NEL.sort . fmap show) & NEL.sort)], ())
   pure $ (map (hash' newEnv) permutedTerms, newEnv)
   where
     names = map fst namedTerms

--- a/unison-hashing-v2/src/Unison/Hashing/V2/DataDeclaration.hs
+++ b/unison-hashing-v2/src/Unison/Hashing/V2/DataDeclaration.hs
@@ -58,7 +58,7 @@ hashDecls0 :: (Eq v, ABT.Var v, Show v) => Map v (DataDeclaration v ()) -> [(v, 
 hashDecls0 decls =
   let abts = toABT <$> decls
       ref r = ABT.tm (Type (Type.TypeRef (ReferenceDerivedId r)))
-      cs = ABT.crashOnHashingFailure $ Reference.Util.hashComponents ref abts
+      cs = ABT.crashOnHashingWarning $ Reference.Util.hashComponents ref abts
    in [(v, r) | (v, (r, _)) <- Map.toList cs]
 
 -- | compute the hashes of these user defined types and update any free vars

--- a/unison-hashing-v2/src/Unison/Hashing/V2/Reference/Util.hs
+++ b/unison-hashing-v2/src/Unison/Hashing/V2/Reference/Util.hs
@@ -15,7 +15,7 @@ hashComponents ::
   (Functor f, Hashable1 f, Foldable f, Eq v, Show v, Var v) =>
   (ReferenceId -> ABT.Term f v ()) ->
   Map v (ABT.Term f v a) ->
-  Either ABT.HashingFailure (Map v (ReferenceId, ABT.Term f v a))
+  ([ABT.HashingWarning], (Map v (ReferenceId, ABT.Term f v a)))
 hashComponents embedRef tms = do
   cs <- Reference.components <$> ABT.hashComponents ref tms
   pure $ Map.fromList [(v, (r, e)) | ((v, e), r) <- cs]

--- a/unison-hashing-v2/src/Unison/Hashing/V2/Term.hs
+++ b/unison-hashing-v2/src/Unison/Hashing/V2/Term.hs
@@ -93,7 +93,7 @@ hashTermComponents ::
   forall v a extra.
   (Var v) =>
   Map v (Term v a, Type v a, extra) ->
-  Either ABT.HashingFailure (Map v (ReferenceId, Term v a, Type v a, extra))
+  ([ABT.HashingWarning], (Map v (ReferenceId, Term v a, Type v a, extra)))
 hashTermComponents terms = do
   hashed <- ReferenceUtil.hashComponents (refId ()) terms'
   pure $ Zip.zipWith keepExtra terms hashed
@@ -117,10 +117,9 @@ hashTermComponents terms = do
 -- What if there's a top-level Annotation but it doesn't match
 -- the type that was provided?
 
-hashTermComponentsWithoutTypes :: (Var v) => Map v (Term v a) -> Map v (ReferenceId, Term v a)
+hashTermComponentsWithoutTypes :: (Var v) => Map v (Term v a) -> ([ABT.HashingWarning], Map v (ReferenceId, Term v a))
 hashTermComponentsWithoutTypes terms =
   ReferenceUtil.hashComponents (refId ()) terms
-    & ABT.crashOnHashingFailure
 
 hashClosedTerm :: (Var v) => Term v a -> ReferenceId
 hashClosedTerm tm = ReferenceId (ABT.hash tm) 0

--- a/unison-runtime/src/Unison/Runtime/ANF.hs
+++ b/unison-runtime/src/Unison/Runtime/ANF.hs
@@ -610,6 +610,7 @@ postFloat orig (FS {floatNames, floated, decomp}) =
   where
     m =
       fmap (fmap deannotate)
+        . snd {- we ignore the hashing warnings in the runtime; they're not relevant -}
         . hashTermComponentsWithoutTypes
         . Map.fromList
         $ floated

--- a/unison-runtime/src/Unison/Runtime/Interface.hs
+++ b/unison-runtime/src/Unison/Runtime/Interface.hs
@@ -677,6 +677,7 @@ normalizeTerm ctx tm =
     orig
       | Tm.LetRecNamed' bs _ <- tm =
           fmap (RF.DerivedId . fst)
+            . snd {- We can ignore the hashing warnings in the runtime, they're not relevant. -}
             . Hashing.hashTermComponentsWithoutTypes
             $ Map.fromList bs
       | otherwise = mempty


### PR DESCRIPTION
## Overview

Fast-follow to https://github.com/unisonweb/unison/pull/6035;
While that seems to have addressed errors for internal let-bindings, it didn't address the floated runtime bindings.

Now we just ignore any incomplete-element-ordering warnings returned from hashing top-level components in the runtime.

## Implementation approach and notes

* Switch from a failure/success approach to a warnings based approach so we can choose to ignore the warnings at the call-site
*  ignore warnings when hashing inside the runtime.

## Test coverage

* I can now run the `@unison/cloud` tests and the `@unison/json` tests without failures.