### PR TITLE
Human-centric let-rec, constructor and ability orderings

### DIFF
--- a/lib/unison-prelude/src/Unison/Util/List.hs
+++ b/lib/unison-prelude/src/Unison/Util/List.hs
@@ -15,10 +15,10 @@ multimap kvs =
   where
     step m (k, v) = Map.insertWith (++) k [v] m
 
-groupBy :: (Foldable f, Ord k) => (v -> k) -> f v -> Map k [v]
-groupBy f vs = reverse <$> foldl' step Map.empty vs
+groupBy :: (Foldable f, Ord k) => (v -> k) -> f v -> Map k (NonEmpty v)
+groupBy f vs = NEL.reverse <$> foldl' step Map.empty vs
   where
-    step m v = Map.insertWith (++) (f v) [v] m
+    step m v = Map.insertWith (<>) (f v) (NEL.singleton v) m
 
 -- | group _consecutive_ elements by a key.
 -- e.g.

--- a/lib/unison-prelude/src/Unison/Util/List.hs
+++ b/lib/unison-prelude/src/Unison/Util/List.hs
@@ -2,6 +2,8 @@ module Unison.Util.List where
 
 import Data.List qualified as List
 import Data.List.Extra qualified as List
+import Data.List.NonEmpty (NonEmpty)
+import Data.List.NonEmpty qualified as NEL
 import Data.Map qualified as Map
 import Data.Set qualified as Set
 import Unison.Prelude
@@ -22,14 +24,14 @@ groupBy f vs = reverse <$> foldl' step Map.empty vs
 -- e.g.
 -- >>> groupMap (\n -> (odd n, show n)) [1, 3, 4, 6, 7]
 -- [(True,["1","3"]),(False,["4","6"]),(True,["7"])]
-groupMap :: (Foldable f, Eq k) => (a -> (k, b)) -> f a -> [(k, [b])]
+groupMap :: (Foldable f, Eq k) => (a -> (k, b)) -> f a -> [(k, NonEmpty b)]
 groupMap f xs =
   xs
     & toList
     & fmap f
     & List.groupOn fst
     -- head is okay since groupOn only returns populated lists.
-    <&> \grp -> (fst . head $ grp, snd <$> grp)
+    <&> \grp -> (fst . head $ grp, NEL.fromList (snd <$> grp))
 
 -- returns the subset of `f a` which maps to unique `b`s.
 -- prefers earlier copies, if many `a` map to some `b`.

--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -99,6 +99,7 @@ module Unison.Codebase.Branch
 where
 
 import Control.Lens hiding (children, cons, transform, uncons)
+import Data.Foldable qualified as Foldable
 import Data.Map qualified as Map
 import Data.Monoid (Any (..))
 import Data.Semialign qualified as Align
@@ -508,7 +509,10 @@ batchUpdatesM ::
 batchUpdatesM (toList -> actions) curBranch = foldM execActions curBranch (groupActionsByLocation actions)
   where
     groupActionsByLocation :: [(Path, b)] -> [(ActionLocation, [(Path, b)])]
-    groupActionsByLocation = List.groupMap \(p, act) -> (pathLocation p, (p, act))
+    groupActionsByLocation xs =
+      xs
+        & List.groupMap (\(p, act) -> (pathLocation p, (p, act)))
+        <&> second Foldable.toList
 
     execActions ::
       ( Branch0 m ->

--- a/parser-typechecker/src/Unison/Syntax/DeclPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/DeclPrinter.hs
@@ -10,6 +10,7 @@ module Unison.Syntax.DeclPrinter
 where
 
 import Control.Monad.Writer (Writer, runWriter, tell)
+import Data.List qualified as List
 import Data.List.NonEmpty (pattern (:|))
 import Data.Map qualified as Map
 import Data.Set qualified as Set
@@ -95,11 +96,22 @@ prettyGADT ::
   DataDeclaration v a ->
   Pretty SyntaxText
 prettyGADT env guid ctorType r name dd =
-  header <> P.newline <> P.indentN 2 constructors
+  header <> P.newline <> P.indentN 2 prettyConstructors
   where
-    constructors = P.lines (constructor <$> zip [0 ..] (DD.constructors' dd))
-    constructor (n, (_, _, t)) =
-      prettyPattern (PPED.unsuffixifiedPPE env) ctorType name (ConstructorReference r n)
+    -- Order Constructors alphabetically by name,
+    -- regardless of their original order in the declaration.
+    -- This is both nice for readability and ensures stable output in diffs, since otherwise
+    -- constructors will jump around in order based on their hash.
+    -- They'll be re-ordered by hash when parsed.
+    orderedConstructors =
+      zip [0 ..] (DD.constructors' dd)
+        & List.sortOn \case
+          (n, (_, _, _)) -> (PPE.termName unsuffixifiedPPE (Referent.Con (ConstructorReference r n) ctorType))
+
+    prettyConstructors = P.lines (printConstructor <$> orderedConstructors)
+    unsuffixifiedPPE = PPED.unsuffixifiedPPE env
+    printConstructor (n, (_, _, t)) =
+      prettyPattern unsuffixifiedPPE ctorType name (ConstructorReference r n)
         <> fmt S.TypeAscriptionColon " :"
           `P.hang` TypePrinter.prettySyntax (PPED.suffixifiedPPE env) t
     header = prettyEffectHeader guid name (DD.EffectDeclaration dd) <> fmt S.ControlKeyword " where"
@@ -132,8 +144,18 @@ prettyDataDecl ::
   Writer (Set AccessorName) (Pretty SyntaxText)
 prettyDataDecl (PrettyPrintEnvDecl unsuffixifiedPPE suffixifiedPPE) guid r name dd =
   (header <>) . P.sep (fmt S.DelimiterChar (" | " `P.orElse` "\n  | "))
-    <$> constructor `traverse` zip [0 ..] (DD.constructors' dd)
+    <$> constructor `traverse` orderedConstructors
   where
+    -- Order Constructors alphabetically by name,
+    -- regardless of their original order in the declaration.
+    -- This is both nice for readability and ensures stable output in diffs, since otherwise
+    -- constructors will jump around in order based on their hash.
+    -- They'll be re-ordered by hash when parsed.
+    orderedConstructors =
+      zip [0 ..] (DD.constructors' dd)
+        & List.sortOn \case
+          (n, (_, _, _)) -> (PPE.termName unsuffixifiedPPE (Referent.Con (ConstructorReference r n) CT.Data))
+
     constructor (n, (_, _, Type.ForallsNamed' _ t)) = constructor' n t
     constructor (n, (_, _, t)) = constructor' n t
     constructor' n t = case Type.unArrows t of

--- a/parser-typechecker/src/Unison/Syntax/DeclPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/DeclPrinter.hs
@@ -101,7 +101,7 @@ prettyGADT ::
 prettyGADT env guid ctorType r name dd =
   header <> P.newline <> P.indentN 2 prettyConstructors
   where
-    prettyConstructors = P.lines (printConstructor <$> orderConstructors unsuffixifiedPPE r dd)
+    prettyConstructors = P.lines (printConstructor <$> orderConstructors unsuffixifiedPPE r dd ctorType)
     unsuffixifiedPPE = PPED.unsuffixifiedPPE env
     printConstructor (n, (_, _, t)) =
       prettyPattern unsuffixifiedPPE ctorType name (ConstructorReference r n)
@@ -132,8 +132,8 @@ prettyPattern env ctorType namespace ref =
 -- This is both nice for readability and ensures stable output in diffs, since otherwise
 -- constructors will jump around in order based on their hash.
 -- They'll be re-ordered by hash when parsed.
-orderConstructors :: (Var v) => PrettyPrintEnv -> TypeReference -> DataDeclaration v a -> [(Word64, (a, v, Type.Type v a))]
-orderConstructors ppe r dd =
+orderConstructors :: (Var v) => PrettyPrintEnv -> TypeReference -> DataDeclaration v a -> CT.ConstructorType -> [(Word64, (a, v, Type.Type v a))]
+orderConstructors ppe r dd ctype =
   zip [0 ..] (DD.constructors' dd)
     -- First we sort by type to ensure that identical types are adjacent.
     & List.sortOn (\(_n, (_a, _v, typ)) -> typ)
@@ -147,7 +147,7 @@ orderConstructors ppe r dd =
             & NEL.sortOn fst
             & \case
               (n, (_, _, _)) :| _rest ->
-                PPE.termName ppe (Referent.Con (ConstructorReference r n) CT.Data)
+                PPE.termName ppe (Referent.Con (ConstructorReference r n) ctype)
       )
     -- Then we flatten back out to a list of constructors.
     & foldMap (toList . snd)
@@ -163,7 +163,7 @@ prettyDataDecl ::
   Writer (Set AccessorName) (Pretty SyntaxText)
 prettyDataDecl (PrettyPrintEnvDecl unsuffixifiedPPE suffixifiedPPE) guid r name dd =
   (header <>) . P.sep (fmt S.DelimiterChar (" | " `P.orElse` "\n  | "))
-    <$> constructor `traverse` (orderConstructors unsuffixifiedPPE r dd)
+    <$> constructor `traverse` (orderConstructors unsuffixifiedPPE r dd CT.Data)
   where
     constructor (n, (_, _, Type.ForallsNamed' _ t)) = constructor' n t
     constructor (n, (_, _, t)) = constructor' n t

--- a/parser-typechecker/src/Unison/Syntax/DeclPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/DeclPrinter.hs
@@ -135,7 +135,9 @@ prettyPattern env ctorType namespace ref =
 orderConstructors :: (Var v) => PrettyPrintEnv -> TypeReference -> DataDeclaration v a -> [(Word64, (a, v, Type.Type v a))]
 orderConstructors ppe r dd =
   zip [0 ..] (DD.constructors' dd)
-    -- First group by type, we need to leave identical types in their constructor order to avoid things like
+    -- First we sort by type to ensure that identical types are adjacent.
+    & List.sortOn (\(_n, (_a, _v, typ)) -> typ)
+    -- Now we group by type, we need to leave identical types in their constructor order to avoid things like
     -- swapping identical constructors, e.g. False turning into True and vice versa.
     & List.groupMap (\con@(_, (_, _, typ)) -> (typ, con))
     -- Then we can sort those _groups_ by the name of the first constructor in the group.

--- a/parser-typechecker/src/Unison/Syntax/DeclPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/DeclPrinter.hs
@@ -12,6 +12,7 @@ where
 import Control.Monad.Writer (Writer, runWriter, tell)
 import Data.List qualified as List
 import Data.List.NonEmpty (pattern (:|))
+import Data.List.NonEmpty.Extra qualified as NEL
 import Data.Map qualified as Map
 import Data.Set qualified as Set
 import Data.Text qualified as Text
@@ -39,6 +40,7 @@ import Unison.Syntax.TypePrinter (runPretty)
 import Unison.Syntax.TypePrinter qualified as TypePrinter
 import Unison.Syntax.Var qualified as Var (namespaced)
 import Unison.Type qualified as Type
+import Unison.Util.List qualified as List
 import Unison.Util.Pretty (Pretty)
 import Unison.Util.Pretty qualified as P
 import Unison.Util.SyntaxText qualified as S
@@ -87,6 +89,7 @@ prettyEffectDecl ::
 prettyEffectDecl ppe guid r name = prettyGADT ppe guid CT.Effect r name . toDataDecl
 
 prettyGADT ::
+  forall v a.
   (Var v) =>
   PrettyPrintEnvDecl ->
   RenderUniqueTypeGuids ->
@@ -98,17 +101,7 @@ prettyGADT ::
 prettyGADT env guid ctorType r name dd =
   header <> P.newline <> P.indentN 2 prettyConstructors
   where
-    -- Order Constructors alphabetically by name,
-    -- regardless of their original order in the declaration.
-    -- This is both nice for readability and ensures stable output in diffs, since otherwise
-    -- constructors will jump around in order based on their hash.
-    -- They'll be re-ordered by hash when parsed.
-    orderedConstructors =
-      zip [0 ..] (DD.constructors' dd)
-        & List.sortOn \case
-          (n, (_, _, _)) -> (PPE.termName unsuffixifiedPPE (Referent.Con (ConstructorReference r n) ctorType))
-
-    prettyConstructors = P.lines (printConstructor <$> orderedConstructors)
+    prettyConstructors = P.lines (printConstructor <$> orderConstructors unsuffixifiedPPE r dd)
     unsuffixifiedPPE = PPED.unsuffixifiedPPE env
     printConstructor (n, (_, _, t)) =
       prettyPattern unsuffixifiedPPE ctorType name (ConstructorReference r n)
@@ -134,7 +127,31 @@ prettyPattern env ctorType namespace ref =
   where
     conRef = Referent.Con ref ctorType
 
+-- Order Constructors alphabetically by name,
+-- regardless of their original order in the declaration.
+-- This is both nice for readability and ensures stable output in diffs, since otherwise
+-- constructors will jump around in order based on their hash.
+-- They'll be re-ordered by hash when parsed.
+orderConstructors :: (Var v) => PrettyPrintEnv -> TypeReference -> DataDeclaration v a -> [(Word64, (a, v, Type.Type v a))]
+orderConstructors ppe r dd =
+  zip [0 ..] (DD.constructors' dd)
+    -- First group by type, we need to leave identical types in their constructor order to avoid things like
+    -- swapping identical constructors, e.g. False turning into True and vice versa.
+    & List.groupMap (\con@(_, (_, _, typ)) -> (typ, con))
+    -- Then we can sort those _groups_ by the name of the first constructor in the group.
+    & List.sortOn
+      ( \(_typ, group) ->
+          group
+            & NEL.sortOn fst
+            & \case
+              (n, (_, _, _)) :| _rest ->
+                PPE.termName ppe (Referent.Con (ConstructorReference r n) CT.Data)
+      )
+    -- Then we flatten back out to a list of constructors.
+    & foldMap (toList . snd)
+
 prettyDataDecl ::
+  forall v a.
   (Var v) =>
   PrettyPrintEnvDecl ->
   RenderUniqueTypeGuids ->
@@ -144,18 +161,8 @@ prettyDataDecl ::
   Writer (Set AccessorName) (Pretty SyntaxText)
 prettyDataDecl (PrettyPrintEnvDecl unsuffixifiedPPE suffixifiedPPE) guid r name dd =
   (header <>) . P.sep (fmt S.DelimiterChar (" | " `P.orElse` "\n  | "))
-    <$> constructor `traverse` orderedConstructors
+    <$> constructor `traverse` (orderConstructors unsuffixifiedPPE r dd)
   where
-    -- Order Constructors alphabetically by name,
-    -- regardless of their original order in the declaration.
-    -- This is both nice for readability and ensures stable output in diffs, since otherwise
-    -- constructors will jump around in order based on their hash.
-    -- They'll be re-ordered by hash when parsed.
-    orderedConstructors =
-      zip [0 ..] (DD.constructors' dd)
-        & List.sortOn \case
-          (n, (_, _, _)) -> (PPE.termName unsuffixifiedPPE (Referent.Con (ConstructorReference r n) CT.Data))
-
     constructor (n, (_, _, Type.ForallsNamed' _ t)) = constructor' n t
     constructor (n, (_, _, t)) = constructor' n t
     constructor' n t = case Type.unArrows t of

--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -695,8 +695,12 @@ printLetBindings ::
 printLetBindings context = \case
   LetBindings bindings -> traverse (printLetBinding context) bindings
   LetrecBindings bindings ->
-    let boundVars = map fst bindings
-     in traverse (printLetrecBinding context boundVars) bindings
+    -- We order let-rec bindings alphabetically rather than hash-ordered when printing
+    -- improve diffing alignment (and sanity). They'll be re-ordered back to hash order when
+    -- parsed.
+    let orderedBindings = sort bindings
+        boundVars = map fst orderedBindings
+     in traverse (printLetrecBinding context boundVars) orderedBindings
 
 printLetBinding :: (MonadPretty v m) => AmbientContext -> (v, Term3 v PrintAnnotation) -> m (Pretty SyntaxText)
 printLetBinding context (v, binding)

--- a/parser-typechecker/src/Unison/Syntax/TypePrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TypePrinter.hs
@@ -18,6 +18,7 @@ module Unison.Syntax.TypePrinter
 where
 
 import Control.Monad.Reader (ask)
+import Data.List qualified as List
 import Data.Map qualified as Map
 import Unison.Builtin.Decls qualified as DD
 import Unison.HashQualified (HashQualified)
@@ -137,10 +138,16 @@ prettyRaw im p tp = go im p tp
                 <$> ((<>) <$> go im 0 fst <*> arrows False False rest)
         _ -> pure . fromString $ "bug: unexpected Arrow form in prettyRaw: " <> show t
       _ -> pure . fromString $ "bug: unexpected form in prettyRaw: " <> show tp
+    -- Sort effects in effect lists by how they're printed rather than hash,
+    -- this helps with both readability and diff alignment.
+    orderEffects :: [Type v a] -> [Type v a]
+    orderEffects = List.sort
+
+    effects :: Maybe [Type v a] -> m (Pretty (S.SyntaxText' Reference))
     effects Nothing = pure mempty
     effects (Just es) =
       PP.group . (fmt S.AbilityBraces "{" <>) . (<> fmt S.AbilityBraces "}")
-        <$> (PP.commas <$> traverse (go im 0) es)
+        <$> (PP.commas <$> traverse (go im 0) (orderEffects es))
     -- `first`: is this the first argument?
     -- `mes`: list of effects
     arrow delay first mes = do

--- a/unison-src/transcripts-using-base/all-base-hashes.output.md
+++ b/unison-src/transcripts-using-base/all-base-hashes.output.md
@@ -3580,14 +3580,14 @@ This transcript is intended to make visible accidental changes to the hashing al
         ->{IO} [(Link.Term, Code)]
         
   991.  -- #srpc2uag5p1grvshbcm3urjntakgi3g3dthfse2cp38sd6uestd5neseces5ue7kum2ca0gsg9i0cilkl0gn8dn3q5dn86v4r8lbha0
-        compose : (i1 ->{g1} o) -> (i ->{g} i1) -> i ->{g1, g} o
+        compose : (i1 ->{g1} o) -> (i ->{g} i1) -> i ->{g, g1} o
         
   992.  -- #stnrk323b8mm7dknlonfl70epd9f9ede60iom7sgok31mmggnic7etgi0are2uccs9g429qo3ruaeb9tk90bh35obnce1038p5qe6co
         compose2 : (i2 ->{g2} o)
         -> (i1 ->{g1} i ->{g} i2)
         -> i1
         -> i
-        ->{g2, g1, g} o
+        ->{g, g1, g2} o
         
   993.  -- #mrc183aovjcae3i03r1a0ia26crmmkcf2e723pda860ps6q11rancsenjoqhc3fn0eraih1mobcvt245jr77l27uoujqa452utq8p68
         compose3 : (i3 ->{g3} o)
@@ -3595,7 +3595,7 @@ This transcript is intended to make visible accidental changes to the hashing al
         -> i2
         -> i1
         -> i
-        ->{g3, g2, g1, g} o
+        ->{g, g1, g2, g3} o
         
   994.  -- #ilkeid6l866bmq90d2v1ilqp9dsjo6ucmf8udgrokq3nr3mo9skl2vao2mo7ish136as52rsf19u9v3jkmd85bl08gnmamo4e5v2fqo
         contains : Text -> Text -> Boolean
@@ -3954,7 +3954,7 @@ This transcript is intended to make visible accidental changes to the hashing al
         Throw.throw : e ->{Throw e} a
         
   1100. -- #f6pkvs6ukf8ngh2j8lm935p1bqadso76o7e3t0j1ukupjh1rg0m1rhtp7u492sq17p3bkbintbnjehc1cqs33qlhnfkoihf5uee4ug0
-        uncurry : (i1 ->{g1} i ->{g} o) -> (i1, i) ->{g1, g} o
+        uncurry : (i1 ->{g1} i ->{g} o) -> (i1, i) ->{g, g1} o
         
   1101. -- #u1o44hd0cdlfa8racf458sahdmgea409k8baajgc5k7bqukf2ak5ggs2ped0u3h85v99pgefgb9r7ct2dv4nn9eihjghnqf30p4l57g
         Value.transitiveDeps : Value ->{IO} [(Link.Term, Code)]

--- a/unison-src/transcripts-using-base/doc.output.md
+++ b/unison-src/transcripts-using-base/doc.output.md
@@ -59,7 +59,7 @@ You can preview what docs will look like when rendered to the console using the 
 
   The 7 days of the week, defined as:
 
-      type DayOfWeek = Fri | Mon | Sat | Sun | Thu | Tue | Wed
+      type DayOfWeek = Sun | Mon | Tue | Wed | Thu | Fri | Sat
 ```
 
 The `docs ImportantConstant` command will look for `ImportantConstant.doc` in the file or codebase. You can do this instead of explicitly linking docs to definitions.

--- a/unison-src/transcripts-using-base/doc.output.md
+++ b/unison-src/transcripts-using-base/doc.output.md
@@ -59,7 +59,7 @@ You can preview what docs will look like when rendered to the console using the 
 
   The 7 days of the week, defined as:
 
-      type DayOfWeek = Sun | Mon | Tue | Wed | Thu | Fri | Sat
+      type DayOfWeek = Fri | Mon | Sat | Sun | Thu | Tue | Wed
 ```
 
 The `docs ImportantConstant` command will look for `ImportantConstant.doc` in the file or codebase. You can do this instead of explicitly linking docs to definitions.
@@ -342,7 +342,7 @@ and the rendered output using `display`:
 
     Unison definitions can be included in docs. For instance:
 
-        structural type Optional a = Some a | None
+        structural type Optional a = None | Some a
         
         sqr : Nat -> Nat
         sqr x =
@@ -351,7 +351,7 @@ and the rendered output using `display`:
 
     Some rendering targets also support folded source:
 
-        structural type Optional a = Some a | None
+        structural type Optional a = None | Some a
         
         sqr : Nat -> Nat
         sqr x =
@@ -658,7 +658,7 @@ Lastly, it's common to build longer documents including subdocuments via `{{ sub
     
       Unison definitions can be included in docs. For instance:
     
-          structural type Optional a = Some a | None
+          structural type Optional a = None | Some a
           
           sqr : Nat -> Nat
           sqr x =
@@ -667,7 +667,7 @@ Lastly, it's common to build longer documents including subdocuments via `{{ sub
     
       Some rendering targets also support folded source:
     
-          structural type Optional a = Some a | None
+          structural type Optional a = None | Some a
           
           sqr : Nat -> Nat
           sqr x =

--- a/unison-src/transcripts-using-base/serial-test-00.output.md
+++ b/unison-src/transcripts-using-base/serial-test-00.output.md
@@ -81,7 +81,7 @@ mkTestCase = do
                  -> (r ->{g2} r ->{g1} r)
                  -> (a ->{g} r)
                  -> Tree a
-                 ->{g2, g1, g} r
+                 ->{g, g1, g2} r
   + mkTestCase : '{IO, Exception} ()
   + tree0      : Tree Nat
   + tree1      : Tree Nat

--- a/unison-src/transcripts/idempotent/affine-handlers.md
+++ b/unison-src/transcripts/idempotent/affine-handlers.md
@@ -145,7 +145,7 @@ count'test = do
   + looped       : '{g} r -> Nat ->{g} ()
   + now          : '{IO, Exception} TimeSpec
   + provide      : e -> Request {Env e} r -> r
-  + repeated     : Request {Repeat, g} () ->{g} ()
+  + repeated     : Request {g, Repeat} () ->{g} ()
   + testPerf     : '() ->{IO, Exception} Result
 
   Run `update` to apply these changes to your codebase.

--- a/unison-src/transcripts/idempotent/bug-strange-closure.md
+++ b/unison-src/transcripts/idempotent/bug-strange-closure.md
@@ -101,7 +101,7 @@ We can display the guide before and after adding it to the codebase:
     
       Unison definitions can be included in docs. For instance:
     
-          structural type Optional a = Some a | None
+          structural type Optional a = None | Some a
           
           sqr : Nat -> Nat
           sqr x =
@@ -110,7 +110,7 @@ We can display the guide before and after adding it to the codebase:
     
       Some rendering targets also support folded source:
     
-          structural type Optional a = Some a | None
+          structural type Optional a = None | Some a
           
           sqr : Nat -> Nat
           sqr x =
@@ -306,7 +306,7 @@ We can display the guide before and after adding it to the codebase:
     
       Unison definitions can be included in docs. For instance:
     
-          structural type Optional a = Some a | None
+          structural type Optional a = None | Some a
           
           sqr : Nat -> Nat
           sqr x =
@@ -315,7 +315,7 @@ We can display the guide before and after adding it to the codebase:
     
       Some rendering targets also support folded source:
     
-          structural type Optional a = Some a | None
+          structural type Optional a = None | Some a
           
           sqr : Nat -> Nat
           sqr x =
@@ -520,7 +520,7 @@ rendered = Pretty.get (docFormatConsole doc.guide)
     
       Unison definitions can be included in docs. For instance:
     
-          structural type Optional a = Some a | None
+          structural type Optional a = None | Some a
           
           sqr : Nat -> Nat
           sqr x =
@@ -529,7 +529,7 @@ rendered = Pretty.get (docFormatConsole doc.guide)
     
       Some rendering targets also support folded source:
     
-          structural type Optional a = Some a | None
+          structural type Optional a = None | Some a
           
           sqr : Nat -> Nat
           sqr x =
@@ -725,7 +725,7 @@ rendered = Pretty.get (docFormatConsole doc.guide)
     
       Unison definitions can be included in docs. For instance:
     
-          structural type Optional a = Some a | None
+          structural type Optional a = None | Some a
           
           sqr : Nat -> Nat
           sqr x =
@@ -734,7 +734,7 @@ rendered = Pretty.get (docFormatConsole doc.guide)
     
       Some rendering targets also support folded source:
     
-          structural type Optional a = Some a | None
+          structural type Optional a = None | Some a
           
           sqr : Nat -> Nat
           sqr x =

--- a/unison-src/transcripts/idempotent/doc1.md
+++ b/unison-src/transcripts/idempotent/doc1.md
@@ -11,11 +11,11 @@ Unison documentation is written in Unison. Documentation is a value of the follo
 
   type lib.builtins.Doc
     = Blob Text
-    | Link Link
-    | Source Link
-    | Signature Link.Term
     | Evaluate Link.Term
     | Join [Doc]
+    | Link Link
+    | Signature Link.Term
+    | Source Link
 ```
 
 You can create these `Doc` values with ordinary code, or you can use the special syntax. A value of structural type `Doc` can be created via syntax like:

--- a/unison-src/transcripts/idempotent/doc1.md
+++ b/unison-src/transcripts/idempotent/doc1.md
@@ -11,11 +11,11 @@ Unison documentation is written in Unison. Documentation is a value of the follo
 
   type lib.builtins.Doc
     = Blob Text
-    | Evaluate Link.Term
     | Join [Doc]
     | Link Link
-    | Signature Link.Term
     | Source Link
+    | Signature Link.Term
+    | Evaluate Link.Term
 ```
 
 You can create these `Doc` values with ordinary code, or you can use the special syntax. A value of structural type `Doc` can be created via syntax like:

--- a/unison-src/transcripts/idempotent/fix1063.md
+++ b/unison-src/transcripts/idempotent/fix1063.md
@@ -15,7 +15,7 @@ noop = not `.` not
 ``` ucm :added-by-ucm
   Loading changes detected in scratch.u.
 
-  + (`.`) : (i1 ->{g1} o) -> (i ->{g} i1) -> i ->{g1, g} o
+  + (`.`) : (i1 ->{g1} o) -> (i ->{g} i1) -> i ->{g, g1} o
   + noop  : Boolean -> Boolean
 
   Run `update` to apply these changes to your codebase.

--- a/unison-src/transcripts/idempotent/fix2254.md
+++ b/unison-src/transcripts/idempotent/fix2254.md
@@ -80,15 +80,15 @@ scratch/a2> update
 scratch/a2> view A NeedsA f f2 f3 g
 
   type A a b c d
-    = E a d
+    = A a
     | B b
-    | A a
-    | D d
     | C c
+    | D d
+    | E a d
 
   structural type NeedsA a b
-    = Zoink Text
-    | NeedsA (A a b Nat Nat)
+    = NeedsA (A a b Nat Nat)
+    | Zoink Text
 
   f : A Nat Nat Nat Nat -> Nat
   f = cases

--- a/unison-src/transcripts/idempotent/fix3265.md
+++ b/unison-src/transcripts/idempotent/fix3265.md
@@ -36,12 +36,12 @@ are three cases that need to be 'fixed up.'
             (w x ->
               let
                 use Nat + drop
-                f1 y = match y with
-                  0 -> w + x
-                  n -> 1 + f0 (drop y 1)
                 f0 y = match y with
                   0 -> x
                   n -> 1 + f1 (drop y 1)
+                f1 y = match y with
+                  0 -> w + x
+                  n -> 1 + f0 (drop y 1)
                 f2 x = f2 x
                 f3 x y = 1 + y + f2 x
                 g h = h 1 + x

--- a/unison-src/transcripts/idempotent/fix693.md
+++ b/unison-src/transcripts/idempotent/fix693.md
@@ -109,7 +109,7 @@ h3 = cases
 ``` ucm :added-by-ucm
   Loading changes detected in scratch.u.
 
-  + h3 : Request {X b, Abort} b -> Optional b
+  + h3 : Request {Abort, X b} b -> Optional b
 
   Run `update` to apply these changes to your codebase.
 ```

--- a/unison-src/transcripts/idempotent/formatter.md
+++ b/unison-src/transcripts/idempotent/formatter.md
@@ -133,8 +133,8 @@ explicit.doc =
 
 Thing.doc = {{ A doc before an ability }}
 ability Thing where
-  doThing : Nat ->{Thing} Int
   more : Nat -> Text ->{Thing} Nat
+  doThing : Nat ->{Thing} Int
 
 
 Ask.doc = {{ Ability with single constructor }}

--- a/unison-src/transcripts/idempotent/formatter.md
+++ b/unison-src/transcripts/idempotent/formatter.md
@@ -133,8 +133,8 @@ explicit.doc =
 
 Thing.doc = {{ A doc before an ability }}
 ability Thing where
-  more : Nat -> Text ->{Thing} Nat
   doThing : Nat ->{Thing} Int
+  more : Nat -> Text ->{Thing} Nat
 
 
 Ask.doc = {{ Ability with single constructor }}

--- a/unison-src/transcripts/idempotent/formatter.md
+++ b/unison-src/transcripts/idempotent/formatter.md
@@ -133,8 +133,8 @@ explicit.doc =
 
 Thing.doc = {{ A doc before an ability }}
 ability Thing where
-  more : Nat -> Text ->{Thing} Nat
   doThing : Nat ->{Thing} Int
+  more : Nat -> Text ->{Thing} Nat
 
 
 Ask.doc = {{ Ability with single constructor }}
@@ -150,7 +150,7 @@ provide a action =
   handle action() with h
 
 Optional.doc = {{ A Doc before a type }}
-structural type Optional a = More Text | Some | Other a | None Nat
+structural type Optional a = More Text | None Nat | Other a | Some
 
 Two.doc = {{ A doc before a type with no type-vars }}
 type Two = One Nat | Two Text

--- a/unison-src/transcripts/idempotent/merge.md
+++ b/unison-src/transcripts/idempotent/merge.md
@@ -1209,7 +1209,7 @@ scratch/alice> merge /bob
 type Foo = Baz Nat Nat | Qux Text
 
 -- scratch/bob
-type Foo = BobQux Text | Baz Nat
+type Foo = Baz Nat | BobQux Text
 
 ```
 
@@ -1287,10 +1287,10 @@ scratch/alice> merge bob
 
 ``` unison :added-by-ucm scratch.u
 -- scratch/alice
-type Foo = Qux Text | Alice Nat
+type Foo = Alice Nat | Qux Text
 
 -- scratch/bob
-type Foo = Bob Text | Baz Nat
+type Foo = Baz Nat | Bob Text
 
 ```
 
@@ -1550,7 +1550,7 @@ scratch/bob> move.term Foo.Bar.Qux Foo.Bar.Hello
 ``` ucm
 scratch/bob> view Foo.Bar
 
-  type Foo.Bar = Hello Nat Nat | Baz Nat
+  type Foo.Bar = Baz Nat | Hello Nat Nat
 ```
 
 At this point, Bob and alice have both updated the name `Foo.Bar.Hello` in different ways, so that's a conflict. Therefore, Bob's entire type (`Foo.Bar` with constructors `Foo.Bar.Baz` and `Foo.Bar.Hello`) gets rendered into the scratch file.
@@ -1595,7 +1595,7 @@ Foo.Bar.Hello : Nat
 Foo.Bar.Hello = 18
 
 -- scratch/bob
-type Foo.Bar = Hello Nat Nat | Baz Nat
+type Foo.Bar = Baz Nat | Hello Nat Nat
 
 ```
 

--- a/unison-src/transcripts/idempotent/print-ordering.md
+++ b/unison-src/transcripts/idempotent/print-ordering.md
@@ -90,8 +90,8 @@ scratch/main> update
 scratch/main> view MyType MyAbility
 
   ability MyAbility where
-    def : Nat ->{MyAbility} Nat
     abc : Nat ->{MyAbility} Int
+    def : Nat ->{MyAbility} Nat
     ghi : Int ->{MyAbility} Int
 
   type MyType = X Int | Y Nat | Z

--- a/unison-src/transcripts/idempotent/print-ordering.md
+++ b/unison-src/transcripts/idempotent/print-ordering.md
@@ -170,7 +170,7 @@ scratch/main> edit MyType
 structural type MyType = B Nat | C | A
 ```
 
-Even if we change the other constructor and update, the Nat mapping should be preserved.
+Since the ordering within each group is preserved, even if we edit and update, the Nat mapping should be preserved.
 
 ``` unison :hide
 structural type MyType = B Text | C | A

--- a/unison-src/transcripts/idempotent/print-ordering.md
+++ b/unison-src/transcripts/idempotent/print-ordering.md
@@ -90,8 +90,8 @@ scratch/main> update
 scratch/main> view MyType MyAbility
 
   ability MyAbility where
-    abc : Nat ->{MyAbility} Int
     def : Nat ->{MyAbility} Nat
+    abc : Nat ->{MyAbility} Int
     ghi : Int ->{MyAbility} Int
 
   type MyType = X Int | Y Nat | Z
@@ -122,4 +122,98 @@ scratch/main> view abilityTerm
     '{x, y, z, AnotherAbility, MyAbility} Nat
     -> '{x, y, z, AnotherAbility, MyAbility} Nat
   abilityTerm action = action
+```
+
+-----
+
+The following tests whether type constructors might be re-assigned to other constructors when updated.
+
+``` unison :hide
+-- Create a type with some identical constructors which are not in alphabetical order.
+structural type MyType = C | B Nat |  A
+
+toNat : MyType -> Nat
+toNat = cases
+  A -> 0
+  B _ -> 1
+  C -> 2
+
+fromNat : Nat -> MyType
+fromNat = cases
+    0 -> A
+    _ -> C
+```
+
+Add it to the codebase.
+
+``` ucm :hide
+scratch/main> update
+```
+
+Now when we edit it, the constructors would be printed in alphabetical order, BUT since 'A' and 'C' are identical
+constructors, they should maintain their original ordering relative to one another. That is, 'C' should precede 'A'.
+This behaviour ensures we don't accidentally swap meanings between identical constructors, e.g. swap True and False due
+to alphabetical re-ordering.
+
+``` ucm
+scratch/main> edit MyType
+
+  ☝️
+
+  I added 1 definitions to the top of scratch.u
+
+  You can edit them there, then run `update` to replace the
+  definitions currently in this namespace.
+```
+
+``` unison :added-by-ucm scratch.u
+structural type MyType = B Nat | C | A
+```
+
+Even if we change the other constructor and update, the Nat mapping should be preserved.
+
+``` unison :hide
+structural type MyType = B Text | C | A
+```
+
+``` ucm
+scratch/main> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
+
+  Done.
+```
+
+``` unison
+> toNat A
+> toNat C
+> fromNat 0
+> fromNat 2
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  No changes found.
+
+    1 | > toNat A
+          ⧩
+          0
+
+    2 | > toNat C
+          ⧩
+          2
+
+    3 | > fromNat 0
+          ⧩
+          A
+
+    4 | > fromNat 2
+          ⧩
+          C
 ```

--- a/unison-src/transcripts/idempotent/print-ordering.md
+++ b/unison-src/transcripts/idempotent/print-ordering.md
@@ -1,0 +1,125 @@
+This transcript tests that let-rec bindings, ability lists and constructors are printed in order according to their
+name, rather than their hashes.
+
+``` ucm
+scratch/main> builtins.mergeio
+
+  Done.
+```
+
+``` unison :hide
+-- Let-rec bindings should be ordered alphabetically by name when printed.
+letRec = do
+  z = do 1 Nat.+ y()
+  x = do 2 Nat.+ z()
+  y = do 3 Nat.+ x()
+  x()
+
+-- Non-cycle bindings dependent bindings are ordered in definition order
+nonLetRec =
+  z = 1
+  x = 2 Nat.+ z
+  y = 3 Nat.+ x
+  y
+
+-- This still isn't a let-rec, so it should keep its original order
+nonDependent =
+  z = 3
+  x = 2
+  y = 1
+  x + y + z
+```
+
+``` ucm
+scratch/main> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+
+scratch/main> view letRec nonLetRec nonDependent
+
+  letRec : 'Nat
+  letRec = do
+    use Nat +
+    x = do 2 + z()
+    y = do 3 + x()
+    z = do 1 + y()
+    x()
+
+  nonDependent : Nat
+  nonDependent =
+    use Nat +
+    z = 3
+    x = 2
+    y = 1
+    x + y + z
+
+  nonLetRec : Nat
+  nonLetRec =
+    use Nat +
+    z = 1
+    x = 2 + z
+    y = 3 + x
+    y
+```
+
+Type and ability constructors should be ordered alphabetically by name when printed.
+
+``` unison :hide
+type MyType =
+    Y Nat
+  | X Int
+  | Z
+
+ability MyAbility where
+  def : Nat -> Nat
+  ghi : Int -> Int
+  abc : Nat -> Int
+```
+
+``` ucm
+scratch/main> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+
+scratch/main> view MyType MyAbility
+
+  ability MyAbility where
+    abc : Nat ->{MyAbility} Int
+    def : Nat ->{MyAbility} Nat
+    ghi : Int ->{MyAbility} Int
+
+  type MyType = X Int | Y Nat | Z
+```
+
+Ability variables should be ordered alphabetically by name, followed by concrete ability heads in alphabetical order.
+
+``` unison :hide
+
+ability AnotherAbility where
+  foo : Nat -> Nat
+
+abilityTerm : '{MyAbility, z, x, AnotherAbility, y} Nat -> '{MyAbility, z, x, AnotherAbility, y} Nat
+abilityTerm action = action
+```
+
+``` ucm
+scratch/main> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+
+scratch/main> view abilityTerm
+
+  abilityTerm :
+    '{x, y, z, AnotherAbility, MyAbility} Nat
+    -> '{x, y, z, AnotherAbility, MyAbility} Nat
+  abilityTerm action = action
+```

--- a/unison-src/transcripts/idempotent/update-type-add-constructor.md
+++ b/unison-src/transcripts/idempotent/update-type-add-constructor.md
@@ -50,7 +50,7 @@ unique type Foo
 
 > view Foo
 
-  type Foo = Baz Nat Nat | Bar Nat
+  type Foo = Bar Nat | Baz Nat Nat
 
 > find.verbose
 

--- a/unison-src/transcripts/pretty-print-libraries.output.md
+++ b/unison-src/transcripts/pretty-print-libraries.output.md
@@ -43,9 +43,9 @@ ability abilities.Label where
   pushScope : Text ->{Label} ()
 
 ability abilities.Random where
-  bytes : Nat ->{Random} Bytes
-  nat! : {Random} Nat
   split! : {Random} (∀ g a. '{g, Random} a ->{g} a)
+  nat! : {Random} Nat
+  bytes : Nat ->{Random} Bytes
 
 structural type abilities.Random.RNG
   = RNG (∀ g a. '{g, Random} a ->{g} a)
@@ -53,8 +53,8 @@ structural type abilities.Random.RNG
 -- abilities.Request is built-in.
 
 structural ability abilities.Store a where
-  get : {Store a} a
   put : a ->{Store a} ()
+  get : {Store a} a
 
 structural ability abilities.Throw e where
   throw : e ->{Throw e} a
@@ -200,42 +200,42 @@ structural type data.Tuple a b
   = Cons a b
 
 type Doc
-  = Anchor Text Doc
-  | Aside Doc
-  | Blankline
-  | Blockquote Doc
-  | Bold Doc
-  | BulletedList [Doc]
+  = Blankline
+  | Linebreak
+  | SectionBreak
   | Callout (Optional Doc) Doc
   | Code Doc
-  | CodeBlock Text Doc
-  | Column [Doc]
-  | Folded Boolean Doc Doc
-  | Group Doc
-  | Image Doc Doc (Optional Doc)
+  | Bold Doc
   | Italic Doc
-  | Join [Doc]
-  | Linebreak
-  | NamedLink Doc Doc
+  | Strikethrough Doc
+  | Blockquote Doc
+  | Aside Doc
+  | Group Doc
+  | CodeBlock Text Doc
+  | Style Text Doc
+  | Anchor Text Doc
+  | Folded Boolean Doc Doc
+  | Image Doc Doc (Optional Doc)
   | NumberedList Nat [Doc]
   | Paragraph [Doc]
+  | BulletedList [Doc]
+  | Join [Doc]
+  | UntitledSection [Doc]
+  | Column [Doc]
   | Section Doc [Doc]
-  | SectionBreak
   | Special SpecialForm
-  | Strikethrough Doc
-  | Style Text Doc
   | Table [[Doc]]
   | Tooltip Doc Doc
-  | UntitledSection [Doc]
+  | NamedLink Doc Doc
   | Word Text
 
 type Doc.Deprecated
   = Blob Text
-  | Evaluate Link.Term
   | Join [Deprecated]
   | Link Link
-  | Signature Link.Term
   | Source Link
+  | Signature Link.Term
+  | Evaluate Link.Term
 
 type Doc.EmbedSvg
   = EmbedSvg Text
@@ -252,15 +252,15 @@ type Doc.MediaSource
 type Doc.SpecialForm
   = Embed Any
   | EmbedInline Any
-  | Eval Doc.Term
-  | EvalInline Doc.Term
   | Example Nat Doc.Term
   | ExampleBlock Nat Doc.Term
-  | FoldedSource [(Either Type Doc.Term, [Doc.Term])]
   | Link (Either Type Doc.Term)
   | Signature [Doc.Term]
   | SignatureInline Doc.Term
+  | Eval Doc.Term
+  | EvalInline Doc.Term
   | Source [(Either Type Doc.Term, [Doc.Term])]
+  | FoldedSource [(Either Type Doc.Term, [Doc.Term])]
 
 type Doc.Term
   = Term Any
@@ -330,17 +330,17 @@ type IO.FilePath
   = FilePath Text
 
 type IO.FilePath.FileMode
-  = Append
-  | Read
-  | ReadWrite
+  = Read
   | Write
+  | Append
+  | ReadWrite
 
 -- IO.Handle is built-in.
 
 type IO.Handle.BufferMode
-  = BlockBuffering
+  = NoBuffering
   | LineBuffering
-  | NoBuffering
+  | BlockBuffering
   | SizedBlockBuffering Nat
 
 type IO.Handle.SeekMode
@@ -349,18 +349,18 @@ type IO.Handle.SeekMode
   | SeekFromEnd
 
 type IO.Handle.Std
-  = StdErr
-  | StdIn
+  = StdIn
   | StdOut
+  | StdErr
 
 type IO.IOError
   = AlreadyExists
-  | EOF
-  | IllegalOperation
   | NoSuchThing
-  | PermissionDenied
   | ResourceBusy
   | ResourceExhausted
+  | EOF
+  | IllegalOperation
+  | PermissionDenied
   | UserError
 
 type IO.IOFailure
@@ -419,15 +419,15 @@ type IO.net.URI.Fragment
   = Fragment Text
 
 type IO.net.URI.Method
-  = CONNECT
-  | DELETE
-  | GET
+  = GET
   | HEAD
-  | OPTIONS
-  | PATCH
   | POST
   | PUT
+  | DELETE
+  | CONNECT
   | TRACE
+  | PATCH
+  | OPTIONS
 
 type IO.net.URI.ParseError
   = 
@@ -460,11 +460,11 @@ type IPattern.Capture
 
 type math.ArithmeticException
   = DividedByZero
-  | NegativeInfinityNotAllowed
-  | NotANumber
   | Overflow
-  | PositiveInfinityNotAllowed
   | Underflow
+  | NotANumber
+  | NegativeInfinityNotAllowed
+  | PositiveInfinityNotAllowed
 
 type math.Natural
   = internal.Natural (List.Nonempty Nat)
@@ -513,9 +513,9 @@ structural type Optional a
   | Some a
 
 type Ordering
-  = Equal
+  = Less
+  | Equal
   | Greater
-  | Less
 
 -- Pattern is built-in.
 
@@ -526,11 +526,11 @@ type Pretty.Annotated w txt
   = Append w [Annotated w txt]
   | Empty
   | Group w (Annotated w txt)
+  | Wrap w (Annotated w txt)
   | Indent w (Annotated w txt) (Annotated w txt) (Annotated w txt)
   | Lit w txt
   | OrElse w (Annotated w txt) (Annotated w txt)
   | Table w [[Annotated w txt]]
-  | Wrap w (Annotated w txt)
 
 -- reflection.Code is built-in.
 
@@ -558,29 +558,29 @@ type reflection.RewriteTerm a b
 
 type system.ANSI.Color
   = Black
-  | Blue
-  | BrightBlack
-  | BrightBlue
-  | BrightCyan
-  | BrightGreen
-  | BrightMagenta
-  | BrightRed
-  | BrightWhite
-  | BrightYellow
-  | Cyan
-  | Green
-  | Magenta
   | Red
-  | White
+  | Green
   | Yellow
+  | Blue
+  | Magenta
+  | Cyan
+  | White
+  | BrightBlack
+  | BrightRed
+  | BrightGreen
+  | BrightYellow
+  | BrightBlue
+  | BrightMagenta
+  | BrightCyan
+  | BrightWhite
 
 type system.ConsoleText
-  = Background Color ConsoleText
-  | Bold ConsoleText
-  | Foreground Color ConsoleText
-  | Invert ConsoleText
-  | Plain Text
+  = Bold ConsoleText
   | Underline ConsoleText
+  | Invert ConsoleText
+  | Foreground Color ConsoleText
+  | Background Color ConsoleText
+  | Plain Text
 
 structural type test.deprecated.Domain a
   = Large (Weighted a)
@@ -597,9 +597,9 @@ structural type test.deprecated.internals.v1.Test.Report
 
 structural type test.deprecated.internals.v1.Test.Status
   = Expected Success
+  | Unexpected Success
   | Failed
   | Pending
-  | Unexpected Success
 
 structural type test.deprecated.internals.v1.Test.Success
   = Passed Nat
@@ -620,13 +620,13 @@ type test.TestFailure
 -- time.Clock.internals.TimeSpec is built-in.
 
 type time.DayOfWeek
-  = Fri
-  | Mon
-  | Sat
+  = Sat
   | Sun
-  | Thu
+  | Mon
   | Tue
   | Wed
+  | Thu
+  | Fri
 
 type time.Duration
   = internal.Duration Int Nat
@@ -83185,8 +83185,8 @@ type HttpResponse.Status.UnexpectedResponseStatus
   = 
 
 type proxy.ProxyPresence
-  = NoProxy
-  | Proxy
+  = Proxy
+  | NoProxy
 
 type server.Config
   = { hostName : Optional HostName,
@@ -83225,8 +83225,8 @@ type websockets.errors.WebSocketClosed
 
 type websockets.Frame
   = Binary Boolean Bytes
-  | Close (Optional (Nat, Text))
   | Continuation Boolean Bytes
+  | Close (Optional (Nat, Text))
   | Ping Bytes
   | Pong Bytes
   | Text Boolean Text

--- a/unison-src/transcripts/pretty-print-libraries.output.md
+++ b/unison-src/transcripts/pretty-print-libraries.output.md
@@ -43,18 +43,18 @@ ability abilities.Label where
   pushScope : Text ->{Label} ()
 
 ability abilities.Random where
-  split! : {Random} (∀ g a. '{g, Random} a ->{g} a)
-  nat! : {Random} Nat
   bytes : Nat ->{Random} Bytes
+  nat! : {Random} Nat
+  split! : {Random} (∀ g a. '{g, Random} a ->{g} a)
 
 structural type abilities.Random.RNG
-  = RNG (∀ g a. '{Random, g} a ->{g} a)
+  = RNG (∀ g a. '{g, Random} a ->{g} a)
 
 -- abilities.Request is built-in.
 
 structural ability abilities.Store a where
-  put : a ->{Store a} ()
   get : {Store a} a
+  put : a ->{Store a} ()
 
 structural ability abilities.Throw e where
   throw : e ->{Throw e} a
@@ -69,8 +69,8 @@ ability abilities.Wait where
 -- Bytes is built-in.
 
 structural type Bytes.base32Hex.Hex32Piece
-  = Single Nat Nat Bytes
-  | Double Nat Nat Nat Bytes
+  = Double Nat Nat Nat Bytes
+  | Single Nat Nat Bytes
 
 -- Char is built-in.
 
@@ -119,8 +119,8 @@ structural type data.deprecated.Heap k v
   = Heap Nat k v [Heap k v]
 
 structural type data.deprecated.Weighted a
-  = Weight Nat ('Weighted a)
-  | Fail
+  = Fail
+  | Weight Nat ('Weighted a)
   | Yield a (Weighted a)
 
 type data.Graph v
@@ -161,15 +161,15 @@ type data.NatMap a
   = NatMap (Optional (NatMap.Nonempty a))
 
 type data.NatMap.Nonempty a
-  = NatMap.Nonempty.Tip Nat a
-  | NatMap.Nonempty.Bin Nat Nat Nat (NatMap.Nonempty a) (NatMap.Nonempty a)
+  = NatMap.Nonempty.Bin Nat Nat Nat (NatMap.Nonempty a) (NatMap.Nonempty a)
+  | NatMap.Nonempty.Tip Nat a
 
 type data.NatSet
   = NatSet (Optional NatSet.Nonempty)
 
 type data.NatSet.Nonempty
-  = Tip Nat Nat
-  | Bin Nat Nat Nat NatSet.Nonempty NatSet.Nonempty
+  = Bin Nat Nat Nat NatSet.Nonempty NatSet.Nonempty
+  | Tip Nat Nat
 
 structural type data.OneOrBoth a b
   = Both a b
@@ -200,42 +200,42 @@ structural type data.Tuple a b
   = Cons a b
 
 type Doc
-  = Folded Boolean Doc Doc
-  | Tooltip Doc Doc
-  | NamedLink Doc Doc
-  | Callout (Optional Doc) Doc
-  | NumberedList Nat [Doc]
-  | Special SpecialForm
-  | Code Doc
-  | Bold Doc
-  | Italic Doc
-  | Strikethrough Doc
-  | Blockquote Doc
+  = Anchor Text Doc
   | Aside Doc
-  | Group Doc
-  | Section Doc [Doc]
-  | Image Doc Doc (Optional Doc)
   | Blankline
-  | Linebreak
-  | SectionBreak
-  | Table [[Doc]]
-  | Word Text
-  | Paragraph [Doc]
+  | Blockquote Doc
+  | Bold Doc
   | BulletedList [Doc]
-  | Join [Doc]
-  | UntitledSection [Doc]
-  | Column [Doc]
+  | Callout (Optional Doc) Doc
+  | Code Doc
   | CodeBlock Text Doc
+  | Column [Doc]
+  | Folded Boolean Doc Doc
+  | Group Doc
+  | Image Doc Doc (Optional Doc)
+  | Italic Doc
+  | Join [Doc]
+  | Linebreak
+  | NamedLink Doc Doc
+  | NumberedList Nat [Doc]
+  | Paragraph [Doc]
+  | Section Doc [Doc]
+  | SectionBreak
+  | Special SpecialForm
+  | Strikethrough Doc
   | Style Text Doc
-  | Anchor Text Doc
+  | Table [[Doc]]
+  | Tooltip Doc Doc
+  | UntitledSection [Doc]
+  | Word Text
 
 type Doc.Deprecated
   = Blob Text
-  | Link Link
-  | Source Link
-  | Signature Link.Term
   | Evaluate Link.Term
   | Join [Deprecated]
+  | Link Link
+  | Signature Link.Term
+  | Source Link
 
 type Doc.EmbedSvg
   = EmbedSvg Text
@@ -250,17 +250,17 @@ type Doc.MediaSource
   = { sourceUrl : Text, mimeType : Optional Text }
 
 type Doc.SpecialForm
-  = Example Nat Doc.Term
-  | ExampleBlock Nat Doc.Term
-  | Signature [Doc.Term]
-  | Link (Either Type Doc.Term)
-  | Embed Any
+  = Embed Any
   | EmbedInline Any
-  | Source [(Either Type Doc.Term, [Doc.Term])]
-  | FoldedSource [(Either Type Doc.Term, [Doc.Term])]
-  | SignatureInline Doc.Term
   | Eval Doc.Term
   | EvalInline Doc.Term
+  | Example Nat Doc.Term
+  | ExampleBlock Nat Doc.Term
+  | FoldedSource [(Either Type Doc.Term, [Doc.Term])]
+  | Link (Either Type Doc.Term)
+  | Signature [Doc.Term]
+  | SignatureInline Doc.Term
+  | Source [(Either Type Doc.Term, [Doc.Term])]
 
 type Doc.Term
   = Term Any
@@ -269,8 +269,8 @@ type Doc.Video
   = { sources : [MediaSource], config : [(Text, Text)] }
 
 structural type Either a b
-  = Right b
-  | Left a
+  = Left a
+  | Right b
 
 -- Float is built-in.
 
@@ -294,9 +294,9 @@ type IO.concurrent.STM.TMap a
   = TMap (TVar (Optional a)) [TVar (F a)]
 
 type IO.concurrent.STM.TMap.impl.F a
-  = One Bytes a
+  = Empty
   | Many (TMap a)
-  | Empty
+  | One Bytes a
 
 type IO.concurrent.STM.TQueue a
   = TQueue (TVar [a]) (TVar Nat)
@@ -330,17 +330,17 @@ type IO.FilePath
   = FilePath Text
 
 type IO.FilePath.FileMode
-  = Read
-  | Write
-  | Append
+  = Append
+  | Read
   | ReadWrite
+  | Write
 
 -- IO.Handle is built-in.
 
 type IO.Handle.BufferMode
-  = NoBuffering
+  = BlockBuffering
   | LineBuffering
-  | BlockBuffering
+  | NoBuffering
   | SizedBlockBuffering Nat
 
 type IO.Handle.SeekMode
@@ -349,18 +349,18 @@ type IO.Handle.SeekMode
   | SeekFromEnd
 
 type IO.Handle.Std
-  = StdIn
+  = StdErr
+  | StdIn
   | StdOut
-  | StdErr
 
 type IO.IOError
   = AlreadyExists
-  | NoSuchThing
-  | ResourceBusy
-  | ResourceExhausted
   | EOF
   | IllegalOperation
+  | NoSuchThing
   | PermissionDenied
+  | ResourceBusy
+  | ResourceExhausted
   | UserError
 
 type IO.IOFailure
@@ -419,15 +419,15 @@ type IO.net.URI.Fragment
   = Fragment Text
 
 type IO.net.URI.Method
-  = GET
+  = CONNECT
+  | DELETE
+  | GET
   | HEAD
+  | OPTIONS
+  | PATCH
   | POST
   | PUT
-  | DELETE
-  | CONNECT
   | TRACE
-  | PATCH
-  | OPTIONS
 
 type IO.net.URI.ParseError
   = 
@@ -460,11 +460,11 @@ type IPattern.Capture
 
 type math.ArithmeticException
   = DividedByZero
-  | Overflow
-  | Underflow
-  | NotANumber
   | NegativeInfinityNotAllowed
+  | NotANumber
+  | Overflow
   | PositiveInfinityNotAllowed
+  | Underflow
 
 type math.Natural
   = internal.Natural (List.Nonempty Nat)
@@ -509,13 +509,13 @@ structural type mutable.ByteArray g
 -- Nat is built-in.
 
 structural type Optional a
-  = Some a
-  | None
+  = None
+  | Some a
 
 type Ordering
-  = Less
-  | Equal
+  = Equal
   | Greater
+  | Less
 
 -- Pattern is built-in.
 
@@ -523,14 +523,14 @@ structural type Pretty txt
   = Pretty (Annotated () txt)
 
 type Pretty.Annotated w txt
-  = Table w [[Annotated w txt]]
-  | Append w [Annotated w txt]
-  | OrElse w (Annotated w txt) (Annotated w txt)
-  | Indent w (Annotated w txt) (Annotated w txt) (Annotated w txt)
-  | Group w (Annotated w txt)
-  | Wrap w (Annotated w txt)
+  = Append w [Annotated w txt]
   | Empty
+  | Group w (Annotated w txt)
+  | Indent w (Annotated w txt) (Annotated w txt) (Annotated w txt)
   | Lit w txt
+  | OrElse w (Annotated w txt) (Annotated w txt)
+  | Table w [[Annotated w txt]]
+  | Wrap w (Annotated w txt)
 
 -- reflection.Code is built-in.
 
@@ -558,29 +558,29 @@ type reflection.RewriteTerm a b
 
 type system.ANSI.Color
   = Black
-  | Red
-  | Green
-  | Yellow
   | Blue
-  | Magenta
-  | Cyan
-  | White
   | BrightBlack
-  | BrightRed
-  | BrightGreen
-  | BrightYellow
   | BrightBlue
-  | BrightMagenta
   | BrightCyan
+  | BrightGreen
+  | BrightMagenta
+  | BrightRed
   | BrightWhite
+  | BrightYellow
+  | Cyan
+  | Green
+  | Magenta
+  | Red
+  | White
+  | Yellow
 
 type system.ConsoleText
-  = Bold ConsoleText
-  | Underline ConsoleText
+  = Background Color ConsoleText
+  | Bold ConsoleText
+  | Foreground Color ConsoleText
   | Invert ConsoleText
   | Plain Text
-  | Foreground Color ConsoleText
-  | Background Color ConsoleText
+  | Underline ConsoleText
 
 structural type test.deprecated.Domain a
   = Large (Weighted a)
@@ -597,9 +597,9 @@ structural type test.deprecated.internals.v1.Test.Report
 
 structural type test.deprecated.internals.v1.Test.Status
   = Expected Success
-  | Unexpected Success
   | Failed
   | Pending
+  | Unexpected Success
 
 structural type test.deprecated.internals.v1.Test.Success
   = Passed Nat
@@ -620,13 +620,13 @@ type test.TestFailure
 -- time.Clock.internals.TimeSpec is built-in.
 
 type time.DayOfWeek
-  = Sat
-  | Sun
+  = Fri
   | Mon
+  | Sat
+  | Sun
+  | Thu
   | Tue
   | Wed
-  | Thu
-  | Fri
 
 type time.Duration
   = internal.Duration Int Nat
@@ -2422,7 +2422,7 @@ abilities.Each.split : '{g, Each} a ->{g} Optional (a, '{g, Each} a)
 abilities.Each.split c =
   use Stream uncons
   h :
-    '{Stream ('{Each, g} a)} ()
+    '{Stream ('{g, Each} a)} ()
     -> Request {Each} a
     ->{g} Optional (a, '{g, Each} a)
   h jq = cases
@@ -20755,7 +20755,7 @@ data.List.Nonempty.zipWith :
   (a ->{g1} b ->{g} c)
   -> List.Nonempty a
   -> List.Nonempty b
-  ->{g1, g} List.Nonempty c
+  ->{g, g1} List.Nonempty c
 data.List.Nonempty.zipWith f = cases
   Nonempty.Nonempty x xs, Nonempty.Nonempty y ys ->
     f x y +| List.zipWith f xs ys
@@ -22394,7 +22394,7 @@ data.List.uncons.doc =
   }}
 
 data.List.uncons.tests.applyOrEmpty :
-  (i1 ->{g1} i ->{g} [elem]) -> Optional (i1, i) ->{g1, g} [elem]
+  (i1 ->{g1} i ->{g} [elem]) -> Optional (i1, i) ->{g, g1} [elem]
 data.List.uncons.tests.applyOrEmpty f = cases
   Some (x, y) -> f x y
   None        -> []
@@ -24107,6 +24107,16 @@ data.Map.internal.balance k x l r =
   use Nat * +
   use Universal gt lt
   use internal Bin
+  doubleL : a -> b -> Map a b -> Map a b -> Map a b
+  doubleL k1 x1 t1 = cases
+    Bin _ k2 x2 (Bin _ k3 x3 t2 t3) t4 ->
+      bin k3 x3 (bin k1 x1 t1 t2) (bin k2 x2 t3 t4)
+    _ -> bug "doubleL: Tip"
+  doubleR : a -> b -> Map a b -> Map a b -> Map a b
+  doubleR k1 x1 = cases
+    Bin _ k2 x2 t1 (Bin _ k3 x3 t2 t3), t4 ->
+      bin k3 x3 (bin k2 x2 t1 t2) (bin k1 x1 t3 t4)
+    _, _ -> bug "doubleR: Tip"
   rotateL : a -> b -> Map a b -> Map a b -> Map a b
   rotateL k x l = cases
     r@(Bin _ _ _ ly ry) | lt (size ly) (ratio * size ry) -> singleL k x l r
@@ -24123,16 +24133,6 @@ data.Map.internal.balance k x l r =
   singleR k1 x1 = cases
     Bin _ k2 x2 t1 t2, t3 -> bin k2 x2 t1 (bin k1 x1 t2 t3)
     _, _                  -> bug "singleR: Tip"
-  doubleL : a -> b -> Map a b -> Map a b -> Map a b
-  doubleL k1 x1 t1 = cases
-    Bin _ k2 x2 (Bin _ k3 x3 t2 t3) t4 ->
-      bin k3 x3 (bin k1 x1 t1 t2) (bin k2 x2 t3 t4)
-    _ -> bug "doubleL: Tip"
-  doubleR : a -> b -> Map a b -> Map a b -> Map a b
-  doubleR k1 x1 = cases
-    Bin _ k2 x2 t1 (Bin _ k3 x3 t2 t3), t4 ->
-      bin k3 x3 (bin k2 x2 t1 t2) (bin k1 x1 t3 t4)
-    _, _ -> bug "doubleR: Tip"
   sizeL = size l
   sizeR = size r
   sizeX = sizeL + sizeR + 1
@@ -42510,7 +42510,7 @@ data.OneOrBoth.isThis.doc =
   }}
 
 data.OneOrBoth.joinThat :
-  (b ->{g1} b ->{g} b) -> OneOrBoth (OneOrBoth a b) b ->{g1, g} OneOrBoth a b
+  (b ->{g1} b ->{g} b) -> OneOrBoth (OneOrBoth a b) b ->{g, g1} OneOrBoth a b
 data.OneOrBoth.joinThat f = cases
   This x            -> x
   That y            -> That y
@@ -42556,7 +42556,7 @@ data.OneOrBoth.joinThat.doc =
   }}
 
 data.OneOrBoth.joinThis :
-  (a ->{g1} a ->{g} a) -> OneOrBoth a (OneOrBoth a b) ->{g1, g} OneOrBoth a b
+  (a ->{g1} a ->{g} a) -> OneOrBoth a (OneOrBoth a b) ->{g, g1} OneOrBoth a b
 data.OneOrBoth.joinThis f = cases
   This x            -> This x
   That y            -> y
@@ -46544,12 +46544,12 @@ data.Stream.splitAt : Nat -> '{g, Stream a} r ->{g} ([a], '{g, Stream a} r)
 data.Stream.splitAt n s =
   use List :+
   use Nat - ==
+  go : [a] -> Nat -> '{g, Stream a} r ->{g} ([a], '{g, Stream a} r)
+  go acc n s = if n == 0 then (acc, s) else handle s() with h acc n
   h : [a] -> Nat -> Request (Stream a) r ->{g} ([a], '{g, Stream a} r)
   h acc n = cases
     { emit a -> k } -> go (acc :+ a) (n - 1) k
     { r }           -> (acc, do r)
-  go : [a] -> Nat -> '{g, Stream a} r ->{g} ([a], '{g, Stream a} r)
-  go acc n s = if n == 0 then (acc, s) else handle s() with h acc n
   go [] n s
 
 data.Stream.splitAt.doc : Doc
@@ -46574,7 +46574,7 @@ data.Stream.splitAt.doc =
     ```
   }}
 
-data.Stream.tails : '{g, Stream a} r -> '{g, Stream ('{Stream a, g} r)} r
+data.Stream.tails : '{g, Stream a} r -> '{g, Stream ('{g, Stream a} r)} r
 data.Stream.tails s = do tails! s
 
 data.Stream.tails.doc : Doc
@@ -46592,7 +46592,7 @@ data.Stream.tails.doc =
     ```
   }}
 
-data.Stream.tails! : '{g, Stream a} r ->{g, Stream ('{Stream a, g} r)} r
+data.Stream.tails! : '{g, Stream a} r ->{g, Stream ('{g, Stream a} r)} r
 data.Stream.tails! s = match Stream.uncons s with
   Left r       -> r
   Right (x, s) -> (Stream.+:) (x Stream.+: s) (do data.Stream.tails! s) ()
@@ -47061,15 +47061,15 @@ data.Stream.zipWith.doc =
 data.Stream.zipWith! :
   (a ->{g} b ->{g} c) -> '{g, Stream a} r -> '{g, Stream b} r ->{g, Stream c} r
 data.Stream.zipWith! f sa sb =
+  readA : '{g, Stream b} r -> Request (Stream a) r ->{g, Stream c} r
+  readA sb = cases
+    { emit a -> sa } -> handle sb() with readB a sa
+    { r }            -> r
   readB : a -> '{g, Stream a} r -> Request (Stream b) r ->{g, Stream c} r
   readB a sa = cases
     { emit b -> sb } ->
       emit (f a b)
       handle sa() with readA sb
-    { r }            -> r
-  readA : '{g, Stream b} r -> Request (Stream a) r ->{g, Stream c} r
-  readA sb = cases
-    { emit a -> sa } -> handle sb() with readB a sa
     { r }            -> r
   handle sa() with readA sb
 
@@ -61895,7 +61895,6 @@ u math.Natural.* v =
   vs = toList (digits v)
   m = size us
   n = size vs
-  m6 j ws = if j < n then m2 j ws else dropRightWhile (x -> x == 0) ws
   m2 j ws =
     use List :+
     vj = if n > j then unsafeAt j vs else 0
@@ -61921,6 +61920,7 @@ u math.Natural.* v =
           (if size ws' > m + j then ws'
           else ws' ++ fill (size ws' - (m + j)) 0)
       m6 (j + 1) ws''
+  m6 j ws = if j < n then m2 j ws else dropRightWhile (x -> x == 0) ws
   mkNatural (dropRightWhile (x -> x == 0) (m2 0 (fill m 0)))
 
 (math.Natural.+) : Natural -> Natural -> Natural
@@ -62473,11 +62473,6 @@ math.Natural.internal.normalize =
   hmask = Nat.complement lmask
   cases
     Natural ns ->
-      rec rem done carry = match rem with
-        []      ->
-          done' = List.dropRightWhile (x -> x == 0) done
-          if carry == 0 then mkNatural done' else mkNatural (done' :+ carry)
-        x +: xs -> go xs x done carry
       go rem next done carry =
         use Nat + <= and
         newNext = next + carry
@@ -62486,6 +62481,11 @@ math.Natural.internal.normalize =
           newNewNext = and lmask newNext
           newCarry = Nat.shiftRight (and hmask newNext) bitWidth
           rec rem (done :+ newNewNext) newCarry
+      rec rem done carry = match rem with
+        []      ->
+          done' = List.dropRightWhile (x -> x == 0) done
+          if carry == 0 then mkNatural done' else mkNatural (done' :+ carry)
+        x +: xs -> go xs x done carry
       go (Nonempty.tail ns) (Nonempty.head ns) [] 0
 
 math.Natural.internal.radix : Nat
@@ -68120,7 +68120,7 @@ Optional.<*>.doc =
   }}
 
 Optional.compareBy :
-  (a ->{g2} a ->{g1} Ordering) -> Optional a -> Optional a ->{g2, g1} Ordering
+  (a ->{g2} a ->{g1} Ordering) -> Optional a -> Optional a ->{g1, g2} Ordering
 Optional.compareBy f = cases
   None, None      -> Equal
   None, _         -> Less
@@ -68916,7 +68916,7 @@ Ordering.Equal.doc =
     ```
   }}
 
-Ordering.gtBy : (a ->{g2} a ->{g1} Ordering) -> a -> a ->{g2, g1} Boolean
+Ordering.gtBy : (a ->{g2} a ->{g1} Ordering) -> a -> a ->{g1, g2} Boolean
 Ordering.gtBy o a a2 = match o a a2 with
   Greater -> true
   _       -> false
@@ -68947,7 +68947,7 @@ Ordering.gtBy.doc =
     ```
   }}
 
-Ordering.gteqBy : (a ->{g2} a ->{g1} Ordering) -> a -> a ->{g2, g1} Boolean
+Ordering.gteqBy : (a ->{g2} a ->{g1} Ordering) -> a -> a ->{g1, g2} Boolean
 Ordering.gteqBy o a a2 = match o a a2 with
   Less -> false
   _    -> true
@@ -69046,7 +69046,7 @@ test> Ordering.list.orderingBy.tests = test.verify do
   p2 = replicate (natIn 0 10) do natIn 0 5
   list.orderingBy ordering p1 p2 |> ensureEqual (ordering p1 p2)
 
-Ordering.ltBy : (a ->{g2} a ->{g1} Ordering) -> a -> a ->{g2, g1} Boolean
+Ordering.ltBy : (a ->{g2} a ->{g1} Ordering) -> a -> a ->{g1, g2} Boolean
 Ordering.ltBy o a a2 = match o a a2 with
   Less -> true
   _    -> false
@@ -69077,7 +69077,7 @@ Ordering.ltBy.doc =
     ```
   }}
 
-Ordering.lteqBy : (a ->{g2} a ->{g1} Ordering) -> a -> a ->{g2, g1} Boolean
+Ordering.lteqBy : (a ->{g2} a ->{g1} Ordering) -> a -> a ->{g1, g2} Boolean
 Ordering.lteqBy o a a2 = match o a a2 with
   Greater -> false
   _       -> true
@@ -69100,7 +69100,7 @@ Ordering.lteqBy.doc =
     ```
   }}
 
-Ordering.maxBy : (a ->{g2} a ->{g1} Ordering) -> a -> a ->{g2, g1} a
+Ordering.maxBy : (a ->{g2} a ->{g1} Ordering) -> a -> a ->{g1, g2} a
 Ordering.maxBy o a a2 = match o a a2 with
   Less -> a2
   _    -> a
@@ -69127,7 +69127,7 @@ Ordering.maxBy.doc =
     ```
   }}
 
-Ordering.medianOf3By : (a ->{g2} a ->{g1} Ordering) -> a -> a -> a ->{g2, g1} a
+Ordering.medianOf3By : (a ->{g2} a ->{g1} Ordering) -> a -> a -> a ->{g1, g2} a
 Ordering.medianOf3By o a a2 a3 =
   go a a2 a3 = if gtBy o a a2 then go2 a2 a a3 else go2 a a2 a3
   go2 a a2 a3 = if gtBy o a2 a3 then go3 a a3 a2 else go3 a a2 a3
@@ -69160,7 +69160,7 @@ test> Ordering.medianOf3By.test =
       && medianOf3By ordering 3 2 1 == 2
       && medianOf3By ordering 3 1 2 == 2)
 
-Ordering.minBy : (a ->{g2} a ->{g1} Ordering) -> a -> a ->{g2, g1} a
+Ordering.minBy : (a ->{g2} a ->{g1} Ordering) -> a -> a ->{g1, g2} a
 Ordering.minBy o a a2 = match o a a2 with
   Greater -> a2
   _       -> a
@@ -72617,8 +72617,6 @@ test.deprecated.internals.v1.Test.Report.toCLIResult r =
   use Nat toText
   use Result Fail
   use Text != ++
-  descend scope = cases
-    (k, t) -> go ((if scope != "" then scope ++ "." else "") ++ k) t
   convert : Text -> Status -> Result
   convert scope = cases
     Failed -> Fail scope
@@ -72628,6 +72626,8 @@ test.deprecated.internals.v1.Test.Report.toCLIResult r =
       Fail (scope ++ " : Passed " ++ toText n ++ " tests.")
     Unexpected Proved -> Fail (scope ++ " : Proved.")
     Pending -> Ok (scope ++ " : Pending.")
+  descend scope = cases
+    (k, t) -> go ((if scope != "" then scope ++ "." else "") ++ k) t
   go : Text -> Trie Text Status -> [Result]
   go scope t =
     use List +:
@@ -73554,7 +73554,7 @@ test.laws.abelianGroup :
   -> (t ->{e} t ->{e1} t)
   -> t
   -> (t ->{e2} t)
-  ->{e2, e1, e, Exception, Each, Random, Label} ()
+  ->{e, e1, e2, Exception, Each, Random, Label} ()
 test.laws.abelianGroup gen op z inv =
   laws.group gen op z inv
   commutativity gen op
@@ -73681,7 +73681,7 @@ test.laws.group :
   -> (t ->{e} t ->{e1} t)
   -> t
   -> (t ->{e2} t)
-  ->{e2, e1, e, Exception, Each, Random, Label} ()
+  ->{e, e1, e2, Exception, Each, Random, Label} ()
 test.laws.group gen op z inv =
   monoid gen op z
   involutive gen inv
@@ -73821,7 +73821,7 @@ test.laws.monoid :
   '{Each, Random} t
   -> (t ->{e} t ->{e1} t)
   -> t
-  ->{e1, e, Exception, Each, Random, Label} ()
+  ->{e, e1, Exception, Each, Random, Label} ()
 test.laws.monoid gen op z =
   associativity gen op
   laws.identity gen op z
@@ -73867,7 +73867,7 @@ test.laws.ring :
   -> (t ->{e2} t)
   -> (t ->{e1} t ->{e} t)
   -> t
-  ->{e4, e3, e2, e1, e, Exception, Each, Random, Label} ()
+  ->{e, e1, e2, e3, e4, Exception, Each, Random, Label} ()
 test.laws.ring gen add zero neg mul one =
   abelianGroup gen add zero neg
   monoid gen mul one
@@ -83185,8 +83185,8 @@ type HttpResponse.Status.UnexpectedResponseStatus
   = 
 
 type proxy.ProxyPresence
-  = Proxy
-  | NoProxy
+  = NoProxy
+  | Proxy
 
 type server.Config
   = { hostName : Optional HostName,
@@ -83195,8 +83195,8 @@ type server.Config
       tlsConfig : Optional ServerConfig }
 
 type server.Handler g
-  = HandlerWebSocket (HttpRequest ->{g, Exception, Abort} WebSocketHandler)
-  | Handler (HttpRequest ->{g, Exception, Abort} HttpResponse)
+  = Handler (HttpRequest ->{g, Exception, Abort} HttpResponse)
+  | HandlerWebSocket (HttpRequest ->{g, Exception, Abort} WebSocketHandler)
 
 type server.Routes g
   = Routes
@@ -83224,16 +83224,16 @@ type websockets.errors.WebSocketClosed
   = 
 
 type websockets.Frame
-  = Text Boolean Text
+  = Binary Boolean Bytes
   | Close (Optional (Nat, Text))
-  | Binary Boolean Bytes
   | Continuation Boolean Bytes
   | Ping Bytes
   | Pong Bytes
+  | Text Boolean Text
 
 type websockets.Message
-  = TextMessage Text
-  | BinaryMessage Bytes
+  = BinaryMessage Bytes
+  | TextMessage Text
 
 type websockets.WebSocket
   = WebSocket
@@ -87231,13 +87231,6 @@ websockets.protocol.receive :
 websockets.protocol.receive =
   do
     use Decode failWith
-    continueMaybe :
-      Boolean
-      -> Message
-      ->{Abort, Decode, DecodeBits, Throw DecodeError, Stream Bytes} Message
-    continueMaybe isFin msg = if isFin then msg else continue msg
-    sendPong : Bytes -> ()
-    sendPong payload = emit (encoder None (Pong payload))
     continue :
       Message
       ->{Abort, Decode, DecodeBits, Throw DecodeError, Stream Bytes} Message
@@ -87261,6 +87254,13 @@ websockets.protocol.receive =
               TextMessage (init ++ payloadText)
             BinaryMessage init -> BinaryMessage (init Bytes.++ payload)
           continueMaybe isFin msg
+    continueMaybe :
+      Boolean
+      -> Message
+      ->{Abort, Decode, DecodeBits, Throw DecodeError, Stream Bytes} Message
+    continueMaybe isFin msg = if isFin then msg else continue msg
+    sendPong : Bytes -> ()
+    sendPong payload = emit (encoder None (Pong payload))
     go : '{Abort, Decode, DecodeBits, Throw DecodeError, Stream Bytes} Message
     go =
       do

--- a/unison-src/transcripts/pretty-print-libraries.output.md
+++ b/unison-src/transcripts/pretty-print-libraries.output.md
@@ -43,9 +43,9 @@ ability abilities.Label where
   pushScope : Text ->{Label} ()
 
 ability abilities.Random where
-  split! : {Random} (∀ g a. '{g, Random} a ->{g} a)
-  nat! : {Random} Nat
   bytes : Nat ->{Random} Bytes
+  nat! : {Random} Nat
+  split! : {Random} (∀ g a. '{g, Random} a ->{g} a)
 
 structural type abilities.Random.RNG
   = RNG (∀ g a. '{g, Random} a ->{g} a)
@@ -53,8 +53,8 @@ structural type abilities.Random.RNG
 -- abilities.Request is built-in.
 
 structural ability abilities.Store a where
-  put : a ->{Store a} ()
   get : {Store a} a
+  put : a ->{Store a} ()
 
 structural ability abilities.Throw e where
   throw : e ->{Throw e} a


### PR DESCRIPTION
## Overview

We've noticed that since let-rec bindings, constructors, and ability lists are all ordered by hash, they sometimes jump around when you make changes; this means the diffs also get much worse since the bindings might have completely re-ordered in-between changes.

closes #5893 

[internal ticket](https://linear.app/unison/issue/SHA-260/improve-ordering-of-let-binding-and-ability-in-signatures)

There's no real need for these to be printed in hash-order, since the parser will re-order them according to hash on ingestion anyways.

This changes the printer to put things in a consistent order by name rather than hash.

## Implementation approach and notes

Add some `sort`s in the printer modules.

## Test coverage

* See the new `print-ordering.md` transcript tests; as well as all the re-rendered existing transcripts