### PR TITLE
Avoid giving an under-application error for 0 arguments

### DIFF
--- a/parser-typechecker/src/Unison/Typechecker/TypeError.hs
+++ b/parser-typechecker/src/Unison/Typechecker/TypeError.hs
@@ -335,7 +335,8 @@ generalMismatch = do
       case (mayNeedArgs, delayMismatch) of
         (_, Just (Left {})) -> pure $ Mismatch ft et fl el mismatchSite n (Just MissingDelay)
         (_, Just (Right {})) -> pure $ Mismatch ft et fl el mismatchSite n (Just SuperfluousDelay)
-        (Just needArgs, _) -> pure $ FunctionUnderApplied ft et fl el mismatchSite n (lowerType <$> needArgs)
+        (Just needArgs, _)
+          | not (null needArgs) -> pure $ FunctionUnderApplied ft et fl el mismatchSite n (lowerType <$> needArgs)
         _ -> do
           pure $ Mismatch ft et fl el mismatchSite n Nothing
     _ -> error "generalMismatch: Mismatched type binding"

--- a/unison-src/transcripts/idempotent/underapply-msg.md
+++ b/unison-src/transcripts/idempotent/underapply-msg.md
@@ -1,0 +1,34 @@
+``` unison :error
+type Exists f = Exists (forall r. (forall a. f a -> r) ->  r)
+
+Exists.apply: (forall a. f a -> r) -> Exists f -> r
+Exists.apply f = cases Exists run -> run f
+
+type Dust =
+
+type Attic a = {
+  fall: a -> Dust
+}
+
+droop: Exists Attic -> (a -> Dust)
+droop attic a =
+  Exists.apply fall attic
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I found a value  of type:  Attic a1 -> a1 -> Dust
+  where I expected to find:  Attic a1 -> a -> 𝕣
+
+      9 |   fall: a -> Dust
+     10 | }
+     11 | 
+     12 | droop: Exists Attic -> (a -> Dust)
+     13 | droop attic a =
+     14 |   Exists.apply fall attic
+
+    from right here:
+
+      9 |   fall: a -> Dust
+```


### PR DESCRIPTION
This seems like an erroneous case that wasn't noticed, but can occur in some situations, like an existential vs. universal mismatch. If at least one argument type wasn't peeled, then it doesn't make sense to suggest that the function is under-applied. So just guard against it.

from https://unisoncomputing.slack.com/archives/CLGTK464E/p1764610297238729