### PR TITLE
Re-enable paged output after a file event.

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -15,6 +15,7 @@ module Unison.Codebase.Editor.Output
     ShareError (..),
     isFailure,
     isNumberedFailure,
+    outputShouldUsePager,
   )
 where
 
@@ -533,6 +534,15 @@ type ShowFailures = Bool -- whether to list results or just summarize
 data UndoFailureReason = CantUndoPastStart | CantUndoPastMerge deriving (Show)
 
 type SourceFileContents = Text
+
+outputShouldUsePager :: Output -> Bool
+outputShouldUsePager o = case o of
+  -- These are typically non-interactive outputs, so we don't page them.
+  LoadingFile {} -> False
+  Typechecked {} -> False
+  Evaluated {} -> False
+  EvaluationFailure {} -> False
+  _ -> True
 
 isFailure :: Output -> Bool
 isFailure o = case o of

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -33,7 +33,7 @@ import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Branch (Branch)
 import Unison.Codebase.Editor.HandleInput qualified as HandleInput
 import Unison.Codebase.Editor.Input (Event (UnisonFileChanged), Input (..))
-import Unison.Codebase.Editor.Output (NumberedArgs, Output)
+import Unison.Codebase.Editor.Output (NumberedArgs, Output, outputShouldUsePager)
 import Unison.Codebase.Editor.UCMVersion (UCMVersion)
 import Unison.Codebase.ProjectPath qualified as PP
 import Unison.Codebase.Watch qualified as Watch
@@ -240,13 +240,12 @@ main dir welcome ppIds initialInputs runtime sbRuntime codebase serverBaseUrl uc
               pp
               getProjectRoot
               (loopState ^. #numberedArgs)
-      let notifier :: Bool -> Output -> IO ()
-          notifier pageOutput =
-            notifyUser (pure dir) fetchIssueFromGitHub
-              >=> ( if pageOutput
-                      then putPrettyNonempty
-                      else putPrettyLnUnpaged
-                  )
+      let notify :: Output -> IO ()
+          notify o = do
+            rendered <- notifyUser (pure dir) fetchIssueFromGitHub o
+            if outputShouldUsePager o
+              then putPrettyNonempty rendered
+              else putPrettyLnUnpaged rendered
 
       let awaitInput :: Cli.LoopState -> IO (Either Event Input)
           awaitInput loopState = do
@@ -280,7 +279,7 @@ main dir welcome ppIds initialInputs runtime sbRuntime codebase serverBaseUrl uc
                 lspCheckForChanges,
                 writeSource = defaultWriteSourceFile,
                 generateUniqueName = Parser.uniqueBase32Namegen <$> Random.getSystemDRG,
-                notify = notifier True,
+                notify,
                 notifyNumbered = \o ->
                   let (p, args) = notifyNumbered o
                    in putPrettyNonempty p $> args,
@@ -298,10 +297,8 @@ main dir welcome ppIds initialInputs runtime sbRuntime codebase serverBaseUrl uc
         let loop0 :: Cli.LoopState -> IO ()
             loop0 s0 = do
               let stepInput :: Either Event Input -> IO (Cli.ReturnType (), Cli.LoopState)
-                  stepInput input = do
-                    -- Don't use a pager on File events, since they're not a response to user input.
-                    let usePager = isRight input
-                    Cli.runCli env {Cli.notify = notifier usePager} s0 (HandleInput.loop input)
+                  stepInput input =
+                    Cli.runCli env s0 (HandleInput.loop input)
 
               -- We want to handle file-change events in a way that allow interruption by other file-change events for
               -- the same file. The idea here is that, if we're (say) typechecking a big file any edits made in the

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -271,7 +271,9 @@ main dir welcome ppIds initialInputs runtime sbRuntime codebase serverBaseUrl uc
                             pure (Left event),
                         do
                           input <- Ki.await userInputThread
-                          pure (pure (Right input))
+                          pure do
+                            writeIORef pageOutput True
+                            pure (Right input)
                       ]
                 action
 

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -225,8 +225,6 @@ main dir welcome ppIds initialInputs runtime sbRuntime codebase serverBaseUrl uc
 
       let initialState = Cli.loopState0 ppIds
       initialInputsRef <- newIORef $ Welcome.run welcome ++ initialInputs ++ invalidProjectNamesInputs
-      pageOutput <- newIORef True
-
       initialEcho <- hGetEcho stdin
       let restoreEcho = (\currentEcho -> when (currentEcho /= initialEcho) $ hSetEcho stdin initialEcho)
       let getInput :: Cli.LoopState -> IO Input
@@ -242,14 +240,12 @@ main dir welcome ppIds initialInputs runtime sbRuntime codebase serverBaseUrl uc
               pp
               getProjectRoot
               (loopState ^. #numberedArgs)
-      let notify :: Output -> IO ()
-          notify =
+      let notifier :: Bool -> Output -> IO ()
+          notifier pageOutput =
             notifyUser (pure dir) fetchIssueFromGitHub
-              >=> ( \o ->
-                      ifM
-                        (readIORef pageOutput)
-                        (putPrettyNonempty o)
-                        (putPrettyLnUnpaged o)
+              >=> ( if pageOutput
+                      then putPrettyNonempty
+                      else putPrettyLnUnpaged
                   )
 
       let awaitInput :: Cli.LoopState -> IO (Either Event Input)
@@ -267,12 +263,10 @@ main dir welcome ppIds initialInputs runtime sbRuntime codebase serverBaseUrl uc
                       [ do
                           event <- Ki.await fileEventThread
                           pure do
-                            writeIORef pageOutput False
                             pure (Left event),
                         do
                           input <- Ki.await userInputThread
                           pure do
-                            writeIORef pageOutput True
                             pure (Right input)
                       ]
                 action
@@ -286,7 +280,7 @@ main dir welcome ppIds initialInputs runtime sbRuntime codebase serverBaseUrl uc
                 lspCheckForChanges,
                 writeSource = defaultWriteSourceFile,
                 generateUniqueName = Parser.uniqueBase32Namegen <$> Random.getSystemDRG,
-                notify,
+                notify = notifier True,
                 notifyNumbered = \o ->
                   let (p, args) = notifyNumbered o
                    in putPrettyNonempty p $> args,
@@ -304,8 +298,10 @@ main dir welcome ppIds initialInputs runtime sbRuntime codebase serverBaseUrl uc
         let loop0 :: Cli.LoopState -> IO ()
             loop0 s0 = do
               let stepInput :: Either Event Input -> IO (Cli.ReturnType (), Cli.LoopState)
-                  stepInput input =
-                    Cli.runCli env s0 (HandleInput.loop input)
+                  stepInput input = do
+                    -- Don't use a pager on File events, since they're not a response to user input.
+                    let usePager = isRight input
+                    Cli.runCli env {Cli.notify = notifier usePager} s0 (HandleInput.loop input)
 
               -- We want to handle file-change events in a way that allow interruption by other file-change events for
               -- the same file. The idea here is that, if we're (say) typechecking a big file any edits made in the


### PR DESCRIPTION
## Overview

An interesting glitch from the Discord;
https://discord.com/channels/862108724948500490/1444704371295129741

User reported that after updating the scratch file the pager no longer worked;


## Implementation approach and notes

Turns out an IORef was being disabled on every File Event, but was never being re-enabled.

I changed it so that whether an output is paged depends on the output message itself.

## Interesting/controversial decisions

I considered a couple approaches (see commit history);
* Easiest fix is to just set the IORef back on each new message type; but global state led to this bug in the first place, doesn't seem great.
* Another option was to edit the `notify` of the Env before running each step
* Use paging depending on the type of message we're printing

I went with the latter approach since it seems the most semantically correct to me, and is also the most flexible.

## Test coverage

Tested manually; seems tough to add an automated test for this one 
