### PR TITLE
Switch to an asymptotically better typing context implementation

### DIFF
--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -22,6 +22,7 @@ import Data.List (find, intersperse, sortBy)
 import Data.List.Extra (nubOrd)
 import Data.List.NonEmpty qualified as Nel
 import Data.Map qualified as Map
+import Data.Monoid (Dual (..))
 import Data.Ord (comparing)
 import Data.Proxy
 import Data.Sequence (Seq (..))
@@ -1363,7 +1364,7 @@ renderContext ::
   (Var v, Ord loc) => Env -> C.Context v loc -> Pretty (AnnotatedText a)
 renderContext env ctx@(C.Context es) =
   "  Γ\n    "
-    <> intercalateMap "\n    " (showElem ctx . fst) (reverse es)
+    <> getDual (intercalateMap (Dual "\n    ") (Dual . showElem ctx) es)
   where
     shortName :: (Var v, IsString loc) => v -> loc
     shortName = fromString . Text.unpack . Var.name

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -104,8 +104,11 @@ import Unison.Syntax.TypePrinter qualified as TP
 import Unison.Term qualified as Term
 import Unison.Type qualified as Type
 import Unison.Typechecker.Components (minimize')
-import Unison.Typechecker.Context.Structure
-  hiding (filter, mapMaybe, partition)
+import Unison.Typechecker.Context.Structure hiding
+  ( filter,
+    mapMaybe,
+    partition,
+  )
 import Unison.Typechecker.Context.Structure qualified as Ctx
 import Unison.Typechecker.TypeLookup qualified as TL
 import Unison.Typechecker.TypeVar qualified as TypeVar
@@ -651,13 +654,14 @@ modifyContextChecked ::
 modifyContextChecked act seg =
   allReserved seg >>= \case
     Nothing -> modifyContext (act seg)
-    Just e -> getContext >>= \ctx ->
-      compilerCrash $
-        IllegalContextExtension ctx e $
-          "Extending context with a variable that is not reserved "
-            <> "by the typechecking environment. That means "
-            <> "`freshenVar` is allowed to return it as a fresh "
-            <> "variable, which would be wrong."
+    Just e ->
+      getContext >>= \ctx ->
+        compilerCrash $
+          IllegalContextExtension ctx e $
+            "Extending context with a variable that is not reserved "
+              <> "by the typechecking environment. That means "
+              <> "`freshenVar` is allowed to return it as a fresh "
+              <> "variable, which would be wrong."
 
 markRetained :: (Var v, Ord loc) => Set v -> M v loc ()
 markRetained keep = setContext . marks =<< getContext
@@ -695,13 +699,13 @@ allReserved seg = do
   env <- get
   let p = all (`isReservedIn` env) . allBoundVars
   if p (info seg)
-  then pure Nothing
-  else case focusProblem (not . p) seg of
-    Position _ e _ -> pure $ Just e
-    _ ->
-      compilerCrash . OtherBug $
-        "I found an unreserved context extension, but couldn't "
-          <> "narrow it down to a specific example"
+    then pure Nothing
+    else case focusProblem (not . p) seg of
+      Position _ e _ -> pure $ Just e
+      _ ->
+        compilerCrash . OtherBug $
+          "I found an unreserved context extension, but couldn't "
+            <> "narrow it down to a specific example"
   where
 
 universals :: (Ord v) => Context v loc -> Set v
@@ -1475,8 +1479,8 @@ synthesizeBinding top binding = do
                   | retain b = Set.insert v s
                 k s (Solved b _ (Type.getPolytype -> sa))
                   | retain b = Set.union vs s
-                    where
-                      vs = freeExistentials (apply ctx sa)
+                  where
+                    vs = freeExistentials (apply ctx sa)
                 k s _ = s
 
                 freeExistentials =

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -104,6 +104,9 @@ import Unison.Syntax.TypePrinter qualified as TP
 import Unison.Term qualified as Term
 import Unison.Type qualified as Type
 import Unison.Typechecker.Components (minimize')
+import Unison.Typechecker.Context.Structure
+  hiding (filter, mapMaybe, partition)
+import Unison.Typechecker.Context.Structure qualified as Ctx
 import Unison.Typechecker.TypeLookup qualified as TL
 import Unison.Typechecker.TypeVar qualified as TypeVar
 import Unison.Typechecker.Variance (Variance (..), defaultVariances)
@@ -139,25 +142,6 @@ existentialp a = existential' a B.Blank
 
 universal' :: (Ord v) => a -> v -> Type.Type (TypeVar v loc) a
 universal' a v = ABT.annotatedVar a (TypeVar.Universal v)
-
--- | Elements of an ordered algorithmic context
-data Element v loc
-  = -- | A variable declaration
-    Var (TypeVar v loc)
-  | -- | `v` is solved to some monotype
-    Solved (B.Blank loc) v (Monotype v loc)
-  | -- | `v` has type `a`, maybe quantified
-    -- loc contains the span of the name of the bound 'v'
-    Ann v loc (Type v loc)
-  | -- | used for scoping
-    Marker v
-
-instance (Ord loc, Var v) => Eq (Element v loc) where
-  Var v == Var v2 = v == v2
-  Solved _ v t == Solved _ v2 t2 = v == v2 && t == t2
-  Ann v _loc t == Ann v2 _loc2 t2 = v == v2 && t == t2
-  Marker v == Marker v2 = v == v2
-  _ == _ = False
 
 -- The typechecking state
 data Env v loc = Env {freshId :: Word64, ctx :: Context v loc}
@@ -430,12 +414,12 @@ topLevelComponent = TopLevelComponent . fmap (over _2 removeSyntheticTypeVars)
 -- generalize types stored in the notes.
 substituteSolved ::
   (Var v, Ord loc) =>
-  [Element v loc] ->
+  CtxSegment v loc ->
   InfoNote v loc ->
   InfoNote v loc
 substituteSolved ctx = \case
-  (SolvedBlank b v t) -> SolvedBlank b v (applyCtx ctx t)
-  VarBinding v loc t -> VarBinding v loc (applyCtx ctx t)
+  (SolvedBlank b v t) -> SolvedBlank b v (apply ctx t)
+  VarBinding v loc t -> VarBinding v loc (apply ctx t)
   i -> i
 
 -- The typechecker generates synthetic type variables as part of type inference.
@@ -532,50 +516,27 @@ scope :: PathElement v loc -> M v loc a -> M v loc a
 scope p (MT m) = MT \ppe pmcSwitch vars datas effects defs env ->
   mapErrors (scope' p) (m ppe pmcSwitch vars datas effects defs env)
 
-newtype Context v loc = Context [(Element v loc, Info v loc)]
-
-data Info v loc = Info
-  { existentialVars :: Set v, -- set of existentials seen so far
-    solvedExistentials :: Map v (Monotype v loc), -- `v` is solved to some monotype
-    universalVars :: Set v, -- set of universals seen so far
-    termVarAnnotations :: Map v (Type v loc),
-    allVars :: Set v -- all variables seen so far
-  }
-
--- | The empty context
-context0 :: Context v loc
-context0 = Context []
-
 occursAnn :: (Var v) => (Ord loc) => TypeVar v loc -> Context v loc -> Bool
-occursAnn v (Context eis) = any p es
+occursAnn v ctx = any (p . snd) . termVarAnnotations $ info ctx
   where
-    es = fst <$> eis
-    p (Ann _v _loc ty) = v `Set.member` ABT.freeVars (applyCtx es ty)
-    p _ = False
-
--- | Focuses on the first element in the list that satisfies the predicate.
--- Returns `(prefix, focusedElem, suffix)`, where `prefix` is in reverse order.
-focusAt :: (a -> Bool) -> [a] -> Maybe ([a], a, [a])
-focusAt p xs = go [] xs
-  where
-    go _ [] = Nothing
-    go l (h : t) = if p h then Just (l, h, t) else go (h : l) t
+    p ty = v `Set.member` ABT.freeVars (apply ctx ty)
 
 -- | Delete from the end of this context up to and including
 -- the given `Element`. Returns `Nothing` if the element is not found.
-retract0 :: (Var v, Ord loc) => Element v loc -> Context v loc -> Maybe (Context v loc, [Element v loc])
-retract0 e (Context ctx) = case focusAt (\(e', _) -> e' == e) ctx of
-  Just (discarded, _, remaining) ->
-    -- note: no need to recompute used variables; any suffix of the
-    -- context snoc list is also a valid context
-    Just (Context remaining, map fst discarded)
-  Nothing -> Nothing
+retract0 :: (Var v, Ord loc) => Element v loc -> Context v loc -> Maybe (Context v loc, CtxSegment v loc)
+retract0 e ctx = proj <$> split (Ctx.variable e) ctx
+  where
+    proj (remaining, _, discarded) = (remaining, discarded)
 
 -- | Adds a marker to the end of the context, runs the `body` and then discards
 -- from the end of the context up to and including the marker. Returns the result
 -- of `body` and the discarded context (not including the marker), respectively.
 -- Freshened `markerHint` is used to create the marker.
-markThenRetract :: (Var v, Ord loc) => v -> M v loc a -> M v loc (a, [Element v loc])
+markThenRetract ::
+  (Var v, Ord loc) =>
+  v ->
+  M v loc a ->
+  M v loc (a, CtxSegment v loc)
 markThenRetract hint body =
   markThenCallWithRetract hint \retract -> adjustNotes do
     r <- body
@@ -589,58 +550,37 @@ markThenRetract0 markerHint body = () <$ markThenRetract markerHint body
 markThenCallWithRetract ::
   (Var v, Ord loc) =>
   v ->
-  (M v loc [Element v loc] -> M v loc a) ->
+  (M v loc (CtxSegment v loc) -> M v loc a) ->
   M v loc a
 markThenCallWithRetract hint k = do
   v <- freshenVar hint
   extendContext (Marker v)
   k (doRetract (Marker v))
   where
-    doRetract :: (Var v, Ord loc) => Element v loc -> M v loc [Element v loc]
+    doRetract :: (Var v, Ord loc) => Element v loc -> M v loc (CtxSegment v loc)
     doRetract e = do
       ctx <- getContext
       case retract0 e ctx of
         Nothing -> compilerCrash (RetractFailure e ctx)
         Just (t, discarded) -> do
-          let solved =
-                [ (b, v, inst $ Type.getPolytype sa)
-                  | Solved (B.Recorded b) v sa <- discarded
-                ]
-              unsolved =
-                [ (b, v, inst $ existential' (B.loc b) b' v)
-                  | Existential b'@(B.Recorded b) v <- discarded
-                ]
-              go (b, v, sa) = solveBlank b v sa
+          let go (v, (b, sa)) = solveBlank b v (inst sa)
               inst = apply ctx
-          Foldable.traverse_ go (solved ++ unsolved)
+          Foldable.traverse_ go (Map.toList . recorded $ info discarded)
           setContext t
           pure discarded
 
 -- unsolved' :: Context v loc -> [(B.Blank loc, v)]
 -- unsolved' (Context ctx) = [(b,v) | (Existential b v, _) <- ctx]
 
-replace :: (Var v, Ord loc) => Element v loc -> [Element v loc] -> Context v loc -> M v loc (Context v loc)
-replace e focus ctx =
-  case breakAt e ctx of
-    Just (l, _, r) -> l `extendN` (focus <> r)
-    Nothing -> pure ctx
-
-breakAt ::
-  (Var v, Ord loc) =>
+replace ::
+  (Var v) =>
   Element v loc ->
+  CtxSegment v loc ->
   Context v loc ->
-  Maybe (Context v loc, Element v loc, [Element v loc])
-breakAt m (Context xs) =
-  case focusAt (\(e, _) -> e === m) xs of
-    Just (r, m, l) ->
-      -- l is a suffix of xs and is already a valid context
-      Just (Context l, fst m, map fst r)
-    Nothing -> Nothing
-  where
-    Existential _ v === Existential _ v2 | v == v2 = True
-    Universal v === Universal v2 | v == v2 = True
-    Marker v === Marker v2 | v == v2 = True
-    _ === _ = False
+  M v loc (Context v loc)
+replace e es ctx = case split (Ctx.variable e) ctx of
+  Just (l, _, r) -> extends (es <> r) l
+  Nothing -> pure ctx
 
 -- | ordered Γ α β = True <=> Γ[α^][β^]
 ordered :: (Var v, Ord loc) => Context v loc -> v -> v -> Bool
@@ -689,7 +629,7 @@ _logContext msg = when debugEnabled $ do
   setContext ctx
 
 usedVars :: (Ord v) => Context v loc -> Set v
-usedVars = allVars . info
+usedVars = allBoundVars . info
 
 getContext :: M v loc (Context v loc)
 getContext = gets ctx
@@ -703,59 +643,72 @@ modifyContext f = do
   c <- f c
   setContext c
 
-appendContext :: (Var v, Ord loc) => [Element v loc] -> M v loc ()
-appendContext = traverse_ extendContext
+modifyContextChecked ::
+  (Var v) =>
+  (CtxSegment v loc -> Context v loc -> M v loc (Context v loc)) ->
+  CtxSegment v loc ->
+  M v loc ()
+modifyContextChecked act seg =
+  allReserved seg >>= \case
+    Nothing -> modifyContext (act seg)
+    Just e -> getContext >>= \ctx ->
+      compilerCrash $
+        IllegalContextExtension ctx e $
+          "Extending context with a variable that is not reserved "
+            <> "by the typechecking environment. That means "
+            <> "`freshenVar` is allowed to return it as a fresh "
+            <> "variable, which would be wrong."
 
 markRetained :: (Var v, Ord loc) => Set v -> M v loc ()
 markRetained keep = setContext . marks =<< getContext
   where
-    marks (Context eis) = Context (fmap mark eis)
-    mark (Existential B.Blank v, i)
-      | v `Set.member` keep = (Var (TypeVar.Existential B.Retain v), i)
-    mark (Solved B.Blank v t, i)
-      | v `Set.member` keep = (Solved B.Retain v t, i)
+    marks (Context eis) = Context (fmap' mark eis)
+    mark (Existential B.Blank v)
+      | v `Set.member` keep = Var (TypeVar.Existential B.Retain v)
+    mark (Solved B.Blank v t)
+      | v `Set.member` keep = Solved B.Retain v t
     mark p = p
 
+appendContext :: (Var v) => [Element v loc] -> M v loc ()
+appendContext = extendsContext . fromList
+
 extendContext :: (Var v) => Element v loc -> M v loc ()
-extendContext e =
-  isReserved (varOf e) >>= \case
-    True -> modifyContext (extend e)
-    False ->
-      getContext >>= \ctx ->
-        compilerCrash $
-          IllegalContextExtension ctx e $
-            "Extending context with a variable that is not reserved by the typechecking environment."
-              <> " That means `freshenVar` is allowed to return it as a fresh variable, which would be wrong."
+extendContext e = extendsContext (single e)
 
-replaceContext :: (Var v, Ord loc) => Element v loc -> [Element v loc] -> M v loc ()
-replaceContext elem replacement = do
-  env <- get
-  case find (not . (`isReservedIn` env) . varOf) replacement of
-    Nothing -> modifyContext (replace elem replacement)
-    Just e ->
-      getContext >>= \ctx ->
-        compilerCrash $
-          IllegalContextExtension ctx e $
-            "Extending context with a variable that is not reserved by the typechecking environment."
-              <> " That means `freshenVar` is allowed to return it as a fresh variable, which would be wrong."
+extendsContext :: (Var v) => CtxSegment v loc -> M v loc ()
+extendsContext seg = modifyContextChecked extends seg
 
-varOf :: Element v loc -> v
-varOf (Var tv) = TypeVar.underlying tv
-varOf (Solved _ v _) = v
-varOf (Ann v _ _) = v
-varOf (Marker v) = v
-
-isReserved :: (Var v) => v -> M v loc Bool
-isReserved v = (v `isReservedIn`) <$> get
+-- Replaces an element `e` with a sequence of elements `es` in the current
+-- context.
+replaceContext ::
+  (Var v) => Element v loc -> [Element v loc] -> M v loc ()
+replaceContext e es = modifyContextChecked (replace e) seg
+  where
+    seg = fromList es
 
 isReservedIn :: (Var v) => v -> Env v loc -> Bool
 isReservedIn v e = freshId e > Var.freshId v
 
+allReserved ::
+  (Var v) => CtxSegment v loc -> M v loc (Maybe (Element v loc))
+allReserved seg = do
+  env <- get
+  let p = all (`isReservedIn` env) . allBoundVars
+  if p (info seg)
+  then pure Nothing
+  else case focusProblem (not . p) seg of
+    Position _ e _ -> pure $ Just e
+    _ ->
+      compilerCrash . OtherBug $
+        "I found an unreserved context extension, but couldn't "
+          <> "narrow it down to a specific example"
+  where
+
 universals :: (Ord v) => Context v loc -> Set v
-universals = universalVars . info
+universals = boundUniversalVars . info
 
 existentials :: (Ord v) => Context v loc -> Set v
-existentials = existentialVars . info
+existentials = boundExistentialVars . info
 
 -- | "Reserves" the given variables in this typechecking environment,
 -- i.e. ensures that they won't be returned from `freshenVar` as fresh.
@@ -805,69 +758,78 @@ wellformedType c t = case t of
           ctx' = fromRight (error "wellformedType: Expected Right") $ extend' (Universal v) ctx
        in (v, ctx')
 
--- | Return the `Info` associated with the last element of the context, or the zero `Info`.
-info :: (Ord v) => Context v loc -> Info v loc
-info (Context []) = Info mempty mempty mempty mempty mempty
-info (Context ((_, i) : _)) = i
+addNotes :: (Var v) => CtxSegment v loc -> M v loc ()
+addNotes seg =
+  getAp
+    . Map.foldMapWithKey (\v (l, t) -> Ap $ noteVarBinding v l t)
+    . termVarAnnotations
+    $ info seg
 
--- | Add an element onto the end of this `Context`. Takes `O(log N)` time,
--- including updates to the accumulated `Info` value.
--- Fail if the new context is not well formed (see Figure 7 of paper).
-extend' :: (Var v) => Element v loc -> Context v loc -> Either (CompilerBug v loc) (Context v loc)
-extend' e c@(Context ctx) = Context . (: ctx) . (e,) <$> i'
+explainExtErr ::
+  (Var v) =>
+  Context v loc ->
+  Element v loc ->
+  BadContext ->
+  CompilerBug v loc
+explainExtErr ctx e = IllegalContextExtension ctx e . msg
   where
-    Info es ses us uas vs = info c
-    -- see figure 7
-    i' = case e of
-      Var v -> case v of
-        -- UvarCtx - ensure no duplicates
-        TypeVar.Universal v ->
-          if Set.notMember v vs
-            then pure $ Info es ses (Set.insert v us) uas (Set.insert v vs)
-            else crash $ "variable " <> show v <> " already defined in the context"
-        -- EvarCtx - ensure no duplicates, and that this existential is not solved earlier in context
-        TypeVar.Existential _ v ->
-          if Set.notMember v vs
-            then pure $ Info (Set.insert v es) ses us uas (Set.insert v vs)
-            else crash $ "variable " <> show v <> " already defined in the context"
-      -- SolvedEvarCtx - ensure `v` is fresh, and the solution is well-formed wrt the context
-      Solved _ v sa@(Type.getPolytype -> t)
-        | Set.member v vs -> crash $ "variable " <> show v <> " already defined in the context"
-        | not (wellformedType c t) -> crash $ "type " <> show t <> " is not well-formed wrt the context"
-        | otherwise ->
-            pure $
-              Info (Set.insert v es) (Map.insert v sa ses) us uas (Set.insert v vs)
-      -- VarCtx - ensure `v` is fresh, and annotation is well-formed wrt the context
-      Ann v _loc t
-        | Set.member v vs -> crash $ "variable " <> show v <> " already defined in the context"
-        | not (wellformedType c t) -> crash $ "type " <> show t <> " is not well-formed wrt the context"
-        | otherwise ->
-            pure $
-              Info
-                es
-                ses
-                us
-                (Map.insert v t uas)
-                (Set.insert v vs)
-      -- MarkerCtx - note that since a Marker is always the first mention of a variable, suffices to
-      -- just check that `v` is not previously mentioned
-      Marker v ->
-        if Set.notMember v vs
-          then pure $ Info es ses us uas (Set.insert v vs)
-          else crash $ "marker variable " <> show v <> " already defined in the context"
-    crash reason = Left $ IllegalContextExtension c e reason
+    v = variable e
 
-extend :: (Var v) => Element v loc -> Context v loc -> M v loc (Context v loc)
-extend e c = do
-  case e of
-    Ann v loc t -> noteVarBinding v loc t
-    _ -> pure ()
-  either compilerCrash pure $ extend' e c
+    edesc
+      | Marker _ <- e = "marker variable "
+      | otherwise = "variable "
 
--- | Add the given elements onto the end of the given `Context`.
--- Fail if the new context is not well-formed.
-extendN :: (Var v) => Context v loc -> [Element v loc] -> M v loc (Context v loc)
-extendN ctx es = foldM (flip extend) ctx es
+    tmsg t = "type " <> show t <> " is not well-formed in the context"
+
+    msg Shadowing =
+      edesc <> show v <> " already defined in the context"
+    msg _
+      | Ann _ _ t <- e = tmsg t
+      | Solved _ _ (Type.getPolytype -> t) <- e = tmsg t
+      | otherwise = "a variable occurrence is not well-scoped"
+
+explainExtErrs ::
+  (Var v) =>
+  CtxSegment v loc ->
+  BadContext ->
+  CompilerBug v loc
+explainExtErrs whole err
+  | (pre, e) <- Ctx.culprit whole err =
+      explainExtErr (Context pre) e err
+
+-- Adds an element to the context. This takes logarithmic time to
+-- aggregate the context information.
+extend' ::
+  (Var v) =>
+  Element v loc ->
+  Context v loc ->
+  Either (CompilerBug v loc) (Context v loc)
+extend' e ctx@(Context c) =
+  first (explainExtErr ctx e) . Ctx.validateSegment $ c |> e
+
+extends ::
+  (Var v) =>
+  CtxSegment v loc ->
+  Context v loc ->
+  M v loc (Context v loc)
+extends r (Context l) = do
+  addNotes r
+  either (compilerCrash . explainExtErrs whole) pure $
+    Ctx.validateSegment whole
+  where
+    whole = l <> r
+
+extendsAround ::
+  (Var v) =>
+  Context v loc ->
+  Element v loc ->
+  CtxSegment v loc ->
+  M v loc (Context v loc)
+extendsAround ctx@(Context l) e r = do
+  addNotes (single e)
+  either (compilerCrash . explainExtErr ctx e) pure
+    . Ctx.validateSegment
+    $ surround l e r
 
 -- | doesn't combine notes
 orElse :: M v loc a -> M v loc a -> M v loc a
@@ -1015,34 +977,6 @@ notMember :: (Var v, Ord loc) => v -> Set (TypeVar v loc) -> Bool
 notMember v s =
   Set.notMember (TypeVar.Universal v) s
     && Set.notMember (TypeVar.Existential B.Blank v) s
-
--- | Replace any existentials with their solution in the context
-apply :: (Var v, Ord loc) => Context v loc -> Type v loc -> Type v loc
-apply ctx = apply' (solvedExistentials . info $ ctx)
-
--- | Replace any existentials with their solution in the context (given as a list of elements)
-applyCtx :: (Var v, Ord loc) => [Element v loc] -> Type v loc -> Type v loc
-applyCtx elems = apply' $ Map.fromList [(v, sa) | Solved _ v sa <- elems]
-
-apply' :: (Var v, Ord loc) => Map v (Monotype v loc) -> Type v loc -> Type v loc
-apply' _ t | Set.null (Type.freeVars t) = t
-apply' solvedExistentials t = go t
-  where
-    go t = case t of
-      Type.Var' (TypeVar.Universal _) -> t
-      Type.Ref' _ -> t
-      Type.Var' (TypeVar.Existential _ v) ->
-        maybe t (\(Type.Monotype t') -> go t') (Map.lookup v solvedExistentials)
-      Type.Arrow' i o -> Type.arrow a (go i) (go o)
-      Type.App' x y -> Type.app a (go x) (go y)
-      Type.Ann' v k -> Type.ann a (go v) k
-      Type.Effect1' e t -> Type.effect1 a (go e) (go t)
-      Type.Effects' es -> Type.effects a (map go es)
-      Type.ForallNamed' v t' -> Type.forAll a v (go t')
-      Type.IntroOuterNamed' v t' -> Type.introOuter a v (go t')
-      _ -> error $ "Match error in Context.apply': " ++ show t
-      where
-        a = ABT.annotation t
 
 loc :: ABT.Term f v loc -> loc
 loc = ABT.annotation
@@ -1200,16 +1134,14 @@ synthesizeTop ::
   M v loc (Type v loc)
 synthesizeTop tm = do
   (ty, want) <- synthesize tm
-  ctx <- getContext
-  want <- substAndDefaultWanted want (out ctx)
+  ctx@(Context out) <- getContext
+  want <- substAndDefaultWanted want out
   when (not $ null want) . failWith $ do
     AbilityCheckFailure
       []
       (Type.flattenEffects . snd =<< want)
       ctx
   applyM ty
-  where
-    out (Context es) = fmap fst es
 
 -- | Synthesize the type of the given term, updating the context in
 -- the process.  Also collect wanted abilities.
@@ -1538,24 +1470,30 @@ synthesizeBinding top binding = do
                 retain B.Retain = True
                 retain _ = False
 
-                erecs = [v | Existential b v <- ctx, retain b]
-                srecs =
-                  [ v
-                    | Solved b _ sa <- ctx,
-                      retain b,
-                      TypeVar.Existential _ v <-
-                        Set.toList . ABT.freeVars . applyCtx ctx $ Type.getPolytype sa
-                  ]
-                keep = Set.fromList (erecs ++ srecs)
+                keep = foldl' k Set.empty ctx
+                k s (Existential b v)
+                  | retain b = Set.insert v s
+                k s (Solved b _ (Type.getPolytype -> sa))
+                  | retain b = Set.union vs s
+                    where
+                      vs = freeExistentials (apply ctx sa)
+                k s _ = s
+
+                freeExistentials =
+                  Set.map TypeVar.underlying . Set.filter p . ABT.freeVars
+                  where
+                    p (TypeVar.Existential {}) = True
+                    p _ = False
+
                 p (Existential _ v)
                   | v `Set.member` keep =
                       Left . Var $ TypeVar.Existential B.Retain v
                 p e = Right e
-                (repush, discard) = partitionEithers $ fmap p ctx
-            appendContext repush
+                (repush, discard) = Ctx.partition p ctx
+            extendsContext repush
             markRetained keep
             vars <- getVariances
-            let tf = generalizeExistentials discard vars (applyCtx ctx tb)
+            let tf = generalizeExistentials discard vars (apply ctx tb)
             pure ((tf, []), substituteSolved ctx)
 
 getDataConstructorsAtType :: forall v loc. (Ord loc, Var v) => Type v loc -> M v loc (EnumeratedConstructors (TypeVar v loc) v loc)
@@ -1924,7 +1862,7 @@ applyM :: (Var v, Ord loc) => Type v loc -> M v loc (Type v loc)
 applyM t = (`apply` t) <$> getContext
 
 lookupAnn :: (Ord v) => Context v loc -> v -> Maybe (Type v loc)
-lookupAnn ctx v = Map.lookup v (termVarAnnotations . info $ ctx)
+lookupAnn ctx v = snd <$> Map.lookup v (termVarAnnotations . info $ ctx)
 
 lookupSolved :: (Ord v) => Context v loc -> v -> Maybe (Monotype v loc)
 lookupSolved ctx v = Map.lookup v (solvedExistentials . info $ ctx)
@@ -2196,15 +2134,15 @@ forcedData ty = Type.freeVars ty
 -- to universals.
 generalizeExistentials ::
   (Var v, Ord loc) =>
-  [Element v loc] ->
+  CtxSegment v loc ->
   Map Reference [Variance] ->
   Type v loc ->
   Type v loc
 generalizeExistentials ctx vars ty0 = generalizeP pred ctx ty
   where
-    gens = Set.fromList $ mapMaybe (fmap snd . existentialP) ctx
+    gens = unsolvedExistentials $ info ctx
 
-    ty = discardCovariant vars gens $ applyCtx ctx ty0
+    ty = discardCovariant vars gens $ apply ctx ty0
     fvs = Type.freeVars ty
 
     pred e
@@ -2217,12 +2155,12 @@ generalizeP ::
   (Var v) =>
   (Ord loc) =>
   (Element v loc -> Maybe (TypeVar v loc, v)) ->
-  [Element v loc] ->
+  CtxSegment v loc ->
   Type v loc ->
   Type v loc
-generalizeP p ctx0 ty = foldr gen (applyCtx ctx0 ty) ctx
+generalizeP p ctx0 ty = foldr gen (apply ctx0 ty) ctx
   where
-    ctx = mapMaybe p ctx0
+    ctx = Ctx.mapMaybe p ctx0
 
     gen (tv, v) t
       | tv `ABT.isFreeIn` t =
@@ -2392,13 +2330,13 @@ substAndDefaultWanted ::
   (Var v) =>
   (Ord loc) =>
   Wanted v loc ->
-  [Element v loc] ->
+  CtxSegment v loc ->
   M v loc (Wanted v loc)
 substAndDefaultWanted want ctx
-  | want <- (fmap . fmap) (applyCtx ctx) want,
+  | want <- (fmap . fmap) (Ctx.apply ctx) want,
     want <- filter q want,
-    repush <- filter keep ctx =
-      appendContext repush *> coalesceWanted want []
+    repush <- Ctx.filter keep ctx =
+      extendsContext repush *> coalesceWanted want []
   where
     isExistential TypeVar.Existential {} = True
     isExistential _ = False
@@ -2411,12 +2349,9 @@ substAndDefaultWanted want ctx
     keep (Var v) = v `Set.member` keeps
     keep _ = False
 
-    p (Var v) | isExistential v = Just v
-    p _ = Nothing
+    outScope = boundExistentialVars $ info ctx
 
-    outScope = Set.fromList $ mapMaybe p ctx
-
-    q (_, Type.Var' u) = u `Set.notMember` outScope
+    q (_, Type.Var' u) = TypeVar.underlying u `Set.notMember` outScope
     q _ = True
 
 -- Defaults unsolved ability variables to the empty row
@@ -3129,7 +3064,7 @@ instantiateR (Type.stripIntroOuters -> t) blank v =
         -- InstRAIIL
         x' <- ABT.freshen body freshenTypeVar
         markThenRetract0 x' $ do
-          appendContext [existential x']
+          extendContext (existential x')
           instantiateR (ABT.bindInheritAnnotation body (existential' () B.Blank x')) B.Blank v
       _ -> failWith $ TypeMismatch ctx
 
@@ -3148,10 +3083,10 @@ solve ctx v t = case lookupSolved ctx v of
       else failWith $ TypeMismatch ctx
     where
       same t1 t2 = apply ctx (Type.getPolytype t1) == apply ctx (Type.getPolytype t2)
-  Nothing -> case breakAt (existential v) ctx of
+  Nothing -> case Ctx.split v ctx of
     Just (ctxL, Existential blank v, ctxR) ->
       if wellformedType ctxL (Type.getPolytype t)
-        then Just <$> ctxL `extendN` ((Solved blank v t) : ctxR)
+        then Just <$> extendsAround ctxL (Solved blank v t) ctxR
         else pure Nothing
     _ -> compilerCrash $ UnknownExistentialVariable v ctx
 
@@ -3682,27 +3617,6 @@ isEqual ::
   (Var v, Ord loc) => Type v loc -> Type v loc -> Either (CompilerBug v loc) Bool
 isEqual t1 t2 =
   (&&) <$> isSubtype t1 t2 <*> isSubtype t2 t1
-
-instance (Var v) => Show (Element v loc) where
-  show (Var v) = case v of
-    TypeVar.Universal x -> "@" <> show x
-    e -> show e
-  show (Solved _ v t) = "'" ++ Text.unpack (Var.name v) ++ " = " ++ Text.unpack (TP.prettyStr 0 PPE.empty (Type.getPolytype t))
-  show (Ann v _loc t) =
-    Text.unpack (Var.name v)
-      ++ " : "
-      ++ Text.unpack (TP.prettyStr 0 PPE.empty t)
-  show (Marker v) = "|" ++ Text.unpack (Var.name v) ++ "|"
-
-instance (Ord loc, Var v) => Show (Context v loc) where
-  show ctx@(Context es) = "Γ\n  " ++ (intercalate "\n  " . map (showElem ctx . fst)) (reverse es)
-    where
-      showElem _ctx (Var v) = case v of
-        TypeVar.Universal x -> "@" <> show x
-        e -> show e
-      showElem ctx (Solved _ v (Type.Monotype t)) = "'" ++ Text.unpack (Var.name v) ++ " = " ++ Text.unpack (TP.prettyStr 0 PPE.empty (apply ctx t))
-      showElem ctx (Ann v _loc t) = Text.unpack (Var.name v) ++ " : " ++ Text.unpack (TP.prettyStr 0 PPE.empty (apply ctx t))
-      showElem _ (Marker v) = "|" ++ Text.unpack (Var.name v) ++ "|"
 
 instance (Monad f) => Monad (MT v loc f) where
   return = pure

--- a/parser-typechecker/src/Unison/Typechecker/Context/Structure.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context/Structure.hs
@@ -1,54 +1,55 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Unison.Typechecker.Context.Structure
-  ( Element (..)
-  , variable
-  , Info (..)
-  , unsolvedExistentials
-  , Context (..)
-  , context0
-  , CtxSegment
-  , (|>)
-  , (<|)
-  , fmap'
-  , BadContext (..)
-  , validateSegment
-  , SearchResult (..)
-  , focusProblem
-  , culprit
-  , info
-  , filter
-  , partition
-  , apply
-  , FT.fromList
-  , mapMaybe
-  , single
-  , split
-  , splitSeg
-  , surround
-  ) where
+  ( Element (..),
+    variable,
+    Info (..),
+    unsolvedExistentials,
+    Context (..),
+    context0,
+    CtxSegment,
+    (|>),
+    (<|),
+    fmap',
+    BadContext (..),
+    validateSegment,
+    SearchResult (..),
+    focusProblem,
+    culprit,
+    info,
+    filter,
+    partition,
+    apply,
+    FT.fromList,
+    mapMaybe,
+    single,
+    split,
+    splitSeg,
+    surround,
+  )
+where
 
 import Data.FingerTree as FT hiding (split)
 import Data.Foldable qualified as FO
 import Data.Function (on)
 import Data.List qualified as List
-import Data.Set as Set hiding (split, filter, partition)
+import Data.Map.Strict as Map hiding (filter, mapMaybe, partition, split)
+import Data.Set as Set hiding (filter, partition, split)
 import Data.Text qualified as Text
-import Data.Map.Strict as Map hiding (split, filter, mapMaybe, partition)
-import Prelude hiding (filter)
-
 import Unison.ABT qualified as ABT
 import Unison.Blank qualified as B
+import Unison.PrettyPrintEnv qualified as PPE
+import Unison.Syntax.TypePrinter qualified as TP
 import Unison.Type qualified as Type
 import Unison.Typechecker.TypeVar qualified as TypeVar
 import Unison.Var (Var)
 import Unison.Var qualified as Var
-
-import Unison.PrettyPrintEnv qualified as PPE
-import Unison.Syntax.TypePrinter qualified as TP
+import Prelude hiding (filter)
 
 type Monotype v loc = Type.Monotype (TypeVar v loc) loc
+
 type TypeVar v loc = TypeVar.TypeVar (B.Blank loc) v
+
 type Type v loc = Type.Type (TypeVar v loc) loc
 
 -- | Elements of an ordered algorithmic context. A context is a sequence
@@ -136,10 +137,10 @@ type CtxSegment v loc = FingerTree (Info v loc) (Element v loc)
 newtype Context v loc = Context (CtxSegment v loc)
 
 -- | The empty context
-context0 :: Ord v => Context v loc
+context0 :: (Ord v) => Context v loc
 context0 = Context FT.empty
 
-instance Ord v => Semigroup (Info v loc) where
+instance (Ord v) => Semigroup (Info v loc) where
   segl <> segr =
     Info
       { boundExistentialVars =
@@ -156,20 +157,22 @@ instance Ord v => Semigroup (Info v loc) where
         freeExistentialVars =
           Set.union
             (freeExistentialVars segl)
-            (Set.difference
-              (freeExistentialVars segr)
-              (boundExistentialVars segl)),
+            ( Set.difference
+                (freeExistentialVars segr)
+                (boundExistentialVars segl)
+            ),
         freeUniversalVars =
           Set.union
             (freeUniversalVars segl)
-            (Set.difference
-              (freeUniversalVars segr)
-              (boundUniversalVars segl)),
+            ( Set.difference
+                (freeUniversalVars segr)
+                (boundUniversalVars segl)
+            ),
         shadowedVars =
           Set.unions
-            [ shadowedVars segl
-            , shadowedVars segr
-            , Set.intersection
+            [ shadowedVars segl,
+              shadowedVars segr,
+              Set.intersection
                 (allBoundVars segl)
                 (allBoundVars segr)
             ],
@@ -178,76 +181,73 @@ instance Ord v => Semigroup (Info v loc) where
 
 emptyInfo :: Info v loc
 emptyInfo =
-  Info {
-    boundExistentialVars = Set.empty,
-    solvedExistentials = Map.empty,
-    boundUniversalVars = Set.empty,
-    termVarAnnotations = Map.empty,
-    allBoundVars = Set.empty,
-    freeExistentialVars = Set.empty,
-    freeUniversalVars = Set.empty,
-    shadowedVars = Set.empty,
-    recorded = Map.empty
-  }
+  Info
+    { boundExistentialVars = Set.empty,
+      solvedExistentials = Map.empty,
+      boundUniversalVars = Set.empty,
+      termVarAnnotations = Map.empty,
+      allBoundVars = Set.empty,
+      freeExistentialVars = Set.empty,
+      freeUniversalVars = Set.empty,
+      shadowedVars = Set.empty,
+      recorded = Map.empty
+    }
 
 -- | Gets the _unsolved_ existential variables of a context info.
 unsolvedExistentials :: (Ord v) => Info v loc -> Set v
 unsolvedExistentials (Info {..}) =
   boundExistentialVars `Set.difference` Map.keysSet solvedExistentials
 
-instance Ord v => Monoid (Info v loc) where
+instance (Ord v) => Monoid (Info v loc) where
   mempty = emptyInfo
 
 part :: Set (TypeVar v loc) -> ([v], [v])
 part = List.foldl' classify ([], []) . Set.toDescList
   where
-    classify (es, us) (TypeVar.Existential _ e) = (e:es, us)
-    classify (es, us) (TypeVar.Universal u) = (es, u:us)
+    classify (es, us) (TypeVar.Existential _ e) = (e : es, us)
+    classify (es, us) (TypeVar.Universal u) = (es, u : us)
 
-instance Ord v => Measured (Info v loc) (Element v loc) where
+instance (Ord v) => Measured (Info v loc) (Element v loc) where
   measure (Var tv)
     | TypeVar.Universal v <- tv =
         emptyInfo
-          { boundUniversalVars = Set.singleton v
-          , allBoundVars = Set.singleton v
+          { boundUniversalVars = Set.singleton v,
+            allBoundVars = Set.singleton v
           }
     | TypeVar.Existential b v <- tv =
         emptyInfo
-          { boundExistentialVars = Set.singleton v
-          , allBoundVars = Set.singleton v
-          , recorded = case b of
+          { boundExistentialVars = Set.singleton v,
+            allBoundVars = Set.singleton v,
+            recorded = case b of
               B.Recorded b' ->
                 Map.singleton v (b', ty)
                 where
                   ty = ABT.annotatedVar (B.loc b') tv
               _ -> Map.empty
           }
-
   measure (Solved b v ty)
     | pty <- Type.getPolytype ty,
       (evs, uvs) <- part $ Type.freeVars pty =
         emptyInfo
-          { boundExistentialVars = Set.singleton v
-          , solvedExistentials = Map.singleton v ty
-          , allBoundVars = Set.singleton v
-          , freeExistentialVars = Set.fromList evs
-          , freeUniversalVars = Set.fromList uvs
-          , recorded = case b of
+          { boundExistentialVars = Set.singleton v,
+            solvedExistentials = Map.singleton v ty,
+            allBoundVars = Set.singleton v,
+            freeExistentialVars = Set.fromList evs,
+            freeUniversalVars = Set.fromList uvs,
+            recorded = case b of
               B.Recorded b' ->
                 Map.singleton v (b', pty)
               _ -> Map.empty
           }
-
   measure (Ann v loc ty)
     | (evs, uvs) <- part $ Type.freeVars ty =
         emptyInfo
-          { allBoundVars = Set.singleton v
-          , termVarAnnotations = Map.singleton v (loc, ty)
-          , freeExistentialVars = Set.fromList evs
-          , freeUniversalVars = Set.fromList uvs
+          { allBoundVars = Set.singleton v,
+            termVarAnnotations = Map.singleton v (loc, ty),
+            freeExistentialVars = Set.fromList evs,
+            freeUniversalVars = Set.fromList uvs
           }
-
-  measure (Marker v) = emptyInfo { allBoundVars = Set.singleton v }
+  measure (Marker v) = emptyInfo {allBoundVars = Set.singleton v}
 
 instance (Ord v) => Measured (Info v loc) (Context v loc) where
   measure (Context c) = measure c
@@ -261,7 +261,7 @@ data BadContext
 -- proper context is yielded. Otherwise an indication of what is wrong
 -- with the segment is returned.
 validateSegment ::
-  Ord v => CtxSegment v loc -> Either BadContext (Context v loc)
+  (Ord v) => CtxSegment v loc -> Either BadContext (Context v loc)
 validateSegment seg
   | not $ Set.null shadowedVars = Left Shadowing
   | not $ Set.null freeExistentialVars = Left UnboundEx
@@ -273,9 +273,10 @@ validateSegment seg
 -- Given a predicate on measures that is monotone, searches for a point
 -- in the sequence at which the predicate first becomes true.
 focusProblem ::
-  Measured v e =>
+  (Measured v e) =>
   (v -> Bool) ->
-  FingerTree v e -> SearchResult v e
+  FingerTree v e ->
+  SearchResult v e
 focusProblem p = search q
   where
     q l _ = p l
@@ -283,9 +284,10 @@ focusProblem p = search q
 -- Searches for the first point at which an extracted set becomes
 -- non-null.
 findFirst ::
-  Measured v e =>
+  (Measured v e) =>
   (v -> Set a) ->
-  FingerTree v e -> SearchResult v e
+  FingerTree v e ->
+  SearchResult v e
 findFirst ex = focusProblem (not . Set.null . ex)
 
 -- Given a malformed context and a validation error, finds an element
@@ -303,7 +305,6 @@ culprit whole err
       Shadowing -> findFirst shadowedVars
       UnboundEx -> findFirst freeExistentialVars
       UnboundUn -> findFirst freeUniversalVars
-
 
 -- | Return the aggregate `Info` associated to the context.
 info :: (Ord v, Measured (Info v loc) c) => c -> Info v loc
@@ -346,7 +347,7 @@ apply' solved t = go t
 -- Technically the context can contain both type and term variable
 -- bindings, and these are not distinguished, so take care.
 splitSeg ::
-  Ord v =>
+  (Ord v) =>
   v ->
   CtxSegment v loc ->
   Maybe (CtxSegment v loc, Element v loc, CtxSegment v loc)
@@ -358,14 +359,14 @@ splitSeg tgt seg = case search p seg of
     -- `tgt` is bound in `i` and not in `j`. This means | i | ends with
     -- the last binding of `tgt`.
     p i j =
-      (tgt `Set.notMember` allBoundVars j) &&
-      (tgt `Set.member` allBoundVars i)
+      (tgt `Set.notMember` allBoundVars j)
+        && (tgt `Set.member` allBoundVars i)
 
 -- Splits a context at an `Element` binding the given variable. Since in
 -- a valid context, a variable only occurs once, this is completely
 -- unambiguous.
 split ::
-  Ord v =>
+  (Ord v) =>
   v ->
   Context v loc ->
   Maybe (Context v loc, Element v loc, CtxSegment v loc)
@@ -375,7 +376,7 @@ split tgt (Context seg) = g <$> splitSeg tgt seg
     g (l, e, r) = (Context l, e, r)
 
 surround ::
-  Ord v =>
+  (Ord v) =>
   CtxSegment v loc ->
   Element v loc ->
   CtxSegment v loc ->
@@ -385,7 +386,8 @@ surround l e r = l >< e <| r
 filter ::
   (Var v) =>
   (Element v loc -> Bool) ->
-  CtxSegment v loc -> CtxSegment v loc
+  CtxSegment v loc ->
+  CtxSegment v loc
 filter p = FO.foldl' c mempty
   where
     c seg e
@@ -437,16 +439,16 @@ renderElement ctx = \case
     | otherwise -> show v
   Solved _ v (Type.Monotype t) ->
     mconcat
-      [ "'"
-      , Text.unpack $ Var.name v
-      , " = "
-      , renderType ctx t
+      [ "'",
+        Text.unpack $ Var.name v,
+        " = ",
+        renderType ctx t
       ]
   Ann v _loc t ->
     mconcat
-      [ Text.unpack $ Var.name v
-      , " : "
-      , renderType ctx t
+      [ Text.unpack $ Var.name v,
+        " : ",
+        renderType ctx t
       ]
   Marker v -> "|" <> Text.unpack (Var.name v) <> "|"
 

--- a/parser-typechecker/src/Unison/Typechecker/Context/Structure.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context/Structure.hs
@@ -1,0 +1,452 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module Unison.Typechecker.Context.Structure
+  ( Element (..)
+  , variable
+  , Info (..)
+  , unsolvedExistentials
+  , Context (..)
+  , context0
+  , CtxSegment
+  , (|>)
+  , (<|)
+  , fmap'
+  , BadContext (..)
+  , validateSegment
+  , SearchResult (..)
+  , focusProblem
+  , culprit
+  , info
+  , filter
+  , partition
+  , apply
+  , FT.fromList
+  , mapMaybe
+  , single
+  , split
+  , splitSeg
+  , surround
+  ) where
+
+import Data.FingerTree as FT hiding (split)
+import Data.Foldable qualified as FO
+import Data.Function (on)
+import Data.List qualified as List
+import Data.Set as Set hiding (split, filter, partition)
+import Data.Text qualified as Text
+import Data.Map.Strict as Map hiding (split, filter, mapMaybe, partition)
+import Prelude hiding (filter)
+
+import Unison.ABT qualified as ABT
+import Unison.Blank qualified as B
+import Unison.Type qualified as Type
+import Unison.Typechecker.TypeVar qualified as TypeVar
+import Unison.Var (Var)
+import Unison.Var qualified as Var
+
+import Unison.PrettyPrintEnv qualified as PPE
+import Unison.Syntax.TypePrinter qualified as TP
+
+type Monotype v loc = Type.Monotype (TypeVar v loc) loc
+type TypeVar v loc = TypeVar.TypeVar (B.Blank loc) v
+type Type v loc = Type.Type (TypeVar v loc) loc
+
+-- | Elements of an ordered algorithmic context. A context is a sequence
+-- of `Element`s (here represented as a finger tree), but not every
+-- sequence represents a valid context. A context is only valid if every
+-- type that occurs in the context is well scoped with regard to the
+-- previous variable bindings in the context.
+--
+-- We will refer to invalid trees as 'context segments' since they can be
+-- prefixed to become part of a valid context. Keeping track of the same
+-- context information for _every_ segment is important to avoiding some
+-- performance problems with a more naive implementation.
+data Element v loc
+  = -- | A variable declaration
+    Var (TypeVar v loc)
+  | -- | `v` is solved to some monotype
+    Solved (B.Blank loc) v (Monotype v loc)
+  | -- | `v` has type `a`, maybe quantified
+    -- loc contains the span of the name of the bound 'v'
+    Ann v loc (Type v loc)
+  | -- | used for scoping
+    Marker v
+
+variable :: Element v loc -> v
+variable (Var v) = TypeVar.underlying v
+variable (Solved _ v _) = v
+variable (Ann v _ _) = v
+variable (Marker v) = v
+
+instance (Var v) => Eq (Element v loc) where
+  Var v == Var v2 = v == v2
+  Solved _ v t == Solved _ v2 t2 = v == v2 && t == t2
+  Ann v _loc t == Ann v2 _loc2 t2 = v == v2 && t == t2
+  Marker v == Marker v2 = v == v2
+  _ == _ = False
+
+-- | Aggregate context (segment) information, built up from `Element`s.
+--
+-- `boundExistentialVars` is the set of existential variables that are
+-- known to be 'in scope' due to the context segment.
+--
+-- `solvedExistentials` is a mapping of existential variables to their
+-- solutions in the segment.
+--
+-- `boundUniversalVars` is the set of universal variables that are known
+-- to be 'in scope' due to the context segment.
+--
+-- `termVarAnnotations` is a mapping of term variables to their type.
+--
+-- `allBoundVars` contains all the variables 'in scope' due to the
+-- segment. Primarily used for freshening.
+--
+-- `freeUniversal/ExistentialVars` contains all the variables that occur
+-- _free_ in types in the segment. This means that they are _not_ bound
+-- in an `Element` previous to the one that the type occurs in.
+--
+-- `shadowedVars` contains variables that occur _multiple_ times in the
+-- segment, and thus the latter shadows the former.
+--
+-- `recorded` tracks certain annotated elements.
+--
+-- A context segment is a well formed context if `free*Vars` and
+-- `shadowedVars` are both empty.
+data Info v loc = Info
+  { boundExistentialVars :: !(Set v),
+    solvedExistentials :: !(Map v (Monotype v loc)),
+    boundUniversalVars :: !(Set v),
+    termVarAnnotations :: !(Map v (loc, Type v loc)),
+    allBoundVars :: !(Set v),
+    freeUniversalVars :: !(Set v),
+    freeExistentialVars :: !(Set v),
+    shadowedVars :: !(Set v),
+    recorded :: Map v (B.Recorded loc, Type v loc)
+  }
+
+type CtxSegment v loc = FingerTree (Info v loc) (Element v loc)
+
+newtype Context v loc = Context (CtxSegment v loc)
+
+-- | The empty context
+context0 :: Ord v => Context v loc
+context0 = Context FT.empty
+
+instance Ord v => Semigroup (Info v loc) where
+  segl <> segr =
+    Info
+      { boundExistentialVars =
+          (Set.union `on` boundExistentialVars) segl segr,
+        boundUniversalVars =
+          (Set.union `on` boundUniversalVars) segl segr,
+        allBoundVars =
+          (Set.union `on` allBoundVars) segl segr,
+        -- Note: prefer solutions/annotations from the _right_
+        solvedExistentials =
+          (Map.union `on` solvedExistentials) segr segl,
+        termVarAnnotations =
+          (Map.union `on` termVarAnnotations) segr segl,
+        freeExistentialVars =
+          Set.union
+            (freeExistentialVars segl)
+            (Set.difference
+              (freeExistentialVars segr)
+              (boundExistentialVars segl)),
+        freeUniversalVars =
+          Set.union
+            (freeUniversalVars segl)
+            (Set.difference
+              (freeUniversalVars segr)
+              (boundUniversalVars segl)),
+        shadowedVars =
+          Set.unions
+            [ shadowedVars segl
+            , shadowedVars segr
+            , Set.intersection
+                (allBoundVars segl)
+                (allBoundVars segr)
+            ],
+        recorded = (Map.union `on` recorded) segr segl
+      }
+
+emptyInfo :: Info v loc
+emptyInfo =
+  Info {
+    boundExistentialVars = Set.empty,
+    solvedExistentials = Map.empty,
+    boundUniversalVars = Set.empty,
+    termVarAnnotations = Map.empty,
+    allBoundVars = Set.empty,
+    freeExistentialVars = Set.empty,
+    freeUniversalVars = Set.empty,
+    shadowedVars = Set.empty,
+    recorded = Map.empty
+  }
+
+-- | Gets the _unsolved_ existential variables of a context info.
+unsolvedExistentials :: (Ord v) => Info v loc -> Set v
+unsolvedExistentials (Info {..}) =
+  boundExistentialVars `Set.difference` Map.keysSet solvedExistentials
+
+instance Ord v => Monoid (Info v loc) where
+  mempty = emptyInfo
+
+part :: Set (TypeVar v loc) -> ([v], [v])
+part = List.foldl' classify ([], []) . Set.toDescList
+  where
+    classify (es, us) (TypeVar.Existential _ e) = (e:es, us)
+    classify (es, us) (TypeVar.Universal u) = (es, u:us)
+
+instance Ord v => Measured (Info v loc) (Element v loc) where
+  measure (Var tv)
+    | TypeVar.Universal v <- tv =
+        emptyInfo
+          { boundUniversalVars = Set.singleton v
+          , allBoundVars = Set.singleton v
+          }
+    | TypeVar.Existential b v <- tv =
+        emptyInfo
+          { boundExistentialVars = Set.singleton v
+          , allBoundVars = Set.singleton v
+          , recorded = case b of
+              B.Recorded b' ->
+                Map.singleton v (b', ty)
+                where
+                  ty = ABT.annotatedVar (B.loc b') tv
+              _ -> Map.empty
+          }
+
+  measure (Solved b v ty)
+    | pty <- Type.getPolytype ty,
+      (evs, uvs) <- part $ Type.freeVars pty =
+        emptyInfo
+          { boundExistentialVars = Set.singleton v
+          , solvedExistentials = Map.singleton v ty
+          , allBoundVars = Set.singleton v
+          , freeExistentialVars = Set.fromList evs
+          , freeUniversalVars = Set.fromList uvs
+          , recorded = case b of
+              B.Recorded b' ->
+                Map.singleton v (b', pty)
+              _ -> Map.empty
+          }
+
+  measure (Ann v loc ty)
+    | (evs, uvs) <- part $ Type.freeVars ty =
+        emptyInfo
+          { allBoundVars = Set.singleton v
+          , termVarAnnotations = Map.singleton v (loc, ty)
+          , freeExistentialVars = Set.fromList evs
+          , freeUniversalVars = Set.fromList uvs
+          }
+
+  measure (Marker v) = emptyInfo { allBoundVars = Set.singleton v }
+
+instance (Ord v) => Measured (Info v loc) (Context v loc) where
+  measure (Context c) = measure c
+
+data BadContext
+  = Shadowing
+  | UnboundEx
+  | UnboundUn
+
+-- | Checks that a context segment forms a valid context. If so, then the
+-- proper context is yielded. Otherwise an indication of what is wrong
+-- with the segment is returned.
+validateSegment ::
+  Ord v => CtxSegment v loc -> Either BadContext (Context v loc)
+validateSegment seg
+  | not $ Set.null shadowedVars = Left Shadowing
+  | not $ Set.null freeExistentialVars = Left UnboundEx
+  | not $ Set.null freeUniversalVars = Left UnboundUn
+  | otherwise = Right $ Context seg
+  where
+    Info {..} = measure seg
+
+-- Given a predicate on measures that is monotone, searches for a point
+-- in the sequence at which the predicate first becomes true.
+focusProblem ::
+  Measured v e =>
+  (v -> Bool) ->
+  FingerTree v e -> SearchResult v e
+focusProblem p = search q
+  where
+    q l _ = p l
+
+-- Searches for the first point at which an extracted set becomes
+-- non-null.
+findFirst ::
+  Measured v e =>
+  (v -> Set a) ->
+  FingerTree v e -> SearchResult v e
+findFirst ex = focusProblem (not . Set.null . ex)
+
+-- Given a malformed context and a validation error, finds an element
+-- that induces the error, and the preceding context.
+culprit ::
+  (Ord v) =>
+  CtxSegment v loc ->
+  BadContext ->
+  (CtxSegment v loc, Element v loc)
+culprit whole err
+  | Position pre e _ <- srch whole = (pre, e)
+  | otherwise = error "Context.Structure.culprit: impossible"
+  where
+    srch = case err of
+      Shadowing -> findFirst shadowedVars
+      UnboundEx -> findFirst freeExistentialVars
+      UnboundUn -> findFirst freeUniversalVars
+
+
+-- | Return the aggregate `Info` associated to the context.
+info :: (Ord v, Measured (Info v loc) c) => c -> Info v loc
+info = measure
+
+-- | Replace any existentials with their solution in the context
+apply ::
+  (Var v, Measured (Info v loc) c) =>
+  c ->
+  Type v loc ->
+  Type v loc
+apply ctx = apply' (solvedExistentials . measure $ ctx)
+
+apply' ::
+  (Var v) => Map v (Monotype v loc) -> Type v loc -> Type v loc
+apply' _ t | Set.null (Type.freeVars t) = t
+apply' solved t = go t
+  where
+    go t = case t of
+      Type.Var' (TypeVar.Universal _) -> t
+      Type.Ref' _ -> t
+      Type.Var' (TypeVar.Existential _ v) ->
+        maybe t (\(Type.Monotype t') -> go t') (Map.lookup v solved)
+      Type.Arrow' i o -> Type.arrow a (go i) (go o)
+      Type.App' x y -> Type.app a (go x) (go y)
+      Type.Ann' v k -> Type.ann a (go v) k
+      Type.Effect1' e t -> Type.effect1 a (go e) (go t)
+      Type.Effects' es -> Type.effects a (fmap go es)
+      Type.ForallNamed' v t' -> Type.forAll a v (go t')
+      Type.IntroOuterNamed' v t' -> Type.introOuter a v (go t')
+      _ -> error $ "Match error in Context.apply': " ++ show t
+      where
+        a = ABT.annotation t
+
+-- Splits a context segment at an `Element` binding the given variable.
+-- In a general context segment, variable bindings needn't be unique, so
+-- this finds the right-most such occurrence, which would be the most
+-- locally relevant occurrence.
+--
+-- Technically the context can contain both type and term variable
+-- bindings, and these are not distinguished, so take care.
+splitSeg ::
+  Ord v =>
+  v ->
+  CtxSegment v loc ->
+  Maybe (CtxSegment v loc, Element v loc, CtxSegment v loc)
+splitSeg tgt seg = case search p seg of
+  Position l e r -> Just (l, e, r)
+  _ -> Nothing
+  where
+    -- Given info for a partition | i | j | of the context, tests whether
+    -- `tgt` is bound in `i` and not in `j`. This means | i | ends with
+    -- the last binding of `tgt`.
+    p i j =
+      (tgt `Set.notMember` allBoundVars j) &&
+      (tgt `Set.member` allBoundVars i)
+
+-- Splits a context at an `Element` binding the given variable. Since in
+-- a valid context, a variable only occurs once, this is completely
+-- unambiguous.
+split ::
+  Ord v =>
+  v ->
+  Context v loc ->
+  Maybe (Context v loc, Element v loc, CtxSegment v loc)
+split tgt (Context seg) = g <$> splitSeg tgt seg
+  where
+    -- Note: every prefix of a valid context is valid.
+    g (l, e, r) = (Context l, e, r)
+
+surround ::
+  Ord v =>
+  CtxSegment v loc ->
+  Element v loc ->
+  CtxSegment v loc ->
+  CtxSegment v loc
+surround l e r = l >< e <| r
+
+filter ::
+  (Var v) =>
+  (Element v loc -> Bool) ->
+  CtxSegment v loc -> CtxSegment v loc
+filter p = FO.foldl' c mempty
+  where
+    c seg e
+      | p e = seg |> e
+      | otherwise = seg
+
+partition ::
+  (Var v) =>
+  (Element v loc -> Either (Element v loc) (Element v loc)) ->
+  CtxSegment v loc ->
+  (CtxSegment v loc, CtxSegment v loc)
+partition f = FO.foldl' g (mempty, mempty)
+  where
+    g (ls, rs) e = case f e of
+      Left l -> (ls |> l, rs)
+      Right r -> (ls, rs |> r)
+
+-- | Applies a partial mapping to a context segment, resulting in a list.
+mapMaybe :: (Element v loc -> Maybe b) -> CtxSegment v loc -> [b]
+mapMaybe f = Prelude.foldr c []
+  where
+    c e = maybe id (:) $ f e
+
+single :: (Var v) => Element v loc -> CtxSegment v loc
+single e = FT.singleton e
+
+instance (Var v) => Show (Element v loc) where
+  show (Var v) = case v of
+    TypeVar.Universal x -> "@" <> show x
+    e -> show e
+  show (Solved _ v t) = "'" ++ Text.unpack (Var.name v) ++ " = " ++ Text.unpack (TP.prettyStr 0 PPE.empty (Type.getPolytype t))
+  show (Ann v _loc t) =
+    Text.unpack (Var.name v)
+      ++ " : "
+      ++ Text.unpack (TP.prettyStr 0 PPE.empty t)
+  show (Marker v) = "|" ++ Text.unpack (Var.name v) ++ "|"
+
+toReverseList :: CtxSegment v loc -> [Element v loc]
+toReverseList = Prelude.foldl (flip (:)) []
+
+renderType :: (Ord loc, Var v) => Context v loc -> Type v loc -> String
+renderType ctx ty = Text.unpack . TP.prettyStr 0 PPE.empty $ apply ctx ty
+
+renderElement ::
+  (Ord loc, Var v) => Context v loc -> Element v loc -> String
+renderElement ctx = \case
+  Var v
+    | TypeVar.Universal x <- v -> "@" <> show x
+    | otherwise -> show v
+  Solved _ v (Type.Monotype t) ->
+    mconcat
+      [ "'"
+      , Text.unpack $ Var.name v
+      , " = "
+      , renderType ctx t
+      ]
+  Ann v _loc t ->
+    mconcat
+      [ Text.unpack $ Var.name v
+      , " : "
+      , renderType ctx t
+      ]
+  Marker v -> "|" <> Text.unpack (Var.name v) <> "|"
+
+renderElements ::
+  (Ord loc, Var v) => Context v loc -> [Element v loc] -> String
+renderElements ctx = List.intercalate "\n  " . fmap (renderElement ctx)
+
+instance (Ord loc, Var v) => Show (Context v loc) where
+  show ctx@(Context es) =
+    "Γ\n  " <> renderElements ctx (toReverseList es)

--- a/parser-typechecker/src/Unison/Typechecker/Context/Structure.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context/Structure.hs
@@ -112,15 +112,22 @@ instance (Var v) => Eq (Element v loc) where
 --
 -- A context segment is a well formed context if `free*Vars` and
 -- `shadowedVars` are both empty.
+--
+-- Note: the fields here are intentionally lazy. In situations where
+-- there is heavy context manipulation, this seems to actually be faster,
+-- probably because the info is not actually used all of the time, and
+-- any fields that are strict are actually demanded by use of every other
+-- field in the info, regardless of whether the strict field ends up
+-- needed.
 data Info v loc = Info
-  { boundExistentialVars :: !(Set v),
-    solvedExistentials :: !(Map v (Monotype v loc)),
-    boundUniversalVars :: !(Set v),
-    termVarAnnotations :: !(Map v (loc, Type v loc)),
-    allBoundVars :: !(Set v),
-    freeUniversalVars :: !(Set v),
-    freeExistentialVars :: !(Set v),
-    shadowedVars :: !(Set v),
+  { boundExistentialVars :: Set v,
+    solvedExistentials :: Map v (Monotype v loc),
+    boundUniversalVars :: Set v,
+    termVarAnnotations :: Map v (loc, Type v loc),
+    allBoundVars :: Set v,
+    freeUniversalVars :: Set v,
+    freeExistentialVars :: Set v,
+    shadowedVars :: Set v,
     recorded :: Map v (B.Recorded loc, Type v loc)
   }
 

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -135,6 +135,7 @@ library
       Unison.Typechecker
       Unison.Typechecker.Components
       Unison.Typechecker.Context
+      Unison.Typechecker.Context.Structure
       Unison.Typechecker.Extractor
       Unison.Typechecker.TypeError
       Unison.Typechecker.TypeLookup
@@ -207,6 +208,7 @@ library
     , extra
     , filelock
     , filepath
+    , fingertree
     , free
     , generic-lens
     , hashable


### PR DESCRIPTION
This changes the implementation of the type checking context to be based on finger trees instead of plain lists.

Previously a context was a list of `Element`s and `Info`s, where the latter aggregated information about all the previous `Element`s in the list. This new implementation uses a finger tree of `Element`s with a modified `Info` type as the "measure" of the finger tree. Each `Element` has a singleton-like `Info` measure, and the information is aggregated up the tree.

This has significant asymptotic advantages in some cases. The `Info` makes it possible to split the context in logarithmic time by looking at which variables are in play in subsequences. Also, by modifying a few parts of the algorithm to operate on these (possibly ill-formed) sequences rather than `[Element v loc]`, the aggregate `Info` is largely maintained. Previously, the algorithm would often discard the info and recalculate it from the elements when appending to the context, which is linear in the number of elements.

Certain pathological type checking examples can result in repeatedly splitting and rejoining _large_ portions of the context. E.G. some tracing of the problem:

```
foo a b c d e f g h i j k l m n o p q r s t u v w x y z =
  (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z)
```

indicates that sequences of _thousands_ of elements are repeatedly split off and rejoined from the context. This is actually the _majority_ of the context, so most of it was being rebuilt from scratch. In this patch, the split is more efficient, _and_ quite a bit of aggregate information should be saved, with only a portion from the rejoined context needed to make the large ill-formed portion of the context back into a valid one. Hence, checking this example is now ~10x faster (but the speedup is actually asymptotic (probably something like `n * (log n)^k` rather than quadratic).

The type checking algorithm is overall the same. Just some core pieces where the context is directly manipulated were altered to take advantage of the new structures.

Transcripts seem to pass without change. I'm not sure how comprehensive those are w/r/t type checking changes for something at such a fundamental level. But it's something at least.