### PR TITLE
Add missing fingertree dependency to parser-typechecker

### DIFF
--- a/parser-typechecker/package.yaml
+++ b/parser-typechecker/package.yaml
@@ -24,6 +24,7 @@ library:
     - extra
     - filelock
     - filepath
+    - fingertree
     - free
     - generic-lens
     - hashable


### PR DESCRIPTION
The fingertree package is used by Unison.Typechecker.Context.Structure but was not listed as an explicit dependency.

cc @dolio don't forget to use the `.yaml` as primary, sorry.