### PR TITLE
Update runtime-tests version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ on:
 
 env:
   ## Some version numbers that are used during CI
-  runtime_tests_version: "@unison/runtime-tests/releases/0.0.3"
+  runtime_tests_version: "@unison/runtime-tests/releases/0.0.6"
 
   ## Some cached directories
   # a temp path for caching a built `ucm`

--- a/unison-src/builtin-tests/interpreter-tests.output.md
+++ b/unison-src/builtin-tests/interpreter-tests.output.md
@@ -13,7 +13,7 @@ Before merging the PR on Github, we'll merge your branch on Share and restore `r
 ```
 
 ``` ucm :hide
-> clone @unison/runtime-tests/releases/0.0.3 runtime-tests/selected
+> clone @unison/runtime-tests/releases/0.0.6 runtime-tests/selected
 ```
 
 ``` ucm

--- a/unison-src/builtin-tests/interpreter-tests.sh
+++ b/unison-src/builtin-tests/interpreter-tests.sh
@@ -8,7 +8,7 @@ else
   ucm="$1"
 fi
 
-runtime_tests_version="@unison/runtime-tests/releases/0.0.3"
+runtime_tests_version="@unison/runtime-tests/releases/0.0.6"
 
 codebase=${XDG_CACHE_HOME:-"$HOME/.cache"}/unisonlanguage/runtime-tests.unison
 


### PR DESCRIPTION
Switches to using unison-lang.org instead of example.com in some tls tests, because a change to example.com started giving a different error than expected.