### PR TITLE
add `watch` / `unwatch` commands

### DIFF
--- a/unison-cli/src/Unison/Cli/Monad.hs
+++ b/unison-cli/src/Unison/Cli/Monad.hs
@@ -75,6 +75,7 @@ import Unison.Codebase (Codebase)
 import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Editor.Input (Input)
 import Unison.Codebase.Editor.Output (NumberedArgs, NumberedOutput, Output)
+import Unison.Codebase.Watch qualified as Watch
 import Unison.Codebase.Editor.UCMVersion (UCMVersion)
 import Unison.Codebase.Path qualified as Path
 import Unison.Codebase.ProjectPath qualified as PP
@@ -178,7 +179,10 @@ data Env = Env
     ucmVersion :: UCMVersion,
     -- | Whether we're running in a transcript test or not.
     -- Avoid using this except when absolutely necessary.
-    isTranscriptTest :: Bool
+    isTranscriptTest :: Bool,
+    -- | The file watch state, if file watching is enabled.
+    -- `Nothing` in contexts like transcripts or MCP where file watching is not supported.
+    watchState :: Maybe Watch.WatchState
   }
   deriving stock (Generic)
 

--- a/unison-cli/src/Unison/Cli/Monad.hs
+++ b/unison-cli/src/Unison/Cli/Monad.hs
@@ -75,10 +75,10 @@ import Unison.Codebase (Codebase)
 import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Editor.Input (Input)
 import Unison.Codebase.Editor.Output (NumberedArgs, NumberedOutput, Output)
-import Unison.Codebase.Watch qualified as Watch
 import Unison.Codebase.Editor.UCMVersion (UCMVersion)
 import Unison.Codebase.Path qualified as Path
 import Unison.Codebase.ProjectPath qualified as PP
+import Unison.Codebase.Watch qualified as Watch
 import Unison.CommandLine.OutputMessages qualified as OutputMessages
 import Unison.Core.Project (ProjectAndBranch (..))
 import Unison.Debug qualified as Debug

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -19,8 +19,8 @@ import Data.Map qualified as Map
 import Data.Set qualified as Set
 import Data.Text qualified as Text
 import Data.Time (UTCTime)
-import System.Directory (makeAbsolute)
 import Data.Tuple.Extra (uncurry3)
+import System.Directory (makeAbsolute)
 import Text.Megaparsec qualified as Megaparsec
 import U.Codebase.Branch.Diff qualified as V2Branch.Diff
 import U.Codebase.Causal qualified as V2Causal
@@ -106,7 +106,6 @@ import Unison.Codebase.Editor.Input
 import Unison.Codebase.Editor.Output
 import Unison.Codebase.Editor.Output qualified as Output
 import Unison.Codebase.Editor.Output.DumpNamespace qualified as Output.DN
-import Unison.Codebase.Watch qualified as Watch
 import Unison.Codebase.Editor.RemoteRepo qualified as RemoteRepo
 import Unison.Codebase.Editor.StructuredArgument qualified as SA
 import Unison.Codebase.Execute qualified as Codebase
@@ -117,6 +116,7 @@ import Unison.Codebase.Path qualified as Path
 import Unison.Codebase.ProjectPath qualified as PP
 import Unison.Codebase.Runtime qualified as Runtime
 import Unison.Codebase.ShortCausalHash qualified as SCH
+import Unison.Codebase.Watch qualified as Watch
 import Unison.CommandLine.BranchRelativePath (BranchRelativePath (..))
 import Unison.CommandLine.Completion qualified as Completion
 import Unison.CommandLine.DisplayValues qualified as DisplayValues

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -19,6 +19,7 @@ import Data.Map qualified as Map
 import Data.Set qualified as Set
 import Data.Text qualified as Text
 import Data.Time (UTCTime)
+import System.Directory (makeAbsolute)
 import Data.Tuple.Extra (uncurry3)
 import Text.Megaparsec qualified as Megaparsec
 import U.Codebase.Branch.Diff qualified as V2Branch.Diff
@@ -103,6 +104,7 @@ import Unison.Codebase.Editor.Input
 import Unison.Codebase.Editor.Output
 import Unison.Codebase.Editor.Output qualified as Output
 import Unison.Codebase.Editor.Output.DumpNamespace qualified as Output.DN
+import Unison.Codebase.Watch qualified as Watch
 import Unison.Codebase.Editor.RemoteRepo qualified as RemoteRepo
 import Unison.Codebase.Editor.StructuredArgument qualified as SA
 import Unison.Codebase.Execute qualified as Codebase
@@ -717,6 +719,29 @@ loop e = do
         UpgradeCommitI -> Cli.returnEarly (Output.Literal "The `upgrade.commit` command has been removed in favor of `update`.")
         UpgradeI libs -> handleUpgrade libs
         VersionI -> Cli.respond $ PrintVersion env.ucmVersion
+        WatchI path -> case env.watchState of
+          Nothing -> Cli.respond Output.WatchDisabled
+          Just ws -> do
+            result <- liftIO $ Watch.watchPath ws path
+            Cli.respond $ Output.WatchAddResult result path
+        UnwatchI paths -> case env.watchState of
+          Nothing -> Cli.respond Output.WatchDisabled
+          Just ws -> do
+            -- Process each path and collect results
+            results <- for paths \path -> do
+              canonPath <- liftIO $ makeAbsolute path
+              success <- liftIO $ Watch.unwatchPath ws canonPath
+              pure (path, canonPath, success)
+            let (removed, failed) = List.partition (\(_, _, success) -> success) results
+            let removedPaths = [canonPath | (_, canonPath, _) <- removed]
+            let failedPaths = [path | (path, _, _) <- failed]
+            remainingPaths <- liftIO $ Set.toList <$> Watch.getWatchedPaths ws
+            Cli.respondNumbered $ Output.WatchRemoved removedPaths failedPaths remainingPaths
+        WatchListI -> case env.watchState of
+          Nothing -> Cli.respond Output.WatchDisabled
+          Just ws -> do
+            watchedPaths <- liftIO $ Set.toList <$> Watch.getWatchedPaths ws
+            Cli.respondNumbered $ Output.WatchList watchedPaths
 
 inputDescription :: Input -> Cli Text
 inputDescription input =
@@ -857,6 +882,9 @@ inputDescription input =
     UpgradeCommitI {} -> wat
     UpgradeI {} -> wat
     VersionI -> wat
+    WatchI {} -> wat
+    UnwatchI {} -> wat
+    WatchListI -> wat
     CancelI -> wat
   where
     p' :: Path' -> Cli Text

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -225,6 +225,12 @@ data Input
   | UpgradeCommitI
   | UpgradeI ![NameSegment]
   | VersionI
+  | -- | Watch an external file or directory for changes
+    WatchI !FilePath
+  | -- | Stop watching one or more external files or directories
+    UnwatchI ![FilePath]
+  | -- | List currently watched external paths
+    WatchListI
   deriving (Eq, Show)
 
 -- | The source of a `branch` command: what to make the new branch from.

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -152,6 +152,11 @@ data NumberedOutput
       MoreEntriesThanShown
       [ProjectReflog.Entry Project ProjectBranch (CausalHash, SCH.ShortCausalHash)]
   | DeletedDefinitions (DefnsF Set Name Name)
+  | -- | List of currently watched paths (working dir is included)
+    WatchList ![FilePath]
+  | -- | Successfully removed paths from the watch list
+    -- (removed paths, failed paths, remaining paths)
+    WatchRemoved ![FilePath] ![FilePath] ![FilePath]
 
 data TodoOutput = TodoOutput
   { defnsInLib :: !Bool,
@@ -481,6 +486,11 @@ data Output
   | CommentAborted
   | AuthorNameRequired
   | ConfigValueGet ConfigKey (Maybe Text)
+  | WatchDisabled
+  | -- | Result of attempting to add a path to the watch list.
+    -- First FilePath is the canonical path on success (Nothing on failure),
+    -- second is the original path requested.
+    WatchAddResult !(Maybe FilePath) !FilePath
 
 data MoreEntriesThanShown = MoreEntriesThanShown | AllEntriesShown
   deriving (Eq, Show)
@@ -731,6 +741,9 @@ isFailure o = case o of
   CommentAborted {} -> True
   AuthorNameRequired {} -> True
   ConfigValueGet {} -> False
+  WatchDisabled -> True
+  WatchAddResult Nothing _ -> True
+  WatchAddResult (Just _) _ -> False
 
 isNumberedFailure :: NumberedOutput -> Bool
 isNumberedFailure = \case
@@ -752,3 +765,5 @@ isNumberedFailure = \case
   Output'Todo {} -> False
   ShowProjectBranchReflog {} -> False
   DeletedDefinitions {} -> False
+  WatchList {} -> False
+  WatchRemoved _ failedPaths _ -> not (null failedPaths)

--- a/unison-cli/src/Unison/Codebase/Editor/StructuredArgument.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/StructuredArgument.hs
@@ -26,4 +26,5 @@ data StructuredArgument
   | HashQualifiedWithBranchPrefix AbsBranchId (HQ'.HashQualified Name)
   | ShallowListEntry Path' (ShallowListEntry Symbol Ann)
   | SearchResult (Maybe Path') SearchResult
+  | FilePath FilePath
   deriving (Eq, Generic, Show)

--- a/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
+++ b/unison-cli/src/Unison/Codebase/Transcript/Runner.hs
@@ -539,7 +539,9 @@ run isTest verbosity codebase runtime sbRuntime ucmVersion baseURL authenticated
             sandboxedRuntime = sbRuntime,
             serverBaseUrl = Nothing,
             ucmVersion,
-            isTranscriptTest = isTest
+            isTranscriptTest = isTest,
+            -- Transcripts don't support file watching
+            watchState = Nothing
           }
 
   let loop :: Cli.LoopState -> IO (Seq Stanza)

--- a/unison-cli/src/Unison/Codebase/Watch.hs
+++ b/unison-cli/src/Unison/Codebase/Watch.hs
@@ -16,9 +16,9 @@ import Data.Time.Clock (UTCTime, diffUTCTime)
 import GHC.Conc (registerDelay)
 import Ki qualified
 import System.Directory (canonicalizePath, doesDirectoryExist, doesFileExist)
-import System.FilePath (splitFileName)
 import System.FSNotify (Event (Added, Modified))
 import System.FSNotify qualified as FSNotify
+import System.FilePath (splitFileName)
 import Unison.Prelude
 import UnliftIO.Exception (tryAny)
 import UnliftIO.STM (atomically)

--- a/unison-cli/src/Unison/Codebase/Watch.hs
+++ b/unison-cli/src/Unison/Codebase/Watch.hs
@@ -14,7 +14,6 @@ import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import Data.Map qualified as Map
 import Data.Time.Clock (UTCTime, diffUTCTime)
 import GHC.Conc (registerDelay)
-import Ki qualified
 import System.Directory (canonicalizePath, doesDirectoryExist, doesFileExist)
 import System.FilePath (splitFileName)
 import System.FSNotify (Event (Added, Modified))
@@ -25,9 +24,7 @@ import UnliftIO.STM (atomically)
 
 -- | State for managing multiple watched paths.
 data WatchState = WatchState
-  { -- | The Ki scope for managing watcher threads
-    scope :: Ki.Scope,
-    -- | The FSNotify watch manager
+  { -- | The FSNotify watch manager
     watchManager :: FSNotify.WatchManager,
     -- | TVar containing the latest event from any watcher
     latestEventVar :: TVar (Maybe (FilePath, UTCTime)),
@@ -41,15 +38,14 @@ data WatchState = WatchState
 
 -- | Create a new watch state. The Ki scope is used for structured concurrency -
 -- when the scope exits, all watcher threads are automatically cleaned up.
-newWatchState :: Ki.Scope -> FSNotify.WatchManager -> (FilePath -> Bool) -> IO WatchState
-newWatchState scope mgr allow = do
+newWatchState :: FSNotify.WatchManager -> (FilePath -> Bool) -> IO WatchState
+newWatchState mgr allow = do
   latestEventVar <- STM.newTVarIO Nothing
   watchedPathsVar <- STM.newTVarIO Map.empty
   previousFilesRef <- newIORef Map.empty
   pure
     WatchState
-      { scope = scope,
-        watchManager = mgr,
+      { watchManager = mgr,
         latestEventVar = latestEventVar,
         watchedPathsVar = watchedPathsVar,
         allowPredicate = allow,

--- a/unison-cli/src/Unison/Codebase/Watch.hs
+++ b/unison-cli/src/Unison/Codebase/Watch.hs
@@ -4,7 +4,6 @@ module Unison.Codebase.Watch
     newWatchState,
     awaitEvent,
     unwatchPath,
-    unwatchAllPaths,
     getWatchedPaths,
   )
 where
@@ -179,15 +178,6 @@ unwatchPath ws path = do
     Just stopAction -> do
       stopAction
       pure True
-
--- | Stop watching all paths.
-unwatchAllPaths :: WatchState -> IO ()
-unwatchAllPaths ws = do
-  stopActions <- atomically $ do
-    paths <- STM.readTVar ws.watchedPathsVar
-    STM.writeTVar ws.watchedPathsVar Map.empty
-    pure (Map.elems paths)
-  sequence_ stopActions
 
 -- | Get the list of currently watched paths.
 getWatchedPaths :: WatchState -> IO (Set FilePath)

--- a/unison-cli/src/Unison/Codebase/Watch.hs
+++ b/unison-cli/src/Unison/Codebase/Watch.hs
@@ -1,38 +1,127 @@
 module Unison.Codebase.Watch
-  ( watchDirectory,
+  ( watchPath,
+    WatchState (..),
+    newWatchState,
+    awaitEvent,
+    unwatchPath,
+    unwatchAllPaths,
+    getWatchedPaths,
   )
 where
 
-import Control.Concurrent (threadDelay)
-import Control.Concurrent.STM (STM)
+import Control.Concurrent.STM (STM, TVar)
 import Control.Concurrent.STM qualified as STM
-import Control.Exception (MaskingState (..))
-import Data.IORef (newIORef, readIORef, writeIORef)
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import Data.Map qualified as Map
 import Data.Time.Clock (UTCTime, diffUTCTime)
 import GHC.Conc (registerDelay)
-import GHC.IO (unsafeUnmask)
 import Ki qualified
+import System.Directory (canonicalizePath, doesDirectoryExist, doesFileExist)
+import System.FilePath (splitFileName)
 import System.FSNotify (Event (Added, Modified))
 import System.FSNotify qualified as FSNotify
 import Unison.Prelude
-import UnliftIO.Exception (finally, tryAny)
+import UnliftIO.Exception (tryAny)
 import UnliftIO.STM (atomically)
 
-watchDirectory :: Ki.Scope -> FSNotify.WatchManager -> FilePath -> (FilePath -> Bool) -> IO (IO (FilePath, Text))
-watchDirectory scope mgr dir allow = do
-  readLatestEvent <- forkDirWatcherThread scope mgr dir allow
+-- | State for managing multiple watched paths.
+data WatchState = WatchState
+  { -- | The Ki scope for managing watcher threads
+    scope :: Ki.Scope,
+    -- | The FSNotify watch manager
+    watchManager :: FSNotify.WatchManager,
+    -- | TVar containing the latest event from any watcher
+    latestEventVar :: TVar (Maybe (FilePath, UTCTime)),
+    -- | Map from watched paths to their stop-watching actions
+    watchedPathsVar :: TVar (Map FilePath (IO ())),
+    -- | Predicate for filtering files (e.g., .u files only)
+    allowPredicate :: FilePath -> Bool,
+    -- | Cache for debouncing file contents
+    previousFilesRef :: IORef (Map FilePath (Text, UTCTime))
+  }
 
-  -- Await an event from the event queue with the following simple debounce logic, which is intended to work around the
-  -- tendency for modern editors to create a flurry of rapid filesystem events when a file is saved:
-  --
-  -- 1. Block until an event arrives that occurred within the last second (which allows us to ignore old filesystem
-  --    events that may have buffered during a long-running IO action).
-  -- 2. Keep consuming events until 50ms elapse without an event.
-  -- 3. Return only the last event.
-  --
-  -- Note we don't have any smarts here for a flurry of events that are related to more than one file; we just throw
-  -- everything away except the last event. In practice, this has seemed to work fine.
+-- | Create a new watch state. The Ki scope is used for structured concurrency -
+-- when the scope exits, all watcher threads are automatically cleaned up.
+newWatchState :: Ki.Scope -> FSNotify.WatchManager -> (FilePath -> Bool) -> IO WatchState
+newWatchState scope mgr allow = do
+  latestEventVar <- STM.newTVarIO Nothing
+  watchedPathsVar <- STM.newTVarIO Map.empty
+  previousFilesRef <- newIORef Map.empty
+  pure
+    WatchState
+      { scope = scope,
+        watchManager = mgr,
+        latestEventVar = latestEventVar,
+        watchedPathsVar = watchedPathsVar,
+        allowPredicate = allow,
+        previousFilesRef = previousFilesRef
+      }
+
+-- | Add a file or directory to be watched. Returns the canonical path if successful, Nothing otherwise.
+--
+-- Each watched path spawns a background thread via Ki that manages the FSNotify watcher.
+-- When the Ki scope exits, all watcher threads are automatically cleaned up.
+watchPath :: WatchState -> FilePath -> IO (Maybe FilePath)
+watchPath ws path = do
+  canonPath <- canonicalizePath path
+  isDir <- doesDirectoryExist canonPath
+  isFile <- doesFileExist canonPath
+  if not (isDir || isFile)
+    then pure Nothing
+    else do
+      alreadyWatched <- atomically $ Map.member canonPath <$> STM.readTVar ws.watchedPathsVar
+      if alreadyWatched
+        then pure (Just canonPath) -- Already watching, consider it a success
+        else do
+          -- Create the handler that writes to our shared TVar
+          let handler :: Event -> IO ()
+              handler = \case
+                Added fp t FSNotify.IsFile | ws.allowPredicate fp -> atomically (STM.writeTVar ws.latestEventVar (Just (fp, t)))
+                Modified fp t FSNotify.IsFile | ws.allowPredicate fp -> atomically (STM.writeTVar ws.latestEventVar (Just (fp, t)))
+                _ -> pure ()
+
+          -- Determine what to watch
+          let watchAction =
+                if isDir
+                  then FSNotify.watchDir ws.watchManager canonPath (const True) handler
+                  else do
+                    -- For a single file, we watch the parent directory and filter for our file
+                    let (parentDir, _) = splitFileName canonPath
+                    FSNotify.watchDir ws.watchManager parentDir (\e -> eventPath e == canonPath) handler
+
+          -- Start watching with FSNotify
+          stopListening <- watchAction
+
+          -- Record that we're watching this path, with the actual stop action
+          atomically $ STM.modifyTVar ws.watchedPathsVar (Map.insert canonPath stopListening)
+          pure (Just canonPath)
+  where
+    eventPath :: Event -> FilePath
+    eventPath = \case
+      Added p _time _isDir -> p
+      Modified p _time _isDir -> p
+      FSNotify.Removed p _time _isDir -> p
+      FSNotify.ModifiedAttributes p _time _isDir -> p
+      FSNotify.WatchedDirectoryRemoved p _time _isDir -> p
+      FSNotify.CloseWrite p _time _isDir -> p
+      FSNotify.Unknown p _time _isDir _eventString -> p
+
+-- | Await an event from any watched source.
+--
+-- This function implements debouncing with the following logic, intended to work around the tendency
+-- for modern editors to create a flurry of rapid filesystem events when a file is saved:
+--
+-- 1. Block until an event arrives.
+-- 2. Keep consuming events until 50ms elapse without an event.
+-- 3. Return only the last event.
+--
+-- Note we don't have any smarts here for a flurry of events that are related to more than one file;
+-- we just throw everything away except the last event. In practice, this has seemed to work fine.
+--
+-- Additionally, we keep in memory the file contents of previously-saved files, so that we can avoid
+-- emitting events for files that last changed less than 500ms ago, and whose contents haven't changed.
+awaitEvent :: WatchState -> IO (FilePath, Text)
+awaitEvent ws = do
   let awaitEvent0 :: IO (FilePath, UTCTime)
       awaitEvent0 = do
         let go :: (FilePath, UTCTime) -> IO (FilePath, UTCTime)
@@ -49,10 +138,15 @@ watchDirectory scope mgr dir allow = do
         event <- atomically readLatestEvent
         go event
 
-  -- Enhance the previous "await event" action with a small file cache that serves as a second debounce implementation.
-  -- We keep in memory the file contents of previously-saved files, so that we can avoid emitting events for files that
-  -- last changed less than 500ms ago, and whose contents haven't changed.
-  previousFilesRef <- newIORef Map.empty
+      readLatestEvent :: STM (FilePath, UTCTime)
+      readLatestEvent =
+        STM.readTVar ws.latestEventVar >>= \case
+          Nothing -> STM.retry
+          Just event -> do
+            STM.writeTVar ws.latestEventVar Nothing
+            pure event
+
+  -- Apply debouncing based on file contents cache
   let awaitEvent1 :: IO (FilePath, Text)
       awaitEvent1 = do
         (file, t) <- awaitEvent0
@@ -60,51 +154,41 @@ watchDirectory scope mgr dir allow = do
           -- Somewhat-expected read error from a file that was just written. Just ignore the event and try again.
           Left _ -> awaitEvent1
           Right contents -> do
-            previousFiles <- readIORef previousFilesRef
+            previousFiles <- readIORef ws.previousFilesRef
             case Map.lookup file previousFiles of
               Just (contents0, t0) | contents == contents0 && (t `diffUTCTime` t0) < 0.5 -> awaitEvent1
               _ -> do
-                writeIORef previousFilesRef $! Map.insert file (contents, t) previousFiles
+                writeIORef ws.previousFilesRef $! Map.insert file (contents, t) previousFiles
                 pure (file, contents)
 
-  pure awaitEvent1
+  awaitEvent1
 
--- | `forkDirWatcherThread scope mgr dir allow` forks a background thread into `scope` that, using "file watcher
--- manager" `mgr` (just a boilerplate argument the caller is responsible for creating), watches directory `dir` for
--- all "added" and "modified" filesystem events that occur on files that pass the `allow` predicate. It returns an STM
--- action that reads (and clears) the latest event, blocking if one isn't available.
-forkDirWatcherThread ::
-  Ki.Scope ->
-  FSNotify.WatchManager ->
-  FilePath ->
-  (FilePath -> Bool) ->
-  IO (STM (FilePath, UTCTime))
-forkDirWatcherThread scope mgr dir allow = do
-  latestEventVar <- STM.newTVarIO Nothing
+-- | Stop watching a path. Returns True if the path was being watched.
+unwatchPath :: WatchState -> FilePath -> IO Bool
+unwatchPath ws path = do
+  canonPath <- canonicalizePath path
+  maybeStop <- atomically $ do
+    paths <- STM.readTVar ws.watchedPathsVar
+    case Map.lookup canonPath paths of
+      Nothing -> pure Nothing
+      Just stopAction -> do
+        STM.writeTVar ws.watchedPathsVar (Map.delete canonPath paths)
+        pure (Just stopAction)
+  case maybeStop of
+    Nothing -> pure False
+    Just stopAction -> do
+      stopAction
+      pure True
 
-  let handler :: Event -> IO ()
-      handler = \case
-        Added fp t FSNotify.IsFile | allow fp -> atomically (STM.writeTVar latestEventVar (Just (fp, t)))
-        Modified fp t FSNotify.IsFile | allow fp -> atomically (STM.writeTVar latestEventVar (Just (fp, t)))
-        _ -> pure ()
+-- | Stop watching all paths.
+unwatchAllPaths :: WatchState -> IO ()
+unwatchAllPaths ws = do
+  stopActions <- atomically $ do
+    paths <- STM.readTVar ws.watchedPathsVar
+    STM.writeTVar ws.watchedPathsVar Map.empty
+    pure (Map.elems paths)
+  sequence_ stopActions
 
-  -- A bit of a "one too many threads" situation but there's not much we can easily do about it. The `fsnotify` API
-  -- doesn't expose any synchronous API; the only option is to fork a background thread with a callback. So, we spawn
-  -- a thread that spawns *that* thread, then waits forever. The purpose here is to simply leverage `ki` exception
-  -- propagation machinery to ensure that the `fsnotify` thread is properly cleaned up.
-  Ki.forkWith_ scope Ki.defaultThreadOptions {Ki.maskingState = MaskedUninterruptible} do
-    -- The goal here is to prevent spawning this background watching thread before installing an exception handler that
-    -- guarantees it's killed. Unfortunately the fsnotify API doesn't seem to make that possible (hence the first
-    -- `unsafeUnmask` here), since we do need the thread *it* spawns to be killable, and (at least as of version
-    -- 0.4.2.0) they don't take care to guarantee that; it just inherits the masking state.
-    stopListening <- unsafeUnmask (FSNotify.watchDir mgr dir (const True) handler) <|> pure (pure ())
-    unsafeUnmask (forever (threadDelay maxBound)) `finally` stopListening
-
-  let readLatestEvent =
-        STM.readTVar latestEventVar >>= \case
-          Nothing -> STM.retry
-          Just event -> do
-            STM.writeTVar latestEventVar Nothing
-            pure event
-
-  pure readLatestEvent
+-- | Get the list of currently watched paths.
+getWatchedPaths :: WatchState -> IO (Set FilePath)
+getWatchedPaths ws = atomically $ Map.keysSet <$> STM.readTVar ws.watchedPathsVar

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -3821,7 +3821,7 @@ unwatchInputPattern =
       params = Parameters [] $ Optional [] (Just ("file or directory", watchedPathArg)),
       help =
         P.wrapColumn2
-          [ ( makeExample unwatchInputPattern ["<file or directory>"],
+          [ ( makeExample unwatchInputPattern ["<files or directories...>"],
               "Stop watching one or more external files or directories for changes."
             ),
             ( makeExample' unwatchInputPattern,

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -121,6 +121,9 @@ module Unison.CommandLine.InputPatterns
     upgrade,
     view,
     viewGlobal,
+    watchInputPattern,
+    watchesInputPattern,
+    unwatchInputPattern,
     deprecatedViewRootReflog,
     branchReflog,
     projectReflog,
@@ -257,6 +260,7 @@ formatStructuredArgument schLength = \case
   SA.HashQualifiedWithBranchPrefix absBranchId hq'Name -> HQ'.toTextWith (prefixBranchId absBranchId) hq'Name
   SA.ShallowListEntry path entry -> entryToHQText path entry
   SA.SearchResult searchRoot searchResult -> HQ.toText $ searchResultToHQ searchRoot searchResult
+  SA.FilePath fp -> Text.pack fp
   where
     -- E.g.
     -- prefixBranchId "#abcdef" "base.List.map" -> "#abcdef:.base.List.map"
@@ -369,6 +373,7 @@ wrongStructuredArgument expected actual =
       SA.HashQualifiedWithBranchPrefix _ _ -> "a hash-qualified name"
       SA.ShallowListEntry _ _ -> "a name"
       SA.SearchResult _ _ -> "a search result"
+      SA.FilePath _ -> "a file path"
 
 wrongArgsLength :: Text -> [a] -> Either (P.Pretty CT.ColorText) b
 wrongArgsLength expected args =
@@ -3720,6 +3725,67 @@ debugSynhashTermInputPattern =
         args -> wrongArgsLength "exactly one argument" args
     }
 
+watchInputPattern :: InputPattern
+watchInputPattern =
+  InputPattern
+    { patternName = "watch",
+      aliases = [],
+      visibility = I.Visible,
+      params = Parameters [("file or directory", filePathArg)] $ Optional [] Nothing,
+      help =
+        P.wrapColumn2
+          [ ( makeExample watchInputPattern ["<file or directory>"],
+              "Watch an external file or directory for changes. Changes to `.u` files in watched locations will be automatically loaded."
+            )
+          ],
+      parse = \case
+        [file] -> Input.WatchI <$> unsupportedStructuredArgument watchInputPattern "a file or directory path" file
+        args -> wrongArgsLength "exactly one argument" args
+    }
+
+watchesInputPattern :: InputPattern
+watchesInputPattern =
+  InputPattern
+    { patternName = "watches",
+      aliases = [],
+      visibility = I.Visible,
+      params = noParams,
+      help = P.wrap "List all external paths currently being watched for changes.",
+      parse = \case
+        [] -> pure Input.WatchListI
+        args -> wrongArgsLength "no arguments" args
+    }
+
+unwatchInputPattern :: InputPattern
+unwatchInputPattern =
+  InputPattern
+    { patternName = "unwatch",
+      aliases = [],
+      visibility = I.Visible,
+      -- Uses watchedPathArg which accepts SA.FilePath from numbered args.
+      -- Users can run `watches` to see the list of watched paths and use numbered args like `unwatch 1 2 3`.
+      params = Parameters [] $ Optional [] (Just ("file or directory", watchedPathArg)),
+      help =
+        P.wrapColumn2
+          [ ( makeExample unwatchInputPattern ["<file or directory>"],
+              "Stop watching one or more external files or directories for changes."
+            ),
+            ( makeExample' unwatchInputPattern,
+              "With no arguments, list currently watched paths."
+            )
+          ],
+      parse = \case
+        [] -> pure Input.WatchListI
+        args -> Input.UnwatchI <$> traverse handleWatchedPathArg args
+    }
+
+handleWatchedPathArg :: I.Argument -> Either (P.Pretty CT.ColorText) FilePath
+handleWatchedPathArg = \case
+  I.RawArg raw -> pure raw
+  I.StructuredArg sa -> case sa of
+    SA.FilePath fp -> pure fp
+    _ -> Left $ wrongStructuredArgument "a file path" sa
+
 validInputs :: [InputPattern]
 validInputs =
   sortOn
@@ -3853,6 +3919,9 @@ validInputs =
       upgradeCommitInputPattern,
       view,
       viewGlobal,
+      watchInputPattern,
+      watchesInputPattern,
+      unwatchInputPattern,
       deprecatedViewRootReflog,
       branchReflog,
       projectReflog,
@@ -3995,6 +4064,16 @@ filePathArg =
       suggestions = \prefix _ _ _ -> filenameCompletion prefix,
       fzfResolver = Just I.DefaultFZFFileSearch,
       isStructured = False
+    }
+
+-- | Accepts file paths from numbered args (SA.FilePath). No completions since we don't have access to WatchState.
+watchedPathArg :: ParameterType
+watchedPathArg =
+  ParameterType
+    { typeName = "watched-path",
+      suggestions = noCompletions,
+      fzfResolver = Nothing,
+      isStructured = True
     }
 
 directoryPathArg :: ParameterType

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -4,6 +4,7 @@ module Unison.CommandLine.Main
 where
 
 import Compat (withInterruptHandler)
+import Control.Concurrent (threadDelay)
 import Control.Exception (displayException, mask)
 import Control.Lens ((?~))
 import Control.Lens.Lens
@@ -175,20 +176,25 @@ main dir welcome ppIds initialInputs runtime sbRuntime codebase serverBaseUrl uc
       _ <- Ki.fork scope (Codebase.expectProjectBranchRoot codebase ppIds.project ppIds.branch)
       -- IOSource takes a while to compile, we should start compiling it on startup
       _ <- Ki.fork scope (IO.evaluate IOSource.typecheckedFile)
-      -- Fork the file watcher thread, which returns an IO action we can call to get one filesystem event.
-      awaitFileEvent <- do
-        (fmap . fmap)
-          (\(file, contents) -> UnisonFileChanged (Text.pack file) contents)
-          ( Watch.watchDirectory
-              scope
-              mgr
-              dir
-              -- We could elect to not spawn a file-watching thread at all if --no-file-watch is passed to ucm, but that
-              -- is an extremely uncommon option, this isn't super inefficient, and this makes the types simpler.
-              case shouldWatchFiles of
-                ShouldNotWatchFiles -> const False
-                ShouldWatchFiles -> allow
-          )
+
+      -- Create the watch state for managing all watched paths (including working directory).
+      -- When --no-file-watch is passed, watchState is Nothing.
+      watchState <- case shouldWatchFiles of
+        ShouldNotWatchFiles -> pure Nothing
+        ShouldWatchFiles -> do
+          ws <- Watch.newWatchState scope mgr allow
+          -- Add the working directory as the first watched path
+          _ <- Watch.watchPath ws dir
+          pure (Just ws)
+
+      -- Await function that gets events from any watched path.
+      -- When --no-file-watch is passed, this blocks forever.
+      let awaitFileEvent :: IO Event
+          awaitFileEvent = case watchState of
+            Nothing -> forever (threadDelay maxBound)
+            Just ws -> do
+              (file, contents) <- Watch.awaitEvent ws
+              pure (UnisonFileChanged (Text.pack file) contents)
 
       -- On startup, we tell the user about any existing project names that don't pass the new project name regex,
       -- which isn't enforced yet.
@@ -292,7 +298,8 @@ main dir welcome ppIds initialInputs runtime sbRuntime codebase serverBaseUrl uc
                 sandboxedRuntime = sbRuntime,
                 serverBaseUrl,
                 ucmVersion,
-                isTranscriptTest = False
+                isTranscriptTest = False,
+                watchState = watchState
               }
 
       (onInterrupt, waitForInterrupt) <- buildInterruptHandler

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -182,7 +182,7 @@ main dir welcome ppIds initialInputs runtime sbRuntime codebase serverBaseUrl uc
       watchState <- case shouldWatchFiles of
         ShouldNotWatchFiles -> pure Nothing
         ShouldWatchFiles -> do
-          ws <- Watch.newWatchState scope mgr allow
+          ws <- Watch.newWatchState mgr allow
           -- Add the working directory as the first watched path
           _ <- Watch.watchPath ws dir
           pure (Just ws)

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -537,8 +537,49 @@ notifyNumbered = \case
             <> undoTip,
           map SA.Name (typesList ++ termsList)
         )
+  WatchList watchedPaths ->
+    ( if null watchedPaths
+        then "I'm not watching any paths."
+        else
+          P.lines
+            [ "I'm watching these paths for changes:",
+              "",
+              P.indentN 2 $ P.numberedList [P.blue (P.string path) | path <- watchedPaths],
+              "",
+              tip "Use `watch` or `unwatch` to add or remove paths."
+            ],
+      map SA.FilePath watchedPaths
+    )
+  WatchRemoved removedPaths failedPaths remainingPaths ->
+    ( P.lines $
+        (if null removedPaths
+           then []
+           else [P.wrap 
+                  $ "I'm no longer watching " <> oxfordOr [P.blue (P.string p) | p <- removedPaths] 
+                  <> (if null remainingPaths then " (or any other paths)" else "") <> " for changes."])
+          <> (if null failedPaths
+                then []
+                else ["", P.warnCallout $ "I already wasn't watching these paths: " <> oxfordOr [P.blue (P.string p) | p <- failedPaths]])
+          <> if null remainingPaths
+               then ["", tip "Use `watch <path>` to watch a file or directory."]
+               else
+                 [ "",
+                   "I'm still watching:",
+                   "",
+                   P.indentN 2 $ P.numberedList [P.blue (P.string path) | path <- remainingPaths]
+                 ],
+      map SA.FilePath remainingPaths
+    )
   where
     absPathToBranchId = BranchAtPath
+    -- Like oxfordCommas but uses "or" instead of "and", without extra spaces.
+    -- Groups each element with its trailing comma to prevent line breaks between them.
+    oxfordOr :: [P.Pretty P.ColorText] -> P.Pretty P.ColorText
+    oxfordOr = \case
+      [] -> ""
+      [x] -> x
+      [x, y] -> x <> " or " <> y
+      xs -> P.spaced (P.group . (<> ",") <$> init xs) <> P.softbreak <> "or " <> last xs
 
 undoTip :: P.Pretty P.ColorText
 undoTip =
@@ -924,7 +965,6 @@ notifyUser dir issueFn = \case
       --       defs in the codebase.  In some cases it's fine for bindings to
       --       shadow codebase names, but you don't want it to capture them in
       --       the decompiled output.
-
         let prettyBindings =
               P.bracket . P.lines $
                 P.wrap "The watch expression(s) reference these definitions:"
@@ -2655,6 +2695,24 @@ notifyUser dir issueFn = \case
             P.text (Config.keyToText key)
               <> " = "
               <> P.text ("\"" <> value <> "\"")
+  WatchDisabled ->
+    pure . P.warnCallout $
+      P.wrap "I can only watch for changes in interactive sessions, which this isn't."
+  WatchAddResult (Just canonPath) _originalPath ->
+    pure . P.lines $
+      [ P.wrap $
+          "I'm now watching"
+            <> P.blue (P.string canonPath)
+            <> "for changes.",
+        "",
+        tip "Use `watches` to see all locations being watched."
+      ]
+  WatchAddResult Nothing originalPath ->
+    pure . P.warnCallout $
+      P.wrap $
+        "When I tried to watch"
+          <> P.group (P.blue (P.string originalPath) <> ",")
+          <> "it seemed to not exist."
   where
     iveCreatedATemporaryBranch scratchFile =
       P.wrap $

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -2747,7 +2747,7 @@ notifyUser dir issueFn = \case
       P.wrap $
         "When I tried to watch"
           <> P.group (P.blue (P.string originalPath) <> ",")
-          <> "it seemed to not exist."
+          <> "it didn't seem to exist."
   where
     iveCreatedATemporaryBranch scratchFile =
       P.wrap $

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -552,22 +552,28 @@ notifyNumbered = \case
     )
   WatchRemoved removedPaths failedPaths remainingPaths ->
     ( P.lines $
-        (if null removedPaths
-           then []
-           else [P.wrap 
-                  $ "I'm no longer watching " <> oxfordOr [P.blue (P.string p) | p <- removedPaths] 
-                  <> (if null remainingPaths then " (or any other paths)" else "") <> " for changes."])
-          <> (if null failedPaths
-                then []
-                else ["", P.warnCallout $ "I already wasn't watching these paths: " <> oxfordOr [P.blue (P.string p) | p <- failedPaths]])
+        ( if null removedPaths
+            then []
+            else
+              [ P.wrap $
+                  "I'm no longer watching "
+                    <> oxfordOr [P.blue (P.string p) | p <- removedPaths]
+                    <> (if null remainingPaths then " (or any other paths)" else "")
+                    <> " for changes."
+              ]
+        )
+          <> ( if null failedPaths
+                 then []
+                 else ["", P.warnCallout $ "I already wasn't watching these paths: " <> oxfordOr [P.blue (P.string p) | p <- failedPaths]]
+             )
           <> if null remainingPaths
-               then ["", tip "Use `watch <path>` to watch a file or directory."]
-               else
-                 [ "",
-                   "I'm still watching:",
-                   "",
-                   P.indentN 2 $ P.numberedList [P.blue (P.string path) | path <- remainingPaths]
-                 ],
+            then ["", tip "Use `watch <path>` to watch a file or directory."]
+            else
+              [ "",
+                "I'm still watching:",
+                "",
+                P.indentN 2 $ P.numberedList [P.blue (P.string path) | path <- remainingPaths]
+              ],
       map SA.FilePath remainingPaths
     )
   where
@@ -1000,6 +1006,7 @@ notifyUser dir issueFn = \case
       --       defs in the codebase.  In some cases it's fine for bindings to
       --       shadow codebase names, but you don't want it to capture them in
       --       the decompiled output.
+
         let prettyBindings =
               P.bracket . P.lines $
                 P.wrap "The watch expression(s) reference these definitions:"

--- a/unison-cli/src/Unison/MCP/Cli.hs
+++ b/unison-cli/src/Unison/MCP/Cli.hs
@@ -157,7 +157,9 @@ cliToMCP projCtx onError cli = do
             sandboxedRuntime = error "Sandboxed runtime not implemented in MCP Server",
             serverBaseUrl = Nothing,
             ucmVersion,
-            isTranscriptTest = False
+            isTranscriptTest = False,
+            -- MCP doesn't support file watching
+            watchState = Nothing
           }
 
   let startState = (Cli.loopState0 (PP.toIds initialPP))

--- a/unison-src/transcripts/idempotent/help.md
+++ b/unison-src/transcripts/idempotent/help.md
@@ -997,11 +997,11 @@
   Like `push`, but forcibly overwrites the remote namespace.
 
   unwatch
-  `unwatch <file or directory>`  Stop watching one or more
-                                 external files or directories
-                                 for changes.
-  `unwatch`                      With no arguments, list
-                                 currently watched paths.
+  `unwatch <files or directories...>`  Stop watching one or more
+                                       external files or
+                                       directories for changes.
+  `unwatch`                            With no arguments, list
+                                       currently watched paths.
 
   update (or add)
   Adds everything in the most recently typechecked file to the

--- a/unison-src/transcripts/idempotent/help.md
+++ b/unison-src/transcripts/idempotent/help.md
@@ -973,6 +973,13 @@
   unsafe.force-push (or push.unsafe-force)
   Like `push`, but forcibly overwrites the remote namespace.
 
+  unwatch
+  `unwatch <file or directory>`  Stop watching one or more
+                                 external files or directories
+                                 for changes.
+  `unwatch`                      With no arguments, list
+                                 currently watched paths.
+
   update (or add)
   Adds everything in the most recently typechecked file to the
   namespace, replacing existing definitions having the same
@@ -998,6 +1005,15 @@
   view.global
   `view.global foo` prints definitions of `foo` within your codebase.
   `view.global` without arguments invokes a search to select definitions to view, which requires that `fzf` can be found within your PATH.
+
+  watch
+  `watch <file or directory>`  Watch an external file or
+                               directory for changes. Changes to
+                               `.u` files in watched locations
+                               will be automatically loaded.
+
+  watches
+  List all external paths currently being watched for changes.
 
 > help-topics
 

--- a/unison-src/transcripts/idempotent/watch-disabled.md
+++ b/unison-src/transcripts/idempotent/watch-disabled.md
@@ -1,0 +1,31 @@
+# Watch commands when watching is disabled
+
+In transcript mode (and other non-interactive contexts), file watching is disabled.
+All watch-related commands should report that watching is disabled.
+
+``` ucm :error
+> watch .
+
+  ⚠️
+
+  I can only watch for changes in interactive sessions, which
+  this isn't.
+```
+
+``` ucm :error
+> unwatch .
+
+  ⚠️
+
+  I can only watch for changes in interactive sessions, which
+  this isn't.
+```
+
+``` ucm :error
+> watches
+
+  ⚠️
+
+  I can only watch for changes in interactive sessions, which
+  this isn't.
+```


### PR DESCRIPTION
## Overview

These commands let you watch multiple directories or multiple individual files. Initially we watch the start-up directory like usual, but you can remove it and/or add other paths.

```
scratch/main> help watches

  watches
  List all external paths currently being watched for changes.

scratch/main> help watch

  watch
  `watch <file or directory>`  Watch an external file or directory for changes.
                               Changes to `.u` files in watched locations will
                               be automatically loaded.

scratch/main> help unwatch

  unwatch
  `unwatch <file or directory>`  Stop watching one or more external files or
                                 directories for changes.
  `unwatch`                      With no arguments, list currently watched
                                 paths.
```

Closes #4850.

## Implementation approach and notes

How does it accomplish it, in broad strokes? i.e. How does it change the Haskell codebase?

## Interesting/controversial decisions

* Hopefully I didn't mess up any Ki / finalizer stuff. (I did?)

* `unwatch` accepts multiple args, but `watch` only accepts one arg. I guess there's no harm in having `watch` accept multiple args, but I wasn't sure it was worth the effort.

## Test coverage

- [x] Have you included tests (which could be a transcript) for this change, or is it somehow covered by existing tests?

Also a transcript showing that the three new commands are disabled (along with file watching in general) during transcripts.

- [x] Would you recommend improving the test coverage (either as part of this PR or as a separate issue) or do you think it’s adequate?

I would like better test coverage, but it would require coordinating two processes to use CLI on one side and trigger file events on the other side, and I acknowledge we don't have any tests like that yet and it might be a pain to set up.

- [x] If you only tested by hand, because that's all that's practical to do for this change, mention that. Include screenshots.

```
  Now starting the Unison Codebase Manager (UCM)...


   _____     _             
  |  |  |___|_|___ ___ ___ 
  |  |  |   | |_ -| . |   |
  |_____|_|_|_|___|___|_|_|
  
  👋 Welcome to Unison!
  
  You are running version: release/1.0.0-88-g6458285fd'


  📚 Read the official docs at https://www.unison-lang.org/docs/
  
  Hint: Type 'projects' to list all your projects, or 'project.create' to start
  something new.

scratch/main> watch /tmp/test-watch          

  I'm now watching /private/tmp/test-watch for changes.
  
  Tip: Use `watches` to see all locations being watched.

scratch/main> 

  Loading changes detected in /private/tmp/test-watch/scratch.u.


  + x : ##Nat
  
  Run `update` to apply these changes to your codebase.

scratch/main> unwatch

  I'm watching these paths for changes:
  
    1. /Users/arya/work/unison/watch-other-file
    2. /private/tmp/test-watch
  
  Tip: Use `watch` or `unwatch` to add or remove paths.

scratch/main> unwatch 2
scratch/main> unwatch /private/tmp/test-watch

  I'm no longer watching /private/tmp/test-watch for changes.
  
  I'm still watching:
  
    1. /Users/arya/work/unison/watch-other-file

scratch/main> load /private/tmp/test-watch/scratch.u 

  Loading changes detected in /private/tmp/test-watch/scratch.u.


  + y : ##Nat
  
  Run `update` to apply these changes to your codebase.

scratch/main> watch /tmp

  I'm now watching /private/tmp for changes.
  
  Tip: Use `watches` to see all locations being watched.

scratch/main> watch /var

  I'm now watching /private/var for changes.
  
  Tip: Use `watches` to see all locations being watched.

scratch/main> watches

  I'm watching these paths for changes:
  
    1. /Users/arya/work/unison/watch-other-file
    2. /private/tmp
    3. /private/var
  
  Tip: Use `watch` or `unwatch` to add or remove paths.

scratch/main> unwatch 2-3
scratch/main> unwatch /private/tmp /private/var

  I'm no longer watching /private/tmp or /private/var for changes.
  
  I'm still watching:
  
    1. /Users/arya/work/unison/watch-other-file

scratch/main> unwatch 1
scratch/main> unwatch /Users/arya/work/unison/watch-other-file

  I'm no longer watching /Users/arya/work/unison/watch-other-file (or any other
  paths) for changes.
  
  Tip: Use `watch <path>` to watch a file or directory.

scratch/main> unwatch /not/a/real/path

  
  ⚠️
  
  I already wasn't watching these paths: /not/a/real/path
  
  Tip: Use `watch <path>` to watch a file or directory.

scratch/main> watch /not/a/real/path

  ⚠️
  
  When I tried to watch /not/a/real/path, it didn't seem to exist.

scratch/main> 
```


Both as shown above.

## Loose ends

n/a

## Final checklist

- [x] **Choose your PR title well:** Your pull request title is what's used to create release notes, so please make it descriptive of the change itself, which may be different from the initial motivation to make the change.
- [x] **Update your PR description** if the specifics of the PR have changed over time.
- [x] **Include transcripts or screenshots** that demonstrate the changed behavior.
- [x] **If you changed `.cabal` files**, make sure the `package.yaml` files are up-to-date instead.
