### PR TITLE
don't search transitive deps by default

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -898,13 +898,14 @@ handleFindI isVerbose fscope ws input = do
     FindLocal p -> do
       searchRoot <- Cli.resolvePath' p
       branch0 <- Cli.getBranch0FromProjectPath searchRoot
-      let names = Branch.toNames (Branch.withoutLib branch0)
+      let filteredBranch = Branch.withoutLib branch0
+      let names = Branch.toNames filteredBranch
       -- Don't exclude anything from the pretty printer, since the type signatures we print for
       -- results may contain things in lib.
       currentNames <- Cli.currentNames
       let pped = PPED.makePPED (PPE.hqNamer 10 currentNames) (PPE.suffixifyByHash currentNames)
       let suffixifiedPPE = PPED.suffixifiedPPE pped
-      results <- searchBranch0 codebase branch0 names
+      results <- searchBranch0 codebase filteredBranch names
       if (null results)
         then do
           Cli.respond FindNoLocalMatches
@@ -914,20 +915,24 @@ handleFindI isVerbose fscope ws input = do
           case mayOnlyLibBranch of
             Nothing -> respondResults codebase suffixifiedPPE (Just p) []
             Just onlyLibBranch -> do
-              let onlyLibNames = Branch.toNames onlyLibBranch
-              results <- searchBranch0 codebase branch0 onlyLibNames
+              -- Apply withoutTransitiveLibs to filter out transitive dependencies
+              -- (lib.*.lib.*) while keeping direct dependencies (lib.*)
+              let filteredLibBranch = Branch.withoutTransitiveLibs onlyLibBranch
+              let onlyLibNames = Branch.toNames filteredLibBranch
+              results <- searchBranch0 codebase filteredLibBranch onlyLibNames
               respondResults codebase suffixifiedPPE (Just p) results
         else respondResults codebase suffixifiedPPE (Just p) results
     FindLocalAndDeps p -> do
       searchRoot <- Cli.resolvePath' p
       branch0 <- Cli.getBranch0FromProjectPath searchRoot
-      let names = Branch.toNames (Branch.withoutTransitiveLibs branch0)
+      let filteredBranch = Branch.withoutTransitiveLibs branch0
+      let names = Branch.toNames filteredBranch
       -- Don't exclude anything from the pretty printer, since the type signatures we print for
       -- results may contain things in lib.
       currentNames <- Cli.currentNames
       let pped = PPED.makePPED (PPE.hqNamer 10 currentNames) (PPE.suffixifyByHash currentNames)
       let suffixifiedPPE = PPED.suffixifiedPPE pped
-      results <- searchBranch0 codebase branch0 names
+      results <- searchBranch0 codebase filteredBranch names
       respondResults codebase suffixifiedPPE (Just p) results
     FindGlobal -> do
       Global.forAllProjectBranches \(projAndBranchNames, _ids) branch -> do
@@ -941,13 +946,13 @@ handleFindI isVerbose fscope ws input = do
           Cli.respond $ GlobalFindBranchResults projAndBranchNames (PPED.suffixifiedPPE pped) isVerbose results'
   where
     searchBranch0 :: Codebase.Codebase m Symbol Ann -> Branch0 IO -> Names -> Cli [SearchResult]
-    searchBranch0 codebase branch0 names =
+    searchBranch0 codebase searchBranch names =
       case ws of
         [] -> pure (List.sortBy SR.compareByName (SR.fromNames names))
         -- type query
         ":" : ws -> do
           typ <- parseSearchType (show input) (unwords ws)
-          let keepNamed = Set.intersection (Branch.deepReferents branch0)
+          let keepNamed = Set.intersection (Branch.deepReferents searchBranch)
           (noExactTypeMatches, matches) <- do
             Cli.runTransaction do
               matches <- keepNamed <$> Codebase.termsOfType codebase typ

--- a/unison-src/transcripts/idempotent/find-by-type.md
+++ b/unison-src/transcripts/idempotent/find-by-type.md
@@ -1,6 +1,10 @@
+# Type-based search
+
 ``` ucm :hide
 > alias.type ##Text builtin.Text
 ```
+
+## Basic type-based search
 
 ``` unison :hide
 unique type A = A Text
@@ -16,14 +20,11 @@ baz = cases
   A t -> t
 ```
 
-``` ucm
+``` ucm :hide
 > add
+```
 
-  Okay, I'm searching the branch for code that needs to be
-  updated...
-
-  Done.
-
+``` ucm
 > find : Text -> A
 
   1. bar : Text -> A
@@ -49,4 +50,101 @@ baz = cases
   1. baz : A -> Text
   2. bar : Text -> A
   3. A.A : Text -> A
+```
+
+## Type-based search should not search transitive dependencies
+
+https://github.com/unisonweb/unison/issues/6052
+
+When using type-based search (`find : <type>`), the search should only return
+results from the local project and direct dependencies, not transitive dependencies.
+
+Set up a scenario with transitive dependencies:
+
+  - `myFn` in the project root
+  - `directDep.fn` in a direct dependency
+  - `directDep.lib.transitive.fn` in a transitive dependency (should NOT appear in `find` results)
+
+``` unison :hide
+myFn : A -> A
+myFn a = a
+
+lib.directDep.fn : A -> A
+lib.directDep.fn a = a
+
+lib.directDep.lib.transitive.fn : A -> A
+lib.directDep.lib.transitive.fn a = a
+```
+
+``` ucm :hide
+> add
+```
+
+Now, `find : A -> A` should only show `myFn` (local) - not things in lib:
+
+``` ucm
+> find : A -> A
+
+  1. myFn : A -> A
+```
+
+Even when there are local matches, `find-in lib` can be used to explicitly search dependencies:
+
+``` ucm
+> find-in lib : A -> A
+
+  1. directDep.fn : A -> A
+```
+
+And `find.all : A -> A` should show `myFn` and `directDep.fn` but NOT `transitive.fn`:
+
+``` ucm
+> find.all : A -> A
+
+  1. lib.directDep.fn : A -> A
+  2. myFn : A -> A
+```
+
+Now test the fallback case: when `find` has no local matches, it falls back to searching
+direct dependencies (but still not transitive deps).
+
+``` unison :hide
+unique type B = B
+
+lib.directDep.libOnlyFn : B -> B
+lib.directDep.libOnlyFn b = b
+
+lib.directDep.lib.transitive.libOnlyFn : B -> B
+lib.directDep.lib.transitive.libOnlyFn b = b
+```
+
+``` ucm :hide
+> add
+```
+
+`find : B -> B` should fall back to lib but still exclude transitive deps:
+
+``` ucm :error
+> find : B -> B
+
+  ☝️
+
+  I couldn't find exact type matches, resorting to fuzzy
+  matching...
+
+  ☝️
+
+  I couldn't find matches in this namespace, searching in
+  'lib'...
+
+  1. lib.directDep.libOnlyFn : B -> B
+```
+
+To explicitly search lib including transitive deps, use `find-in.all lib`:
+
+``` ucm
+> find-in.all lib : A -> A
+
+  1. directDep.fn : A -> A
+  2. directDep.lib.transitive.fn : A -> A
 ```


### PR DESCRIPTION
## Overview
Fixes https://github.com/unisonweb/unison/issues/6052

Given
```
  + myFn                                          : A -> A
  + lib.directDep.fn                              : A -> A
  + lib.directDep.lib.transitive.fn               : A -> A
  + lib.directDep.libOnlyFn                       : B -> B
  + lib.directDep.lib.transitive.libOnlyFn        : B -> B
  + lib.directDep.lib.transitive.transitiveOnlyFn : C -> C
```
```
> find : A -> A

  1. myFn : A -> A
  
> find : B -> B

  1. lib.directDep.libOnlyFn : B -> B
  Old behavior also showed:
  2. lib.directDep.lib.transitive.libOnlyFn : B -> B
  
> find : C -> C

  No results. Check your spelling, or try using tab completion to supply command arguments.
  Old behavior also showed:
  1. lib.directDep.lib.transitive.transitiveOnlyFn : C -> C
  
> find.all : A -> A

  1. lib.directDep.fn : A -> A
  2. myFn : A -> A
  
> find.all : B -> B

  1. lib.directDep.libOnlyFn : B -> B
  
> find.all : C -> C

  No results. Check your spelling, or try using tab completion to supply command arguments.
  
> find-in lib : A -> A

  1. directDep.fn : A -> A
  
> find-in lib : B -> B

  1. directDep.libOnlyFn : B -> B
  
> find-in lib : C -> C

  No results. Check your spelling, or try using tab completion to supply command arguments.
  
> find-in.all lib : A -> A

  1. directDep.fn : A -> A
  2. directDep.lib.transitive.fn : A -> A
  
> find-in.all lib : B -> B

  1. directDep.libOnlyFn : B -> B
  2. directDep.lib.transitive.libOnlyFn : B -> B
  
> find-in.all lib : C -> C

  1. directDep.lib.transitive.transitiveOnlyFn : C -> C
```

## Implementation approach and notes

How does it accomplish it, in broad strokes? i.e. How does it change the Haskell codebase?

## Interesting/controversial decisions

Include anything that you thought twice about, debated, chose arbitrarily, etc.
What could have been done differently, but wasn't? And why?

## Test coverage

- [ ] Have you included tests (which could be a transcript) for this change, or is it somehow covered by existing tests?

- [ ] Would you recommend improving the test coverage (either as part of this PR or as a separate issue) or do you think it’s adequate?

- [ ] If you only tested by hand, because that's all that's practical to do for this change, mention that. Include screenshots.

## Loose ends

Link to related issues that address things you didn't get to. Stuff you encountered on the way and decided not to include in this PR.

## Final checklist

- [ ] **Choose your PR title well:** Your pull request title is what's used to create release notes, so please make it descriptive of the change itself, which may be different from the initial motivation to make the change.
- [ ] **Update your PR description** if the specifics of the PR have changed over time.
- [ ] **Include transcripts or screenshots** that demonstrate the changed behavior.
