### PR TITLE
Give more readable errors for `dataBranch` failures

### DIFF
--- a/unison-runtime/src/Unison/Runtime/Machine.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine.hs
@@ -1255,17 +1255,25 @@ dataBranchClosureError (Just rftgt) (DataC rf _ _)
   | rftgt /= rf =
       die [] $
         "dataBranch: type mismatch detected\n"
-          <> "    expected: " <> prettyRef rftgt <> "\n"
-          <> "    received: " <> prettyRef rf
+          <> "    expected: "
+          <> prettyRef rftgt
+          <> "\n"
+          <> "    received: "
+          <> prettyRef rf
 dataBranchClosureError _ (DataC rf t _) =
   die [] $
     "dataBranch: unexpected tag for data type\n"
-      <> "    type: " <> prettyRef rf <> "\n"
-      <> "    data tag: " <> show (maskTags t)
+      <> "    type: "
+      <> prettyRef rf
+      <> "\n"
+      <> "    data tag: "
+      <> show (maskTags t)
 dataBranchClosureError mrf clo =
   die [] $
     "dataBranch: unexpected closure type\n"
-      <> expected <> "but instead I received " <> description
+      <> expected
+      <> "but instead I received "
+      <> description
   where
     expected = case mrf of
       Just rftgt ->

--- a/unison-runtime/src/Unison/Runtime/Machine.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine.hs
@@ -55,6 +55,7 @@ import Unison.Prelude hiding (Text)
 import Unison.Reference
   ( Reference,
     Reference' (Builtin),
+    showShort,
   )
 import Unison.Referent (Referent, pattern Ref)
 import Unison.ReferentPrime (Referent' (..))
@@ -1246,16 +1247,45 @@ dumpBin sz k e l r stk = do
   pure stk
 {-# INLINE dumpBin #-}
 
+prettyRef :: Reference -> String
+prettyRef = Text.unpack . showShort 10
+
 dataBranchClosureError :: Maybe Reference -> Closure -> IO a
+dataBranchClosureError (Just rftgt) (DataC rf _ _)
+  | rftgt /= rf =
+      die [] $
+        "dataBranch: type mismatch detected\n"
+          <> "    expected: " <> prettyRef rftgt <> "\n"
+          <> "    received: " <> prettyRef rf
+dataBranchClosureError _ (DataC rf t _) =
+  die [] $
+    "dataBranch: unexpected tag for data type\n"
+      <> "    type: " <> prettyRef rf <> "\n"
+      <> "    data tag: " <> show (maskTags t)
 dataBranchClosureError mrf clo =
   die [] $
-    "dataBranch: bad closure: "
-      ++ show clo
-      ++ maybe "" (\r -> "\nexpected type: " ++ show r) mrf
+    "dataBranch: unexpected closure type\n"
+      <> expected <> "but instead I received " <> description
+  where
+    expected = case mrf of
+      Just rftgt ->
+        "    expected type: " <> prettyRef rftgt <> "\n  "
+      Nothing -> "I expected a data type, "
+    description = case clo of
+      PAp {} -> "a partially applied function"
+      Captured {} -> "a continuation"
+      Affine {} -> "an affine handler info"
+      BlackHole -> "a black hole"
+      UnboxedTypeTag CharTag -> "a character"
+      UnboxedTypeTag FloatTag -> "a floating point number"
+      UnboxedTypeTag IntTag -> "an integer"
+      UnboxedTypeTag NatTag -> "a natural number"
+      Foreign (Wrap rf _) ->
+        "a builtin value of type `" <> prettyRef rf <> "`"
 
 dataBranchBranchError :: MBranch -> IO a
 dataBranchBranchError br =
-  die [] $ "dataBranch: unexpected branch: " ++ show br
+  die [] $ "dataBranch: unexpected branch: " <> show br
 
 -- Splits off a portion of the continuation up to a given prompt.
 --

--- a/unison-runtime/src/Unison/Runtime/Machine.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine.hs
@@ -1165,7 +1165,7 @@ dataBranch mrf stk (Test1 u cu df) = \case
         M.Tip
           | u == Rf.mapTip -> pure (cu, stk)
         _ -> pure (df, stk)
-  clo -> dataBranchClosureError mrf clo
+  clo -> (df, stk) <$ dataBranchClosureError mrf clo
 dataBranch mrf stk (Test2 u cu v cv df) = \case
   Enum _ t
     | maskTags t == u -> pure (cu, stk)
@@ -1202,7 +1202,7 @@ dataBranch mrf stk (Test2 u cu v cv df) = \case
           | u == Rf.mapTip -> pure (cu, stk)
           | v == Rf.mapTip -> pure (cv, stk)
         _ -> pure (df, stk)
-  clo -> dataBranchClosureError mrf clo
+  clo -> (df, stk) <$ dataBranchClosureError mrf clo
 dataBranch mrf stk (TestW df bs) = \case
   Enum _ t
     | Just ca <- EC.lookup (maskTags t) bs -> pure (ca, stk)
@@ -1231,7 +1231,7 @@ dataBranch mrf stk (TestW df bs) = \case
           | Just ca <- EC.lookup Rf.mapTip bs ->
               pure (ca, stk)
         _ -> pure (df, stk)
-  clo -> dataBranchClosureError mrf clo
+  clo -> (df, stk) <$ dataBranchClosureError mrf clo
 dataBranch _ _ br = \_ ->
   dataBranchBranchError br
 {-# INLINE dataBranch #-}
@@ -1250,7 +1250,8 @@ dumpBin sz k e l r stk = do
 prettyRef :: Reference -> String
 prettyRef = Text.unpack . showShort 10
 
-dataBranchClosureError :: Maybe Reference -> Closure -> IO a
+dataBranchClosureError ::
+  Maybe Reference -> Closure -> IO ()
 dataBranchClosureError (Just rftgt) (DataC rf _ _)
   | rftgt /= rf =
       die [] $


### PR DESCRIPTION
This PR should give more comprehensible errors in the case of a `dataBranch` problem. Instead of just printing the closure, it does some case analysis to just explain what sort of closure it was. Also, I've switched to using short printing of `Reference` values.

It has cases for when you have a data type case that isn't covered by the branches, but I'm not sure the interpreter can ever actually get there, because default cases are inserted by the compiler.