### PR TITLE
Support single-quotes in ucm arg parsing

### DIFF
--- a/unison-cli/src/Unison/CommandLine.hs
+++ b/unison-cli/src/Unison/CommandLine.hs
@@ -104,7 +104,7 @@ expandArguments numberedArgs params args = do
         ( \acc (_, param) arg ->
             case arg of
               -- Don't expand numbers in quoted args
-              Left (InputPattern.QuotedArg quoted _) -> Right (RawArg quoted : acc, [])
+              Left (InputPattern.QuotedArg quoted _ _) -> Right (RawArg quoted : acc, [])
               Left (InputPattern.UnquotedArg raw) -> Right $ (RawArg raw : acc, [])
               Left (InputPattern.NumberedArg n) ->
                 case expandNumber numberedArgs n of
@@ -212,7 +212,7 @@ parseInput codebase projPath currentProjectRoot numberedArgs patterns cliArgs = 
     [] -> throwE NoCommand
     (NumberedArg {} : _) -> throwE NoCommand
     (UnquotedArg cmd : args) -> pure (cmd, args)
-    (QuotedArg cmd _ : args) -> pure (cmd, args)
+    (QuotedArg cmd _ _ : args) -> pure (cmd, args)
   pat@(InputPattern {params, parse}) <- case Map.lookup cmd patterns of
     Just pat -> pure pat
     Nothing -> throwE $ UnknownCommand cmd

--- a/unison-cli/src/Unison/CommandLine/Completion.hs
+++ b/unison-cli/src/Unison/CommandLine/Completion.hs
@@ -96,10 +96,10 @@ haskelineTabComplete patterns codebase authedHTTPClient ppCtx = \(beforeCursorRe
 
     let finalize completion =
           let newReplacement = case lastArg of
-                QuotedArg _ _
-                  | completion.isFinished -> "\"" <> completion.replacement <> "\""
-                QuotedArg _ False -> "\"" <> completion.replacement <> "\""
-                QuotedArg _ True -> "\"" <> completion.replacement
+                QuotedArg _ _ quoteChar
+                  | completion.isFinished -> [quoteChar] <> completion.replacement <> [quoteChar]
+                QuotedArg _ False quoteChar -> [quoteChar] <> completion.replacement <> [quoteChar]
+                QuotedArg _ True quoteChar -> [quoteChar] <> completion.replacement
                 UnquotedArg _ -> completion.replacement
                 NumberedArg _ -> completion.replacement
            in completion {Line.replacement = newReplacement}

--- a/unison-cli/src/Unison/CommandLine/InputPattern.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPattern.hs
@@ -259,6 +259,7 @@ data CliArg
   | QuotedArg
       String
       Bool -- whether the quote was terminated
+      Char -- the quote character used
   | UnquotedArg String
   deriving (Eq, Show)
 
@@ -271,8 +272,8 @@ renderCliArg =
       NumberedRange s e -> show s <> "-" <> show e
       NumberedAfterStart s -> show s <> "-"
       NumberedBeforeEnd e -> "-" <> show e
-    QuotedArg s False -> "\"" <> s <> "\""
-    QuotedArg s True -> "\"" <> s
+    QuotedArg s False quoteChar -> [quoteChar] <> s <> [quoteChar]
+    QuotedArg s True quoteChar -> [quoteChar] <> s
     UnquotedArg s -> s
 
 -- | Like `renderCliArg`, but does not include quotes regardless of whether the argument was quoted.
@@ -284,8 +285,8 @@ renderCliArgUnquoted =
       NumberedRange s e -> show s <> "-" <> show e
       NumberedAfterStart s -> show s <> "-"
       NumberedBeforeEnd e -> "-" <> show e
-    QuotedArg s False -> s
-    QuotedArg s True -> s
+    QuotedArg s False _quoteChar -> s
+    QuotedArg s True _quoteChar -> s
     UnquotedArg s -> s
 
 -- | Like `parseArgs`, but indicates whether each argument was quoted, and also whether the quote was terminated..
@@ -308,7 +309,7 @@ argP = do
     escapedQuote :: Parser Char
     escapedQuote = do
       _ <- MP.char '\\'
-      MP.char '"'
+      MP.char '"' <|> MP.char '\''
 
     numberedArgP :: Parser CliArg
     numberedArgP = do
@@ -334,13 +335,13 @@ argP = do
 
     quotedArgP :: Parser CliArg
     quotedArgP = do
-      _ <- MP.char '"'
+      quoteChar <- MP.char '"' <|> MP.char '\''
       (content, hasUnterminatedQuote) <-
         MP.manyTill_
           (escapedQuote <|> MP.anySingle)
           -- Treat EOF as closing quote so completion still functions on unterminated quotes
-          (((MP.char '"') $> False) <|> (MP.eof $> True))
-      pure $ QuotedArg content hasUnterminatedQuote
+          (((MP.char quoteChar) $> False) <|> (MP.eof $> True))
+      pure $ QuotedArg content hasUnterminatedQuote quoteChar
     unquotedArgP :: Parser CliArg
     unquotedArgP = do
       UnquotedArg <$> MP.some (MP.satisfy (not . Char.isSpace))
@@ -349,14 +350,14 @@ argP = do
 -- Just [UnquotedArg "one",UnquotedArg "two",UnquotedArg "three"]
 --
 -- >>> MP.parseMaybe argsP "\"one two\" three"
--- Just [QuotedArg "one two" False,UnquotedArg "three"]
+-- Just [QuotedArg "one two" False '"',UnquotedArg "three"]
 --
 -- >>> MP.parseMaybe argsP "one    two    three"
 -- Just [UnquotedArg "one",UnquotedArg "two",UnquotedArg "three"]
 --
 -- Unfinished quote should auto-close quote at end of input, but indicate that it was unterminated
 -- >>> MP.parseMaybe argsP "one two \"three four"
--- Just [UnquotedArg "one",UnquotedArg "two",QuotedArg "three four" True]
+-- Just [UnquotedArg "one",UnquotedArg "two",QuotedArg "three four" True '"']
 --
 -- Should require args to take up a whole segment, and should fall back to raw args.
 -- >>> MP.parseMaybe argsP "1.2.3 abc-def"

--- a/unison-src/transcripts/idempotent/input-parsing.md
+++ b/unison-src/transcripts/idempotent/input-parsing.md
@@ -18,11 +18,12 @@ scratch/main> update
 Quoting allows spaces in arguments.
 
 ``` ucm
-scratch/main> run main "all one arg" "contains escaped \" quote" second third
+scratch/main> run main "all one arg" "contains escaped \" quote" 'single quoted' second third
 
   Right
     [ "all one arg"
     , "contains escaped \" quote"
+    , "single quoted"
     , "second"
     , "third"
     ]


### PR DESCRIPTION
## Overview

@ceedubs  noticed we currently parse single-quotes as part of the string, which isn't great 😓 

https://discord.com/channels/862108724948500490/1200119393061969951/1451599108010676235

<img width="942" height="450" alt="image" src="https://github.com/user-attachments/assets/36c47080-46f5-4ab4-8777-9eb7a1eac2a8" />

This changes the arg parser to understand single or double quotes.

## Implementation approach and notes

Small tweak to the parser

## Test coverage

* Small transcript update

