### PR TITLE
block for lock during `transcript.inplace`

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Init.hs
+++ b/parser-typechecker/src/Unison/Codebase/Init.hs
@@ -49,6 +49,8 @@ data SpecifiedCodebase
 data CodebaseLockOption
   = DoLock
   | DontLock
+  | BlockUntilLock
+  deriving stock (Show)
 
 data BackupStrategy
   = -- Create a backup of the codebase in the same directory as the codebase,

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -14,7 +14,7 @@ import Data.Either.Extra ()
 import Data.Foldable qualified as Foldable
 import Data.Map qualified as Map
 import Data.Set qualified as Set
-import System.FileLock (SharedExclusive (Exclusive), withTryFileLock)
+import System.FileLock (SharedExclusive (Exclusive), withFileLock, withTryFileLock)
 import U.Codebase.HashTags (BranchHash, CausalHash)
 import U.Codebase.Sqlite.Operations qualified as Operations
 import Unison.Codebase (Codebase, CodebasePath)
@@ -322,6 +322,12 @@ sqliteCodebase debugName root localOrRemote lockOption migrationStrategy action 
         withTryFileLock (lockfilePath root) Exclusive (\_flock -> runInIO ma) <&> \case
           Nothing -> Left OpenCodebaseFileLockFailed
           Just x -> x
+      BlockUntilLock -> withRunInIO \runInIO ->
+        withTryFileLock (lockfilePath root) Exclusive (\_flock -> runInIO ma) >>= \case
+          Nothing -> do
+            liftIO (putStrLn "Waiting for codebase lock...")
+            withFileLock (lockfilePath root) Exclusive (\_flock -> runInIO ma)
+          Just x -> pure x
 
 ensureMigrated ::
   (MonadUnliftIO m) =>

--- a/unison-cli/src/Unison/Main.hs
+++ b/unison-cli/src/Unison/Main.hs
@@ -515,7 +515,7 @@ runTranscripts' version progName transcriptDir markdownFiles = do
   and
     <$> getCodebaseOrExit
       (Just (DontCreateCodebaseWhenMissing transcriptDir))
-      SC.DoLock
+      SC.BlockUntilLock
       (SC.MigrateAutomatically SC.Backup SC.Vacuum)
       \(_, codebasePath, theCodebase) -> do
         let isTest = False


### PR DESCRIPTION
## Overview

The `transcript.inplace` runner seems to open the codebase for migrations, then opens it a second time to tun the actual transcript. There seems to be a race condition in which releasing the lock the first time doesn't actually block for the lock to be released; and in fact it doesn't seem to be released in time to acquire the lock the second time, and we were seeing crashes in CI as a result. cc @dolio 

Not sure why this locking issue just started manifesting recently.

- [x] What does this change accomplish and why?
  - [x] i.e. How does it change the user experience?
  - [x] i.e. What was the old behavior/API and what is the new behavior/API?

- [x] Include "before and after" examples if appropriate. (You can copy/paste screenshots directly into this editor.)

- [x] List any Github issues that this PR closes, in [closing-issues-using-keywords](https://help.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords) format.

n/a

## Implementation approach and notes

Adds a new locking type which prints a message and blocks until it can acquire a lock, if it can't immediately acquire one. Then it uses that new locking type when trying to open the codebase the second time after running migrations before running the transcript.

## Interesting/controversial decisions

There were a few other places where it looked like it might be fine and good (though not necessary) to also block for the lock, but I left them out in order to have a more surgical PR.

## Test coverage

- [x] Have you included tests (which could be a transcript) for this change, or is it somehow covered by existing tests?

CI has started passing again
https://github.com/unisonweb/unison/actions/runs/20403439799/job/58629670481?pr=6075
vs 
https://github.com/unisonweb/unison/actions/runs/20391436262/job/58601486802?pr=6075

- [x] Would you recommend improving the test coverage (either as part of this PR or as a separate issue) or do you think it’s adequate?

not needed

- [x] If you only tested by hand, because that's all that's practical to do for this change, mention that. Include screenshots.

## Loose ends

Not exactly lose ends because they're not related to this issue, but see the remaining open conversations.

Also, like with any PR I'm reminded that CI is too slow, and could maybe use _mOrE cAcHiNg_

## Final checklist

- [x] **Choose your PR title well:** Your pull request title is what's used to create release notes, so please make it descriptive of the change itself, which may be different from the initial motivation to make the change.
- [x] **Update your PR description** if the specifics of the PR have changed over time.
- [x] **Include transcripts or screenshots** that demonstrate the changed behavior.
- [x] **If you changed `.cabal` files**, make sure the `package.yaml` files are up-to-date instead.
