### PR TITLE
fix parsing certain multiline `match` / indentation cases

### DIFF
--- a/unison-src/transcripts/idempotent/6048.md
+++ b/unison-src/transcripts/idempotent/6048.md
@@ -1,0 +1,137 @@
+``` ucm :hide
+scratch/main> builtins.merge lib.builtins
+```
+
+## Issue \#6048: Match scrutinee column alignment bug
+
+The bug occurs when function arguments align with the same column as the start of the scrutinee expression, even if there's whitespace before the scrutinee.
+
+### Case 1: No args align with scrutinee - OK
+
+``` unison
+a = match ##todo 1 2 3 with _ -> 777
+b = match ##todo
+           1 2 3 with _ -> 777
+c = match ##todo
+         1 2 3 with _ -> 777
+d = match ##todo
+       1 2 3 with _ -> 777
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  + a : Nat
+  + b : Nat
+  + c : Nat
+  + d : Nat
+
+  Run `update` to apply these changes to your codebase.
+```
+
+### Case 2: An identifier in the scrutinee aligns with the start of the scrutinee - BROKEN
+
+``` unison :bug
+e = match ##todo
+          1 2 3 with _ -> 777
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I got confused here:
+
+      2 |           1 2 3 with _ -> 777
+
+
+  I was surprised to find an end of stanza here.
+  I was expecting one of these instead:
+
+  * :
+  * and
+  * bang
+  * do
+  * end of input
+  * false
+  * force
+  * handle
+  * if
+  * infixApp
+  * let
+  * or
+  * quote
+  * termLink
+  * true
+  * tuple
+  * typeLink
+```
+
+``` unison :bug
+f = match ##todo
+        1 2 3 with _ -> 777
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I got confused here:
+
+      2 |         1 2 3 with _ -> 777
+
+
+  I was surprised to find an end of stanza here.
+  I was expecting one of these instead:
+
+  * :
+  * and
+  * bang
+  * do
+  * end of input
+  * false
+  * force
+  * handle
+  * if
+  * infixApp
+  * let
+  * or
+  * quote
+  * termLink
+  * true
+  * tuple
+  * typeLink
+```
+
+``` unison :bug
+g = match  ##todo
+       1 2 3 with _ -> 777
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I got confused here:
+
+      2 |        1 2 3 with _ -> 777
+
+
+  I was surprised to find an end of stanza here.
+  I was expecting one of these instead:
+
+  * :
+  * and
+  * bang
+  * do
+  * end of input
+  * false
+  * force
+  * handle
+  * if
+  * infixApp
+  * let
+  * or
+  * quote
+  * termLink
+  * true
+  * tuple
+  * typeLink
+```

--- a/unison-src/transcripts/idempotent/6048.md
+++ b/unison-src/transcripts/idempotent/6048.md
@@ -6,15 +6,21 @@ scratch/main> builtins.merge lib.builtins
 
 The bug occurs when function arguments align with the same column as the start of the scrutinee expression, even if there's whitespace before the scrutinee.
 
-### Case 1: No args align with scrutinee - OK
+### All cases should parse correctly
 
 ``` unison
 a = match ##todo 1 2 3 with _ -> 777
 b = match ##todo
            1 2 3 with _ -> 777
+e = match ##todo
+          1 2 3 with _ -> 777
 c = match ##todo
          1 2 3 with _ -> 777
+f = match ##todo
+        1 2 3 with _ -> 777
 d = match ##todo
+       1 2 3 with _ -> 777
+g = match  ##todo
        1 2 3 with _ -> 777
 ```
 
@@ -25,113 +31,9 @@ d = match ##todo
   + b : Nat
   + c : Nat
   + d : Nat
+  + e : Nat
+  + f : Nat
+  + g : Nat
 
   Run `update` to apply these changes to your codebase.
-```
-
-### Case 2: An identifier in the scrutinee aligns with the start of the scrutinee - BROKEN
-
-``` unison :bug
-e = match ##todo
-          1 2 3 with _ -> 777
-```
-
-``` ucm :added-by-ucm
-  Loading changes detected in scratch.u.
-
-  I got confused here:
-
-      2 |           1 2 3 with _ -> 777
-
-
-  I was surprised to find an end of stanza here.
-  I was expecting one of these instead:
-
-  * :
-  * and
-  * bang
-  * do
-  * end of input
-  * false
-  * force
-  * handle
-  * if
-  * infixApp
-  * let
-  * or
-  * quote
-  * termLink
-  * true
-  * tuple
-  * typeLink
-```
-
-``` unison :bug
-f = match ##todo
-        1 2 3 with _ -> 777
-```
-
-``` ucm :added-by-ucm
-  Loading changes detected in scratch.u.
-
-  I got confused here:
-
-      2 |         1 2 3 with _ -> 777
-
-
-  I was surprised to find an end of stanza here.
-  I was expecting one of these instead:
-
-  * :
-  * and
-  * bang
-  * do
-  * end of input
-  * false
-  * force
-  * handle
-  * if
-  * infixApp
-  * let
-  * or
-  * quote
-  * termLink
-  * true
-  * tuple
-  * typeLink
-```
-
-``` unison :bug
-g = match  ##todo
-       1 2 3 with _ -> 777
-```
-
-``` ucm :added-by-ucm
-  Loading changes detected in scratch.u.
-
-  I got confused here:
-
-      2 |        1 2 3 with _ -> 777
-
-
-  I was surprised to find an end of stanza here.
-  I was expecting one of these instead:
-
-  * :
-  * and
-  * bang
-  * do
-  * end of input
-  * false
-  * force
-  * handle
-  * if
-  * infixApp
-  * let
-  * or
-  * quote
-  * termLink
-  * true
-  * tuple
-  * typeLink
 ```

--- a/unison-syntax/src/Unison/Syntax/Lexer/Unison.hs
+++ b/unison-syntax/src/Unison/Syntax/Lexer/Unison.hs
@@ -214,11 +214,11 @@ token'' tok p = do
                 -- `{layout = [], opening = Nothing, inLayout = True}`
                   fail "internal error: token''"
 
-    -- don't emit virtual semis in (, {, or [ blocks
+    -- don't emit virtual semis in (, {, [, or match blocks
     topContainsVirtualSemis :: Layout -> Bool
     topContainsVirtualSemis = \case
       [] -> False
-      ((name, _) : _) -> name /= "(" && name /= "{" && name /= "["
+      ((name, _) : _) -> name `notElem` ["(", "{", "[", "match"]
 
     topHasClosePair :: Layout -> Bool
     topHasClosePair [] = False


### PR DESCRIPTION
## Overview

There is a weird situation currently in a `match` / `with` where if a function argument starts in the same column as the start of the scrutinee, there's a parse failure. e.g.,

```
-- ok
match a 
       b c with _ -> ()
-- bad
match a 
      b c with _ -> ()
-- ok
match a 
     b c with _ -> ()
-- bad
match a 
    b c with _ -> ()
-- ok
match a 
   b c with _ -> ()
```            

So that's weird.

How do we want this to work?

If we want all of the above to work, then merging this PR will do that and fix #6048.

- [x] What does this change accomplish and why?
  - [x] i.e. How does it change the user experience?
  - [x] i.e. What was the old behavior/API and what is the new behavior/API?

- [x] Include "before and after" examples if appropriate. (You can copy/paste screenshots directly into this editor.)

- [x] List any Github issues that this PR closes, in [closing-issues-using-keywords](https://help.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords) format.

## Implementation approach and notes

The PR just adds `match` to the set of syntax constructions in which to not emit virtual semis; equivalent to surrounding the contents in parens.

I wonder whether `handle`/`with` needs the same treatment? But it didn't exhibit exactly the same bug so idk.

## Interesting/controversial decisions

## Test coverage

- [x] Have you included tests (which could be a transcript) for this change, or is it somehow covered by existing tests?

New before-and-after transcript in the two commits.

- [x] Would you recommend improving the test coverage (either as part of this PR or as a separate issue) or do you think it’s adequate?

Seems good.

- [x] If you only tested by hand, because that's all that's practical to do for this change, mention that. Include screenshots.

## Loose ends

n/a
## Final checklist

- [x] **Choose your PR title well:** Your pull request title is what's used to create release notes, so please make it descriptive of the change itself, which may be different from the initial motivation to make the change.
- [x] **Update your PR description** if the specifics of the PR have changed over time.
- [x] **Include transcripts or screenshots** that demonstrate the changed behavior.
- [x] **If you changed `.cabal` files**, make sure the `package.yaml` files are up-to-date instead.
