### PR TITLE
let `text.find` detect numbers in patterns

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/FindAndReplace.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/FindAndReplace.hs
@@ -132,6 +132,10 @@ handleTextFindI allowLib tokens = do
             r = join $ Pattern.foldMap' txtPattern . Term.matchPattern <$> cases
         txts _ = ABT.Continue
         txtPattern (Pattern.Text _ txt) = [txt]
+        txtPattern (Pattern.Nat _ n) = [Text.pack (show n)]
+        txtPattern (Pattern.Int _ n) = [Text.pack (show n)]
+        txtPattern (Pattern.Float _ n) = [Text.pack (show n)]
+        txtPattern (Pattern.Char _ c) = [Text.pack [c]]
         txtPattern _ = []
 
 lookupRewrite ::

--- a/unison-src/transcripts/idempotent/textfind.md
+++ b/unison-src/transcripts/idempotent/textfind.md
@@ -49,17 +49,26 @@ qux =
 
 lib.foo = [Any 46, Any "hi", Any "zoink"]
 lib.bar = 3
+
+magicNumber = 230971246918247
+
+openSesame : Nat -> Text
+openSesame = cases
+  230971246918247 -> "You guessed the password!"
+  _ -> "Try again."
 ```
 
 ``` ucm :added-by-ucm
   Loading changes detected in scratch.u.
 
-  + bar     : Nat
-  + baz     : [Text]
-  + foo     : Nat
-  + lib.bar : Nat
-  + lib.foo : [Any]
-  + qux     : Nat
+  + bar         : Nat
+  + baz         : [Text]
+  + foo         : Nat
+  + lib.bar     : Nat
+  + lib.foo     : [Any]
+  + magicNumber : Nat
+  + openSesame  : Nat -> Text
+  + qux         : Nat
 
   Run `update` to apply these changes to your codebase.
 ```
@@ -207,4 +216,18 @@ Notice it gives the tip about `text.find.all`. But not here:
 > grep.all lsdkfjlskdjfsd
 
   😶 I couldn't find any matches.
+```
+
+Searching for numeric literals should find them both in expression position (rval) and in pattern position:
+
+``` ucm
+> grep "230971246918247"
+
+  🔎
+
+  These definitions from the current namespace (excluding `lib`) have matches:
+
+    1. magicNumber
+
+  Tip: Try `edit 1` to bring this into your scratch file.
 ```

--- a/unison-src/transcripts/idempotent/textfind.md
+++ b/unison-src/transcripts/idempotent/textfind.md
@@ -228,6 +228,8 @@ Searching for numeric literals should find them both in expression position (rva
   These definitions from the current namespace (excluding `lib`) have matches:
 
     1. magicNumber
+    2. openSesame
 
-  Tip: Try `edit 1` to bring this into your scratch file.
+  Tip: Try `edit 1` or `edit 1-2` to bring these into your
+       scratch file.
 ```


### PR DESCRIPTION
## Overview
#6073 reported that `text.find` doesn't find `Nat` literals in pattern matches.

See transcript diff for before and after.

Closes #6073 
- [x] What does this change accomplish and why?
  - [x] i.e. How does it change the user experience?
  - [x] i.e. What was the old behavior/API and what is the new behavior/API?

- [x] Include "before and after" examples if appropriate. (You can copy/paste screenshots directly into this editor.)

- [x] List any Github issues that this PR closes, in [closing-issues-using-keywords](https://help.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords) format.

## Implementation approach and notes

Changes `txtPattern` to recognize more that `Text` cases.

## Interesting/controversial decisions

I wasn't sure if `show` was the right move here or if we needed something more sophisticated, but it's a step in the right direction in any case.

## Test coverage

- [x] Have you included tests (which could be a transcript) for this change, or is it somehow covered by existing tests?

- [x] Would you recommend improving the test coverage (either as part of this PR or as a separate issue) or do you think it’s adequate?

adequate

- [x] If you only tested by hand, because that's all that's practical to do for this change, mention that. Include screenshots.
n/a

## Loose ends

It doesn't work to use a negative number to search for a negative number, not sure why yet, but that limitation already existed.

n/a
## Final checklist

- [x] **Choose your PR title well:** Your pull request title is what's used to create release notes, so please make it descriptive of the change itself, which may be different from the initial motivation to make the change.
- [x] **Update your PR description** if the specifics of the PR have changed over time.
- [x] **Include transcripts or screenshots** that demonstrate the changed behavior.
- [x] **If you changed `.cabal` files**, make sure the `package.yaml` files are up-to-date instead.
