### PR TITLE
Adding MCP commands: "rename", "move", "moveTo", "delete", "delete.namespace"

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -95,3 +95,4 @@ The format for this list: name, GitHub handle
 * Régis Kuckaertz (@regiskuckaertz)
 * Emil Petersen (@leetemil)
 * Lars Wilhelmsen (@larsw)
+* Nic Luciano (@kn0ll)

--- a/unison-cli/src/Unison/MCP/Tools.hs
+++ b/unison-cli/src/Unison/MCP/Tools.hs
@@ -65,6 +65,7 @@ tools =
     deleteDefinitionsTool,
     renameDefinitionTool,
     moveDefinitionTool,
+    moveToTool,
     deleteNamespaceTool
   ]
 
@@ -609,6 +610,30 @@ moveDefinitionTool =
         output <- handleInputMCP projectContext [Right $ Input.MoveAllI src dest]
         let outputJSON = Text.decodeUtf8 . BL.toStrict $ Aeson.encode output
         pure $ textToolResult outputJSON
+    }
+
+moveToTool :: Tool MCP
+moveToTool =
+  Tool
+    { toolName = toToolName MoveToTool,
+      toolDescription = "Move one or more definitions or namespaces into a destination namespace. The final segment of each source is preserved in the destination.",
+      toolAnnotations =
+        ToolAnnotations
+          { title = Just "Move To",
+            readOnlyHint = Just False,
+            destructiveHint = Just True,
+            idempotentHint = Just False,
+            openWorldHint = Just False
+          },
+      toolArgType = Proxy,
+      toolHandler = \(MoveToToolArguments {projectContext, sources, destination}) -> handleToolError $ do
+        case NEL.nonEmpty sources of
+          Nothing ->
+            pure $ errorToolResult "No sources provided to move"
+          Just nonEmptySources -> do
+            output <- handleInputMCP projectContext [Right $ Input.MoveToI nonEmptySources destination]
+            let outputJSON = Text.decodeUtf8 . BL.toStrict $ Aeson.encode output
+            pure $ textToolResult outputJSON
     }
 
 deleteNamespaceTool :: Tool MCP

--- a/unison-cli/src/Unison/MCP/Tools.hs
+++ b/unison-cli/src/Unison/MCP/Tools.hs
@@ -573,7 +573,7 @@ renameDefinitionTool :: Tool MCP
 renameDefinitionTool =
   Tool
     { toolName = toToolName RenameDefinitionTool,
-      toolDescription = "Rename a definition (term, type, or namespace) by changing only its final name segment. The parent path is preserved.",
+      toolDescription = "Rename a definition (term, type, or namespace) by changing only its final name segment. The parent path is preserved. For example, `rename foo.bar.baz Qux` changes the name `baz` to `Qux`, producing `foo.bar.Qux`. To move a definition to a different namespace, use `move-to` instead.",
       toolAnnotations =
         ToolAnnotations
           { title = Just "Rename Definition",
@@ -594,7 +594,7 @@ moveDefinitionTool :: Tool MCP
 moveDefinitionTool =
   Tool
     { toolName = toToolName MoveDefinitionTool,
-      toolDescription = "Move a definition (term, type, or namespace) to a new path. Can change the full path including parent namespace.",
+      toolDescription = "Move a definition (term, type, or namespace) to a completely new path. For example, `move foo.bar baz.qux` renames `foo.bar` to `baz.qux`. This changes the full path, not just the final segment.",
       toolAnnotations =
         ToolAnnotations
           { title = Just "Move Definition",
@@ -616,7 +616,7 @@ moveToTool :: Tool MCP
 moveToTool =
   Tool
     { toolName = toToolName MoveToTool,
-      toolDescription = "Move one or more definitions or namespaces into a destination namespace. The final segment of each source is preserved in the destination.",
+      toolDescription = "Move one or more definitions or namespaces into a destination namespace. The final segment of each source is preserved. For example, `moveTo foo.bar dest` moves `foo.bar` into namespace `dest`, producing `dest.bar`. Multiple sources can be moved at once: `moveTo foo bar baz dest` moves all three into `dest`.",
       toolAnnotations =
         ToolAnnotations
           { title = Just "Move To",

--- a/unison-cli/src/Unison/MCP/Tools.hs
+++ b/unison-cli/src/Unison/MCP/Tools.hs
@@ -22,6 +22,7 @@ import Unison.Codebase.ProjectPath
 import Unison.Codebase.Runtime.Profile (ProfileSpec (..))
 import Unison.Core.Project (ProjectBranchName (..), ProjectName (..))
 import Unison.HashQualified qualified as HQ
+import Unison.HashQualifiedPrime qualified as HQ'
 import Unison.MCP.Cli (cliToMCP, handleInputMCP, virtualSourceName)
 import Unison.MCP.Share.API (ReadmeResponse (..))
 import Unison.MCP.Share.API qualified as Share
@@ -60,7 +61,11 @@ tools =
     searchByTypeTool,
     dependenciesTool,
     dependentsTool,
-    runTestsTool
+    runTestsTool,
+    deleteDefinitionsTool,
+    renameDefinitionTool,
+    moveDefinitionTool,
+    deleteNamespaceTool
   ]
 
 currentProjectContext :: (MonadIO m, MonadReader Env m) => m ProjectContext
@@ -537,3 +542,95 @@ handleToolError action = do
   case result of
     Left err -> pure $ errorToolResult err
     Right res -> pure res
+
+deleteDefinitionsTool :: Tool MCP
+deleteDefinitionsTool =
+  Tool
+    { toolName = toToolName DeleteDefinitionsTool,
+      toolDescription = "Delete one or more definitions (terms or types) from the codebase.",
+      toolAnnotations =
+        ToolAnnotations
+          { title = Just "Delete Definitions",
+            readOnlyHint = Just False,
+            destructiveHint = Just True,
+            idempotentHint = Just False,
+            openWorldHint = Just False
+          },
+      toolArgType = Proxy,
+      toolHandler = \(DeleteDefinitionsToolArguments {projectContext, names, force}) -> handleToolError $ do
+        case NEL.nonEmpty names of
+          Nothing ->
+            pure $ errorToolResult "No names provided to delete"
+          Just nonEmptyNames -> do
+            let names' = HQ'.NameOnly <$> NEL.toList nonEmptyNames
+            output <- handleInputMCP projectContext [Right $ Input.DeleteI force Input.DeleteTarget'TermOrType names']
+            let outputJSON = Text.decodeUtf8 . BL.toStrict $ Aeson.encode output
+            pure $ textToolResult outputJSON
+    }
+
+renameDefinitionTool :: Tool MCP
+renameDefinitionTool =
+  Tool
+    { toolName = toToolName RenameDefinitionTool,
+      toolDescription = "Rename a definition (term, type, or namespace) by changing only its final name segment. The parent path is preserved.",
+      toolAnnotations =
+        ToolAnnotations
+          { title = Just "Rename Definition",
+            readOnlyHint = Just False,
+            destructiveHint = Just True,
+            idempotentHint = Just False,
+            openWorldHint = Just False
+          },
+      toolArgType = Proxy,
+      toolHandler = \(RenameDefinitionToolArguments {projectContext, oldName, newNameSegment}) -> handleToolError $ do
+        let src = Path.fromName' oldName
+        output <- handleInputMCP projectContext [Right $ Input.RenameI src newNameSegment]
+        let outputJSON = Text.decodeUtf8 . BL.toStrict $ Aeson.encode output
+        pure $ textToolResult outputJSON
+    }
+
+moveDefinitionTool :: Tool MCP
+moveDefinitionTool =
+  Tool
+    { toolName = toToolName MoveDefinitionTool,
+      toolDescription = "Move a definition (term, type, or namespace) to a new path. Can change the full path including parent namespace.",
+      toolAnnotations =
+        ToolAnnotations
+          { title = Just "Move Definition",
+            readOnlyHint = Just False,
+            destructiveHint = Just True,
+            idempotentHint = Just False,
+            openWorldHint = Just False
+          },
+      toolArgType = Proxy,
+      toolHandler = \(MoveDefinitionToolArguments {projectContext, oldName, newName}) -> handleToolError $ do
+        let src = Path.fromName' oldName
+            dest = Path.fromName' newName
+        output <- handleInputMCP projectContext [Right $ Input.MoveAllI src dest]
+        let outputJSON = Text.decodeUtf8 . BL.toStrict $ Aeson.encode output
+        pure $ textToolResult outputJSON
+    }
+
+deleteNamespaceTool :: Tool MCP
+deleteNamespaceTool =
+  Tool
+    { toolName = toToolName DeleteNamespaceTool,
+      toolDescription = "Delete a namespace and all definitions within it from the codebase.",
+      toolAnnotations =
+        ToolAnnotations
+          { title = Just "Delete Namespace",
+            readOnlyHint = Just False,
+            destructiveHint = Just True,
+            idempotentHint = Just False,
+            openWorldHint = Just False
+          },
+      toolArgType = Proxy,
+      toolHandler = \(DeleteNamespaceToolArguments {projectContext, namespaceName, force}) -> handleToolError $ do
+        let (path, finalSegment) = Path.splitFromName namespaceName
+            split = (Path.Relative path, finalSegment)
+            insistence = if force then Input.Force else Input.Try
+        output <- handleInputMCP projectContext [Right $ Input.DeleteNamespaceI insistence (Just split)]
+        let outputJSON = Text.decodeUtf8 . BL.toStrict $ Aeson.encode output
+        pure $ textToolResult outputJSON
+    }
+

--- a/unison-cli/src/Unison/MCP/Types.hs
+++ b/unison-cli/src/Unison/MCP/Types.hs
@@ -25,6 +25,7 @@ module Unison.MCP.Types
     DeleteDefinitionsToolArguments (..),
     RenameDefinitionToolArguments (..),
     MoveDefinitionToolArguments (..),
+    MoveToToolArguments (..),
     DeleteNamespaceToolArguments (..),
     toToolName,
     fromToolName,
@@ -93,6 +94,7 @@ data ToolKind
   | DeleteDefinitionsTool
   | RenameDefinitionTool
   | MoveDefinitionTool
+  | MoveToTool
   | DeleteNamespaceTool
   deriving (Eq, Ord, Show, Bounded, Enum)
 
@@ -122,6 +124,7 @@ kindNameMapping =
       (DeleteDefinitionsTool, "delete-definitions"),
       (RenameDefinitionTool, "rename-definition"),
       (MoveDefinitionTool, "move-definition"),
+      (MoveToTool, "move-to"),
       (DeleteNamespaceTool, "delete-namespace")
     ]
 
@@ -780,6 +783,47 @@ instance FromJSON MoveDefinitionToolArguments where
     oldName <- Name.unsafeParseText <$> o .: "oldName"
     newName <- Name.unsafeParseText <$> o .: "newName"
     pure $ MoveDefinitionToolArguments {projectContext, oldName, newName}
+
+data MoveToToolArguments = MoveToToolArguments
+  { projectContext :: ProjectContext,
+    sources :: [Path.Path'],
+    destination :: Path.Path'
+  }
+  deriving (Eq, Show)
+
+instance HasInputSchema MoveToToolArguments where
+  toInputSchema _ =
+    object
+      [ "type" .= ("object" :: Text),
+        "properties"
+          .= object
+            [ "projectContext" .= toInputSchema (Proxy :: Proxy ProjectContext),
+              "sources"
+                .= object
+                  [ "type" .= ("array" :: Text),
+                    "items"
+                      .= object
+                        [ "type" .= ("string" :: Text),
+                          "description" .= ("A path to move, e.g. `mynamespace.foo` or `MyType`." :: Text)
+                        ],
+                    "description" .= ("The paths of the definitions or namespaces to move. The final segment of each source is preserved in the destination." :: Text),
+                    "minItems" .= (1 :: Int)
+                  ],
+              "destination"
+                .= object
+                  [ "type" .= ("string" :: Text),
+                    "description" .= ("The destination namespace to move the sources into, e.g. `othernamespace` or `foo.bar`. Each source's final segment is preserved." :: Text)
+                  ]
+            ],
+        "required" .= ["projectContext", "sources", "destination" :: Text]
+      ]
+
+instance FromJSON MoveToToolArguments where
+  parseJSON = withObject "MoveToToolArguments" $ \o -> do
+    projectContext <- o .: "projectContext"
+    sources <- fmap Path.unsafeParseText' <$> o .: "sources"
+    destination <- Path.unsafeParseText' <$> o .: "destination"
+    pure $ MoveToToolArguments {projectContext, sources, destination}
 
 data DeleteNamespaceToolArguments = DeleteNamespaceToolArguments
   { projectContext :: ProjectContext,

--- a/unison-cli/src/Unison/MCP/Types.hs
+++ b/unison-cli/src/Unison/MCP/Types.hs
@@ -22,6 +22,10 @@ module Unison.MCP.Types
     ProjectNameArgument (..),
     ProjectDefinitionNameArgument (..),
     TestToolArguments (..),
+    DeleteDefinitionsToolArguments (..),
+    RenameDefinitionToolArguments (..),
+    MoveDefinitionToolArguments (..),
+    DeleteNamespaceToolArguments (..),
     toToolName,
     fromToolName,
   )
@@ -39,11 +43,13 @@ import Unison.Codebase.Path qualified as Path
 import Unison.Core.Project (ProjectBranchName (UnsafeProjectBranchName), ProjectName (UnsafeProjectName))
 import Unison.MCP.Wrapper (HasInputSchema (..))
 import Unison.Name (Name)
+import Unison.NameSegment (NameSegment)
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
 import Unison.Runtime (Runtime)
 import Unison.Symbol (Symbol)
 import Unison.Syntax.Name qualified as Name
+import Unison.Syntax.NameSegment qualified as NameSegment
 
 data Env = Env
   { codebase :: Codebase IO Symbol Ann,
@@ -84,6 +90,10 @@ data ToolKind
   | DependenciesTool
   | DependentsTool
   | TestsTool
+  | DeleteDefinitionsTool
+  | RenameDefinitionTool
+  | MoveDefinitionTool
+  | DeleteNamespaceTool
   deriving (Eq, Ord, Show, Bounded, Enum)
 
 kindNameMapping :: Map ToolKind Text
@@ -108,7 +118,11 @@ kindNameMapping =
       (GetCurrentProjectContextTool, "get-current-project-context"),
       (DependenciesTool, "list-definition-dependencies"),
       (DependentsTool, "list-definition-dependents"),
-      (TestsTool, "run-tests")
+      (TestsTool, "run-tests"),
+      (DeleteDefinitionsTool, "delete-definitions"),
+      (RenameDefinitionTool, "rename-definition"),
+      (MoveDefinitionTool, "move-definition"),
+      (DeleteNamespaceTool, "delete-namespace")
     ]
 
 data ProjectDefinitionNameArgument = ProjectDefinitionNameArgument
@@ -656,6 +670,151 @@ instance FromJSON TestToolArguments where
     projectContext <- o .: "projectContext"
     subnamespace <- fmap (Path.Relative . Path.unsafeParseText) <$> (o .:? "subnamespace")
     pure $ TestToolArguments {projectContext, subnamespace}
+
+data DeleteDefinitionsToolArguments = DeleteDefinitionsToolArguments
+  { projectContext :: ProjectContext,
+    names :: [Name],
+    force :: Bool
+  }
+  deriving (Eq, Show)
+
+instance HasInputSchema DeleteDefinitionsToolArguments where
+  toInputSchema _ =
+    object
+      [ "type" .= ("object" :: Text),
+        "properties"
+          .= object
+            [ "projectContext" .= toInputSchema (Proxy :: Proxy ProjectContext),
+              "names"
+                .= object
+                  [ "type" .= ("array" :: Text),
+                    "items"
+                      .= object
+                        [ "type" .= ("string" :: Text),
+                          "description" .= ("A definition name to delete, e.g. `mynamespace.foo` or `MyType`." :: Text)
+                        ],
+                    "description" .= ("The names of the definitions to delete." :: Text)
+                  ],
+              "force"
+                .= object
+                  [ "type" .= ("boolean" :: Text),
+                    "description" .= ("If true, force delete even if the definition has dependents. Default is false." :: Text)
+                  ]
+            ],
+        "required" .= ["projectContext", "names" :: Text]
+      ]
+
+instance FromJSON DeleteDefinitionsToolArguments where
+  parseJSON = withObject "DeleteDefinitionsToolArguments" $ \o -> do
+    projectContext <- o .: "projectContext"
+    names <- fmap Name.unsafeParseText <$> o .: "names"
+    force <- o .:? "force" .!= False
+    pure $ DeleteDefinitionsToolArguments {projectContext, names, force}
+
+data RenameDefinitionToolArguments = RenameDefinitionToolArguments
+  { projectContext :: ProjectContext,
+    oldName :: Name,
+    newNameSegment :: NameSegment
+  }
+  deriving (Eq, Show)
+
+instance HasInputSchema RenameDefinitionToolArguments where
+  toInputSchema _ =
+    object
+      [ "type" .= ("object" :: Text),
+        "properties"
+          .= object
+            [ "projectContext" .= toInputSchema (Proxy :: Proxy ProjectContext),
+              "oldName"
+                .= object
+                  [ "type" .= ("string" :: Text),
+                    "description" .= ("The current name of the definition to rename, e.g. `mynamespace.foo` or `MyType`." :: Text)
+                  ],
+              "newNameSegment"
+                .= object
+                  [ "type" .= ("string" :: Text),
+                    "description" .= ("The new name segment (final part only). For example, to rename `foo.bar` to `foo.baz`, provide `baz`. The parent path is preserved." :: Text)
+                  ]
+            ],
+        "required" .= ["projectContext", "oldName", "newNameSegment" :: Text]
+      ]
+
+instance FromJSON RenameDefinitionToolArguments where
+  parseJSON = withObject "RenameDefinitionToolArguments" $ \o -> do
+    projectContext <- o .: "projectContext"
+    oldName <- Name.unsafeParseText <$> o .: "oldName"
+    newNameSegment <- NameSegment.unsafeParseText <$> o .: "newNameSegment"
+    pure $ RenameDefinitionToolArguments {projectContext, oldName, newNameSegment}
+
+data MoveDefinitionToolArguments = MoveDefinitionToolArguments
+  { projectContext :: ProjectContext,
+    oldName :: Name,
+    newName :: Name
+  }
+  deriving (Eq, Show)
+
+instance HasInputSchema MoveDefinitionToolArguments where
+  toInputSchema _ =
+    object
+      [ "type" .= ("object" :: Text),
+        "properties"
+          .= object
+            [ "projectContext" .= toInputSchema (Proxy :: Proxy ProjectContext),
+              "oldName"
+                .= object
+                  [ "type" .= ("string" :: Text),
+                    "description" .= ("The current full path of the definition to move, e.g. `mynamespace.foo` or `MyType`." :: Text)
+                  ],
+              "newName"
+                .= object
+                  [ "type" .= ("string" :: Text),
+                    "description" .= ("The new full path for the definition, e.g. `othernamespace.bar` or `NewType`. Can move to a different namespace." :: Text)
+                  ]
+            ],
+        "required" .= ["projectContext", "oldName", "newName" :: Text]
+      ]
+
+instance FromJSON MoveDefinitionToolArguments where
+  parseJSON = withObject "MoveDefinitionToolArguments" $ \o -> do
+    projectContext <- o .: "projectContext"
+    oldName <- Name.unsafeParseText <$> o .: "oldName"
+    newName <- Name.unsafeParseText <$> o .: "newName"
+    pure $ MoveDefinitionToolArguments {projectContext, oldName, newName}
+
+data DeleteNamespaceToolArguments = DeleteNamespaceToolArguments
+  { projectContext :: ProjectContext,
+    namespaceName :: Name,
+    force :: Bool
+  }
+  deriving (Eq, Show)
+
+instance HasInputSchema DeleteNamespaceToolArguments where
+  toInputSchema _ =
+    object
+      [ "type" .= ("object" :: Text),
+        "properties"
+          .= object
+            [ "projectContext" .= toInputSchema (Proxy :: Proxy ProjectContext),
+              "namespaceName"
+                .= object
+                  [ "type" .= ("string" :: Text),
+                    "description" .= ("The name of the namespace to delete, e.g. `mynamespace` or `foo.bar`. This will delete the namespace and all definitions within it." :: Text)
+                  ],
+              "force"
+                .= object
+                  [ "type" .= ("boolean" :: Text),
+                    "description" .= ("If true, force delete even if definitions in the namespace have dependents. Default is false." :: Text)
+                  ]
+            ],
+        "required" .= ["projectContext", "namespaceName" :: Text]
+      ]
+
+instance FromJSON DeleteNamespaceToolArguments where
+  parseJSON = withObject "DeleteNamespaceToolArguments" $ \o -> do
+    projectContext <- o .: "projectContext"
+    namespaceName <- Name.unsafeParseText <$> o .: "namespaceName"
+    force <- o .:? "force" .!= False
+    pure $ DeleteNamespaceToolArguments {projectContext, namespaceName, force}
 
 nameKindMapping :: Map Text ToolKind
 nameKindMapping =

--- a/unison-src/transcripts/idempotent/mcp.md
+++ b/unison-src/transcripts/idempotent/mcp.md
@@ -637,6 +637,69 @@ RESPONSE:
 
 ```
 
+## move-to
+
+First, set up a branch with terms to move:
+
+``` ucm
+scratch/move-to-test> builtins.merge lib.builtins
+
+  Done.
+```
+
+``` unison :hide
+source.termA = 1
+source.termB = 2
+```
+
+``` ucm
+scratch/move-to-test> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+```
+
+Now move multiple terms into a destination namespace (preserving final segments):
+
+``` api
+POST /mcp
+BODY:
+  {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "move-to",
+      "arguments": {
+        "projectContext": {
+          "projectName": "scratch",
+          "branchName": "move-to-test"
+        },
+        "sources": ["source.termA", "source.termB"],
+        "destination": "dest"
+      }
+    }
+  }
+
+RESPONSE:
+  {
+      "id": 1,
+      "jsonrpc": "2.0",
+      "result": {
+          "content": [
+              {
+                  "text": "{\"errorMessages\":[],\"outputMessages\":[\"Moved:\\n\\n  source.termA -> dest.termA\\n  source.termB -> dest.termB\",\"Moved:\\n\\n  source.termA -> dest.termA\\n  source.termB -> dest.termB\"],\"sourceCodeUpdates\":[],\"stderr\":\"\",\"stdout\":\"\"}",
+                  "type": "text"
+              }
+          ],
+          "isError": false
+      }
+  }
+
+```
+
 ## delete-definitions
 
 First, set up a branch with a term to delete:

--- a/unison-src/transcripts/idempotent/mcp.md
+++ b/unison-src/transcripts/idempotent/mcp.md
@@ -514,3 +514,250 @@ RESPONSE:
   }
 
 ```
+
+## rename-definition
+
+``` ucm
+scratch/foo> builtins.merge lib.builtins
+
+  Done.
+```
+
+``` unison :hide
+termToRename = 42
+```
+
+``` ucm
+scratch/rename-test> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+```
+
+Now rename it (only changes the final segment):
+
+``` api
+POST /mcp
+BODY:
+  {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "rename-definition",
+      "arguments": {
+        "projectContext": {
+          "projectName": "scratch",
+          "branchName": "rename-test"
+        },
+        "oldName": "termToRename",
+        "newNameSegment": "renamedTerm"
+      }
+    }
+  }
+
+RESPONSE:
+  {
+      "id": 1,
+      "jsonrpc": "2.0",
+      "result": {
+          "content": [
+              {
+                  "text": "{\"errorMessages\":[],\"outputMessages\":[\"Renamed:\\n\\n  termToRename -> renamedTerm\",\"Renamed:\\n\\n  termToRename -> renamedTerm\"],\"sourceCodeUpdates\":[],\"stderr\":\"\",\"stdout\":\"\"}",
+                  "type": "text"
+              }
+          ],
+          "isError": false
+      }
+  }
+
+```
+
+## move-definition
+
+First, set up a branch with a term to move:
+
+``` ucm
+scratch/move-test> builtins.merge lib.builtins
+
+  Done.
+```
+
+``` unison :hide
+original.termToMove = 99
+```
+
+``` ucm
+scratch/move-test> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+```
+
+Now move it to a different namespace:
+
+``` api
+POST /mcp
+BODY:
+  {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "move-definition",
+      "arguments": {
+        "projectContext": {
+          "projectName": "scratch",
+          "branchName": "move-test"
+        },
+        "oldName": "original.termToMove",
+        "newName": "destination.movedTerm"
+      }
+    }
+  }
+
+RESPONSE:
+  {
+      "id": 1,
+      "jsonrpc": "2.0",
+      "result": {
+          "content": [
+              {
+                  "text": "{\"errorMessages\":[],\"outputMessages\":[\"Done.\",\"Done.\"],\"sourceCodeUpdates\":[],\"stderr\":\"\",\"stdout\":\"\"}",
+                  "type": "text"
+              }
+          ],
+          "isError": false
+      }
+  }
+
+```
+
+## delete-definitions
+
+First, set up a branch with a term to delete:
+
+``` ucm
+scratch/delete-test> builtins.merge lib.builtins
+
+  Done.
+```
+
+``` unison :hide
+termToDelete = 42
+```
+
+``` ucm
+scratch/delete-test> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+```
+
+Now delete it:
+
+``` api
+POST /mcp
+BODY:
+  {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "delete-definitions",
+      "arguments": {
+        "projectContext": {
+          "projectName": "scratch",
+          "branchName": "delete-test"
+        },
+        "names": ["termToDelete"],
+        "force": false
+      }
+    }
+  }
+
+RESPONSE:
+  {
+      "id": 1,
+      "jsonrpc": "2.0",
+      "result": {
+          "content": [
+              {
+                  "text": "{\"errorMessages\":[],\"outputMessages\":[\"I deleted these terms:\\n\\n  1. termToDelete\\n\\nTip: You can use `undo` or use a hash from `reflog` to undo this change.\"],\"sourceCodeUpdates\":[],\"stderr\":\"\",\"stdout\":\"\"}",
+                  "type": "text"
+              }
+          ],
+          "isError": false
+      }
+  }
+
+```
+
+## delete-namespace
+
+First, set up a branch with a namespace containing definitions:
+
+``` ucm
+scratch/delete-ns-test> builtins.merge lib.builtins
+
+  Done.
+```
+
+``` unison :hide
+MyNamespace.foo = 1
+MyNamespace.bar = 2
+```
+
+``` ucm
+scratch/delete-ns-test> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+```
+
+Now delete the namespace:
+
+``` api
+POST /mcp
+BODY:
+  {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "delete-namespace",
+      "arguments": {
+        "projectContext": {
+          "projectName": "scratch",
+          "branchName": "delete-ns-test"
+        },
+        "namespaceName": "MyNamespace",
+        "force": false
+      }
+    }
+  }
+
+RESPONSE:
+  {
+      "id": 1,
+      "jsonrpc": "2.0",
+      "result": {
+          "content": [
+              {
+                  "text": "{\"errorMessages\":[],\"outputMessages\":[\"Done.\",\"Done.\"],\"sourceCodeUpdates\":[],\"stderr\":\"\",\"stdout\":\"\"}",
+                  "type": "text"
+              }
+          ],
+          "isError": false
+      }
+  }
+
+```


### PR DESCRIPTION
## Overview

Implements `rename`, `move`, `delete`, and `delete.namespace` MCP commands. Discussed briefly on [Discord](https://discord.com/channels/862108724948500490/1200259538369130639/1455572067897315441).

## Implementation approach and notes

I have not written Haskell in 5 years and I was never good. This was AI assisted. I've reviewed and tested thoroughly.

## Interesting/controversial decisions

I found the asymmetry in move/rename namespace vs delete namespace confusing, but I tried to respect the primitive behavior of UCM. If there is something interesting or controversial I have done something wrong. If anything, maybe someone can verify the `toolDescription` are all accurate?

## Test coverage

The MCP transcript has been updated, and I have compiled this version of UCM locally and verified an agent can successfully use the tools:

<img width="1849" height="991" alt="image" src="https://github.com/user-attachments/assets/c2dfe7c2-d992-4b6e-8248-89ce56dbd414" />

## Loose ends

- [x] Add examples to tool descriptions
- [x] Add `moveTo`