### PR TITLE
allow delete.force to delete things out of lib

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Delete.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Delete.hs
@@ -267,18 +267,18 @@ handleDelete False {- force? -} which (List.nubOrd -> targetNames) = do
   Cli.respondNumbered (DeletedDefinitions (bimap BiMultimap.ran BiMultimap.ran target))
 -- A force-delete is muuch simpler: don't care if we leave nameless dependencies, just nuke things from the namespace.
 -- You also have to use this version when deleting a constructor, which doesn't happen often, but could (e.g. if you
--- have an incoherent decl due to extra constructor alias).
+-- have an incoherent decl due to extra constructor alias). This is also the ony way to delete from lib.*, which we want
+-- do discourage or even prevent in general, but is useful in transcripts.
 handleDelete True {- force? -} which targetNames = do
   projectAndBranch <- Cli.getCurrentProjectAndBranch
 
   currentNamespace <- Cli.getCurrentProjectRoot
   let currentNamespace0 = Branch.head currentNamespace
-  let currentNamespaceSansLib0 = Branch.deleteLibdeps currentNamespace0
 
   -- Identify the terms, types, and constructors identified by the provided names.
   let target :: DefnsF (Relation Name) Referent TypeReference
       target =
-        currentNamespaceSansLib0
+        currentNamespace0
           & Branch.deepDefns
           & bimap Relation.swap Relation.swap
           & resolveTargetInConflicted which targetNames

--- a/unison-src/transcripts/idempotent/delete.md
+++ b/unison-src/transcripts/idempotent/delete.md
@@ -307,6 +307,61 @@ scratch/main> delete.force a.Foo.Foo
 scratch/main> project.delete scratch
 ```
 
+Deleting something from `lib.*` is possible with `delete.force`, not `delete`.
+
+``` ucm :hide
+scratch/main> builtins.mergeio lib.builtins
+```
+
+``` unison
+foo = 17
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  + foo : Nat
+
+  Run `update` to apply these changes to your codebase.
+```
+
+``` ucm
+scratch/main> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+
+scratch/main> move foo lib.foo.foo
+
+  Done.
+```
+
+``` ucm :error
+scratch/main> delete lib.foo.foo
+
+  ⚠️
+
+  I couldn't find any terms or types that match the name
+  lib.foo.foo.
+```
+
+``` ucm
+scratch/main> delete.force lib.foo.foo
+
+  I deleted these terms:
+
+    1. lib.foo.foo
+
+  Tip: You can use `undo` or use a hash from `reflog` to undo
+       this change.
+```
+
+``` ucm :hide
+scratch/main> project.delete scratch
+```
+
 Finally, let's try to delete a term and a type with the same name.
 
 ``` ucm :hide

--- a/unison-src/transcripts/idempotent/delete.md
+++ b/unison-src/transcripts/idempotent/delete.md
@@ -313,29 +313,14 @@ Deleting something from `lib.*` is possible with `delete.force`, not `delete`.
 scratch/main> builtins.mergeio lib.builtins
 ```
 
-``` unison
+``` unison :hide
 foo = 17
 ```
 
-``` ucm :added-by-ucm
-  Loading changes detected in scratch.u.
-
-  + foo : Nat
-
-  Run `update` to apply these changes to your codebase.
-```
-
-``` ucm
+``` ucm :hide
 scratch/main> update
 
-  Okay, I'm searching the branch for code that needs to be
-  updated...
-
-  Done.
-
 scratch/main> move foo lib.foo.foo
-
-  Done.
 ```
 
 ``` ucm :error


### PR DESCRIPTION
This PR tweaks `delete.force` so that it can delete things out of `lib`

## Test coverage

I've added a transcript