### PR TITLE
bugfix: disallow duplicate binders

### DIFF
--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -2134,7 +2134,7 @@ renderParseErrors s = \case
                 "",
                 Pr.wrap "A variable can only be bound once in a pattern."
               ]
-      in (msg, mapMaybe rangeForAnnotated [ann1, ann2])
+       in (msg, mapMaybe rangeForAnnotated [ann1, ann2])
 
 annotatedAsErrorSite ::
   (Annotated a) => String -> a -> Pretty ColorText

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -2122,6 +2122,19 @@ renderParseErrors s = \case
                 tokenAsErrorSite s $ HQ.toText <$> tok
               ]
        in (msg, [rangeForToken tok])
+    go (Parser.DuplicateBinders ann1 ann2 var) =
+      let msg =
+            Pr.lines
+              [ Pr.wrap $
+                  "I found the variable "
+                    <> style ErrorSite (Var.nameStr var)
+                    <> " bound twice in this pattern:",
+                "",
+                annotatedsAsErrorSite s [ann1, ann2],
+                "",
+                Pr.wrap "A variable can only be bound once in a pattern."
+              ]
+      in (msg, mapMaybe rangeForAnnotated [ann1, ann2])
 
 annotatedAsErrorSite ::
   (Annotated a) => String -> a -> Pretty ColorText

--- a/parser-typechecker/src/Unison/Syntax/TermParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermParser.hs
@@ -14,7 +14,7 @@ module Unison.Syntax.TermParser
 where
 
 import Control.Comonad.Trans.Cofree (CofreeF ((:<)))
-import Control.Lens (mapped, _2)
+import Control.Lens (_2)
 import Control.Monad.Reader (asks, local)
 import Control.Monad.Trans.Writer
 import Data.Bitraversable (bitraverse)
@@ -210,21 +210,7 @@ matchCase :: forall m v. (Monad m, Var v) => P v m (Int, [Term.MatchCase Ann (Te
 matchCase = do
   pats <- sepBy1 (label "\",\"" $ reserved ",") (parsePattern >>= bindConstructorsInPattern)
   let boundVars0 = concatMap snd pats
-  -- Disallow binding the same variable twice.
-  let checkForDuplicateBinders :: Map v Ann -> [(Ann, v)] -> P v m ()
-      checkForDuplicateBinders seen = \case
-        [] -> pure ()
-        (ann, v) : vs -> do
-          seen1 <-
-            Map.upsertF
-              ( \case
-                  Nothing -> pure ann
-                  Just ann0 -> P.customFailure (DuplicateBinders ann0 ann v)
-              )
-              v
-              seen
-          checkForDuplicateBinders seen1 vs
-  checkForDuplicateBinders Map.empty boundVars0
+  checkForDuplicateBinders boundVars0
   let boundVars' = map snd boundVars0
   let pat = case fst <$> pats of
         [p] -> p
@@ -248,6 +234,23 @@ matchCase = do
   let absChain vs t = foldr (\v t -> ABT.abs' (ann t) v t) t vs
   let mk (guard, t) = Term.MatchCase pat (fmap (absChain boundVars') guard) (absChain boundVars' t)
   pure $ (length pats, mk <$> guardsAndBlocks)
+
+-- Disallow binding the same variable twice.
+checkForDuplicateBinders :: (Ord v) => [(Ann, v)] -> P v m ()
+checkForDuplicateBinders =
+  let go seen = \case
+        [] -> pure ()
+        (ann, v) : vs -> do
+          seen1 <-
+            Map.upsertF
+              ( \case
+                  Nothing -> pure ann
+                  Just ann0 -> P.customFailure (DuplicateBinders ann0 ann v)
+              )
+              v
+              seen
+          go seen1 vs
+   in go Map.empty
 
 parsePattern :: forall m v. (Monad m, Var v) => P v m (Syntax.Pattern.Pattern v)
 parsePattern =
@@ -1020,8 +1023,10 @@ destructuringBind = do
   --   vs
   --   (Some 42) = List.head elems
   pat <- P.try (parsePattern <* P.lookAhead (openBlockWith "="))
-  (p, boundVars) <- over (_2 . mapped) snd <$> bindConstructorsInPattern pat
+  (p, boundVars0) <- bindConstructorsInPattern pat
+  checkForDuplicateBinders boundVars0
   (_eqAnn, _spanAnn, scrute) <- layoutBlock "=" -- Dwight K. Scrute ("The People's Scrutinee")
+  let boundVars = map snd boundVars0
   let guard = Nothing
   let absChain vs t = foldr (\v t -> ABT.abs' (ann t) v t) t vs
       thecase t = Term.MatchCase p (fmap (absChain boundVars) guard) $ absChain boundVars t

--- a/parser-typechecker/src/Unison/Syntax/TermParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermParser.hs
@@ -24,6 +24,7 @@ import Data.List qualified as List
 import Data.List.Extra qualified as List.Extra
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import Data.List.NonEmpty qualified as NonEmpty
+import Data.Map.Strict qualified as Map
 import Data.Maybe qualified as Maybe
 import Data.Set qualified as Set
 import Data.Text qualified as Text
@@ -65,6 +66,7 @@ import Unison.Type (Type)
 import Unison.Type qualified as Type
 import Unison.Typechecker.Components qualified as Components
 import Unison.Util.Bytes qualified as Bytes
+import Unison.Util.Map qualified as Map
 import Unison.Util.Recursion
 import Unison.Var (Var)
 import Unison.Var qualified as Var
@@ -204,11 +206,27 @@ matchCases = sepBy semi matchCase <&> \cases_ -> [(n, c) | (n, cs) <- cases_, c 
 --
 --   42, x -> ...
 --   (42, x) -> ...
-matchCase :: (Monad m, Var v) => P v m (Int, [Term.MatchCase Ann (Term v Ann)])
+matchCase :: forall m v. (Monad m, Var v) => P v m (Int, [Term.MatchCase Ann (Term v Ann)])
 matchCase = do
   pats <- sepBy1 (label "\",\"" $ reserved ",") (parsePattern >>= bindConstructorsInPattern)
-  let boundVars' = [v | (_, vs) <- pats, (_ann, v) <- vs]
-      pat = case fst <$> pats of
+  let boundVars0 = concatMap snd pats
+  -- Disallow binding the same variable twice.
+  let checkForDuplicateBinders :: Map v Ann -> [(Ann, v)] -> P v m ()
+      checkForDuplicateBinders seen = \case
+        [] -> pure ()
+        (ann, v) : vs -> do
+          seen1 <-
+            Map.upsertF
+              ( \case
+                  Nothing -> pure ann
+                  Just ann0 -> P.customFailure (DuplicateBinders ann0 ann v)
+              )
+              v
+              seen
+          checkForDuplicateBinders seen1 vs
+  checkForDuplicateBinders Map.empty boundVars0
+  let boundVars' = map snd boundVars0
+  let pat = case fst <$> pats of
         [p] -> p
         pats -> foldr pair (unit (ann . last $ pats)) pats
       unit ann = Pattern.Constructor ann (ConstructorReference DD.unitRef 0) []

--- a/unison-src/transcripts/idempotent/fix-4463.md
+++ b/unison-src/transcripts/idempotent/fix-4463.md
@@ -4,6 +4,8 @@ myproj/main> builtins.mergeio
 
 Repeated variable names in a pattern match fail to parse.
 
+Standard `match with` / `cases`:
+
 ``` unison :error
 first : (Text, Text) -> Text
 first = cases (p, p) -> p
@@ -15,6 +17,26 @@ first = cases (p, p) -> p
   I found the variable p bound twice in this pattern:
 
       2 | first = cases (p, p) -> p
+
+
+  A variable can only be bound once in a pattern.
+```
+
+Destructuring bind:
+
+``` unison :error
+foo : (Text, Text) -> Text
+foo x =
+  (p, p) = x
+  p
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I found the variable p bound twice in this pattern:
+
+      3 |   (p, p) = x
 
 
   A variable can only be bound once in a pattern.

--- a/unison-src/transcripts/idempotent/fix-4463.md
+++ b/unison-src/transcripts/idempotent/fix-4463.md
@@ -2,51 +2,20 @@
 myproj/main> builtins.mergeio
 ```
 
-Repeated variable names in a pattern match (like `p` below), should fail to parse, but doesn’t.
+Repeated variable names in a pattern match fail to parse.
 
-``` unison :error :bug
+``` unison :error
 first : (Text, Text) -> Text
 first = cases (p, p) -> p
-
-main: '{IO, Exception} Text
-main = do first ("one", "two")
 ```
 
 ``` ucm :added-by-ucm
   Loading changes detected in scratch.u.
 
-  + first : (Text, Text) -> Text
-  + main  : '{IO, Exception} Text
+  I found the variable p bound twice in this pattern:
 
-  Run `update` to apply these changes to your codebase.
-```
+      2 | first = cases (p, p) -> p
 
-``` ucm
-scratch/main> add
 
-  Okay, I'm searching the branch for code that needs to be
-  updated...
-
-  Done.
-```
-
-Instead, we get a runtime error when we try to run the function.
-
-``` ucm :bug
-scratch/main> run main
-
-  ❗️
-
-  Sorry – I've encountered a bug in the Unison runtime.
-
-    renameTo: duplicate rename
-
-  Please check if one of these known issues matches your
-  situation:
-
-  * https://github.com/unisonweb/unison/issues/3625
-  * https://github.com/unisonweb/unison/issues/4463
-
-  If not, please open a new one:
-  https://github.com/unisonweb/unison/issues/new/choose
+  A variable can only be bound once in a pattern.
 ```

--- a/unison-syntax/src/Unison/Syntax/Parser.hs
+++ b/unison-syntax/src/Unison/Syntax/Parser.hs
@@ -222,6 +222,8 @@ data Error v
   | -- | PatternArityMismatch expectedArity actualArity location
     PatternArityMismatch Int Int Ann
   | FloatPattern Ann
+  | -- Bound the same variable twice
+    DuplicateBinders Ann Ann v
   deriving (Show, Eq, Ord)
 
 tokenToPair :: L.Token a -> (Ann, a)


### PR DESCRIPTION
## Overview

Fixes #4463 

Disallow duplicate binders. It's a parse error.

## Test coverage

Transcript included