### PR TITLE
Add a missing case to the lambda lifting transformation

### DIFF
--- a/unison-runtime/src/Unison/Runtime/ANF.hs
+++ b/unison-runtime/src/Unison/Runtime/ANF.hs
@@ -221,6 +221,11 @@ enclose keep rec (Let1NamedTop' top v b@(unAnn -> LamsNamed' vs bd) e) =
       | Ann' _ ty <- b = ann a tm ty
       | otherwise = tm
     lamb = lamWithoutBindingAnns a evs (annotate $ lamWithoutBindingAnns a vs lbody)
+-- No lambda. Won't be floated, might shadow variable in `keep`.
+enclose keep rec (Let1NamedTop' top v bn bd) =
+  Just $
+    let1' top [(v, rec keep bn)]
+      (rec (Set.delete v keep) bd)
 enclose keep rec t@(LamsAnnot vs0 mty vs1 body) =
   Just $ if null evs then lamb else apps' lamb $ map (var a) evs
   where

--- a/unison-runtime/src/Unison/Runtime/ANF.hs
+++ b/unison-runtime/src/Unison/Runtime/ANF.hs
@@ -224,7 +224,9 @@ enclose keep rec (Let1NamedTop' top v b@(unAnn -> LamsNamed' vs bd) e) =
 -- No lambda. Won't be floated, might shadow variable in `keep`.
 enclose keep rec (Let1NamedTop' top v bn bd) =
   Just $
-    let1' top [(v, rec keep bn)]
+    let1'
+      top
+      [(v, rec keep bn)]
       (rec (Set.delete v keep) bd)
 enclose keep rec t@(LamsAnnot vs0 mty vs1 body) =
   Just $ if null evs then lamb else apps' lamb $ map (var a) evs

--- a/unison-src/transcripts/idempotent/fix5889.md
+++ b/unison-src/transcripts/idempotent/fix5889.md
@@ -1,0 +1,31 @@
+Tests a problem with shadowing in the lambda lifter.
+
+``` ucm :hide
+> builtins.merge
+```
+
+``` unison
+zig x y z =
+  zig = 0xba5e
+  go i =
+    if i < 5
+    then match zig with
+      0xba5e -> go (i Nat.+ 1)
+      _ -> bug "take off every zig"
+    else 10
+  go 0
+
+> zig 1 2 3
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  + zig : x -> y -> z -> Nat
+
+  Run `update` to apply these changes to your codebase.
+
+    11 | > zig 1 2 3
+           ⧩
+           10
+```


### PR DESCRIPTION
This PR fixes an oversight in the lambda lifter.

The first step of the process is to enclose terms that will be floated, so that they take their local references as arguments. We avoid adding arguments for references that will become part of the overall let-rec. However, this step was missing that lets could shadow the let-rec variables, so it would avoid enclosing these shadowing variables.

For instance, in code of the form

```unison
foo x =
   foo = ...
   bar y = ... foo ...
```

`bar` would not have `foo` enclosed, even though its `foo` reference is the inner one, not the top level.

Fixes #5889, which was caused by the test using a `result` variable, and the test process tweaking the code to use `result` to refer to the overall test result (I think).