### PR TITLE
delete Relative path type

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Path.hs
+++ b/parser-typechecker/src/Unison/Codebase/Path.hs
@@ -7,8 +7,6 @@ module Unison.Codebase.Path
     Namey (..),
     Absolute (..),
     absPath_,
-    Relative (..),
-    relPath_,
     Resolve (..),
     pattern Current,
     pattern Current',
@@ -16,7 +14,6 @@ module Unison.Codebase.Path
     pattern Root',
     singleton,
     isAbsolute,
-    isRelative,
     parentOfName,
     maybePrefix,
     unprefix,
@@ -66,9 +63,6 @@ import Unison.Util.Recursion (Recursive, XNor, cata, embed)
 -- | A `Path` is an internal structure representing some namespace in the codebase.
 --
 --  @Foo.Bar.baz@ becomes @["Foo", "Bar", "baz"]@.
---
---  __NB__:  This shouldn’t be exposed outside of this module (prefer`Path'`, `Absolute`, or `Relative`), but it’s
---   currently used pretty widely. Such usage should be replaced when encountered.
 newtype Path = Path {toSeq :: Seq NameSegment}
   deriving stock (Eq, Ord, Show)
   deriving newtype (Semigroup, Monoid)
@@ -100,22 +94,10 @@ instance Recursive Absolute (XNor NameSegment) where
 absPath_ :: Lens' Absolute Path
 absPath_ = lens unabsolute (\_ new -> Absolute new)
 
--- | A namespace path that doesn’t necessarily start from the root.
--- Typically refers to a path from the current namespace.
-newtype Relative = Relative {unrelative :: Path}
-  deriving stock (Eq, Ord, Show)
-  deriving newtype (Semigroup, Monoid)
-
-instance From Relative Text where
-  from = toText
-
-relPath_ :: Lens' Relative Path
-relPath_ = lens unrelative (\_ new -> Relative new)
-
 -- | A namespace that may be either absolute or relative, This is the most general type that should be used.
 data Path'
   = AbsolutePath' Absolute
-  | RelativePath' Relative
+  | RelativePath' Path
   deriving (Eq, Ord, Show)
 
 instance From Path' Text where
@@ -125,12 +107,8 @@ isAbsolute :: Path' -> Bool
 isAbsolute (AbsolutePath' _) = True
 isAbsolute _ = False
 
-isRelative :: Path' -> Bool
-isRelative (RelativePath' _) = True
-isRelative _ = False
-
-pattern Current :: Relative
-pattern Current = Relative (Path Seq.Empty)
+pattern Current :: Path
+pattern Current = Path Seq.Empty
 
 pattern Current' :: Path'
 pattern Current' = RelativePath' Current
@@ -147,10 +125,10 @@ type Split path = (path, NameSegment)
 --   unprefix foo.bar .blah == .blah (absolute paths left alone)
 --   unprefix foo.bar id    == id    (relative paths starting w/ nonmatching prefix left alone)
 --   unprefix foo.bar foo.bar.baz == baz (relative paths w/ common prefix get stripped)
-unprefix :: Relative -> Path' -> Path'
-unprefix (Relative prefix) = \case
+unprefix :: Path -> Path' -> Path'
+unprefix prefix = \case
   AbsolutePath' abs -> AbsolutePath' abs
-  RelativePath' rel -> RelativePath' . Relative . fromList . dropPrefix (toList prefix) . toList $ unrelative rel
+  RelativePath' rel -> RelativePath' . fromList . dropPrefix (toList prefix) . toList $ rel
 
 -- | Returns `Nothing` if the second argument is absolute. A common pattern is
 --   @fromMaybe path $ maybePrefix prefix path@ to use the unmodified path in that case.
@@ -167,10 +145,10 @@ maybePrefix pre = \case
 --
 -- >>> longestPathPrefix Empty ("a" :< "b" :< "c" :< Empty)
 -- (,,a.b.c)
-longestPathPrefix :: Absolute -> Absolute -> (Absolute, Relative, Relative)
+longestPathPrefix :: Absolute -> Absolute -> (Absolute, Path, Path)
 longestPathPrefix a b =
   List.splitOnLongestCommonPrefix (toList $ unabsolute a) (toList $ unabsolute b)
-    & \(a, b, c) -> (Absolute $ fromList a, Relative $ fromList b, Relative $ fromList c)
+    & \(a, b, c) -> (Absolute $ fromList a, fromList b, fromList c)
 
 toAbsoluteSplit :: Absolute -> Split Path' -> Split Absolute
 toAbsoluteSplit = first . resolve
@@ -185,7 +163,7 @@ pattern Root' = AbsolutePath' Root
 fromPath' :: Path' -> Path
 fromPath' = \case
   AbsolutePath' (Absolute p) -> p
-  RelativePath' (Relative p) -> p
+  RelativePath' p -> p
 
 toList :: Path -> [NameSegment]
 toList = Foldable.toList . toSeq
@@ -212,7 +190,7 @@ splitFromName name =
 --
 -- >>> unprefixName (Relative $ fromList ["base", "List"]) (Name.unsafeFromText "base.List.map")
 -- Just (Name Relative (NameSegment {toText = "map"} :| []))
-unprefixName :: Relative -> Name -> Maybe Name
+unprefixName :: Path -> Name -> Maybe Name
 unprefixName prefix = toName . unprefix prefix . fromName'
 
 -- | Returns `Nothing` if the second argument is absolute. A common pattern is
@@ -238,8 +216,7 @@ class Pathy path where
   ascend = fmap fst . split
   descend :: path -> NameSegment -> path
 
-  -- | This always prefixes, since the second argument can never be absolute.
-  prefix :: path -> Relative -> path
+  prefix :: path -> Path -> path
 
   split :: path -> Maybe (Split path)
 
@@ -256,7 +233,7 @@ class (Pathy path) => Namey path where
 
 instance Pathy Path where
   descend (Path p) = Path . (p :|>)
-  prefix pre = Path . (toSeq pre <>) . toSeq . unrelative
+  prefix = resolve
   split (Path seq) = case seq of
     Seq.Empty -> Nothing
     p :|> n -> pure (Path p, n)
@@ -269,29 +246,18 @@ instance Namey Path where
 
 instance Pathy Absolute where
   descend (Absolute p) = Absolute . descend p
-  prefix (Absolute pre) = Absolute . prefix pre
+  prefix = resolve
   split (Absolute p) = first Absolute <$> split p
   toText = ("." <>) . toText . unabsolute
 
 instance Namey Absolute where
   nameFromSplit = Name.makeAbsolute . nameFromSplit . first unabsolute
 
-instance Pathy Relative where
-  descend (Relative p) = Relative . descend p
-  prefix (Relative pre) = Relative . prefix pre
-  split (Relative p) = first Relative <$> split p
-  toText = toText . unrelative
-
-instance Namey Relative where
-  nameFromSplit = Name.makeRelative . nameFromSplit . first unrelative
-
 instance Pathy Path' where
   descend = \case
     AbsolutePath' p -> AbsolutePath' . descend p
     RelativePath' p -> RelativePath' . descend p
-  prefix = \case
-    AbsolutePath' p -> AbsolutePath' . prefix p
-    RelativePath' p -> RelativePath' . prefix p
+  prefix = resolve
   split = \case
     AbsolutePath' p -> first AbsolutePath' <$> split p
     RelativePath' p -> first RelativePath' <$> split p
@@ -322,14 +288,14 @@ parentOfName name =
       path = fromList $ reverse t
    in ( if Name.isAbsolute name
           then AbsolutePath' (Absolute path)
-          else RelativePath' (Relative path),
+          else RelativePath' path,
         h
       )
 
 fromName' :: Name -> Path'
 fromName' n
   | Name.isAbsolute n = AbsolutePath' (Absolute path)
-  | otherwise = RelativePath' (Relative path)
+  | otherwise = RelativePath' path
   where
     path = fromName n
 
@@ -350,36 +316,31 @@ unsafeParseText = \case
 -- ""
 unsafeParseText' :: Text -> Path'
 unsafeParseText' = \case
-  "" -> RelativePath' (Relative mempty)
+  "" -> RelativePath' mempty
   "." -> AbsolutePath' (Absolute mempty)
   text -> fromName' (Name.unsafeParseText text)
 
 class Resolve l r o where
   resolve :: l -> r -> o
 
-instance Resolve Path Path Path where
-  resolve (Path l) (Path r) = Path (l <> r)
-
-instance Resolve Relative Relative Relative where
-  resolve (Relative (Path l)) (Relative (Path r)) = Relative (Path (l <> r))
-
-instance Resolve Absolute Relative Absolute where
-  resolve (Absolute l) (Relative r) = Absolute (resolve l r)
-
-instance Resolve Absolute Relative Path' where
-  resolve l r = AbsolutePath' (resolve l r)
-
 instance Resolve Absolute Path Absolute where
   resolve (Absolute l) r = Absolute (resolve l r)
+
+instance Resolve Absolute Path' Absolute where
+  resolve _ (AbsolutePath' a) = a
+  resolve a (RelativePath' r) = resolve a r
+
+instance Resolve Absolute (Split Path) (Split Absolute) where
+  resolve l r = first (resolve l) r
+
+instance Resolve Path Path Path where
+  resolve (Path l) (Path r) = Path (l <> r)
 
 instance Resolve Path' Path' Path' where
   resolve _ a@(AbsolutePath' {}) = a
   resolve (AbsolutePath' a) (RelativePath' r) = AbsolutePath' (resolve a r)
   resolve (RelativePath' r1) (RelativePath' r2) = RelativePath' (resolve r1 r2)
 
-instance Resolve Absolute (Split Path) (Split Absolute) where
-  resolve l r = first (resolve l) r
-
-instance Resolve Absolute Path' Absolute where
-  resolve _ (AbsolutePath' a) = a
-  resolve a (RelativePath' r) = resolve a r
+instance Resolve Path' Path Path' where
+  resolve (AbsolutePath' l) r = AbsolutePath' (resolve l r)
+  resolve (RelativePath' l) r = RelativePath' (resolve l r)

--- a/parser-typechecker/src/Unison/Codebase/Path/Parse.hs
+++ b/parser-typechecker/src/Unison/Codebase/Path/Parse.hs
@@ -53,7 +53,7 @@ parseHashOrHQSplit' = runParser shortHashOrHQSplitP'
 parseHQSplit :: String -> Either Text (HQ'.HashQualified (Split Path))
 parseHQSplit s =
   parseHQSplit' s >>= traverse \(path, seg) -> case path of
-    RelativePath' (Relative p) -> pure (p, seg)
+    RelativePath' p -> pure (p, seg)
     AbsolutePath' (Absolute _) -> Left $ "Sorry, you can't use an absolute name like " <> Text.pack s <> " here."
 
 parseHQSplit' :: String -> Either Text (HQ'.HashQualified (Split Path'))

--- a/parser-typechecker/tests/Unison/Test/Codebase/Path.hs
+++ b/parser-typechecker/tests/Unison/Test/Codebase/Path.hs
@@ -4,7 +4,7 @@ module Unison.Test.Codebase.Path where
 
 import Data.Maybe (fromJust)
 import EasyTest
-import Unison.Codebase.Path (Path' (..), Relative (..))
+import Unison.Codebase.Path (Path' (..))
 import Unison.Codebase.Path qualified as Path
 import Unison.Codebase.Path.Parse (parseHQSplit', parseHashOrHQSplit')
 import Unison.HashQualifiedPrime qualified as HQ'
@@ -39,4 +39,4 @@ test =
     ]
 
 relative :: [Text] -> Path'
-relative = RelativePath' . Relative . Path.fromList . fmap NameSegment
+relative = RelativePath' . Path.fromList . fmap NameSegment

--- a/unison-cli/src/Unison/Cli/MonadUtils.hs
+++ b/unison-cli/src/Unison/Cli/MonadUtils.hs
@@ -288,7 +288,7 @@ getMaybeBranch0FromProjectPath pp =
   fmap Branch.head <$> getMaybeBranchFromProjectPath pp
 
 -- | Get the branch at a relative path, or return early if there's no such branch.
-expectBranchAtPath :: Path.Relative -> Cli (Branch IO)
+expectBranchAtPath :: Path -> Cli (Branch IO)
 expectBranchAtPath =
   expectBranchAtPath' . RelativePath'
 
@@ -304,7 +304,7 @@ expectBranch0AtPath' =
   fmap Branch.head . expectBranchAtPath'
 
 -- | Get the branch0 at a relative path, or return early if there's no such branch.
-expectBranch0AtPath :: Path.Relative -> Cli (Branch0 IO)
+expectBranch0AtPath :: Path -> Cli (Branch0 IO)
 expectBranch0AtPath =
   expectBranch0AtPath' . RelativePath'
 

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -910,7 +910,7 @@ inputDescription input =
     hhqs' = either (pure . SH.toText) hqs'
     hqs' :: HQ'.HashQualified (Path.Split Path') -> Cli Text
     hqs' = pure . HQ'.toTextWith (Path.toText . Path.unsplit)
-    hqs = hqs' . fmap (first $ Path.RelativePath' . Path.Relative)
+    hqs = hqs' . fmap (first Path.RelativePath')
     ps' = p' . Path.unsplit
     bid2 :: BranchId2 -> Cli Text
     bid2 = \case

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/DeleteNamespace.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/DeleteNamespace.hs
@@ -28,7 +28,7 @@ import Unison.PrettyPrintEnvDecl qualified as PPED
 import Unison.Referent qualified as Referent
 import Unison.Sqlite qualified as Sqlite
 
-handleDeleteNamespace :: Input -> Insistence -> Maybe (Path.Split Path.Relative) -> Cli ()
+handleDeleteNamespace :: Input -> Insistence -> Maybe (Path.Split Path.Path) -> Cli ()
 handleDeleteNamespace input insistence = \case
   Nothing -> do
     loopState <- State.get

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/MoveBranch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/MoveBranch.hs
@@ -28,8 +28,8 @@ moveBranchFunc hasConfirmed src' dest' = do
     let (changeRootPath, srcLoc, destLoc) = Path.longestPathPrefix srcAbs destAbs
     let doMove changeRoot =
           changeRoot
-            & Branch.modifyAt (Path.unrelative srcLoc) (const Branch.empty)
-            & Branch.modifyAt (Path.unrelative destLoc) (const srcBranch)
+            & Branch.modifyAt srcLoc (const Branch.empty)
+            & Branch.modifyAt destLoc (const srcBranch)
     if (destBranchExists && not isRootMove)
       then Cli.respond (MovedOverExistingBranch dest')
       else pure ()

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Tests.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Tests.hs
@@ -160,7 +160,7 @@ handleIOTest main = do
       refs
   Cli.respondNumbered $ TestResults Output.NewlyComputed suffixifiedPPE True True oks fails
 
-findTermsOfTypes :: Codebase.Codebase m Symbol Ann -> Bool -> Path.Relative -> NESet (Type.Type Symbol Ann) -> Cli (Set TermReferenceId)
+findTermsOfTypes :: Codebase.Codebase m Symbol Ann -> Bool -> Path.Path -> NESet (Type.Type Symbol Ann) -> Cli (Set TermReferenceId)
 findTermsOfTypes codebase includeLib path filterTypes = do
   branch <- Cli.expectBranch0AtPath path
 

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -150,7 +150,7 @@ data Input
   | DebugTypecheckedUnisonFileI
   | DeleteBranchI (ProjectAndBranch (Maybe ProjectName) ProjectBranchName)
   | DeleteI !Bool {- force? -} !DeleteTarget ![HQ'.HashQualified Name]
-  | DeleteNamespaceI Insistence (Maybe (Path.Split Path.Relative))
+  | DeleteNamespaceI Insistence (Maybe (Path.Split Path))
   | DeleteProjectI ProjectName
   | DiffBranchI !DiffBranchArg !DiffBranchArg
   | DiffNamespaceI BranchId2 BranchId2 -- old new
@@ -182,10 +182,10 @@ data Input
   | ListDependentsI (HQ.HashQualified Name)
   | LoadI (Maybe FilePath)
   | MakeStandaloneI String (HQ.HashQualified Name)
-  | MergeBuiltinsI (Maybe Path.Relative)
+  | MergeBuiltinsI (Maybe Path)
   | MergeCommitI
   | MergeI (ProjectAndBranch (Maybe ProjectName) ProjectBranchName)
-  | MergeIOBuiltinsI (Maybe Path.Relative)
+  | MergeIOBuiltinsI (Maybe Path)
   | MoveAllI Path.Path' Path.Path'
   | MoveBranchI Path.Path' Path.Path'
   | MoveTermI (HQ'.HashQualified (Path.Split Path')) (Path.Split Path')
@@ -281,7 +281,7 @@ data TestInput = TestInput
   { -- | Should we run tests in the `lib` namespace?
     includeLibNamespace :: Bool,
     -- | Relative path to run the tests in. Ignore if `includeLibNamespace` is True - that means test everything.
-    path :: Path.Relative,
+    path :: Path,
     showFailures :: Bool,
     showSuccesses :: Bool
   }

--- a/unison-cli/src/Unison/CommandLine/BranchRelativePath.hs
+++ b/unison-cli/src/Unison/CommandLine/BranchRelativePath.hs
@@ -187,7 +187,7 @@ incrementalBranchRelativePathParser =
       path' >>= \case
         Path.AbsolutePath' _ -> failureAt offset "Branch qualified paths don't require a leading '.'"
         -- Branch relative paths are written as relative paths, but are always absolute to the branch root
-        Path.RelativePath' (Path.Relative x) -> pure $ Path.Absolute x
+        Path.RelativePath' x -> pure $ Path.Absolute x
     path' = Megaparsec.try do
       offset <- Megaparsec.getOffset
       either (failureAt offset) pure . Path.parsePath' . Text.unpack =<< Megaparsec.takeRest

--- a/unison-cli/src/Unison/CommandLine/FZFResolvers.hs
+++ b/unison-cli/src/Unison/CommandLine/FZFResolvers.hs
@@ -93,7 +93,7 @@ typeDefinitionOptions = genericDefinitionOptions False True
 namespaceOptions :: OptionFetcher
 namespaceOptions _codebase _projCtx searchBranch0 = do
   let intoPath' :: Path -> Path'
-      intoPath' = Path.RelativePath' . Path.Relative
+      intoPath' = Path.RelativePath'
   searchBranch0
     & Branch.deepPaths
     & Set.delete mempty {- The current path just renders as an empty string which isn't a valid arg -}

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -500,16 +500,15 @@ handleNewPath = \case
   I.StructuredArg _sa -> Left $ "can’t use a numbered argument for a new namespace"
 
 -- | When only a relative name is allowed.
-handleSplitArg :: I.Argument -> Either (P.Pretty CT.ColorText) (Path.Split Path.Relative)
+handleSplitArg :: I.Argument -> Either (P.Pretty CT.ColorText) (Path.Split Path)
 handleSplitArg arg =
-  fmap (first Path.Relative) $
-    case arg of
-      I.RawArg raw -> first P.text . Path.parseSplit $ raw
-      I.StructuredArg sa ->
-        case sa of
-          SA.Name name | Name.isRelative name -> pure $ Path.splitFromName name
-          SA.NameWithBranchPrefix _ name | Name.isRelative name -> pure $ Path.splitFromName name
-          otherNumArg -> Left $ wrongStructuredArgument "a relative name" otherNumArg
+  case arg of
+    I.RawArg raw -> first P.text . Path.parseSplit $ raw
+    I.StructuredArg sa ->
+      case sa of
+        SA.Name name | Name.isRelative name -> pure $ Path.splitFromName name
+        SA.NameWithBranchPrefix _ name | Name.isRelative name -> pure $ Path.splitFromName name
+        otherNumArg -> Left $ wrongStructuredArgument "a relative name" otherNumArg
 
 handleSplit'Arg :: I.Argument -> Either (P.Pretty CT.ColorText) (Path.Split Path')
 handleSplit'Arg = fmap Path.parentOfName . handleNameArg
@@ -632,7 +631,7 @@ handleHashQualifiedSplitArg = \case
         . bitraverse
           ( \case
               Path.AbsolutePath' _ -> Left $ expectedButActually "a relative name" n "an absolute name"
-              Path.RelativePath' p -> pure $ Path.unrelative p
+              Path.RelativePath' p -> pure p
           )
           pure
         $ Path.parentOfName name
@@ -793,7 +792,7 @@ mergeBuiltins =
     "Adds the builtins (excluding `io` and misc) to the specified namespace. Defaults to `builtin.`"
     \case
       [] -> pure . Input.MergeBuiltinsI $ Nothing
-      p : _ -> Input.MergeBuiltinsI . pure . Path.Relative <$> handlePathArg p
+      p : _ -> Input.MergeBuiltinsI . pure <$> handlePathArg p
 
 mergeIOBuiltins :: InputPattern
 mergeIOBuiltins =
@@ -805,7 +804,7 @@ mergeIOBuiltins =
     "Adds all the builtins, including `io` and misc., to the specified namespace. Defaults to `builtin.`"
     \case
       [] -> pure . Input.MergeIOBuiltinsI $ Nothing
-      p : _ -> Input.MergeIOBuiltinsI . pure . Path.Relative <$> handlePathArg p
+      p : _ -> Input.MergeIOBuiltinsI . pure <$> handlePathArg p
 
 updateBuiltins :: InputPattern
 updateBuiltins =
@@ -1990,7 +1989,7 @@ pullImpl name aliases pullMode addendum = do
                 -- Oops we're ignoring the "pull mode" but `pull.without-history` shouldn't really be a `pull` anyway...
                 ( Right (RemoteRepo.ReadShare'ProjectBranch source),
                   Left _,
-                  Right (Path.RelativePath' (Path.Relative (Path.toList -> NameSegment.LibSegment : _)))
+                  Right (Path.RelativePath' (Path.toList -> NameSegment.LibSegment : _))
                   ) ->
                     case source of
                       This sourceProject -> Right (Input.LibInstallI True (ProjectAndBranch sourceProject Nothing))
@@ -3160,7 +3159,7 @@ test =
               Input.TestI
                 Input.TestInput
                   { includeLibNamespace = False,
-                    path = Path.Relative path,
+                    path = path,
                     showFailures = True,
                     showSuccesses = True
                   }

--- a/unison-cli/src/Unison/MCP/Tools.hs
+++ b/unison-cli/src/Unison/MCP/Tools.hs
@@ -670,8 +670,7 @@ deleteNamespaceTool =
           },
       toolArgType = Proxy,
       toolHandler = \(DeleteNamespaceToolArguments {projectContext, namespaceName, force}) -> handleToolError $ do
-        let (path, finalSegment) = Path.splitFromName namespaceName
-            split = (Path.Relative path, finalSegment)
+        let split = Path.splitFromName namespaceName
             insistence = if force then Input.Force else Input.Try
         output <- handleInputMCP projectContext [Right $ Input.DeleteNamespaceI insistence (Just split)]
         let outputJSON = Text.decodeUtf8 . BL.toStrict $ Aeson.encode output

--- a/unison-cli/src/Unison/MCP/Types.hs
+++ b/unison-cli/src/Unison/MCP/Types.hs
@@ -714,7 +714,7 @@ instance FromJSON ShareProjectSearchToolArguments where
 
 data TestToolArguments = TestToolArguments
   { projectContext :: ProjectContext,
-    subnamespace :: Maybe Path.Relative
+    subnamespace :: Maybe Path.Path
   }
   deriving (Eq, Show)
 
@@ -737,7 +737,7 @@ instance HasInputSchema TestToolArguments where
 instance FromJSON TestToolArguments where
   parseJSON = withObject "TestToolArguments" $ \o -> do
     projectContext <- o .: "projectContext"
-    subnamespace <- fmap (Path.Relative . Path.unsafeParseText) <$> (o .:? "subnamespace")
+    subnamespace <- fmap Path.unsafeParseText <$> (o .:? "subnamespace")
     pure $ TestToolArguments {projectContext, subnamespace}
 
 data DeleteDefinitionsToolArguments = DeleteDefinitionsToolArguments

--- a/unison-share-api/src/Unison/Server/Orphans.hs
+++ b/unison-share-api/src/Unison/Server/Orphans.hs
@@ -256,12 +256,6 @@ instance ToParamSchema Path.Path where
       & type_ ?~ OpenApiString
       & example ?~ Aeson.String "base.List"
 
-instance ToParamSchema Path.Relative where
-  toParamSchema _ =
-    mempty
-      & type_ ?~ OpenApiString
-      & example ?~ Aeson.String "base.List"
-
 instance ToParam (QueryParam "name" Name) where
   toParam _ =
     DocQueryParam
@@ -290,15 +284,6 @@ instance FromJSON ConstructorType where
     "Effect" -> pure CT.Effect
     _ -> fail $ "Invalid ConstructorType: " <> Text.unpack txt
 
-instance FromHttpApiData Path.Relative where
-  parseUrlPiece txt = case Path.parsePath' (Text.unpack txt) of
-    Left s -> Left s
-    Right (Path.RelativePath' p) -> Right p
-    Right (Path.AbsolutePath' _) -> Left $ "Expected relative path, but " <> txt <> " was absolute."
-
-instance ToHttpApiData Path.Relative where
-  toUrlPiece = tShow
-
 instance FromHttpApiData Path.Absolute where
   parseUrlPiece txt = case Path.parsePath' (Text.unpack txt) of
     Left s -> Left s
@@ -317,7 +302,7 @@ instance ToHttpApiData Path.Path' where
 instance FromHttpApiData Path.Path where
   parseUrlPiece txt = case Path.parsePath' (Text.unpack txt) of
     Left s -> Left s
-    Right (Path.RelativePath' p) -> Right (Path.unrelative p)
+    Right (Path.RelativePath' p) -> Right p
     Right (Path.AbsolutePath' _) -> Left $ "Expected relative path, but " <> txt <> " was absolute."
 
 instance ToHttpApiData Path.Path where

--- a/weeder.toml
+++ b/weeder.toml
@@ -267,8 +267,6 @@ roots = [
     '''^Unison\.Codebase\.Init\.Type\.Init$''',
     '''^Unison\.Codebase\.Init\.initCodebaseAndExit$''',
     '''^Unison\.Codebase\.Metadata\.delete$''',
-    '''^Unison\.Codebase\.Path\.relPath_$''',
-    '''^Unison\.Codebase\.Path\.isRelative$''',
     '''^Unison\.Codebase\.Path\.maybePrefix$''',
     '''^Unison\.Codebase\.Path\.toAbsoluteSplit$''',
     '''^Unison\.Codebase\.Path\.ancestors$''',


### PR DESCRIPTION
## Overview

I felt motivated to do a bit of cleanup in the `Path` module because it's a wild mess in there and was slowing me down. First up: I deleted the `Relative` newtype wrapper. This newtype doesn't add any additional information, since a lack of `Absolute` newtype wrapper communicates the same thing. If some code must use absolute paths for correctness, use `Absolute`, otherwise just use `Path`.