### PR TITLE
fix full type definition not being shown for new type defs in diff.update

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/DiffUpdate.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/DiffUpdate.hs
@@ -16,12 +16,11 @@ import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Branch qualified as Branch
 import Unison.Codebase.Branch.Names qualified as Branch
 import Unison.Codebase.Editor.Output qualified as Output
-import Unison.DataDeclaration (Decl, DeclOrBuiltin)
+import Unison.DataDeclaration (Decl)
 import Unison.DeclCoherencyCheck qualified as DeclCoherencyCheck
 import Unison.Name (Name)
 import Unison.Names (Names (Names))
 import Unison.Names qualified as Names
-import Unison.OrBuiltin (OrBuiltin (..))
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
 import Unison.PrettyPrintEnv.Names qualified as PPE
@@ -148,24 +147,6 @@ handleDiffUpdate = do
             )
             updatedTermRefIds
             updatedFileTerms
-
-  -- Get type declarations from the file (including reference IDs)
-  let fileDataDecls :: Map Name (DeclOrBuiltin Symbol Ann)
-      fileDataDecls =
-        Map.fromList
-          [ (Name.unsafeParseVar var, NotBuiltin (Right decl))
-            | (var, (_, decl)) <- Map.toList (UF.dataDeclarationsId' tuf)
-          ]
-
-  let fileEffectDecls :: Map Name (DeclOrBuiltin Symbol Ann)
-      fileEffectDecls =
-        Map.fromList
-          [ (Name.unsafeParseVar var, NotBuiltin (Left decl))
-            | (var, (_, decl)) <- Map.toList (UF.effectDeclarationsId' tuf)
-          ]
-
-  let fileTypeDecls :: Map Name (DeclOrBuiltin Symbol Ann)
-      fileTypeDecls = Map.union fileDataDecls fileEffectDecls
 
   -- File types with their reference IDs (for updated types rendering)
   let fileTypeDeclsWithRefIds :: Map Name (TypeReferenceId, Decl Symbol Ann)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/DiffUpdate.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/DiffUpdate.hs
@@ -178,8 +178,8 @@ handleDiffUpdate = do
                  | (var, (refId, decl)) <- Map.toList (UF.effectDeclarationsId' tuf)
                ]
 
-  let newTypes :: Map Name (DeclOrBuiltin Symbol Ann)
-      newTypes = Map.restrictKeys fileTypeDecls newTypeNames
+  let newTypes :: Map Name (TypeReferenceId, Decl Symbol Ann)
+      newTypes = Map.restrictKeys fileTypeDeclsWithRefIds newTypeNames
 
   -- Types from the file that are updates to existing codebase definitions
   let updatedFileTypes :: Map Name (TypeReferenceId, Decl Symbol Ann)

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -493,8 +493,8 @@ data Output
       !PPE.PrettyPrintEnvDecl
       -- PPE for old definitions (namespace names without file shadowing)
       !PPE.PrettyPrintEnvDecl
-      -- New definitions (terms with body and type, types with decl)
-      !(Defns (Map Name (Term Symbol Ann, Type Symbol Ann)) (Map Name (DeclOrBuiltin Symbol Ann)))
+      -- New definitions (terms with body and type, types with refId and decl)
+      !(Defns (Map Name (Term Symbol Ann, Type Symbol Ann)) (Map Name (TypeReferenceId, DD.Decl Symbol Ann)))
       -- Updated definitions: ((old term, old type), (new term, new type)) for terms,
       -- ((old refId, old decl), (new refId, new decl)) for types
       !(Defns (Map Name ((Term Symbol Ann, Type Symbol Ann), (Term Symbol Ann, Type Symbol Ann))) (Map Name ((TypeReferenceId, DD.Decl Symbol Ann), (TypeReferenceId, DD.Decl Symbol Ann))))

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -2696,7 +2696,6 @@ notifyUser dir issueFn = \case
             ]
   ShowUpdateDiff ppedNew ppedOld newDefns updatedDefns dependents -> do
     let ppe = PPED.suffixifiedPPE ppedNew
-    let colorAdd = P.green . ("+ " <>)
 
     -- Render new types with "+ " prefix on each line
     -- Similar to renderTerms, we render multiline text for full type definitions

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -2698,21 +2698,24 @@ notifyUser dir issueFn = \case
     let ppe = PPED.suffixifiedPPE ppedNew
     let colorAdd = P.green . ("+ " <>)
 
-    let renderTypes :: (Pretty -> Pretty) -> Map Name (DeclOrBuiltin Symbol Ann) -> Pretty
-        renderTypes colored types =
+    -- Render new types with "+ " prefix on each line
+    -- Similar to renderTerms, we render multiline text for full type definitions
+    let renderNewTypes :: Map Name (TypeReferenceId, DD.Decl Symbol Ann) -> Pretty
+        renderNewTypes types =
           types
             & Map.toList
             & sortAlphabeticallyOn (view _1)
             & map
-              ( \(name, decl) ->
-                  colored $
-                    P.syntaxToColor $
-                      DeclPrinter.prettyDeclOrBuiltinHeader
-                        DeclPrinter.RenderUniqueTypeGuids'No
-                        (HQ.fromName name)
-                        decl
+              ( \(name, (refId, decl)) ->
+                  let ref = Reference.fromId refId
+                      typeText =
+                        P.toPlain 80 $
+                          P.syntaxToColor $
+                            DeclPrinter.prettyDecl ppedNew DeclPrinter.RenderUniqueTypeGuids'No ref (HQ.fromName name) decl
+                      typeLines = Text.lines typeText
+                   in P.lines $ map (\line -> P.green $ P.text $ "+ " <> line) typeLines
               )
-            & P.lines
+            & P.sepNonEmpty "\n"
 
     -- Render new terms with "+ " prefix on each line
     -- Note: We use prettyBindingForDiff which renders multiline text with actual newlines
@@ -2813,7 +2816,7 @@ notifyUser dir issueFn = \case
                 then
                   P.linesNonEmpty
                     [ P.wrap "New definitions:",
-                      if Map.null newDefns.types then mempty else P.indentN 2 $ renderTypes colorAdd newDefns.types,
+                      if Map.null newDefns.types then mempty else P.indentN 2 $ renderNewTypes newDefns.types,
                       if Map.null newDefns.terms then mempty else P.indentN 2 $ renderTerms newDefns.terms
                     ]
                 else mempty,

--- a/unison-src/transcripts/idempotent/diff-update.md
+++ b/unison-src/transcripts/idempotent/diff-update.md
@@ -150,6 +150,74 @@ scratch/main> update
   Done.
 ```
 
+## Test diff.update with a new type
+
+Let's test adding a brand new type (not modifying an existing one) to see if diff.update
+shows the full type structure or just the type name:
+
+``` unison
+structural type Person = { name : Text, age : Nat }
+
+unique ability Counter where
+  increment : Nat
+  getCount : Nat
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  + ability Counter
+  + structural type Person
+
+  + Person.age         : Person -> Nat
+  + Person.age.modify  : (Nat ->{g} Nat) -> Person ->{g} Person
+  + Person.age.set     : Nat -> Person -> Person
+  + Person.name        : Person -> Text
+  + Person.name.modify : (Text ->{g} Text)
+                         -> Person
+                         ->{g} Person
+  + Person.name.set    : Text -> Person -> Person
+
+  Run `update` to apply these changes to your codebase.
+```
+
+Running `diff.update` should show the new type with its full structure:
+
+``` ucm
+scratch/main> diff.update
+
+  Preview of changes that would be made by `update`:
+
+  New definitions:
+    + ability Counter where
+    +   increment : {Counter} Nat
+    +   getCount : {Counter} Nat
+    + structural type Person = { name : Text, age : Nat }
+    + Person.age : Person -> Nat
+    + Person.age = cases Person _ age -> age
+    + Person.age.modify : (Nat ->{g} Nat) -> Person ->{g} Person
+    + Person.age.modify f = cases Person name age -> Person name (f age)
+    + Person.age.set : Nat -> Person -> Person
+    + Person.age.set age1 = cases Person name _ -> Person name age1
+    + Person.name : Person -> Text
+    + Person.name = cases Person name _ -> name
+    + Person.name.modify : (Text ->{g} Text) -> Person ->{g} Person
+    + Person.name.modify f = cases Person name age -> Person (f name) age
+    + Person.name.set : Text -> Person -> Person
+    + Person.name.set name1 = cases Person _ age -> Person name1 age
+
+  Run `update` to apply these changes.
+```
+
+``` ucm
+scratch/main> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+```
+
 ## Test diff.update with a modified type
 
 Let's add a type to the codebase:


### PR DESCRIPTION
## Overview

The `diff.update` command now shows the full structure of new types and abilities, not just their names.

**Before:**
```
New definitions:
  + ability Counter
  + structural type Person
```

**After:**
```
New definitions:
  + ability Counter where
  +   increment : {Counter} Nat
  +   getCount : {Counter} Nat
  + structural type Person = { name : Text, age : Nat }
```

This matches the behavior for updated types, which already showed their full structure with inline diffs.

## Implementation approach and notes

Changed `renderNewTypes` in `OutputMessages.hs` to use `DeclPrinter.prettyDecl` (full declaration rendering) instead of `DeclPrinter.prettyDeclOrBuiltinHeader` (header only). This required threading `TypeReferenceId` through from `DiffUpdate.hs` and updating the `ShowUpdateDiff` type in `Output.hs`.

## Test coverage

- [x] Added test case to `unison-src/transcripts/idempotent/diff-update.md` that covers new structural types and abilities

## Loose ends

None.

## Final checklist

- [x] PR title describes the change
- [x] Transcript demonstrates the changed behavior