### PR TITLE
diff.branch: include current branch in completion

### DIFF
--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -2448,7 +2448,7 @@ diffBranch =
                       ProjectBranchSuggestionsConfig
                         { showProjectCompletions = False,
                           projectInclusion = OnlyWithinCurrentProject,
-                          branchInclusion = ExcludeCurrentBranch
+                          branchInclusion = AllBranches
                         }
                in [ ("first branch", completion),
                     ("second branch", completion)


### PR DESCRIPTION
This addresses one of the two issues described in [#6044](https://github.com/unisonweb/unison/issues/6044).

Ideally `diff.branch` would also support a single-arg variant, which is tracked in [#6013](https://github.com/unisonweb/unison/issues/6013).
