### PR TITLE
Add Reflog and History MCP Tools

### DIFF
--- a/unison-cli/src/Unison/MCP/Tools.hs
+++ b/unison-cli/src/Unison/MCP/Tools.hs
@@ -14,7 +14,6 @@ import Data.Time.Format.ISO8601 (iso8601Show)
 import Text.RawString.QQ (r)
 import U.Codebase.HashTags (CausalHash (..))
 import U.Codebase.Sqlite.DbId (RemoteProjectId (..))
-import U.Codebase.Sqlite.HistoryComment (HistoryComment (..))
 import U.Codebase.Sqlite.ProjectReflog qualified as ProjectReflog
 import U.Codebase.Sqlite.Queries qualified as Q
 import Unison.Cli.MonadUtils qualified as Cli
@@ -22,7 +21,6 @@ import Unison.Cli.Share.Projects qualified as Share.Projects
 import Unison.Cli.Share.Projects.Types (RemoteProject (..))
 import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Branch qualified as Branch
-import Unison.Codebase.Causal qualified as Causal
 import Unison.Codebase.Editor.HandleInput.InstallLib (handleInstallLib)
 import Unison.Codebase.Editor.Input (Event (..), FindScope (..), Input (..))
 import Unison.Codebase.Editor.Input qualified as Input
@@ -40,7 +38,6 @@ import Unison.MCP.Types
 import Unison.MCP.Wrapper
 import Unison.MCP.Wrapper qualified as MCPWrapper
 import Unison.NameSegment qualified as NameSegment
-import Unison.NamesWithHistory qualified as Names
 import Unison.Prelude (fromMaybe, into, readUtf8)
 import Unison.Project (ProjectBranchNameOrLatestRelease (..))
 import Unison.Syntax.NameSegment qualified as NameSegment

--- a/unison-cli/src/Unison/MCP/Tools.hs
+++ b/unison-cli/src/Unison/MCP/Tools.hs
@@ -10,19 +10,26 @@ import Data.List.NonEmpty qualified as NEL
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
+import Data.Time.Format.ISO8601 (iso8601Show)
 import Text.RawString.QQ (r)
+import U.Codebase.HashTags (CausalHash (..))
 import U.Codebase.Sqlite.DbId (RemoteProjectId (..))
+import U.Codebase.Sqlite.HistoryComment (HistoryComment (..))
+import U.Codebase.Sqlite.ProjectReflog qualified as ProjectReflog
+import U.Codebase.Sqlite.Queries qualified as Q
 import Unison.Cli.MonadUtils qualified as Cli
 import Unison.Cli.Share.Projects qualified as Share.Projects
 import Unison.Cli.Share.Projects.Types (RemoteProject (..))
 import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Branch qualified as Branch
+import Unison.Codebase.Causal qualified as Causal
 import Unison.Codebase.Editor.HandleInput.InstallLib (handleInstallLib)
 import Unison.Codebase.Editor.Input (Event (..), FindScope (..), Input (..))
 import Unison.Codebase.Editor.Input qualified as Input
 import Unison.Codebase.Path qualified as Path
 import Unison.Codebase.ProjectPath
 import Unison.Codebase.Runtime.Profile (ProfileSpec (..))
+import Unison.Codebase.ShortCausalHash qualified as SCH
 import Unison.Core.Project (ProjectBranchName (..), ProjectName (..))
 import Unison.HashQualified qualified as HQ
 import Unison.HashQualifiedPrime qualified as HQ'
@@ -33,7 +40,8 @@ import Unison.MCP.Types
 import Unison.MCP.Wrapper
 import Unison.MCP.Wrapper qualified as MCPWrapper
 import Unison.NameSegment qualified as NameSegment
-import Unison.Prelude (into, readUtf8)
+import Unison.NamesWithHistory qualified as Names
+import Unison.Prelude (fromMaybe, into, readUtf8)
 import Unison.Project (ProjectBranchNameOrLatestRelease (..))
 import Unison.Syntax.NameSegment qualified as NameSegment
 import Unison.Util.Relation qualified as R
@@ -71,7 +79,9 @@ tools =
     renameDefinitionTool,
     moveDefinitionTool,
     moveToTool,
-    deleteNamespaceTool
+    deleteNamespaceTool,
+    reflogTool,
+    historyTool
   ]
 
 currentProjectContext :: (MonadIO m, MonadReader Env m) => m ProjectContext
@@ -711,6 +721,92 @@ deleteNamespaceTool =
         let split = Path.splitFromName namespaceName
             insistence = if force then Input.Force else Input.Try
         output <- handleInputMCP projectContext [Right $ Input.DeleteNamespaceI insistence (Just split)]
+        let outputJSON = Text.decodeUtf8 . BL.toStrict $ Aeson.encode output
+        pure $ textToolResult outputJSON
+    }
+
+reflogTool :: Tool MCP
+reflogTool =
+  Tool
+    { toolName = toToolName ReflogTool,
+      toolDescription = "Get the reflog (history of branch state changes) for a project or branch. Returns structured data about recent changes.",
+      toolAnnotations =
+        ToolAnnotations
+          { title = Just "Reflog",
+            readOnlyHint = Just True,
+            destructiveHint = Just False,
+            idempotentHint = Just True,
+            openWorldHint = Just False
+          },
+      toolArgType = Proxy,
+      toolHandler = \(ReflogToolArguments {projectContext, scope, limit}) -> handleToolError $ do
+        let limitVal = fromMaybe 100 limit
+            scopeVal = fromMaybe "branch" scope
+        Env {codebase} <- ask
+
+        -- Resolve project and branch from context
+        let projName = projectContext.projectName
+            branchName = projectContext.branchName
+
+        entries <- liftIO $ Codebase.runTransaction codebase $ do
+          schLength <- Codebase.branchHashLength
+          mayProject <- Q.loadProjectByName projName
+          case mayProject of
+            Nothing -> pure []
+            Just project -> do
+              mayBranch <- Q.loadProjectBranchByName project.projectId branchName
+              rawEntries <- case scopeVal of
+                "global" -> Codebase.getGlobalReflog (limitVal + 1)
+                "project" -> Codebase.getProjectReflog (limitVal + 1) project.projectId
+                _ -> case mayBranch of
+                  Nothing -> pure []
+                  Just branch -> Codebase.getProjectBranchReflog (limitVal + 1) branch.branchId
+              -- Convert entries to JSON-friendly format
+              pure $ map (reflogEntryToJSON schLength) rawEntries
+
+        let hasMore = length entries > limitVal
+            finalEntries = take limitVal entries
+            response =
+              Aeson.object
+                [ "entries" Aeson..= finalEntries,
+                  "hasMore" Aeson..= hasMore
+                ]
+        pure $ textToolResult $ Text.decodeUtf8 . BL.toStrict $ Aeson.encode response
+    }
+
+reflogEntryToJSON :: Int -> ProjectReflog.Entry Project ProjectBranch CausalHash -> Aeson.Value
+reflogEntryToJSON schLength entry =
+  Aeson.object
+    [ "project" Aeson..= (into @Text $ entry.project.name),
+      "branch" Aeson..= (into @Text $ entry.branch.name),
+      "time" Aeson..= iso8601Show entry.time,
+      "fromHash" Aeson..= fmap (("#" <>) . SCH.toText . SCH.fromHash schLength) entry.fromRootCausalHash,
+      "toHash" Aeson..= (("#" <>) . SCH.toText . SCH.fromHash schLength $ entry.toRootCausalHash),
+      "reason" Aeson..= entry.reason
+    ]
+
+historyTool :: Tool MCP
+historyTool =
+  Tool
+    { toolName = toToolName HistoryTool,
+      toolDescription = "Get the causal history of a branch, showing changes over time. Returns structured data about commits and diffs.",
+      toolAnnotations =
+        ToolAnnotations
+          { title = Just "History",
+            readOnlyHint = Just True,
+            destructiveHint = Just False,
+            idempotentHint = Just True,
+            openWorldHint = Just False
+          },
+      toolArgType = Proxy,
+      toolHandler = \(HistoryToolArguments {projectContext, startHash, limit, diffLimit}) -> handleToolError $ do
+        -- Build the BranchId from startHash or use the current branch (root path)
+        branchId <- case startHash of
+          Just hash -> case SCH.fromText hash of
+            Just sch -> pure $ Input.BranchAtSCH sch
+            Nothing -> throwError $ "Invalid causal hash: " <> hash
+          Nothing -> pure $ Input.BranchAtPath Path.Current'
+        output <- handleInputMCP projectContext [Right $ Input.HistoryI limit diffLimit branchId]
         let outputJSON = Text.decodeUtf8 . BL.toStrict $ Aeson.encode output
         pure $ textToolResult outputJSON
     }

--- a/unison-cli/src/Unison/MCP/Tools.hs
+++ b/unison-cli/src/Unison/MCP/Tools.hs
@@ -736,9 +736,10 @@ reflogTool =
             openWorldHint = Just False
           },
       toolArgType = Proxy,
-      toolHandler = \(ReflogToolArguments {projectContext, scope, limit}) -> handleToolError $ do
+      toolHandler = \(ReflogToolArguments {projectContext, scope, limit, includeTimestamps}) -> handleToolError $ do
         let limitVal = fromMaybe 100 limit
             scopeVal = fromMaybe "branch" scope
+            includeTs = fromMaybe True includeTimestamps
         Env {codebase} <- ask
 
         -- Resolve project and branch from context
@@ -759,7 +760,7 @@ reflogTool =
                   Nothing -> pure []
                   Just branch -> Codebase.getProjectBranchReflog (limitVal + 1) branch.branchId
               -- Convert entries to JSON-friendly format
-              pure $ map (reflogEntryToJSON schLength) rawEntries
+              pure $ map (reflogEntryToJSON includeTs schLength) rawEntries
 
         let hasMore = length entries > limitVal
             finalEntries = take limitVal entries
@@ -771,16 +772,16 @@ reflogTool =
         pure $ textToolResult $ Text.decodeUtf8 . BL.toStrict $ Aeson.encode response
     }
 
-reflogEntryToJSON :: Int -> ProjectReflog.Entry Project ProjectBranch CausalHash -> Aeson.Value
-reflogEntryToJSON schLength entry =
-  Aeson.object
+reflogEntryToJSON :: Bool -> Int -> ProjectReflog.Entry Project ProjectBranch CausalHash -> Aeson.Value
+reflogEntryToJSON includeTimestamps schLength entry =
+  Aeson.object $
     [ "project" Aeson..= (into @Text $ entry.project.name),
       "branch" Aeson..= (into @Text $ entry.branch.name),
-      "time" Aeson..= iso8601Show entry.time,
       "fromHash" Aeson..= fmap (("#" <>) . SCH.toText . SCH.fromHash schLength) entry.fromRootCausalHash,
       "toHash" Aeson..= (("#" <>) . SCH.toText . SCH.fromHash schLength $ entry.toRootCausalHash),
       "reason" Aeson..= entry.reason
     ]
+      <> ["time" Aeson..= iso8601Show entry.time | includeTimestamps]
 
 historyTool :: Tool MCP
 historyTool =

--- a/unison-cli/src/Unison/MCP/Types.hs
+++ b/unison-cli/src/Unison/MCP/Types.hs
@@ -29,6 +29,8 @@ module Unison.MCP.Types
     MoveDefinitionToolArguments (..),
     MoveToToolArguments (..),
     DeleteNamespaceToolArguments (..),
+    ReflogToolArguments (..),
+    HistoryToolArguments (..),
     toToolName,
     fromToolName,
   )
@@ -100,6 +102,8 @@ data ToolKind
   | MoveToTool
   | DeleteNamespaceTool
   | DiffUpdateTool
+  | ReflogTool
+  | HistoryTool
   deriving (Eq, Ord, Show, Bounded, Enum)
 
 kindNameMapping :: Map ToolKind Text
@@ -131,7 +135,9 @@ kindNameMapping =
       (MoveDefinitionTool, "move-definition"),
       (MoveToTool, "move-to"),
       (DeleteNamespaceTool, "delete-namespace"),
-      (DiffUpdateTool, "diff-update")
+      (DiffUpdateTool, "diff-update"),
+      (ReflogTool, "reflog"),
+      (HistoryTool, "history")
     ]
 
 data ProjectDefinitionNameArgument = ProjectDefinitionNameArgument
@@ -949,6 +955,86 @@ instance FromJSON DeleteNamespaceToolArguments where
     namespaceName <- Name.unsafeParseText <$> o .: "namespaceName"
     force <- o .:? "force" .!= False
     pure $ DeleteNamespaceToolArguments {projectContext, namespaceName, force}
+
+-- | Arguments for the reflog tool
+data ReflogToolArguments = ReflogToolArguments
+  { projectContext :: ProjectContext,
+    scope :: Maybe Text, -- "branch" | "project" | "global", default "branch"
+    limit :: Maybe Int
+  }
+  deriving (Eq, Show)
+
+instance HasInputSchema ReflogToolArguments where
+  toInputSchema _ =
+    object
+      [ "type" .= ("object" :: Text),
+        "properties"
+          .= object
+            [ "projectContext" .= toInputSchema (Proxy :: Proxy ProjectContext),
+              "scope"
+                .= object
+                  [ "type" .= ("string" :: Text),
+                    "enum" .= (["branch", "project", "global"] :: [Text]),
+                    "description" .= ("The scope of the reflog: 'branch' (default) shows entries for the current branch, 'project' shows entries for all branches in the project, 'global' shows entries for all projects." :: Text)
+                  ],
+              "limit"
+                .= object
+                  [ "type" .= ("integer" :: Text),
+                    "description" .= ("Maximum number of entries to return. Default is 100." :: Text)
+                  ]
+            ],
+        "required" .= ["projectContext" :: Text]
+      ]
+
+instance FromJSON ReflogToolArguments where
+  parseJSON = withObject "ReflogToolArguments" $ \o -> do
+    projectContext <- o .: "projectContext"
+    scope <- o .:? "scope"
+    limit <- o .:? "limit"
+    pure $ ReflogToolArguments {projectContext, scope, limit}
+
+-- | Arguments for the history tool
+data HistoryToolArguments = HistoryToolArguments
+  { projectContext :: ProjectContext,
+    startHash :: Maybe Text, -- optional starting causal hash
+    limit :: Maybe Int,
+    diffLimit :: Maybe Int
+  }
+  deriving (Eq, Show)
+
+instance HasInputSchema HistoryToolArguments where
+  toInputSchema _ =
+    object
+      [ "type" .= ("object" :: Text),
+        "properties"
+          .= object
+            [ "projectContext" .= toInputSchema (Proxy :: Proxy ProjectContext),
+              "startHash"
+                .= object
+                  [ "type" .= ("string" :: Text),
+                    "description" .= ("Optional causal hash to start history from. If not provided, starts from the current branch head." :: Text)
+                  ],
+              "limit"
+                .= object
+                  [ "type" .= ("integer" :: Text),
+                    "description" .= ("Maximum number of history entries to return. Default is 100." :: Text)
+                  ],
+              "diffLimit"
+                .= object
+                  [ "type" .= ("integer" :: Text),
+                    "description" .= ("Maximum number of diff elements to show per entry. Default is 10." :: Text)
+                  ]
+            ],
+        "required" .= ["projectContext" :: Text]
+      ]
+
+instance FromJSON HistoryToolArguments where
+  parseJSON = withObject "HistoryToolArguments" $ \o -> do
+    projectContext <- o .: "projectContext"
+    startHash <- o .:? "startHash"
+    limit <- o .:? "limit"
+    diffLimit <- o .:? "diffLimit"
+    pure $ HistoryToolArguments {projectContext, startHash, limit, diffLimit}
 
 nameKindMapping :: Map Text ToolKind
 nameKindMapping =

--- a/unison-cli/src/Unison/MCP/Types.hs
+++ b/unison-cli/src/Unison/MCP/Types.hs
@@ -960,7 +960,8 @@ instance FromJSON DeleteNamespaceToolArguments where
 data ReflogToolArguments = ReflogToolArguments
   { projectContext :: ProjectContext,
     scope :: Maybe Text, -- "branch" | "project" | "global", default "branch"
-    limit :: Maybe Int
+    limit :: Maybe Int,
+    includeTimestamps :: Maybe Bool -- default True
   }
   deriving (Eq, Show)
 
@@ -981,6 +982,11 @@ instance HasInputSchema ReflogToolArguments where
                 .= object
                   [ "type" .= ("integer" :: Text),
                     "description" .= ("Maximum number of entries to return. Default is 100." :: Text)
+                  ],
+              "includeTimestamps"
+                .= object
+                  [ "type" .= ("boolean" :: Text),
+                    "description" .= ("Whether to include timestamps in the output. Default is true." :: Text)
                   ]
             ],
         "required" .= ["projectContext" :: Text]
@@ -991,7 +997,8 @@ instance FromJSON ReflogToolArguments where
     projectContext <- o .: "projectContext"
     scope <- o .:? "scope"
     limit <- o .:? "limit"
-    pure $ ReflogToolArguments {projectContext, scope, limit}
+    includeTimestamps <- o .:? "includeTimestamps"
+    pure $ ReflogToolArguments {projectContext, scope, limit, includeTimestamps}
 
 -- | Arguments for the history tool
 data HistoryToolArguments = HistoryToolArguments

--- a/unison-src/transcripts/idempotent/mcp.md
+++ b/unison-src/transcripts/idempotent/mcp.md
@@ -878,7 +878,7 @@ RESPONSE:
       "result": {
           "content": [
               {
-                  "text": "{\"entries\":[{\"branch\":\"reflog-test\",\"fromHash\":\"#btddbo4t1j\",\"project\":\"scratch\",\"reason\":\"update\",\"toHash\":\"#6bknb5j9uv\"},{\"branch\":\"reflog-test\",\"fromHash\":\"#sg60bvjo91\",\"project\":\"scratch\",\"reason\":\"builtins.merge scratch/reflog-test:lib.builtins\",\"toHash\":\"#btddbo4t1j\"},{\"branch\":\"reflog-test\",\"fromHash\":null,\"project\":\"scratch\",\"reason\":\"Branch Created\",\"toHash\":\"#sg60bvjo91\"}],\"hasMore\":false}",
+                  "text": "{\"entries\":[{\"branch\":\"reflog-test\",\"fromHash\":\"#2rdi4drjr4\",\"project\":\"scratch\",\"reason\":\"update\",\"toHash\":\"#fihb62nh02\"},{\"branch\":\"reflog-test\",\"fromHash\":\"#sg60bvjo91\",\"project\":\"scratch\",\"reason\":\"builtins.merge scratch/reflog-test:lib.builtins\",\"toHash\":\"#2rdi4drjr4\"},{\"branch\":\"reflog-test\",\"fromHash\":null,\"project\":\"scratch\",\"reason\":\"Branch Created\",\"toHash\":\"#sg60bvjo91\"}],\"hasMore\":false}",
                   "type": "text"
               }
           ],
@@ -916,7 +916,7 @@ RESPONSE:
       "result": {
           "content": [
               {
-                  "text": "{\"errorMessages\":[],\"outputMessages\":[\"Note: The most recent namespace hash is immediately below this message.\\n\\nâ 1. #6bknb5j9uv\\n\\n  + Adds / updates:\\n  \\n    reflogTestTerm\\n\\nâ¡ 2. #btddbo4t1j (start of history)\"],\"sourceCodeUpdates\":[],\"stderr\":\"\",\"stdout\":\"\"}",
+                  "text": "{\"errorMessages\":[],\"outputMessages\":[\"Note: The most recent namespace hash is immediately below this message.\\n\\nâ 1. #fihb62nh02\\n\\n  + Adds / updates:\\n  \\n    reflogTestTerm\\n\\nâ¡ 2. #2rdi4drjr4 (start of history)\"],\"sourceCodeUpdates\":[],\"stderr\":\"\",\"stdout\":\"\"}",
                   "type": "text"
               }
           ],

--- a/unison-src/transcripts/idempotent/mcp.md
+++ b/unison-src/transcripts/idempotent/mcp.md
@@ -824,3 +824,104 @@ RESPONSE:
   }
 
 ```
+
+## reflog
+
+First, set up a branch with some changes to create reflog entries:
+
+``` ucm
+scratch/reflog-test> builtins.merge lib.builtins
+
+  Done.
+```
+
+``` unison :hide
+reflogTestTerm = 1
+```
+
+``` ucm
+scratch/reflog-test> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+```
+
+Now get the reflog:
+
+``` api
+POST /mcp
+BODY:
+  {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "reflog",
+      "arguments": {
+        "projectContext": {
+          "projectName": "scratch",
+          "branchName": "reflog-test"
+        },
+        "scope": "branch",
+        "limit": 5,
+        "includeTimestamps": false
+      }
+    }
+  }
+
+RESPONSE:
+  {
+      "id": 1,
+      "jsonrpc": "2.0",
+      "result": {
+          "content": [
+              {
+                  "text": "{\"entries\":[{\"branch\":\"reflog-test\",\"fromHash\":\"#btddbo4t1j\",\"project\":\"scratch\",\"reason\":\"update\",\"toHash\":\"#6bknb5j9uv\"},{\"branch\":\"reflog-test\",\"fromHash\":\"#sg60bvjo91\",\"project\":\"scratch\",\"reason\":\"builtins.merge scratch/reflog-test:lib.builtins\",\"toHash\":\"#btddbo4t1j\"},{\"branch\":\"reflog-test\",\"fromHash\":null,\"project\":\"scratch\",\"reason\":\"Branch Created\",\"toHash\":\"#sg60bvjo91\"}],\"hasMore\":false}",
+                  "type": "text"
+              }
+          ],
+          "isError": false
+      }
+  }
+
+```
+
+## history
+
+``` api
+POST /mcp
+BODY:
+  {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "history",
+      "arguments": {
+        "projectContext": {
+          "projectName": "scratch",
+          "branchName": "reflog-test"
+        },
+        "limit": 5
+      }
+    }
+  }
+
+RESPONSE:
+  {
+      "id": 1,
+      "jsonrpc": "2.0",
+      "result": {
+          "content": [
+              {
+                  "text": "{\"errorMessages\":[],\"outputMessages\":[\"Note: The most recent namespace hash is immediately below this message.\\n\\nâ 1. #6bknb5j9uv\\n\\n  + Adds / updates:\\n  \\n    reflogTestTerm\\n\\nâ¡ 2. #btddbo4t1j (start of history)\"],\"sourceCodeUpdates\":[],\"stderr\":\"\",\"stdout\":\"\"}",
+                  "type": "text"
+              }
+          ],
+          "isError": false
+      }
+  }
+
+```


### PR DESCRIPTION
## Overview

Adds two new MCP tools to expose Unison's reflog and history functionality to AI agents:

- `reflog` - Get branch state change history (wraps UCM `reflog` command)
- `history` - Get causal history with diffs (wraps UCM `history` command)

**reflog tool arguments:**
```json
{
  "projectContext": { "projectName": "@user/project", "branchName": "main" },
  "scope": "branch" | "project" | "global",  // optional, default "branch"
  "limit": 100   // optional, default 100
}
```

**history tool arguments:**
```json
{
  "projectContext": { "projectName": "@user/project", "branchName": "main" },
  "startHash": "#abc123...",  // optional
  "limit": 100,               // optional, uses UCM history default
  "diffLimit": 10             // optional, uses UCM history default
}
```

## Implementation notes

- **reflogTool**: Uses `Codebase.getProjectBranchReflog`, `getProjectReflog`, and `getGlobalReflog` - same functions as UCM reflog command. Returns structured JSON.

- **historyTool**: Uses `handleInputMCP` with `Input.HistoryI` - same handler as UCM history command. Returns UCM-formatted text output.

- **No core file modifications**: Only added code to `MCP/Types.hs` and `MCP/Tools.hs`.

## Test coverage

Tested manually via MCP tool invocations on a local project after restarting the unison mcp server from claude code.