### PR TITLE
improve ambiguous `run` error message

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/MainTerm.hs
+++ b/parser-typechecker/src/Unison/Codebase/MainTerm.hs
@@ -17,6 +17,7 @@ import Data.Set.NonEmpty qualified as NESet
 import Unison.Builtin.Decls qualified as DD
 import Unison.HashQualified qualified as HQ
 import Unison.Name (Name)
+import Unison.Name qualified as Name
 import Unison.Names qualified as Names
 import Unison.Parser.Ann (Ann)
 import Unison.Parser.Ann qualified as Parser.Ann
@@ -57,10 +58,11 @@ getMainTerm loadTypeOfTerm parseNames mainName mainType = do
   let allReferents :: [(Name, Referent)]
       allReferents =
         Relation.toList $
-          HQ.filterBySuffix
-            Referent.toShortHash
-            mainName
-            (Names.terms parseNames)
+          Name.keepHighestPriority $
+            HQ.filterBySuffix
+              Referent.toShortHash
+              mainName
+              (Names.terms parseNames)
 
   -- Keep only the terms (throwing away constructors)
   allTermReferences :: [(Name, TermReference, Type v Ann)] <-

--- a/parser-typechecker/src/Unison/Codebase/MainTerm.hs
+++ b/parser-typechecker/src/Unison/Codebase/MainTerm.hs
@@ -1,8 +1,16 @@
 {-# LANGUAGE PartialTypeSignatures #-}
 
 -- | Find a computation of type '{IO} () in the codebase.
-module Unison.Codebase.MainTerm where
+module Unison.Codebase.MainTerm
+  ( MainTerm (..),
+    getMainTerm,
+    builtinIOTestTypes,
+    builtinMain,
+    builtinMainWithResultType,
+  )
+where
 
+import Control.Lens (mapped, _1)
 import Data.List.NonEmpty qualified as NEList
 import Data.Set.NonEmpty (NESet)
 import Data.Set.NonEmpty qualified as NESet
@@ -10,24 +18,32 @@ import Unison.Builtin.Decls qualified as DD
 import Unison.HashQualified qualified as HQ
 import Unison.Name (Name)
 import Unison.Names qualified as Names
-import Unison.NamesWithHistory qualified as Names
 import Unison.Parser.Ann (Ann)
 import Unison.Parser.Ann qualified as Parser.Ann
 import Unison.Prelude
 import Unison.Reference (Reference, TermReference)
+import Unison.Referent (Referent)
 import Unison.Referent qualified as Referent
 import Unison.Term (Term)
 import Unison.Term qualified as Term
 import Unison.Type (Type)
 import Unison.Type qualified as Type
 import Unison.Typechecker qualified as Typechecker
+import Unison.Util.Relation qualified as Relation
 import Unison.Var (Var)
 import Unison.Var qualified as Var
 
 data MainTerm v
-  = NotFound (HQ.HashQualified Name)
-  | BadType (HQ.HashQualified Name) (Maybe (Type v Ann))
-  | Success (HQ.HashQualified Name) TermReference (Term v Ann) (Type v Ann)
+  = -- No terms were found with this name
+    NotFound
+  | -- 1 or more terms were found with this name, but none of them have the right type
+    -- Invariant: list is not empty
+    BadType [(HQ.HashQualified Name, TermReference, Type v Ann)]
+  | -- 2 or more terms were found with this name, and of those, 2 or more have the right type
+    -- Invariant: length of list is >= 2
+    Ambiguous [(HQ.HashQualified Name, TermReference, Type v Ann)]
+  | -- 1 or more terms were found with this name, and exactly 1 has the right type
+    Success (HQ.HashQualified Name) TermReference (Term v Ann) (Type v Ann)
 
 getMainTerm ::
   (Monad m, Var v) =>
@@ -37,21 +53,42 @@ getMainTerm ::
   Type.Type v Ann ->
   m (MainTerm v)
 getMainTerm loadTypeOfTerm parseNames mainName mainType = do
-  let refs = Names.lookupHQTerm Names.IncludeSuffixes mainName parseNames
-  let a = Parser.Ann.External
-  case toList refs of
-    [] -> pure (NotFound mainName)
-    [Referent.Ref ref] -> do
-      typ <- loadTypeOfTerm ref
-      case typ of
-        Just typ ->
-          if Typechecker.fitsScheme typ mainType
-            then do
-              let tm = DD.forceTerm a a (Term.ref a ref)
-              return (Success mainName ref tm typ)
-            else pure (BadType mainName $ Just typ)
-        _ -> pure (BadType mainName Nothing)
-    _ -> pure (error "multiple matching refs") -- TODO: make a real exception
+  -- Get all terms and constructors referred to by that name
+  let allReferents :: [(Name, Referent)]
+      allReferents =
+        Relation.toList $
+          HQ.filterBySuffix
+            Referent.toShortHash
+            mainName
+            (Names.terms parseNames)
+
+  -- Keep only the terms (throwing away constructors)
+  allTermReferences :: [(Name, TermReference, Type v Ann)] <-
+    allReferents & mapMaybeM \case
+      (name, Referent.Ref ref) -> do
+        loadTypeOfTerm ref <&> \case
+          Just ty -> Just (name, ref, ty)
+          -- this shouldn't really happen
+          Nothing -> Nothing
+      _ -> pure Nothing
+
+  -- Keep only the terms that are of the right 'main' type
+  let allTermReferencesThatCouldBeRun :: [(Name, TermReference, Type v Ann)]
+      allTermReferencesThatCouldBeRun =
+        filter
+          (\(_, _, ty) -> Typechecker.fitsScheme ty mainType)
+          allTermReferences
+
+  pure case allTermReferencesThatCouldBeRun of
+    [(name, ref, ty)] ->
+      let a = Parser.Ann.External
+          tm = DD.forceTerm a a (Term.ref a ref)
+       in Success (mainName $> name) ref tm ty
+    [] ->
+      case allTermReferences of
+        [] -> NotFound
+        _ -> BadType (over (mapped . _1) (mainName $>) allTermReferences)
+    _ -> Ambiguous (over (mapped . _1) (mainName $>) allTermReferencesThatCouldBeRun)
 
 -- forall x. '{ io2.IO, Exception } x
 builtinMain :: (Var v) => a -> Type.Type v a

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1151,7 +1151,10 @@ searchBranchScored names0 score queries =
 doCompile :: Bool -> String -> HQ.HashQualified Name -> Cli ()
 doCompile profile output main = do
   Cli.Env {codebase, runtime} <- ask
-  (ref, ppe) <- resolveMainRef main
+  (_, ref, _, _) <- resolveMainRef "compile" main
+  names <- Cli.currentNames
+  let pped = PPED.makePPED (PPE.hqNamer 10 names) (PPE.suffixifyByHash names)
+  let ppe = pped.suffixifiedPPE
   let codeLookup = () <$ Codebase.codebaseToCodeLookup codebase
       outf = output <> ".uc"
       copts = Runtime.defaultCompileOpts {Runtime.profile = profile}

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Run.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Run.hs
@@ -29,8 +29,8 @@ import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Branch qualified as Branch
 import Unison.Codebase.Branch.Names qualified as Branch
 import Unison.Codebase.Editor.HandleInput.Load (EvalMode (..), evalUnisonFile)
+import Unison.Codebase.Editor.HandleInput.TermResolution (resolveMainRef)
 import Unison.Codebase.Editor.Output qualified as Output
-import Unison.Codebase.MainTerm qualified as MainTerm
 import Unison.Codebase.Runtime qualified as Runtime
 import Unison.Codebase.Runtime.Profile (ProfileSpec (..))
 import Unison.Hash qualified as Hash
@@ -104,72 +104,51 @@ handleRun prof main args = do
     bonk (_, (_ann, watchKind, _id, _term0, term1, _isCacheHit)) =
       (watchKind, term1)
 
-data GetTermResult
-  = NoTermWithThatName
-  | TermHasBadType (Type Symbol Ann)
-  | GetTermSuccess (Symbol, Term Symbol Ann, Type Symbol Ann, Type Symbol Ann, Maybe TermReference)
-
 -- | Look up runnable term with the given name in the codebase or
 -- latest typechecked unison file. Return its symbol, term, type, and
 -- the type of the evaluated term, and whether it was found in the codebase (Just ref) or file (Nothing)
 getTerm :: HQ.HashQualified Name -> Cli (Symbol, Term Symbol Ann, Type Symbol Ann, Type Symbol Ann, Maybe TermReference)
-getTerm main =
-  getTerm' main >>= \case
-    NoTermWithThatName -> do
-      mainType <- Runtime.mainType <$> view #runtime
-      names <- Cli.currentNames
-      let pped = PPED.makePPED (PPE.hqNamer 10 names) (PPE.suffixifyByHash names)
-      let suffixifiedPPE = PPED.suffixifiedPPE pped
-      Cli.returnEarly $ Output.NoMainFunction main suffixifiedPPE [mainType]
-    TermHasBadType ty -> do
-      mainType <- Runtime.mainType <$> view #runtime
-      names <- Cli.currentNames
-      let pped = PPED.makePPED (PPE.hqNamer 10 names) (PPE.suffixifyByHash names)
-      let suffixifiedPPE = PPED.suffixifiedPPE pped
-      Cli.returnEarly $ Output.BadMainFunction "run" main ty suffixifiedPPE [mainType]
-    GetTermSuccess x -> pure x
-
-getTerm' :: HQ.HashQualified Name -> Cli GetTermResult
-getTerm' mainName =
+getTerm mainName =
   let getFromCodebase = do
-        Cli.Env {codebase, runtime} <- ask
-        names <- Cli.currentNames
-        let loadTypeOfTerm ref = Cli.runTransaction (Codebase.getTypeOfTerm codebase ref)
-        mainToFile
-          =<< MainTerm.getMainTerm loadTypeOfTerm names mainName (Runtime.mainType runtime)
-        where
-          mainToFile (MainTerm.NotFound _) = pure NoTermWithThatName
-          mainToFile (MainTerm.BadType _ ty) = pure $ maybe NoTermWithThatName TermHasBadType ty
-          mainToFile (MainTerm.Success hq ref tm typ) =
-            let v = Var.named (HQ.toText hq)
-             in checkType Nothing typ \otyp ->
-                  pure (GetTermSuccess (v, tm, typ, otyp, Just ref))
+        (hq, ref, tm, typ) <- resolveMainRef "run" mainName
+        let v = Var.named (HQ.toText hq)
+        otyp <- doSynthesizeForce Nothing typ
+        pure (v, tm, typ, otyp, Just ref)
 
       getFromFile uf = do
         let components = join $ UF.topLevelComponents uf
         -- __TODO__: We shouldn’t need to serialize mainName` for this check
         let mainComponent = filter ((\v -> Var.name v == HQ.toText mainName) . view _1) components
         case mainComponent of
-          [(v, _, tm, ty)] ->
-            checkType (Just uf) ty \otyp ->
-              let runMain = DD.forceTerm a a (Term.var a v)
-                  v2 = Var.freshIn (Set.fromList [v]) v
-                  a = ABT.annotation tm
-               in pure (GetTermSuccess (v2, runMain, ty, otyp, Nothing))
+          [(v, _, tm, ty)] -> do
+            env <- ask
+            let mainType = Runtime.mainType env.runtime
+            when (not (Typechecker.fitsScheme ty (Runtime.mainType env.runtime))) do
+              names <- Cli.currentNames
+              let pped = PPED.makePPED (PPE.hqNamer 10 names) (PPE.suffixifyByHash names)
+              let ppe = pped.suffixifiedPPE
+              Cli.returnEarly $
+                Output.BadMainFunction
+                  "run"
+                  [(mainName, ty)]
+                  ppe
+                  [mainType]
+            otyp <- doSynthesizeForce (Just uf) ty
+            let runMain = DD.forceTerm a a (Term.var a v)
+                v2 = Var.freshIn (Set.fromList [v]) v
+                a = ABT.annotation tm
+            pure (v2, runMain, ty, otyp, Nothing)
           _ -> getFromCodebase
 
-      checkType :: Maybe (TypecheckedUnisonFile Symbol Ann) -> Type Symbol Ann -> (Type Symbol Ann -> Cli GetTermResult) -> Cli GetTermResult
-      checkType mayTuf ty f = do
-        Cli.Env {codebase, runtime} <- ask
+      doSynthesizeForce :: Maybe (TypecheckedUnisonFile Symbol Ann) -> Type Symbol Ann -> Cli (Type Symbol Ann)
+      doSynthesizeForce mayTuf ty = do
+        env <- ask
         let ufDeps = maybe mempty UF.externalTypeDependencies mayTuf
-        case Typechecker.fitsScheme ty (Runtime.mainType runtime) of
-          True -> do
-            tlCodebase <-
-              Cli.runTransaction $
-                Codebase.typeLookupForDependencies codebase Defns {terms = Set.empty, types = Type.dependencies ty <> ufDeps}
-            let tlTuf = Monoid.fromMaybe (fmap UF.typecheckedToTypeLookup mayTuf)
-            f $! synthesizeForce (tlTuf <> tlCodebase) ty
-          False -> pure (TermHasBadType ty)
+        tlCodebase <-
+          Cli.runTransaction $
+            Codebase.typeLookupForDependencies env.codebase Defns {terms = Set.empty, types = Type.dependencies ty <> ufDeps}
+        let tlTuf = Monoid.fromMaybe (fmap UF.typecheckedToTypeLookup mayTuf)
+        pure (synthesizeForce (tlTuf <> tlCodebase) ty)
    in Cli.getLatestTypecheckedFile >>= \case
         Nothing -> getFromCodebase
         Just uf -> getFromFile uf

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/TermResolution.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/TermResolution.hs
@@ -9,14 +9,13 @@ module Unison.Codebase.Editor.HandleInput.TermResolution
 where
 
 import Control.Monad.Reader (ask)
-import Control.Monad.Trans (liftIO)
-import Data.Maybe (catMaybes)
-import Data.Set (fromList, toList)
+import Data.Set qualified as Set
 import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
 import Unison.Cli.NamesUtils qualified as Cli
 import Unison.Codebase qualified as Codebase
-import Unison.Codebase.Editor.Output (Output (..))
+import Unison.Codebase.Editor.Output (NumberedOutput (..), Output (..))
+import Unison.Codebase.MainTerm qualified as MainTerm
 import Unison.Codebase.Path qualified as Path
 import Unison.Codebase.Runtime qualified as Runtime
 import Unison.ConstructorReference
@@ -26,17 +25,17 @@ import Unison.Name (Name)
 import Unison.Names (Names)
 import Unison.NamesWithHistory qualified as Names
 import Unison.Parser.Ann (Ann)
-import Unison.PrettyPrintEnv (PrettyPrintEnv)
+import Unison.Prelude
 import Unison.PrettyPrintEnv.Names qualified as PPE
 import Unison.PrettyPrintEnvDecl qualified as PPED
-import Unison.Reference (Reference)
+import Unison.Reference (Reference, TermReference)
 import Unison.Referent (Referent, pattern Con, pattern Ref)
 import Unison.Symbol (Symbol)
+import Unison.Term (Term)
 import Unison.Type (Type)
-import Unison.Typechecker qualified as Typechecker
 
 lookupTerm :: HQ.HashQualified Name -> Names -> [Referent]
-lookupTerm hq parseNames = toList (Names.lookupHQTerm Names.IncludeSuffixes hq parseNames)
+lookupTerm hq parseNames = Set.toList (Names.lookupHQTerm Names.IncludeSuffixes hq parseNames)
 
 lookupCon ::
   HQ.HashQualified Name ->
@@ -75,7 +74,7 @@ resolveTerm name = do
   case lookupTerm name names of
     [] -> Cli.returnEarly . either TermNotFound' (TermNotFound . fmap Path.parentOfName) $ HQ'.fromHQ name
     [rf] -> pure rf
-    rfs -> Cli.returnEarly . TermAmbiguous suffixifiedPPE name $ fromList rfs
+    rfs -> Cli.returnEarly . TermAmbiguous suffixifiedPPE name $ Set.fromList rfs
 
 resolveCon :: HQ.HashQualified Name -> Cli ConstructorReference
 resolveCon name = do
@@ -85,9 +84,9 @@ resolveCon name = do
   case lookupCon name names of
     ([], _) -> Cli.returnEarly . either TermNotFound' (TermNotFound . fmap Path.parentOfName) $ HQ'.fromHQ name
     ([co], _) -> pure co
-    (_, rfts) -> Cli.returnEarly . TermAmbiguous suffixifiedPPE name $ fromList rfts
+    (_, rfts) -> Cli.returnEarly . TermAmbiguous suffixifiedPPE name $ Set.fromList rfts
 
-resolveTermRef :: HQ.HashQualified Name -> Cli Reference
+resolveTermRef :: HQ.HashQualified Name -> Cli TermReference
 resolveTermRef name = do
   names <- Cli.currentNames
   let pped = PPED.makePPED (PPE.hqNamer 10 names) (PPE.suffixifyByHash names)
@@ -95,17 +94,35 @@ resolveTermRef name = do
   case lookupTermRefs name names of
     ([], _) -> Cli.returnEarly . either TermNotFound' (TermNotFound . fmap Path.parentOfName) $ HQ'.fromHQ name
     ([rf], _) -> pure rf
-    (_, rfts) -> Cli.returnEarly . TermAmbiguous suffixifiedPPE name $ fromList rfts
+    (_, rfts) -> Cli.returnEarly . TermAmbiguous suffixifiedPPE name $ Set.fromList rfts
 
-resolveMainRef :: HQ.HashQualified Name -> Cli (Reference, PrettyPrintEnv)
-resolveMainRef main = do
+resolveMainRef :: Text -> HQ.HashQualified Name -> Cli (HQ.HashQualified Name, TermReference, Term Symbol Ann, Type Symbol Ann)
+resolveMainRef what mainName = do
   Cli.Env {codebase, runtime} <- ask
+  let mainType = Runtime.mainType runtime
   names <- Cli.currentNames
   let pped = PPED.makePPED (PPE.hqNamer 10 names) (PPE.suffixifyByHash names)
-  let suffixifiedPPE = PPED.suffixifiedPPE pped
-  let mainType = Runtime.mainType runtime
-  lookupTermRefWithType codebase main >>= \case
-    [(rf, ty)]
-      | Typechecker.fitsScheme ty mainType -> pure (rf, suffixifiedPPE)
-      | otherwise -> Cli.returnEarly (BadMainFunction "main" main ty suffixifiedPPE [mainType])
-    _ -> Cli.returnEarly (NoMainFunction main suffixifiedPPE [mainType])
+  let ppe = pped.suffixifiedPPE
+  mainTermResult <-
+    MainTerm.getMainTerm
+      (liftIO . Codebase.runTransaction codebase . Codebase.getTypeOfTerm codebase)
+      names
+      mainName
+      mainType
+  case mainTermResult of
+    MainTerm.Success mainName1 ref term ty -> pure (mainName1, ref, term, ty)
+    MainTerm.NotFound -> Cli.returnEarly (NoMainFunction mainName ppe [mainType])
+    MainTerm.BadType terms ->
+      Cli.returnEarly $
+        BadMainFunction
+          what
+          (map (\(s, _, t) -> (s, t)) terms)
+          ppe
+          [mainType]
+    MainTerm.Ambiguous terms -> do
+      Cli.respondNumbered $
+        AmbiguousMainFunction
+          what
+          (map (\(s, _, t) -> (s, t)) terms)
+          ppe
+      Cli.returnEarlyWithoutOutput

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/TermResolution.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/TermResolution.hs
@@ -1,6 +1,5 @@
 module Unison.Codebase.Editor.HandleInput.TermResolution
   ( lookupTermRefs,
-    lookupTermRefWithType,
     resolveCon,
     resolveTerm,
     resolveTermRef,
@@ -54,17 +53,6 @@ lookupTermRefs hq parseNames =
   where
     extract rt@(Ref rf) = Just (rf, rt)
     extract _ = Nothing
-
-lookupTermRefWithType ::
-  Codebase.Codebase IO Symbol Ann ->
-  HQ.HashQualified Name ->
-  Cli [(Reference, Type Symbol Ann)]
-lookupTermRefWithType codebase name = do
-  names <- Cli.currentNames
-  liftIO . Codebase.runTransaction codebase . fmap catMaybes . traverse annot . fst $ lookupTermRefs name names
-  where
-    annot tm =
-      fmap ((,) tm) <$> Codebase.getTypeOfTerm codebase tm
 
 resolveTerm :: HQ.HashQualified Name -> Cli Referent
 resolveTerm name = do

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Tests.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Tests.hs
@@ -148,11 +148,13 @@ handleIOTest main = do
   (fails, oks) <-
     Foldable.foldrM
       ( \(ref, typ) (f, o) -> do
-          when (not $ isIOTest typ)
-            . Cli.returnEarly
-            . BadMainFunction "io.test" main typ suffixifiedPPE
-            . Foldable.toList
-            $ Runtime.ioTestTypes runtime
+          when (not $ isIOTest typ) do
+            Cli.returnEarly $
+              BadMainFunction
+                "io.test"
+                [(main, typ)]
+                suffixifiedPPE
+                (Foldable.toList (Runtime.ioTestTypes runtime))
           bimap (\ts -> if null ts then f else Map.insert ref ts f) (\ts -> if null ts then o else Map.insert ref ts o)
             <$> runIOTest suffixifiedPPE ref
       )

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -158,6 +158,7 @@ data NumberedOutput
   | -- | Successfully removed paths from the watch list
     -- (removed paths, failed paths, remaining paths)
     WatchRemoved ![FilePath] ![FilePath] ![FilePath]
+  | AmbiguousMainFunction Text [(HQ.HashQualified Name, Type Symbol Ann)] PPE.PrettyPrintEnv
 
 data TodoOutput = TodoOutput
   { defnsInLib :: !Bool,
@@ -197,10 +198,8 @@ data Output
     BadMainFunction
       -- | what we were trying to do (e.g. "run", "io.test")
       Text
-      -- | name of function
-      (HQ.HashQualified Name)
-      -- | bad type of function
-      (Type Symbol Ann)
+      -- | names and bad types of functions matching input name. invariant: length >= 1
+      [(HQ.HashQualified Name, Type Symbol Ann)]
       PPE.PrettyPrintEnv
       -- | acceptable type(s) of function
       [Type Symbol Ann]
@@ -781,6 +780,7 @@ isFailure o = case o of
 
 isNumberedFailure :: NumberedOutput -> Bool
 isNumberedFailure = \case
+  AmbiguousMainFunction {} -> True
   AmbiguousReset {} -> True
   AmbiguousSwitch {} -> True
   CantDeleteNamespace {} -> True

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -578,6 +578,31 @@ notifyNumbered = \case
               ],
       map SA.FilePath remainingPaths
     )
+  AmbiguousMainFunction what terms ppe ->
+    ( P.wrap "I don't know which function you're referring to:"
+        <> P.newline
+        <> P.newline
+        <> P.indentN
+          2
+          ( P.numberedList
+              ( map
+                  ( \(name, ty) ->
+                      P.syntaxToColor (prettyHashQualified name) <> " : " <> TypePrinter.pretty ppe ty
+                  )
+                  terms
+              )
+          )
+        <> P.newline
+        <> P.newline
+        <> tip
+          ( "use "
+              <> P.backticked (P.text what <> " 1")
+              <> " or "
+              <> P.backticked (P.text what <> " 2")
+              <> " to pick one of these."
+          ),
+      map (SA.HashQualified . fst) terms
+    )
   where
     absPathToBranchId = BranchAtPath
     -- Like oxfordCommas but uses "or" instead of "and", without extra spaces.
@@ -788,17 +813,19 @@ notifyUser dir issueFn = \case
           "",
           P.indentN 2 $ P.lines [P.text (HQ.toText main) <> " : " <> TypePrinter.pretty ppe t | t <- ts]
         ]
-  BadMainFunction what main ty ppe ts ->
-    pure . P.callout "😶" $
-      P.lines
-        [ P.string "I found this function:",
-          "",
-          P.indentN 2 $ P.text (HQ.toText main) <> " : " <> TypePrinter.pretty ppe ty,
-          "",
-          P.wrap $ P.string "but in order for me to" <> P.backticked (P.text what) <> "it needs to be a subtype of:",
-          "",
-          P.indentN 2 $ P.lines [P.text (HQ.toText main) <> " : " <> TypePrinter.pretty ppe t | t <- ts]
-        ]
+  BadMainFunction what terms ppe ts ->
+    let f (main, ty) =
+          P.lines
+            [ P.string "I found this function:",
+              "",
+              P.indentN 2 $ P.text (HQ.toText main) <> " : " <> TypePrinter.pretty ppe ty,
+              "",
+              P.wrap $ P.string "but in order for me to" <> P.backticked (P.text what) <> "it needs to be a subtype of:",
+              "",
+              P.indentN 2 $ P.lines [P.text (HQ.toText main) <> " : " <> TypePrinter.pretty ppe t | t <- ts]
+            ]
+     in pure . P.callout "😶" $
+          intercalateMap "\n\n" f terms
   NoUnisonFile -> do
     fileName <- maybe (pure . P.group $ P.blue "〈redacted〉") (renderFileName <=< canonicalizePath) dir
     pure . P.callout "😶" $

--- a/unison-core/src/Unison/HashQualified.hs
+++ b/unison-core/src/Unison/HashQualified.hs
@@ -1,5 +1,8 @@
 module Unison.HashQualified where
 
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
+import Data.Set.NonEmpty qualified as Set.NonEmpty
 import Data.Text qualified as Text
 import Unison.ConstructorReference (ConstructorReference)
 import Unison.ConstructorReference qualified as ConstructorReference
@@ -12,6 +15,8 @@ import Unison.Referent (Referent)
 import Unison.Referent qualified as Referent
 import Unison.ShortHash (ShortHash)
 import Unison.ShortHash qualified as SH
+import Unison.Util.Relation (Relation)
+import Unison.Util.Relation qualified as Relation
 import Prelude hiding (take)
 
 data HashQualified n
@@ -130,6 +135,73 @@ requalify hq r = case hq of
   NameOnly n -> fromNamedReferent n r
   HashQualified n _ -> fromNamedReferent n r
   HashOnly _ -> fromReferent r
+
+-- | Like 'Name.searchBySuffix', but uses a hash-qualified name to search instead.
+--
+-- The name *and* the hash are used to determine whether something is an exact match. For example, in namespace
+-- {foo#foo, hello.foo#bar}, searching for foo#bar will return the singleton set {hello.foo#bar}, because even though
+-- there is an exact name match on foo, its hash doesn't match so we fall back to "suffix" matches. This probably isn't
+-- a very important detail in practice, but the other possible implementation (do name-only search, *then* filter result
+-- down to matching hashes) seems worse.
+searchBySuffix :: forall ref. (Ord ref) => (ref -> ShortHash) -> HashQualified Name -> Relation Name ref -> Set ref
+searchBySuffix refHash name0 rel =
+  case name0 of
+    NameOnly name -> Name.searchBySuffix name rel
+    HashQualified name hash
+      | Set.null exactMatches -> suffixMatches
+      | otherwise -> exactMatches
+      where
+        exactMatches :: Set ref
+        exactMatches =
+          keepMatchingHashes (Relation.lookupDom name rel)
+
+        suffixMatches :: Set ref
+        suffixMatches =
+          keepMatchingHashes (Relation.searchDom (Name.compareSuffix name) rel)
+
+        keepMatchingHashes :: Set ref -> Set ref
+        keepMatchingHashes =
+          Set.filter \ref -> hash `SH.isPrefixOf` refHash ref
+    HashOnly hash ->
+      Map.foldlWithKey'
+        (\acc ref _ -> if hash `SH.isPrefixOf` refHash ref then Set.insert ref acc else acc)
+        Set.empty
+        (Relation.range rel)
+
+-- | Like 'searchBySuffix', but also keeps the names around.
+filterBySuffix ::
+  forall ref.
+  (Ord ref) =>
+  (ref -> ShortHash) ->
+  HashQualified Name ->
+  Relation Name ref ->
+  Relation Name ref
+filterBySuffix refHash name0 rel =
+  case name0 of
+    NameOnly name -> Name.filterBySuffix name rel
+    HashQualified name hash
+      | Relation.null exactMatches -> suffixMatches
+      | otherwise -> exactMatches
+      where
+        exactMatches :: Relation Name ref
+        exactMatches =
+          matches name (Relation.lookupDom name rel)
+
+        suffixMatches :: Relation Name ref
+        suffixMatches =
+          Relation.searchDomG matches (Name.compareSuffix name) rel
+
+        matches :: Name -> Set ref -> Relation Name ref
+        matches name =
+          Set.filter (hashMatches hash)
+            >>> Set.NonEmpty.nonEmptySet
+            >>> maybe Relation.empty (Relation.singletonSet name)
+    HashOnly hash ->
+      Relation.filterRan (hashMatches hash) rel
+  where
+    hashMatches :: ShortHash -> ref -> Bool
+    hashMatches hash ref =
+      hash `SH.isPrefixOf` refHash ref
 
 instance (Name.Alphabetical n) => Name.Alphabetical (HashQualified n) where
   -- Ordered alphabetically, based on the name. Hashes come last.

--- a/unison-core/src/Unison/HashQualifiedPrime.hs
+++ b/unison-core/src/Unison/HashQualifiedPrime.hs
@@ -23,7 +23,6 @@ module Unison.HashQualifiedPrime
 where
 
 import Data.Set qualified as Set
-import Data.Set.NonEmpty qualified as Set.NonEmpty
 import Data.Text qualified as Text
 import Unison.HashQualified qualified as HQ
 import Unison.Name (Name)
@@ -39,7 +38,6 @@ import Unison.ShortHash qualified as SH
 import Unison.Util.BiMultimap (BiMultimap)
 import Unison.Util.BiMultimap qualified as BiMultimap
 import Unison.Util.Relation (Relation)
-import Unison.Util.Relation qualified as Relation
 import Prelude hiding (take)
 
 -- | Like Unison.HashQualified, but doesn't support a HashOnly variant
@@ -116,29 +114,9 @@ requalify hq r = case hq of
   HashQualified n _ -> fromNamedReferent n r
 
 -- | Like 'Name.searchBySuffix', but uses a hash-qualified name to search instead.
---
--- The name *and* the hash are used to determine whether something is an exact match. For example, in namespace
--- {foo#foo, hello.foo#bar}, searching for foo#bar will return the singleton set {hello.foo#bar}, because even though
--- there is an exact name match on foo, its hash doesn't match so we fall back to "suffix" matches. This probably isn't
--- a very important detail in practice, but the other possible implementation (do name-only search, *then* filter result
--- down to matching hashes) seems worse.
 searchBySuffix :: forall ref. (Ord ref) => (ref -> ShortHash) -> HashQualified Name -> Relation Name ref -> Set ref
-searchBySuffix _ (NameOnly name) rel = Name.searchBySuffix name rel
-searchBySuffix refHash (HashQualified name hash) rel
-  | Set.null exactMatches = suffixMatches
-  | otherwise = exactMatches
-  where
-    exactMatches :: Set ref
-    exactMatches =
-      keepMatchingHashes (Relation.lookupDom name rel)
-
-    suffixMatches :: Set ref
-    suffixMatches =
-      keepMatchingHashes (Relation.searchDom (Name.compareSuffix name) rel)
-
-    keepMatchingHashes :: Set ref -> Set ref
-    keepMatchingHashes =
-      Set.filter \ref -> hash `SH.isPrefixOf` refHash ref
+searchBySuffix refHash =
+  HQ.searchBySuffix refHash . toHQ
 
 -- | Like 'searchBySuffix', but also keeps the names around.
 filterBySuffix ::
@@ -148,28 +126,8 @@ filterBySuffix ::
   HashQualified Name ->
   Relation Name ref ->
   Relation Name ref
-filterBySuffix _ (NameOnly name) rel = Name.filterBySuffix name rel
-filterBySuffix refHash (HashQualified name hash) rel
-  | Relation.null exactMatches = suffixMatches
-  | otherwise = exactMatches
-  where
-    exactMatches :: Relation Name ref
-    exactMatches =
-      matches name (Relation.lookupDom name rel)
-
-    suffixMatches :: Relation Name ref
-    suffixMatches =
-      Relation.searchDomG matches (Name.compareSuffix name) rel
-
-    matches :: Name -> Set ref -> Relation Name ref
-    matches name =
-      Set.filter hashMatches
-        >>> Set.NonEmpty.nonEmptySet
-        >>> maybe Relation.empty (Relation.singletonSet name)
-
-    hashMatches :: ref -> Bool
-    hashMatches ref =
-      hash `SH.isPrefixOf` refHash ref
+filterBySuffix refHash =
+  HQ.filterBySuffix refHash . toHQ
 
 searchUnconflictedBySuffix ::
   forall ref.

--- a/unison-core/src/Unison/Name.hs
+++ b/unison-core/src/Unison/Name.hs
@@ -49,6 +49,7 @@ module Unison.Name
     -- ** Filter
     filterBySuffix,
     filterByRankedSuffix,
+    keepHighestPriority,
 
     -- * To organize later
     commonPrefix,
@@ -388,15 +389,28 @@ searchByRankedSuffix suffix rel =
 -- | Like 'searchByRankedSuffix', but also keeps the names around.
 filterByRankedSuffix :: (Ord r) => Name -> R.Relation Name r -> R.Relation Name r
 filterByRankedSuffix suffix rel =
-  let matches = filterBySuffix suffix rel
-      highestNamePriority = foldMap prio (R.dom matches)
-      keep (name, _) = prio name <= highestNamePriority
-   in -- Keep only names that are at or less than the highest name priority. This effectively throws out all indirect
-      -- dependencies (NamePriorityTwo) if there are any direct dependencies (NamePriorityOne) or local definitions
-      -- (also NamePriorityOne).
-      R.filter keep matches
+  keepHighestPriority (filterBySuffix suffix rel)
+
+-- Keep only names that are at or less than the highest name priority. This effectively throws out all indirect
+-- dependencies (NamePriorityTwo) if there are any direct dependencies (NamePriorityOne) or local definitions
+-- (also NamePriorityOne).
+keepHighestPriority :: (Ord r) => R.Relation Name r -> R.Relation Name r
+keepHighestPriority =
+  gkeepHighestPriority
+    (\f -> foldMap f . R.dom)
+    (\f -> R.filter (f . fst))
+
+gkeepHighestPriority ::
+  (forall m. (Monoid m) => (Name -> m) -> names -> m) ->
+  ((Name -> Bool) -> names -> names) ->
+  names ->
+  names
+gkeepHighestPriority foldMap filter names =
+  filter keep names
   where
     prio = nameLocationPriority . classifyNameLocation
+    highestNamePriority = foldMap prio names
+    keep name = prio name <= highestNamePriority
 
 -- | precondition: input list is deduped, and so is the Name list in
 -- the tuple

--- a/unison-runtime/src/Unison/Codebase/Execute.hs
+++ b/unison-runtime/src/Unison/Codebase/Execute.hs
@@ -11,6 +11,7 @@ where
 
 import Control.Exception (finally)
 import Control.Monad.Except
+import Data.Text qualified as Text
 import U.Codebase.Sqlite.Project (Project (..))
 import U.Codebase.Sqlite.ProjectBranch (ProjectBranch (..))
 import U.Codebase.Sqlite.Queries qualified as Q
@@ -36,6 +37,7 @@ import Unison.Runtime (Error (UnstructuredError), Runtime)
 import Unison.Runtime.IOSource qualified as IOSource
 import Unison.Symbol (Symbol)
 import Unison.Syntax.HashQualified qualified as HQ (toText)
+import Unison.Util.Monoid (intercalateMap)
 
 execute :: Codebase.Codebase IO Symbol Ann -> Runtime Symbol -> PP.ProjectPathNames -> IO (Either Error ())
 execute codebase runtime mainPath =
@@ -60,8 +62,15 @@ execute codebase runtime mainPath =
 
     mt <- liftIO $ Codebase.runTransaction codebase $ getMainTerm loadTypeOfTerm projectRootNames mainName mainType
     case mt of
-      MainTerm.NotFound s -> throwError . UnstructuredError $ "Not found: " <> HQ.toText s
-      MainTerm.BadType s _ -> throwError . UnstructuredError $ HQ.toText s <> " is not of type '{IO} ()"
+      MainTerm.NotFound -> throwError . UnstructuredError $ "Not found: " <> HQ.toText mainName
+      MainTerm.BadType ss ->
+        throwError . UnstructuredError $
+          case ss of
+            [(s, _, _)] -> HQ.toText s <> " is not of type '{IO} ()"
+            _ -> "None of " <> intercalateMap Text.empty (\(s, _, _) -> HQ.toText s) ss <> " are of type '{IO} ()"
+      MainTerm.Ambiguous ss ->
+        throwError . UnstructuredError $
+          "I don't know which of these you mean: " <> intercalateMap Text.empty (\(s, _, _) -> HQ.toText s) ss
       MainTerm.Success _ _ tm _ -> do
         let codeLookup = codebaseToCodeLookup codebase
             ppe = PPE.empty

--- a/unison-src/transcripts/idempotent/run.md
+++ b/unison-src/transcripts/idempotent/run.md
@@ -35,6 +35,8 @@ scratch/main> run foo
 scratch/main> project.delete scratch
 ```
 
+-----
+
 The scratch file contents are prioritized over the codebase.
 
 ``` ucm :hide
@@ -86,6 +88,8 @@ scratch/main> run foo
 scratch/main> project.delete scratch
 ```
 
+-----
+
 If you try to run something of an incompatible type, you'll get an error.
 
 ``` ucm :hide
@@ -121,6 +125,8 @@ scratch/main> run foo
 ``` ucm :hide
 scratch/main> project.delete scratch
 ```
+
+-----
 
 There's a "staleness check" that works as follows. If you try to `run x`, where `x` isn't hash-qualified, and where `x`
 (either found in the scratch file or codebase) depends on a type or term `y` that has registered as a pending update in
@@ -237,6 +243,8 @@ scratch/main> run baz
 scratch/main> project.delete scratch
 ```
 
+-----
+
 This example demonstrates the same error as above, but by trying to run a term in the codebase, not the scratch file.
 
 ``` ucm :hide
@@ -302,6 +310,8 @@ scratch/main> run bar
 scratch/main> project.delete scratch
 ```
 
+-----
+
 And this example demonstrates the same error as above, but via an uncommitted type, not term.
 
 ``` ucm :hide
@@ -362,6 +372,95 @@ scratch/main> run foo
   the scratch file without performing an `update`.
 
   Then, you can try `run foo` again for an up-to-date result.
+```
+
+``` ucm :hide
+scratch/main> project.delete scratch
+```
+
+-----
+
+You can't provide an ambiguous suffix to `run`, if multiple terms match and have the correct type.
+
+``` ucm :hide
+scratch/main> builtins.mergeio lib.builtin
+```
+
+``` unison :hide
+one.foo = do 17
+two.foo = do 18
+```
+
+``` ucm :hide
+scratch/main> update
+```
+
+``` ucm :error
+scratch/main> run foo
+
+  I don't know which function you're referring to:
+
+    1. one.foo : 'Nat
+    2. two.foo : 'Nat
+
+  Tip: use `run 1` or `run 2` to pick one of these.
+```
+
+``` ucm :hide
+scratch/main> project.delete scratch
+```
+
+-----
+
+But if only one of all matching names has a compatible type, it'll be run.
+
+``` ucm :hide
+scratch/main> builtins.mergeio lib.builtin
+```
+
+``` unison :hide
+one.foo = do 17
+two.foo = 18
+```
+
+``` ucm :hide
+scratch/main> update
+```
+
+``` ucm
+scratch/main> run foo
+
+  17
+```
+
+``` ucm :hide
+scratch/main> project.delete scratch
+```
+
+-----
+
+For resolving ambiguity, indirect dependencies are also ignored if anything in the current project or its direct
+dependencies match. Here we show `run foo` working even though even though there's a `foo` in an indirect dependency.
+
+``` ucm :hide
+scratch/main> builtins.mergeio lib.builtin
+```
+
+``` unison :hide
+one.foo = do 17
+two.foo = do 18
+```
+
+``` ucm :hide
+scratch/main> update
+
+scratch/main> move two.foo lib.x.lib.y.two.foo
+```
+
+``` ucm
+scratch/main> run foo
+
+  17
 ```
 
 ``` ucm :hide


### PR DESCRIPTION
## Overview

Fixes #5974 

This PR improves the error message we see on ambiguous `run`.

Previously, `run` would crash with a bad error message whenever given an ambiguous suffix, even if not all matching names were of the right type.

Now, `run` first filters the list of candidate terms down to the ones that have the right type, and then runs if there's only one, otherwise fails with a decent error message. Like other commands, indirect dependencies are in scope but don't contribute to ambiguous name errors.

## Test coverage

I've included a transcript that demonstrates the changes