### PR TITLE
make `dependents` work on constructors

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Dependents.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Dependents.hs
@@ -4,16 +4,20 @@ module Unison.Codebase.Editor.HandleInput.Dependents
 where
 
 import Control.Lens (review)
+import Control.Monad.Reader (ask)
 import Data.Bifoldable (binull)
+import Data.Foldable qualified as Foldable
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 import Data.Set.NonEmpty (NESet)
 import Data.Set.NonEmpty qualified as Set.NonEmpty
+import Data.These (These (..))
 import U.Codebase.Sqlite.Operations qualified as Operations
 import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
 import Unison.Cli.MonadUtils qualified as Cli
 import Unison.Cli.NameResolutionUtils (resolveHQName)
+import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Branch qualified as Branch
 import Unison.Codebase.Branch.Names qualified as Branch
 import Unison.Codebase.Editor.Output
@@ -23,6 +27,7 @@ import Unison.DataDeclaration (DataDeclaration, Decl, EffectDeclaration)
 import Unison.DataDeclaration qualified as DataDeclaration
 import Unison.HashQualified qualified as HQ
 import Unison.HashQualifiedPrime qualified as HQ'
+import Unison.LabeledDependency qualified as LabeledDependency
 import Unison.Name (Name)
 import Unison.Name qualified as Name
 import Unison.NamesUtils qualified as NamesUtils
@@ -44,6 +49,7 @@ import Unison.UnisonFile qualified as UnisonFile
 import Unison.UnisonFile.Names qualified as UnisonFile
 import Unison.Util.Defns (Defns (..), DefnsF, DefnsF2, defnsAreEmpty, zipDefnsWith)
 import Unison.Util.Map qualified as Map
+import Unison.Util.Set qualified as Set
 import Unison.Var (Var)
 import Unison.WatchKind (WatchKind)
 import Unison.WatchKind qualified as WatchKind
@@ -66,11 +72,56 @@ handleCodebaseDependents dependenciesRefs = do
         let names = Branch.toNames (Branch.deleteLibdeps namespace)
          in PPE.makePPE (PPE.hqNamer 10 names) (PPE.suffixifyByHash names)
 
-  dependents <-
+  dependents0 <-
     Cli.runTransaction do
       Operations.directDependentsWithinScope
         (Branch.deepDefnsIds namespace)
         (NamesUtils.referentsToRefs dependenciesRefs)
+
+  -- Here we have the dependents of all of the dependencies, having treated all constructors as the entire type, because
+  -- that's all our dependencies index currently supports.
+  --
+  -- So, we have some special logic: if the dependencies actually contained *any* constructors (common case: just 1),
+  -- then we do a slower thing of hydrating all dependents and keeping only the ones whose direct dependencies overlaps
+  -- with the input set.
+  dependents :: DefnsF Set TermReferenceId TypeReferenceId <-
+    case Foldable.find Referent'.isConstructor dependenciesRefs.terms of
+      Nothing -> pure dependents0
+      Just _ -> do
+        env <- ask
+        Cli.runTransaction do
+          dependentTermRefs :: Set TermReferenceId <-
+            Set.filterM
+              ( \dependentTermRef ->
+                  Codebase.getTerm env.codebase dependentTermRef <&> \case
+                    Just dependentTerm ->
+                      let (dependentTermTermDependencies, dependentTermTypeDependencies) =
+                            Set.unalignWith
+                              ( \case
+                                  LabeledDependency.TermReferent x -> This x
+                                  LabeledDependency.TypeReference x -> That x
+                              )
+                              (Term.labeledDependencies dependentTerm)
+                       in Set.intersects dependentTermTermDependencies dependenciesRefs.terms
+                            || Set.intersects dependentTermTypeDependencies dependenciesRefs.types
+                    Nothing -> False
+              )
+              dependents0.terms
+          dependentTypeRefs :: Set TypeReferenceId <-
+            if Set.null dependenciesRefs.types
+              then pure Set.empty
+              else
+                Set.filterM
+                  ( \dependentTypeRef ->
+                      Codebase.getTypeDeclaration env.codebase dependentTypeRef <&> \case
+                        Just dependentType ->
+                          Set.intersects
+                            (DataDeclaration.typeDependencies (DataDeclaration.asDataDecl dependentType))
+                            dependenciesRefs.types
+                        Nothing -> False
+                  )
+                  dependents0.types
+          pure Defns {terms = dependentTermRefs, types = dependentTypeRefs}
 
   let dependentNames ::
         DefnsF

--- a/unison-core/src/Unison/LabeledDependency.hs
+++ b/unison-core/src/Unison/LabeledDependency.hs
@@ -25,7 +25,7 @@ import Unison.Referent qualified as Referent
 
 -- | A Union Type which contains either Type References or Term Referents.
 data LabeledDependency
-  = TypeReference Reference
+  = TypeReference TypeReference
   | TermReferent Referent
   deriving (Eq, Ord, Show)
 
@@ -34,7 +34,7 @@ pattern ConReference :: ConstructorReference -> ConstructorType -> LabeledDepend
 pattern ConReference ref conType = TermReferent (Referent.Con ref conType)
 
 -- | Match on a TermReferent which is NOT a Constructor.
-pattern TermReference :: Reference -> LabeledDependency
+pattern TermReference :: TermReference -> LabeledDependency
 pattern TermReference ref = TermReferent (Referent.Ref ref)
 
 {-# COMPLETE ConReference, TermReference, TypeReference #-}

--- a/unison-src/transcripts/idempotent/dependents-dependencies.md
+++ b/unison-src/transcripts/idempotent/dependents-dependencies.md
@@ -78,10 +78,6 @@ scratch/main> dependents A
   Tip: Try `view 2` to see the source of any numbered item in
        the above list.
 
--- We do have constructor-level granularity, though it's implemented as a post-processing step rather than leveraging
-
--- the SQLite index directly. So, myVal doesn't appear below (it used to).
-
 scratch/main> dependents B
 
   Dependents of: B

--- a/unison-src/transcripts/idempotent/dependents-dependencies.md
+++ b/unison-src/transcripts/idempotent/dependents-dependencies.md
@@ -78,7 +78,9 @@ scratch/main> dependents A
   Tip: Try `view 2` to see the source of any numbered item in
        the above list.
 
--- For better or worse, we don't have constructor-level granularity yet, so myVal shows here.
+-- We do have constructor-level granularity, though it's implemented as a post-processing step rather than leveraging
+
+-- the SQLite index directly. So, myVal doesn't appear below (it used to).
 
 scratch/main> dependents B
 
@@ -87,9 +89,8 @@ scratch/main> dependents B
     Terms:
 
     1. myCase
-    2. myVal
 
-  Tip: Try `view 2` to see the source of any numbered item in
+  Tip: Try `view 1` to see the source of any numbered item in
        the above list.
 ```
 


### PR DESCRIPTION
## Overview

Fixes #5246 

This PR amends `dependents` to work better on constructors.

Previously, `dependents <constructor>` would function like `dependents <type>`, since that's the fidelity of the information available to us in the dependents index.

To avoid a migration and lengthy development cycle, this PR simply implements `dependents <constructor>` against the existing database schema.

After fetching term and type dependents with `dependents <arg>`, if `<arg>` matches any constructors, we pass back over the results, deserialize the types and terms, crawl the dependencies of the in-memory ABTs, and filter out any dependents without any direct dependencies that overlap `<arg>`. It's obviously slower than using a database index, so we can reconsider if in practice we are seeing inexcusably slow `dependents` runs. I tried a couple and they seem fast enough, though.

## Test coverage

I tested this manually, and amended the transcript which showed that previously we didn't have constructor-granularity dependents implemented.