### PR TITLE
bugfix: `update` no longer leaves deleted constructors in underlying namespace of update branch

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
@@ -110,19 +110,19 @@ handleUpdate2 = do
   -- Of all the namespace bindings in the latest typechecked Unison file, keep the ones that don't correspond to "no
   -- change" (i.e. the thing was just `edit`-ed and untouched). We also reject the update entirely if it touches
   -- anything in lib.*.
-  let addedOrUpdatedNamespaceBindings0 :: Defns (Set Name, Map Name ()) (Set Name, Map Name ())
+  let addedOrUpdatedNamespaceBindings0 :: Defns (Set Name, Map Name Bool) (Set Name, Map Name Bool)
       addedOrUpdatedNamespaceBindings0 =
-        let f :: (Eq ref1) => Relation Name ref1 -> (ref2 -> ref1) -> Name -> ref2 -> (Set Name, ())
+        let f :: (Eq ref1) => Relation Name ref1 -> (ref2 -> ref1) -> Name -> ref2 -> (Set Name, Bool)
             f libdeps toRef name fileRef
               | Name.beginsWithSegment name NameSegment.libSegment,
                 maybe True (/= toRef fileRef) (Set.asSingleton (Relation.lookupDom name libdeps)) =
-                  (Set.singleton name, ())
-              | otherwise = (Set.empty, ())
-            g :: (Eq ref1) => (ref2 -> ref1) -> name -> ref1 -> ref2 -> Maybe ()
+                  (Set.singleton name, False)
+              | otherwise = (Set.empty, False)
+            g :: (Eq ref1) => (ref2 -> ref1) -> name -> ref1 -> ref2 -> Maybe Bool
             g toRef _ codebaseRef fileRef
               | codebaseRef == toRef fileRef = Nothing
-              | otherwise = Just ()
-            h :: (Eq ref1) => Relation Name ref1 -> (ref2 -> ref1) -> BiMultimap ref1 Name -> Map Symbol ref2 -> (Set Name, Map Name ())
+              | otherwise = Just True
+            h :: (Eq ref1) => Relation Name ref1 -> (ref2 -> ref1) -> BiMultimap ref1 Name -> Map Symbol ref2 -> (Set Name, Map Name Bool)
             h libdeps toRef codebaseDefns fileDefns =
               Map.mergeA
                 Map.dropMissing
@@ -209,7 +209,8 @@ handleUpdate2 = do
                               (over (#terms . mapped) snd hydratedDependents)
                           )
 
-              parsingEnv <- Cli.makeParsingEnv pp namesIncludingLibdeps
+              parsingEnv <-
+                Cli.makeParsingEnv pp namesIncludingLibdeps
 
               secondTuf <-
                 parseAndTypecheck prettyUnisonFile parsingEnv & onNothingM do
@@ -219,7 +220,30 @@ handleUpdate2 = do
                           nextNamespace =
                             unconflictedView.defns
                               & bimap
-                                (BiMultimap.range >>> (`Map.withoutKeys` namespaceBindings.terms))
+                                ( BiMultimap.range
+                                    >>> ( `Map.withoutKeys`
+                                            -- Toss (by name):
+                                            --   1. the terms in the file
+                                            --   2. the old constructors of the types in the file
+                                            ( Map.foldlWithKey'
+                                                ( \acc typeName isUpdate ->
+                                                    if isUpdate
+                                                      then
+                                                        foldr
+                                                          Set.insert
+                                                          acc
+                                                          ( Map.findWithDefault
+                                                              [] -- impossible, could error
+                                                              typeName
+                                                              declNameLookup.declToConstructors
+                                                          )
+                                                      else acc
+                                                )
+                                                namespaceBindings.terms
+                                                (snd addedOrUpdatedNamespaceBindings0.types)
+                                            )
+                                        )
+                                )
                                 (BiMultimap.range >>> (`Map.withoutKeys` namespaceBindings.types))
                               & subtractDependents dependentsRefs
                               & Branch.fromUnconflictedDefns

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -234,7 +234,7 @@ library
     , conduit
     , conduit-extra
     , containers >=0.6.3
-    , cryptonite
+    , crypton
     , directory
     , either
     , errors
@@ -428,7 +428,7 @@ test-suite cli-tests
       base
     , code-page
     , containers
-    , cryptonite
+    , crypton
     , directory
     , easytest
     , extra

--- a/unison-core/unison-core1.cabal
+++ b/unison-core/unison-core1.cabal
@@ -105,7 +105,7 @@ library
     , base
     , bytestring
     , containers >=0.6.3
-    , cryptonite
+    , crypton
     , deepseq
     , edit-distance
     , extra

--- a/unison-hashing-v2/unison-hashing-v2.cabal
+++ b/unison-hashing-v2/unison-hashing-v2.cabal
@@ -71,7 +71,7 @@ library
     , bytestring
     , cborg
     , containers
-    , cryptonite
+    , crypton
     , lens
     , memory
     , semialign

--- a/unison-runtime/unison-runtime.cabal
+++ b/unison-runtime/unison-runtime.cabal
@@ -124,11 +124,11 @@ library
     , bytestring
     , clock
     , containers >=0.6.3
+    , crypton
     , crypton-x509
     , crypton-x509-store
     , crypton-x509-system
     , crypton-x509-validation
-    , cryptonite
     , data-default
     , data-memocombinators
     , deepseq
@@ -239,7 +239,7 @@ test-suite runtime-tests
     , bytestring
     , code-page
     , containers
-    , cryptonite
+    , crypton
     , directory
     , easytest
     , filemanip

--- a/unison-src/transcripts/idempotent/fix6130.md
+++ b/unison-src/transcripts/idempotent/fix6130.md
@@ -51,7 +51,7 @@ foo = cases
 ```
 
 ``` ucm
-scratch/update-main> ls Foo
+scratch/update-main> ls
 
-  1. Bar (#0qbc2dfom7)
+  1. builtin. (857 terms, 126 types)
 ```

--- a/unison-src/transcripts/idempotent/fix6130.md
+++ b/unison-src/transcripts/idempotent/fix6130.md
@@ -1,0 +1,57 @@
+``` ucm :hide
+scratch/main> builtins.mergeio
+```
+
+``` unison :hide
+type Foo = Foo | Bar
+
+foo = cases
+  Foo -> 1
+  Bar -> 2
+```
+
+``` ucm :hide
+scratch/main> update
+```
+
+``` unison :hide
+type Foo = Foo
+```
+
+``` ucm :error
+scratch/main> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  I couldn't complete the update, because some existing
+  definitions would no longer typecheck.
+
+  I've created a temporary branch and added the affected
+  definitions to scratch.u, where you can fix them up or remove
+  any that are obsolete.
+
+  Once you're happy with the results, use `update` to merge them
+  back into main, or `cancel` if you change your mind.
+```
+
+``` unison :added-by-ucm scratch.u
+type Foo = Foo
+
+-- The definitions below no longer typecheck with the changes above.
+-- Please fix the errors and try `update` again.
+
+foo : Foo -> Nat
+foo = cases
+  Foo -> 1
+  Bar -> 2
+
+```
+
+``` ucm
+scratch/update-main> ls Foo
+
+  1. Bar (#0qbc2dfom7)
+```

--- a/unison-src/transcripts/idempotent/fix6130.md
+++ b/unison-src/transcripts/idempotent/fix6130.md
@@ -1,13 +1,16 @@
+There was a bug in `update` that left constructors in the namespace for types being updated.
+
 ``` ucm :hide
 scratch/main> builtins.mergeio
 ```
 
 ``` unison :hide
-type Foo = Foo | Bar
+type Foo = Foo | Bar Nat | Qux Nat Nat
 
 foo = cases
   Foo -> 1
-  Bar -> 2
+  Bar _ -> 2
+  Qux _ _ -> 3
 ```
 
 ``` ucm :hide
@@ -15,7 +18,7 @@ scratch/main> update
 ```
 
 ``` unison :hide
-type Foo = Foo
+type Foo = Foo Nat | RenamedQux Nat Nat
 ```
 
 ``` ucm :error
@@ -38,17 +41,22 @@ scratch/main> update
 ```
 
 ``` unison :added-by-ucm scratch.u
-type Foo = Foo
+type Foo = Foo Nat | RenamedQux Nat Nat
 
 -- The definitions below no longer typecheck with the changes above.
 -- Please fix the errors and try `update` again.
 
 foo : Foo -> Nat
 foo = cases
-  Foo -> 1
-  Bar -> 2
+  Foo     -> 1
+  Bar _   -> 2
+  Qux _ _ -> 3
 
 ```
+
+Here, we observe `Foo.*` doesn't exist in the namespace on the update branch, which is correct. Previously, `update`
+left behind both `Foo.Bar` (deleted in new version) and `Foo.Qux` ("renamed" to `RenamedQux` in the new version), both
+with a nameless hash in their type for the old type `Foo`.
 
 ``` ucm
 scratch/update-main> ls

--- a/unison-syntax/unison-syntax.cabal
+++ b/unison-syntax/unison-syntax.cabal
@@ -71,7 +71,7 @@ library
       base
     , bytes
     , containers
-    , cryptonite
+    , crypton
     , deriving-compat
     , extra
     , free


### PR DESCRIPTION
## Overview

Fixes #6130 

## Test coverage

I've added a regression test transcript that demonstrates the issue is fixed