### PR TITLE
bugfix: fix `cases` parsing in doc eval block

### DIFF
--- a/unison-src/transcripts/idempotent/fix5983.md
+++ b/unison-src/transcripts/idempotent/fix5983.md
@@ -1,11 +1,21 @@
 This transcript demonstrates that it is no longer necessary to wrap a top-level `cases`-block in a doc eval block in parens.
 
-``` union
-x.doc = {{
+``` ucm :hide
+scratch/main> builtins.mergeio lib.builtin
 ```
 
-cases x -\> 1
-
-``` 
+```` unison
+x.doc = {{
+  ```
+  cases x -> 1
+  ```
 }}
+````
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  + x.doc : Doc2
+
+  Run `update` to apply these changes to your codebase.
 ```

--- a/unison-src/transcripts/idempotent/fix5983.md
+++ b/unison-src/transcripts/idempotent/fix5983.md
@@ -1,0 +1,11 @@
+This transcript demonstrates that it is no longer necessary to wrap a top-level `cases`-block in a doc eval block in parens.
+
+``` union
+x.doc = {{
+```
+
+cases x -\> 1
+
+``` 
+}}
+```

--- a/unison-syntax/src/Unison/Syntax/Parser.hs
+++ b/unison-syntax/src/Unison/Syntax/Parser.hs
@@ -185,7 +185,13 @@ uniqueBase32Namegen rng =
 uniqueName :: (Monad m, Var v) => Int -> P v m Text
 uniqueName lenInBase32Hex = do
   UniqueName mkName <- asks uniqueNames
-  pos <- L.start <$> P.lookAhead anyToken
+  pos <-
+    asum
+      [ L.start <$> P.lookAhead anyToken,
+        -- if we're at EOF, we still want to be able to generate a unique name. so, just use a dummy pos that's not
+        -- equal to any other pos
+        pure (L.Pos (-1) (-1))
+      ]
   let none = Base32Hex.toText . Base32Hex.fromByteString . encodeUtf8 . Text.pack $ show pos
   pure . fromMaybe none $ mkName pos lenInBase32Hex
 


### PR DESCRIPTION
## Overview

Fixes #5983 

This PR fixes the issue where docs would fail to parse with a terrible empty error message when they contained an eval block that ended with a `cases`, such as

````
x.doc = {{
  ```
  cases x -> 1
  ```
}}
````

(or just try editing all `@unison/cloud` docs for many more realistic examples in the wild).

It took a bit to track down, but the issue is that we need to generate a random name for the variable binding, when desugaring to a lambda, for which we use a unique name generator that is a function of next token's position in the file. If there are no more tokens in the file, it fails. (Tokens in an eval block are lex'd separately, so we hit EOF at the end of each one).

I fixed this by simply allowing unique name generation at the end of a file, by using the dummy position `Pos (-1) (-1)`.

## Test coverage

I added a regression test