### PR TITLE
bump haskeline dependency to one that supports ANSI terminals

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -56,7 +56,7 @@ extra-deps:
   # Windows terminal.
   # https://github.com/judah/haskeline/pull/126
   - github: unisonweb/haskeline
-    commit: 9275eea7982dabbf47be2ba078ced669ae7ef3d5
+    commit: d7791c203f71e7da93c9570b51519bd31eec47d6 # branch unison-26-01-28
   - github: ChrisPenner/hs-mcp
     commit: d8564c70ca09e333b7ce1717d1ac97a62d62966c
 

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -7,14 +7,14 @@ packages:
 - completed:
     name: haskeline
     pantry-tree:
-      sha256: c14fd8b9ad5e9fcf629e50affe26e655d6c4d18c3f77169995b857b5fd32ca44
-      size: 3769
-    sha256: 3997e23bacea83e1e6b94098f74378fa54baf99755a0d834d9008bfe7071ed58
-    size: 74277
-    url: https://github.com/unisonweb/haskeline/archive/9275eea7982dabbf47be2ba078ced669ae7ef3d5.tar.gz
-    version: 0.8.0.0
+      sha256: eacdfbdccd946a26dcb0b42ac598c2c0891cc9096cb25bd7b217af0ceaa57e73
+      size: 3742
+    sha256: aa5a5aebf75a7c8e5238d1a6d9edfbdf208fe4e945e7ff1ceadfb23ea1cbb6e8
+    size: 80734
+    url: https://github.com/unisonweb/haskeline/archive/d7791c203f71e7da93c9570b51519bd31eec47d6.tar.gz
+    version: 0.8.4.1
   original:
-    url: https://github.com/unisonweb/haskeline/archive/9275eea7982dabbf47be2ba078ced669ae7ef3d5.tar.gz
+    url: https://github.com/unisonweb/haskeline/archive/d7791c203f71e7da93c9570b51519bd31eec47d6.tar.gz
 - completed:
     name: hs-mcp
     pantry-tree:


### PR DESCRIPTION
## Overview

Partially addresses #6119 

This PR swaps our `haskeline` dependency to a different branch, where I've added support for ANSI terminals. Now we no longer fall back on the "dumb terminal" logic, which horizontally scrolls the input line when it becomes long, rather than rendering the input on multiple lines.

I accomplished this by first extracting out an interface from the existing `terminfo`-based implementation that doesn't depend on `terminfo`, then implementing a second instance of that interface using ANSI escape sequences instead, for moving the cursor around, clearing lines, etc.

I say this "partially" addresses #6119 because although I think it really improves the status quo, the prompt still seems to behave kind of... weirdly. I've seen it kind of get visually out of sync, where my cursor isn't where it appears to be, when moving around the wrapped line threshold, either by left/right arrow keys, or backspace. I observed the exact same behavior with the `terminfo` backend, so I think the logic in haskeline just kind of sucks and is woefully behind other languages' repl libraries in functionality and polish.

## Test coverage

I tested this change manually and it seems to work