### PR TITLE
[unison-cli] Fix prompt rendering after reverse search in Haskeline

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -96,3 +96,4 @@ The format for this list: name, GitHub handle
 * Emil Petersen (@leetemil)
 * Lars Wilhelmsen (@larsw)
 * Nic Luciano (@kn0ll)
+* Maurice Scheffmacher (@MauScheff)

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -103,7 +103,7 @@ getUserInput codebase authHTTPClient pp currentProjectRoot numberedArgs =
                   branchString,
                   fromString prompt
                 ]
-      line <- Line.getInputLine $ Text.unpack fullPrompt
+      line <- Line.getInputLine $ markNonPrinting (Text.unpack fullPrompt)
       case line of
         Nothing -> pure QuitI
         Just l -> case fromMaybe [] $ IP.parseArgs l of
@@ -144,6 +144,29 @@ getUserInput codebase authHTTPClient pp currentProjectRoot numberedArgs =
           autoAddHistory = False
         }
     tabComplete = haskelineTabComplete IP.patternMap codebase authHTTPClient pp
+
+    -- Haskeline needs non-printing prompt segments wrapped with \SOH/\STX so
+    -- cursor positioning stays correct with ANSI colors.
+    markNonPrinting :: String -> String
+    markNonPrinting = \case
+      [] -> []
+      '\ESC' : rest ->
+        let (seqChars, rest') = takeAnsi rest
+         in '\SOH' : '\ESC' : seqChars ++ "\STX" ++ markNonPrinting rest'
+      c : rest -> c : markNonPrinting rest
+
+    -- Consume a CSI sequence after ESC, if present.
+    takeAnsi :: String -> (String, String)
+    takeAnsi = \case
+      '[' : rest ->
+        let (body, rest') = span (not . isFinalAnsi) rest
+         in case rest' of
+              [] -> ('[' : body, [])
+              f : fs -> ('[' : body ++ [f], fs)
+      rest -> ([], rest)
+
+    isFinalAnsi :: Char -> Bool
+    isFinalAnsi c = c >= '@' && c <= '~'
 
 loopStateProjectPath ::
   Codebase IO Symbol Ann ->


### PR DESCRIPTION
## Overview

  - [x] What does this change accomplish and why?
    Fixes terminal artifacting after Ctrl‑R reverse search by
    marking ANSI prompt sequences as non‑printing for Haskeline.
  - [x] i.e. How does it change the user experience?
    After pressing Enter from reverse search, the line no longer
    shows duplicated “tail” text.
  - [x] i.e. What was the old behavior/API and what is the new
    behavior/API?
    Old: Prompt ANSI sequences were counted as printable width,
    causing cursor misplacement and residual characters.
    New: ANSI sequences are wrapped with SOH/STX so Haskeline
    ignores their width.
  - [x] Include "before and after" examples if appropriate. (You can
    copy/paste screenshots directly into this editor.)
 
    (Screenshots can be added.)
  - [ ] List any Github issues that this PR closes, in closing-
    issues-using-keywords format.

  ## Implementation approach and notes

  Wrap ANSI escape sequences in the prompt passed to getInputLine
  using SOH/STX markers, as recommended by Haskeline, so cursor
  positioning is correct.

  ## Interesting/controversial decisions

  No major alternatives; this is the standard Haskeline approach for
  colored prompts.

  ## Test coverage

  - [ ] Have you included tests (which could be a transcript) for
    this change, or is it somehow covered by existing tests?
    No automated tests; manual verification only.
  - [ ] Would you recommend improving the test coverage (either as
    part of this PR or as a separate issue) or do you think it’s
    adequate?
    Probably adequate for now; terminal interaction is hard to test.
  - [x] If you only tested by hand, because that's all that's
    practical to do for this change, mention that. Include
    screenshots.
    Tested manually by running UCM, using Ctrl‑R on a long history
    entry, and confirming the line renders correctly after Enter.

  ## Loose ends

  None.

  ## Final checklist

  - [x] Choose your PR title well: Your pull request title is what's
    used to create release notes, so please make it descriptive of
    the change itself, which may be different from the initial
    motivation to make the change.
  - [x] Update your PR description if the specifics of the PR have
    changed over time.
  - [ ] Include transcripts or screenshots that demonstrate the
    changed behavior.
  - [x] If you changed .cabal files, make sure the package.yaml
    files are up-to-date instead.
