### PR TITLE
fix accidental swap of local<->remote in difftool invocation

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/DiffBranch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/DiffBranch.hs
@@ -299,7 +299,7 @@ handleDiffBranch aliceArg bobArg = do
                   }
               where
                 slugs =
-                  mangleDiffBranchArg <$> maybeSwap originalArgs
+                  mangleDiffBranchArg <$> originalArgs
 
         let difftool =
               difftool0
@@ -326,19 +326,20 @@ handleDiffBranch aliceArg bobArg = do
                             diffblob.defns.lca
                             builtins
                             hydratedDefns
-                        _ -> aliceAndBobFiles.alice
+                        _ -> if swapped then aliceAndBobFiles.bob else aliceAndBobFiles.alice
                     )
                     aliceAndBobFiles
                   where
                     aliceAndBobFiles :: Merge.TwoWay Text
                     aliceAndBobFiles =
-                      renderUnisonFile
-                        <$> Merge.ThreeWay.gforgetLca diffblob.declNameLookups
-                        <*> Merge.TwoOrThreeWay.forgetLca namespaces
-                        <*> Merge.ThreeWay.forgetLca libdepsDiffs
-                        <*> Merge.ThreeWay.forgetLca diffblob.defns
-                        <*> Merge.TwoOrThreeWay.forgetLca changedBuiltinDefns
-                        <*> pure hydratedDefns
+                      maybeSwap $
+                        renderUnisonFile
+                          <$> Merge.ThreeWay.gforgetLca diffblob.declNameLookups
+                          <*> Merge.TwoOrThreeWay.forgetLca namespaces
+                          <*> Merge.ThreeWay.forgetLca libdepsDiffs
+                          <*> Merge.ThreeWay.forgetLca diffblob.defns
+                          <*> Merge.TwoOrThreeWay.forgetLca changedBuiltinDefns
+                          <*> pure hydratedDefns
 
             for_ ((,) <$> filenames <*> renderedUnisonFiles) \(name, contents) ->
               env.writeSource name contents True


### PR DESCRIPTION
## Overview

Fixes #6157 

This PR fixes the accidental swapping of "local" & "remote" in the difftool invocation. It's a little hard to capture in a test since the fix doesn't affect the ucm-rendered difference between the branches, but here is a screenshot of it working:

<img width="849" height="283" alt="Screenshot 2026-02-02 at 1 10 54 PM" src="https://github.com/user-attachments/assets/bb5516ae-63be-463e-9a1b-4519661ec031" />

This is just showing a run with `UCM_DIFFTOOL='echo $LOCAL $REMOTE'`. On trunk, we'd echo

```
/private/var/folders/0m/cpz59dyj3ts58crh9m1gbcyr0000gn/T/nix-shell.gZ8Y6T/unison-e836d32e1092301f/main.u /private/var/folders/0m/cpz59dyj3ts58crh9m1gbcyr0000gn/T/nix-shell.gZ8Y6T/unison-e836d32e1092301f/topic.u
```

no matter the argument order. On this branch, the argument order is reflected in the arguments passed to the difftool.