### PR TITLE
Change the `test` command to use the sandboxed runtime instead of `evalPureUnison`

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Tests.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Tests.hs
@@ -121,7 +121,7 @@ handleTest TestInput {includeLibNamespace, path, showFailures, showSuccesses} = 
             liftIO (Text.putStrLn $ "\nAbout to run test:" <> ("\n" <> P.toPlain 80 testName))
           Cli.respond $ TestIncrementalOutputStart fqnPPE (n, total) r
           --                        v don't cache; test cache populated below
-          tm' <- Cli.time ("\n" <> P.toPlain 80 testName) $ RuntimeUtils.evalPureUnison fqnPPE False tm
+          tm' <- Cli.time ("\n" <> P.toPlain 80 testName) $ RuntimeUtils.evalUnisonTermE Sandboxed fqnPPE False tm
           case tm' of
             Left e -> do
               Cli.respond $ TestIncrementalOutputEnd fqnPPE (n, total) r False

--- a/unison-runtime/src/Unison/Runtime/Machine.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine.hs
@@ -385,7 +385,7 @@ exec _ _ !_activeThreads !stk !k cix (Prim2 THRO i j) = do
   where
     r = combRef cix
 exec env henv !_activeThreads !stk !k _ (Prim2 TRCE i j)
-  | sandboxed env = die [] "attempted to use sandboxed operation: trace"
+  | sandboxed env = pure (False, henv, stk, k)
   | otherwise = do
       tx <- peekOffBi stk i
       clo <- peekOff stk j

--- a/unison-runtime/src/Unison/Runtime/Machine/Primops.hs
+++ b/unison-runtime/src/Unison/Runtime/Machine/Primops.hs
@@ -500,10 +500,7 @@ tltt stk r =
 {-# INLINE tltt #-}
 
 dbtx :: CCache p -> Stack -> Val -> IO ()
-dbtx env stk val
-  | sandboxed env =
-      die [] "attempted to use sandboxed operation: Debug.toText"
-  | otherwise = writeBack stk traced
+dbtx env stk val = writeBack stk traced
   where
     traced = case tracer env False val of
       NoTrace -> Nothing

--- a/unison-src/transcripts/idempotent/name-test-sandbox-violators.md
+++ b/unison-src/transcripts/idempotent/name-test-sandbox-violators.md
@@ -1,24 +1,37 @@
 ``` ucm :hide
-> builtins.merge
+> builtins.mergeio
 ```
 
 This passes, because the IO sandbox doesn't seem to apply to `test>` watch expressions.
 
 ``` unison
+toException : Either Failure r ->{Exception} r
+toException = cases
+  Left e -> Exception.raise e
+  Right a -> a
+
+printLine : Text ->{IO, Exception} ()
+printLine t =
+  stdOut = stdHandle StdOut
+  toException (putBytes.impl stdOut (toUtf8 t))
+  toException (putBytes.impl stdOut (toUtf8 "\n"))
+
 test> foo.test =
   x = 192
-  Debug.trace "x" x
+  coerceAbilities (do printLine "hello") ()
   [Ok "Passed"]
 ```
 
 ``` ucm :added-by-ucm
   Loading changes detected in scratch.u.
 
-  + foo.test : [Result]
+  + foo.test    : [Result]
+  + printLine   : Text ->{IO, Exception} ()
+  + toException : Either Failure r ->{Exception} r
 
   Run `update` to apply these changes to your codebase.
 
-    2 |   x = 192
+    13 |   x = 192
     
     ✅ Passed Passed
 ```
@@ -52,7 +65,7 @@ This test which is essentially the same will fail, because it is never run with 
 bar.test : [Test.Result]
 bar.test =
   x = 42
-  Debug.trace "x" x
+  unsafe.coerceAbilities (do printLine "hello") ()
   [Ok "Passed"]
 ```
 
@@ -89,14 +102,12 @@ bar.test =
 
   Error while evaluating test `bar.test`:
 
-    💔💥
+    ❗️
     
-    I've encountered a call to builtin.bug with the following
-    value:
+    Sorry – I’ve encountered a Unison runtime error.
     
-      "pure code can't perform I/O"
+      Attempted to use disallowed builtin in sandboxed environment: IO.stdHandle
     
-    Stack trace:
-      #1k885m4e7g
-      #tnbpslc0n3
+    Please report it at
+    https://github.com/unisonweb/unison/issues/new/choose.
 ```


### PR DESCRIPTION
This PR reworks a few things to improve the behavior of tests. Currently, tests run via `evalPureUnison`, which surrounds the term with a sandboxing check, looking for any _reference_ to a disallowed term (except `Debug.toText` and `Value.value`, which is enables). If the check fails, a fairly opaque message is printed out. You can end up in this situation because `test` runs things this way, but `test>` watches are relatively unrestricted. So, you can have a test that appears to be fine during creation, but will fail due to sandboxing later.

This instead changes `test` to use the sandboxed runtime, with no up front check. This has sensitive operations replaced to throw exceptions, so it's still not possible to use them. But, the error messages will be more targeted (mentioning the disallowed operation), and it won't fail merely because a disallowed operation is _referred to_, only if it's actually run. E.G. the following would previously fail as a test:

    foo =
      unused = printLine
      [Ok "done"]

But won't anymore, because `printLine` isn't actually called with enough arguments.

I also made the following adjustments to the sandboxed runtime

- Made `Debug.trace` a _no-op_ when running in sandboxed mode, instead of throwing an exception. This means that if you forget a trace statement in a test, it just won't do anything, instead of causing a failing test.
- Allowed `Debug.toText` in the sandboxed runtime. This was enabled by tests previously.

`Value.value` was already allowed in the sandboxed runtime.

Addresses #4685. I thought there was another issue asking for either `trace` or `toText` in docs, which this would also allow (with no-op behavior for the former), but I can't seem to find it.