### PR TITLE
Add explicit locale to attestation script

### DIFF
--- a/scripts/proofs/lib-attestation-hash.sh
+++ b/scripts/proofs/lib-attestation-hash.sh
@@ -25,6 +25,8 @@
 
 set -euo pipefail
 
+export LC_ALL=C
+
 if [[ -z "${PATTERNS+x}" ]]; then
     echo "Error: PATTERNS array must be defined before sourcing lib-attestation-hash.sh" >&2
     exit 1


### PR DESCRIPTION
## Overview

My locale was different than the one in CI, meaning `sort` would not return the same results, and I'd get a different assertion hash. Explicitly setting a locale for the script fixes that for me.

## Implementation approach and notes

Sets the C locale within the script.

