### PR TITLE
Batch test watches.

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Runtime.hs
+++ b/parser-typechecker/src/Unison/Codebase/Runtime.hs
@@ -3,8 +3,11 @@
 
 module Unison.Codebase.Runtime where
 
+import Control.Lens
+import Control.Monad.Except
 import Data.Map qualified as Map
 import Data.Set.NonEmpty (NESet)
+import Data.Zip qualified as Zip
 import Unison.ABT qualified as ABT
 import Unison.Builtin.Decls (tupleTerm, pattern TupleTerm')
 import Unison.Codebase.CodeLookup qualified as CL
@@ -197,3 +200,45 @@ evaluateTerm ::
   Term.Term v a ->
   IO (Either e (Response e', Term v))
 evaluateTerm codeLookup = evaluateTerm' codeLookup noCache
+
+evaluateTermBatch ::
+  forall v a e e'.
+  (Var v, Monoid a) =>
+  CL.CodeLookup v IO a ->
+  (Reference.Id -> IO (Maybe (Term v))) ->
+  PPE.PrettyPrintEnv ->
+  ProfileSpec ->
+  Runtime e e' v ->
+  Map v (Term.Term v a) ->
+  IO (Either e (Map v (Response e', Term v)))
+evaluateTermBatch codeLookup cache ppe prof rt tms = do
+  results :: Map v (Maybe (Term v)) <- traverse (cache . Hashing.hashClosedTerm) tms
+  let cacheTagged :: Map v (Either (Response e', Term v) (v, Term.Term v a))
+      cacheTagged =
+        Zip.zip tms results
+          & Map.mapWithKey \k -> \case
+            (_tm, Just cached) -> (Left (EmptyResponse, cached))
+            (tm, Nothing) -> (Right (k, tm))
+
+  cacheTagged
+    & unsafePartsOf (traversed . _Right)
+      %%~ ( \vs -> do
+              let watches = vs <&> \(v, tm) -> (WK.RegularWatch, [(v, mempty, tm, mempty <$> mainType rt)])
+              let tuf =
+                    UF.typecheckedUnisonFile
+                      mempty
+                      mempty
+                      mempty
+                      watches
+              r <- liftIO $ evaluateWatches (void codeLookup) ppe prof cache rt (void tuf)
+              case r of
+                Left e -> throwError e
+                Right (_, errs, resultMap) ->
+                  pure
+                    ( vs <&> \(v, _tm) ->
+                        let (_loc, _kind, _hash, _src, value, _isHit) = resultMap Map.! v
+                         in (errs, value)
+                    )
+          )
+    & runExceptT
+    <&> (fmap . fmap) (either id id)

--- a/parser-typechecker/src/Unison/Codebase/Runtime.hs
+++ b/parser-typechecker/src/Unison/Codebase/Runtime.hs
@@ -201,7 +201,7 @@ evaluateTerm ::
   IO (Either e (Response e', Term v))
 evaluateTerm codeLookup = evaluateTerm' codeLookup noCache
 
-evaluateTermBatch ::
+evaluateTermBatch' ::
   forall v a e e'.
   (Var v, Monoid a) =>
   CL.CodeLookup v IO a ->
@@ -211,7 +211,7 @@ evaluateTermBatch ::
   Runtime e e' v ->
   Map v (Term.Term v a) ->
   IO (Either e (Map v (Response e', Term v)))
-evaluateTermBatch codeLookup cache ppe prof rt tms = do
+evaluateTermBatch' codeLookup cache ppe prof rt tms = do
   results :: Map v (Maybe (Term v)) <- traverse (cache . Hashing.hashClosedTerm) tms
   let cacheTagged :: Map v (Either (Response e', Term v) (v, Term.Term v a))
       cacheTagged =
@@ -242,3 +242,13 @@ evaluateTermBatch codeLookup cache ppe prof rt tms = do
           )
     & runExceptT
     <&> (fmap . fmap) (either id id)
+
+evaluateTermBatch ::
+  (Var v, Monoid a) =>
+  CL.CodeLookup v IO a ->
+  PPE.PrettyPrintEnv ->
+  ProfileSpec ->
+  Runtime e e' v ->
+  (Map v (Term.Term v a)) ->
+  IO (Either e (Map v (Response e', Term v)))
+evaluateTermBatch codeLookup = evaluateTermBatch' codeLookup noCache

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/RuntimeUtils.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/RuntimeUtils.hs
@@ -1,6 +1,7 @@
 module Unison.Codebase.Editor.HandleInput.RuntimeUtils
   ( evalUnisonTerm,
     evalUnisonTermE,
+    evalUnisonTermBatch,
     evalPureUnison,
     displayDecompileErrors,
     displayResponse,
@@ -12,6 +13,7 @@ where
 
 import Control.Lens
 import Control.Monad.Reader (ask)
+import Data.Zip qualified as Zip
 import Unison.ABT qualified as ABT
 import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
@@ -93,6 +95,43 @@ evalUnisonTermE mode ppe useCache tm = do
         displayResponse resp
       Left _ -> pure ()
   pure $ r <&> Term.amap (\() -> Ann.External) . snd
+
+-- | Evaluate many closed definitions in a batch.
+evalUnisonTermBatch ::
+  EvalMode ->
+  PPE.PrettyPrintEnv ->
+  Bool ->
+  Map Symbol (Term Symbol Ann) ->
+  Cli (Either Error (Map Symbol (Term Symbol Ann)))
+evalUnisonTermBatch mode ppe useCache tms = do
+  Cli.Env {codebase} <- ask
+  theRuntime <- selectRuntime mode
+  let prof = modeProfSpec mode
+
+  let watchCache :: Reference.Id -> IO (Maybe (Term Symbol ()))
+      watchCache ref = do
+        maybeTerm <- Codebase.runTransaction codebase (Codebase.lookupWatchCache codebase ref)
+        pure (Term.amap (\(_ :: Ann) -> ()) <$> maybeTerm)
+
+  let cache = if useCache then watchCache else Runtime.noCache
+  r <- liftIO (Runtime.evaluateTermBatch' (Codebase.codebaseToCodeLookup codebase) cache ppe prof theRuntime tms)
+  when useCache do
+    case r of
+      Right evalled ->
+        for_ (Zip.zip tms evalled) \case
+          -- don't cache when there were errors
+          (_tm, (Runtime.DecompErrs errs, _)) | not $ null errs -> displayDecompileErrors errs
+          (tm, (resp, tmr)) -> do
+            Cli.runTransaction do
+              Codebase.putWatch
+                WK.RegularWatch
+                (Hashing.hashClosedTerm tm)
+                (Term.amap (const Ann.External) tmr)
+            displayResponse resp
+      Left _ -> pure ()
+  pure $
+    r <&> \result ->
+      Term.amap (\() -> Ann.External) . snd <$> result
 
 displayResponse :: Runtime.Response DecompError -> Cli ()
 displayResponse (Runtime.DecompErrs errs)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Tests.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Tests.hs
@@ -15,6 +15,7 @@ import Data.Set qualified as Set
 import Data.Set.NonEmpty (NESet)
 import Data.Set.NonEmpty qualified as NESet
 import Data.Text.IO qualified as Text
+import Data.Zip qualified as Zip
 import Unison.ABT qualified as ABT
 import Unison.Builtin.Decls qualified as DD
 import Unison.Cli.Monad (Cli)
@@ -59,7 +60,10 @@ import Unison.Util.Monoid (foldMapM)
 import Unison.Util.Pretty qualified as P
 import Unison.Util.Relation qualified as R
 import Unison.Util.Set qualified as Set
+import Unison.Util.Timing qualified as Timing
+import Unison.Var qualified as Var
 import Unison.WatchKind qualified as WK
+import Witherable qualified as Wither
 
 -- | Handle a @test@ command.
 -- Run pure tests in the current subnamespace.
@@ -67,9 +71,9 @@ handleTest :: TestInput -> Cli ()
 handleTest TestInput {includeLibNamespace, path, showFailures, showSuccesses} = do
   Cli.Env {codebase} <- ask
 
-  testRefs <- findTermsOfTypes codebase includeLibNamespace path (NESet.singleton (DD.testResultListType mempty))
+  testRefs <- Timing.time "Test Search" $ findTermsOfTypes codebase includeLibNamespace path (NESet.singleton (DD.testResultListType mempty))
 
-  cachedTests <-
+  cachedTests <- Timing.time "Check Caches" do
     Map.fromList <$> Cli.runTransaction do
       Set.toList testRefs & wither \case
         rid -> fmap (rid,) <$> Codebase.getWatch codebase WK.TestWatch rid
@@ -95,44 +99,57 @@ handleTest TestInput {includeLibNamespace, path, showFailures, showSuccesses} = 
                 | otherwise -> Nothing
             _ -> Nothing
   let stats = Output.CachedTests (Set.size testRefs) (Map.size cachedTests)
-  names <- Cli.currentNames
+  names <- Timing.time "Get names" Cli.currentNames
   let pped = PPED.makePPED (PPE.hqNamer 10 names) (PPE.suffixifyByHash names)
   let fqnPPE = PPED.unsuffixifiedPPE pped
-  Cli.respondNumbered $
-    TestResults
-      stats
-      fqnPPE
-      showSuccesses
-      showFailures
-      oks
-      fails
+  Timing.time "Respond TestResults:1" $
+    Cli.respondNumbered $
+      TestResults
+        stats
+        fqnPPE
+        showSuccesses
+        showFailures
+        oks
+        fails
   let toCompute = Set.difference testRefs (Map.keysSet cachedTests)
-  when (not (Set.null toCompute)) do
-    let total = Set.size toCompute
-    computedTests <- fmap join . for (toList toCompute `zip` [1 ..]) $ \(r, n) ->
-      Cli.runTransaction (Codebase.getTerm codebase r) >>= \case
-        Nothing -> do
-          hqLength <- Cli.runTransaction Codebase.hashLength
-          Cli.respond (TermNotFound' . SH.shortenTo hqLength . Reference.toShortHash $ Reference.DerivedId r)
-          pure []
-        Just tm -> do
-          let testName = Cli.prettyTermName fqnPPE (Referent.fromTermReferenceId r)
-          Debug.whenDebug Debug.Tests $
-            liftIO (Text.putStrLn $ "\nAbout to run test:" <> ("\n" <> P.toPlain 80 testName))
-          Cli.respond $ TestIncrementalOutputStart fqnPPE (n, total) r
-          --                        v don't cache; test cache populated below
-          tm' <- Cli.time ("\n" <> P.toPlain 80 testName) $ RuntimeUtils.evalUnisonTermE Sandboxed fqnPPE False tm
-          case tm' of
-            Left e -> do
-              Cli.respond $ TestIncrementalOutputEnd fqnPPE (n, total) r False
-              Cli.returnEarly $ EvaluationFailure (P.callout ("Error while evaluating test " <> P.backticked testName <> ":") . P.indentN 2) e
-            Right tm' -> do
-              -- After evaluation, cache the result of the test
-              Cli.runTransaction (Codebase.putWatch WK.TestWatch r tm')
-              Cli.respond $ TestIncrementalOutputEnd fqnPPE (n, total) r (isTestOk tm')
-              pure [(r, tm')]
+  Timing.time "Computing tests " $ when (not (Set.null toCompute)) do
+    let _total = Set.size toCompute
+    let termsMap :: Map Symbol TermReferenceId
+        termsMap = Map.fromList $ do
+          (n, termRef) <- (zip [1 :: Int ..] $ toList toCompute)
+          let testVar = Var.named $ "t" <> tShow n
+          pure (testVar, termRef)
+    preparedTests :: Map Symbol (Term Symbol Ann) <-
+      termsMap
+        & Wither.wither
+          ( \r ->
+              Cli.runTransaction (Codebase.getTerm codebase r) >>= \case
+                Nothing -> do
+                  hqLength <- Cli.runTransaction Codebase.hashLength
+                  Cli.respond (TermNotFound' . SH.shortenTo hqLength . Reference.toShortHash $ Reference.DerivedId r)
+                  pure Nothing
+                Just tm -> do
+                  let testName = Cli.prettyTermName fqnPPE (Referent.fromTermReferenceId r)
+                  Debug.whenDebug Debug.Tests $
+                    liftIO (Text.putStrLn $ "\nAbout to run test:" <> ("\n" <> P.toPlain 80 testName))
+                  pure $ Just tm
+          )
 
-    let m = Map.fromList computedTests
+    -- Cli.respond $ TestIncrementalOutputStart fqnPPE (n, total) r
+    -- --                        v don't cache; test cache populated below
+    res <- Cli.time "Run batch tests" $ RuntimeUtils.evalUnisonTermBatch Sandboxed fqnPPE False preparedTests
+    computedTests <- case res of
+      Left e -> do
+        -- Cli.respond $ TestIncrementalOutputEnd fqnPPE (n, total) r False
+        Cli.returnEarly $ EvaluationFailure (P.callout ("Error while evaluating test batch: ") . P.indentN 2) e
+      Right tmsResult -> do
+        for (Zip.zip tmsResult termsMap) \(tm', r) -> do
+          -- After evaluation, cache the result of the test
+          Cli.runTransaction (Codebase.putWatch WK.TestWatch r tm')
+          -- Cli.respond $ TestIncrementalOutputEnd fqnPPE (n, total) r (isTestOk tm')
+          pure (r, tm')
+
+    let m = Map.fromList $ Map.elems computedTests
         (mFails, mOks) = passFails m
     Cli.respondNumbered $ TestResults Output.NewlyComputed fqnPPE showSuccesses showFailures mOks mFails
 


### PR DESCRIPTION
## Overview

[Folks in Discord](https://discord.com/channels/862108724948500490/1482830156081922148) noticed that the `test` helper is much slower when running many tests than just loading all those tests into a single scratch file and running them there.

A look under the hood revealed we were creating an independent Unison File and runtime kick-off for each test independently; which meant a lot of duplicated overhead; and meant we were loading a lot of the same dependent code multiple times.

Instead we can create a single virtual Unison File with many Test Watches in it, run them all in one go; this is much faster.

* [ ] TODO: Running them this way is much faster, but of course we don't get dynamic updates when we run them all at once, so will need to figure that out yet. 


For a project like [typed-json](https://share.unison-lang.org/@frawa/typed-json); running `debug.clear-cache` and then `test` goes from 104s -> 30s

## Implementation approach and notes

How does it accomplish it, in broad strokes? i.e. How does it change the Haskell codebase?

## Interesting/controversial decisions

Add `batch` versions of the unison Term evaluation functions, these load many terms into the runtime as watches all at once, execute them in a single go, then unpack the results back into a map.

## Test coverage

TODO