### PR TITLE
only amend a commit if the attestation actually changed

### DIFF
--- a/scripts/hooks/lib-pre-push.sh
+++ b/scripts/hooks/lib-pre-push.sh
@@ -153,7 +153,10 @@ EOF
         exit 1
     fi
 
-    AMEND_FILES+=("$tracked_file")
+    # Only amend when the proof script actually changed the tracked proofs file.
+    if ! git diff --quiet -- "$tracked_path"; then
+        AMEND_FILES+=("$tracked_file")
+    fi
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Reduce churn by only amending the commit if the proof has changed