### PR TITLE
Exempt .github/workflows/proofs/ from CODEOWNERS review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,7 @@
 # Require approval from ucm team when editing repository workflows
 # This helps prevent users from sneaking in malicious changes to CI workflows.
 /.github/ @unisonweb/ucm
+
+# Proofs are auto-generated attestation files updated by most PRs,
+# so they don't need ucm team review.
+/.github/workflows/proofs/ # no owner


### PR DESCRIPTION
## Summary
- The `/.github/` CODEOWNERS rule requires `@unisonweb/ucm` review for all changes under `.github/`
- The proofs directory (`.github/workflows/proofs/`) contains auto-generated attestation files updated by most PRs
- This means every PR that runs checks triggers a ucm team review requirement, which isn't the intent of the rule
- Adds an override so `.github/workflows/proofs/` has no required owner

## Test plan
- [ ] Verify that PRs touching only proof files no longer require ucm team review
- [ ] Verify that PRs touching other `.github/` files still require ucm team review

🤖 Generated with [Claude Code](https://claude.com/claude-code)