### PR TITLE
Fix "occured" typo in user-facing messages and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Overview
 
 * No builds. Unison has perfect incremental compilation, with a shared compilation cache that is part of the codebase format. Despite the strong static typing, you are almost never waiting for code to compile.
 * Instant, non-breaking renaming of definitions.
-* Perfect caching of tests, only rerunning determinstic tests if dependencies changed.
+* Perfect caching of tests, only rerunning deterministic tests if dependencies changed.
 * Semantically-aware version control, avoiding spurious merge conflicts from things like order of imports, whitespace or code formatting differences, and so on.
 
 Unison can be used like any other general-purpose language, or you can use it in conjunction with [Unison Cloud](https://unison.cloud) for building distributed systems.

--- a/unison-cli/src/Unison/CommandLine/DisplayValues.hs
+++ b/unison-cli/src/Unison/CommandLine/DisplayValues.hs
@@ -212,7 +212,7 @@ displayPretty pped terms typeOf eval types tm = go tm
         eval tm >>= \case
           Nothing -> do
             p <- displayTerm pped terms typeOf eval types tm
-            pure . P.indentN 4 $ P.lines [p, "⧨", P.red "🆘  An error occured during evaluation"]
+            pure . P.indentN 4 $ P.lines [p, "⧨", P.red "🆘  An error occurred during evaluation"]
           Just result -> do
             p1 <- displayTerm pped terms typeOf eval types tm
             p2 <- displayTerm pped terms typeOf eval types result

--- a/unison-runtime/src/Unison/Runtime/Interface.hs
+++ b/unison-runtime/src/Unison/Runtime/Interface.hs
@@ -1153,7 +1153,7 @@ tabulateErrors errs | null errs = mempty
 tabulateErrors errs =
   P.indentN 2 . P.lines $
     ""
-      : P.wrap "The following errors occured while decompiling:"
+      : P.wrap "The following errors occurred while decompiling:"
       : (P.indentN 2 . renderDecompError <$> toList errs)
 
 formatIssues :: (Applicative f) => (Word -> f (Pretty P.ColorText)) -> [Word] -> f (Pretty P.ColorText)

--- a/unison-share-api/src/Unison/Server/Doc.hs
+++ b/unison-share-api/src/Unison/Server/Doc.hs
@@ -222,7 +222,7 @@ renderDoc pped doc = renderSpecial <$> doc
       ERenderError (InvalidTerm tm) -> Embed ("🆘  unable to render " <> source tm)
 
     evalErrMsg :: SyntaxText
-    evalErrMsg = "🆘  An error occured during evaluation"
+    evalErrMsg = "🆘  An error occurred during evaluation"
 
     renderSrc :: [EvaluatedSrc v] -> [Ref (UnisonHash, DisplayObject SyntaxText Src)]
     renderSrc srcs =


### PR DESCRIPTION

**Repo:** unisonweb/unison (⭐ 5400)
**Type:** docs
**Files changed:** 4
**Lines:** +4/-4

## What
Fixes the misspelling "occured" → "occurred" in three user-facing runtime/CLI/doc-rendering error messages, and corrects "determinstic" → "deterministic" in the project README.

## Why
These are strings that end users see when decompilation fails, when a doc evaluation errors, or when reading the top-level project README. Correct spelling matters for polish and professionalism; no behavioral change is involved.

## Testing
Pure string changes with no logic impact. Grepping the tree confirms no remaining instances of "occured" or "determinstic". No tests reference the literal strings.

## Risk
Low — string-only changes to display messages and README prose.
