### PR TITLE
Implicit parameters for Unison — RFC + working prototype

### DIFF
--- a/codebase2/codebase-sqlite-hashing-v2/src/Unison/Hashing/V2/Convert2.hs
+++ b/codebase2/codebase-sqlite-hashing-v2/src/Unison/Hashing/V2/Convert2.hs
@@ -84,6 +84,8 @@ v2ToH2Type' mkReference = ABT.transform convertF
       V2.Type.Effects a -> H2.TypeEffects a
       V2.Type.Forall a -> H2.TypeForall a
       V2.Type.IntroOuter a -> H2.TypeIntroOuter a
+      -- ADR-019: implicit arrows hash distinctly via 'TypeImplicitArrow'.
+      V2.Type.ImplicitArrow a b -> H2.TypeImplicitArrow a b
 
 convertKind :: V2.Kind -> H2.Kind
 convertKind = \case

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -2738,6 +2738,8 @@ c2sDecl saveText saveDefn (C.Decl.DataDeclaration dt m b cts) = do
       C.Type.Effects es -> pure $ C.Type.Effects es
       C.Type.Forall a -> pure $ C.Type.Forall a
       C.Type.IntroOuter a -> pure $ C.Type.IntroOuter a
+      -- ADR-019: implicit arrows round-trip through the on-disk format.
+      C.Type.ImplicitArrow i o -> pure $ C.Type.ImplicitArrow i o
     done :: (S.Decl.Decl Symbol, (Seq Text, Seq Hash)) -> m (LocalIds' t d, S.Decl.Decl Symbol)
     done (decl, (localTextValues, localDefnValues)) = do
       textIds <- traverse saveText localTextValues
@@ -2806,6 +2808,8 @@ c2xTerm saveText saveDefn tm tp =
       C.Type.Effects es -> pure $ C.Type.Effects es
       C.Type.Forall a -> pure $ C.Type.Forall a
       C.Type.IntroOuter a -> pure $ C.Type.IntroOuter a
+      -- ADR-019: implicit arrows round-trip through the on-disk format.
+      C.Type.ImplicitArrow i o -> pure $ C.Type.ImplicitArrow i o
     goCase ::
       forall m w s a.
       ( MonadState s m,

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Serialization.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Serialization.hs
@@ -452,6 +452,9 @@ getType getReference = getABT getSymbol getUnit go
         5 -> Type.Effects <$> getList getChild
         6 -> Type.Forall <$> getChild
         7 -> Type.IntroOuter <$> getChild
+        -- New tag for implicit arrows (ADR-019). Distinct from
+        -- the regular 'Arrow' tag (1).
+        8 -> Type.ImplicitArrow <$> getChild <*> getChild
         tag -> unknownTag "getType" tag
     getKind :: (MonadGet m) => m Kind
     getKind =
@@ -1128,6 +1131,9 @@ putType putReference putVar = putABT putVar putUnit go
       Type.Effects es -> putWord8 5 *> putFoldable putChild es
       Type.Forall body -> putWord8 6 *> putChild body
       Type.IntroOuter body -> putWord8 7 *> putChild body
+      -- New tag for implicit arrows (ADR-019). Distinct from
+      -- the regular 'Arrow' tag (1).
+      Type.ImplicitArrow i o -> putWord8 8 *> putChild i *> putChild o
     putKind :: (MonadPut m) => Kind -> m ()
     putKind k = case k of
       Kind.Star -> putWord8 0

--- a/codebase2/codebase/U/Codebase/Decl.hs
+++ b/codebase2/codebase/U/Codebase/Decl.hs
@@ -145,3 +145,6 @@ unhashComponent componentHash refToVar m =
             Type.Effects as -> ABT.tm () $ Type.Effects as
             Type.Forall a -> ABT.tm () $ Type.Forall a
             Type.IntroOuter a -> ABT.tm () $ Type.IntroOuter a
+            -- ADR-019: implicit arrows round-trip through the V2
+            -- codebase representation.
+            Type.ImplicitArrow a b -> ABT.tm () $ Type.ImplicitArrow a b

--- a/codebase2/codebase/U/Codebase/Type.hs
+++ b/codebase2/codebase/U/Codebase/Type.hs
@@ -27,6 +27,11 @@ data F' r a
   | IntroOuter a -- binder like ∀, used to introduce variables that are
   -- bound by outer type signatures, to support scoped type
   -- variables
+  | -- | Mirror of 'Unison.Type.ImplicitArrow' (ADR-019) in the V2
+    -- codebase representation. Treated like 'Arrow' by everything but
+    -- the elaborator (Phase 2 chunks D2/D3); needed here so that the
+    -- conversion between the in-memory and on-disk type ASTs round-trips.
+    ImplicitArrow a a
   deriving (Foldable, Functor, Eq, Ord, Show, Traversable)
 
 -- | Non-recursive type

--- a/docs/architecture/decisions/ADR-001-constraint-syntax.md
+++ b/docs/architecture/decisions/ADR-001-constraint-syntax.md
@@ -1,0 +1,74 @@
+# ADR-001: Constraint syntax — Haskell-style `C =>`
+
+**Status:** Accepted
+**Date:** 2026-05-01
+**Deciders:** core maintainers (per design discussion)
+**Related:** ADR-002, ADR-003, ADR-006, ADR-010; `docs/implicits-plan.md` §1.2
+
+## Context
+
+Unison is gaining Scala-3-style implicit parameters under the working name
+`givens`. A function that *consumes* a given needs syntax in its type
+signature so that the elaborator can identify which leading parameters are
+implicit. This is a one-way door at the surface level — once we ship a
+syntax, every library written with implicits will use it forever and any
+change carries an ecosystem-wide migration cost.
+
+The choice here is independent of the underlying semantics (the constraint
+desugars to an ordinary leading argument either way) but it strongly shapes
+the look-and-feel of the feature, the ergonomics of multiple constraints,
+and what "implicit-bearing function" looks like on the page.
+
+## Options considered
+
+### Option A: Haskell-style `C =>` in the signature
+
+A constraint precedes the rest of the type: `Show a => a -> Text`.
+Multiple constraints group with parentheses: `(Monad m, Traversable t) =>
+…`. The `=>` arrow is distinct from the value-level `->`, so a reader can
+tell at a glance which arguments will be filled implicitly. Pros: familiar
+to Haskell, PureScript, Idris, Rust trait-bound users; visually compact;
+groups well; aligns with how subclassing-via-records reads in `docs/implicits-plan.md` §1.2. Cons: `=>` is one new symbolic keyword and its
+ordering vs `==>` matters in the lexer.
+
+### Option B: Scala 3 `using` parameters in the signature
+
+Mark each implicit parameter individually, e.g. `(using Show a) -> a ->
+Text`. Pros: parameters are listed in left-to-right order, matching the
+elaborated form one-for-one; uniform with the local `using`-bound form.
+Cons: verbose for the common case of multiple constraints; visually
+heavier; loses the at-a-glance "this function takes a typeclass" cue;
+requires `using` to be a hard keyword in type-syntax position.
+
+### Option C: No type-level constraint syntax (only `using`-bound locals)
+
+Don't introduce any signature-level constraint syntax at all; users would
+construct dictionaries explicitly and bind them with `using` at call
+sites. Pros: minimal language addition. Cons: defeats the point — every
+caller has to know about and manually thread every dictionary; eliminates
+the "constraint" abstraction users came for; unusable in practice.
+
+## Decision
+
+We adopt **Option A: Haskell-style `C =>` in signatures.** The constraint
+arrow `=>` precedes the rest of the type and groups with parentheses for
+multiple constraints. It desugars to a leading positional parameter
+tagged as implicit (per the elaborator).
+
+## Consequences
+
+- The `=>` token becomes a hard symbolic keyword in the type grammar.
+  `unison-syntax/src/Unison/Syntax/Lexer/Unison.hs` (`symbolyKw`) must
+  list `=>` *after* `==>` so the longer match wins.
+- Users get a familiar surface reminiscent of Haskell/PureScript/Idris.
+  Existing tutorials from those ecosystems carry over with minor edits.
+- Multiple constraints fall out naturally as tuple-style grouping
+  (`(C1 a, C2 b) =>`); no special multi-constraint syntax is needed.
+- Locks us out of repurposing `=>` for anything else in type position
+  (e.g. higher-kinded arrows, effect arrows). Effect arrows already use
+  the orthogonal `->{e}` form, so the conflict surface is small.
+- ADR-019 must specify how the implicit-ness is represented in `Type.F`;
+  the surface choice here doesn't decide that, but it commits us to
+  preserving the distinction at parse time.
+- Pretty-printer default (ADR-015) renders `=>` rather than `using`
+  parameters, matching how users will write signatures.

--- a/docs/architecture/decisions/ADR-002-givenness-namespace-metadata.md
+++ b/docs/architecture/decisions/ADR-002-givenness-namespace-metadata.md
@@ -1,0 +1,86 @@
+# ADR-002: Givenness is namespace metadata, not a term-level tag
+
+**Status:** Accepted
+**Date:** 2026-05-01
+**Deciders:** core maintainers (per design discussion)
+**Related:** ADR-004, ADR-005, ADR-013, ADR-014, ADR-020; `docs/implicits-plan.md` §1.1 principle 4, §5.2
+
+## Context
+
+A "given" is an ordinary Unison term that the elaborator is allowed to
+pick up implicitly. Something has to record the bit "this term is
+eligible for implicit resolution." Where that bit lives — in the term, in
+the type, or in the namespace — has consequences for hashing, aliasing,
+forking, and how downstream consumers can disagree with upstream about
+what counts as a given.
+
+Unison's identity story is built around content-addressed term hashes:
+two definitions with the same hash are the same term forever, history
+pointers don't break, and aliases are free. Anything that "tags" a term
+must not perturb that hash, or the abstraction breaks down. At the same
+time the namespace already has a metadata slot — `MdValues` per
+`(NameSegment, Referent)` in
+`codebase2/codebase/U/Codebase/Branch/Type.hs` — designed for exactly
+this kind of attribution.
+
+## Options considered
+
+### Option A: Namespace metadata tag
+
+Mark the (name, hash) binding in the current namespace as "given." The
+term hash is unchanged; the *branch* (causal) hash changes, since branch
+hashing in `unison-hashing-v2/src/Unison/Hashing/V2/Branch.hs` includes
+`MdValues` in its tokens. Pros: aliases are independent (a downstream
+namespace can demote an upstream given or promote a non-given without
+touching its hash); fits an existing schema slot; matches Unison's
+"namespace = view onto the codebase" model. Cons: requires plumbing
+metadata through name lookup and all read sites (presently `MdValues` is
+written but barely read); requires ADR-020 to settle storage shape.
+
+### Option B: Term-level tag (special term form)
+
+Wrap given terms in a new ABT node like `Given e` or introduce a
+distinct top-level declaration form. Pros: fully self-describing —
+fetching the term tells you it's a given. Cons: changes the term hash
+(every given hashes differently from a same-bodied non-given), so
+flipping givenness becomes a destructive update; `unison-runtime` and
+`unison-hashing-v2` both grow a concept; aliases can't disagree; rules
+out the downstream-reclassification story.
+
+### Option C: Type-level marker
+
+Encode givenness in the type, e.g. with a phantom newtype `Given a`.
+Pros: zero runtime/storage changes. Cons: can't tag an existing
+upstream definition without changing its type (and therefore its hash);
+forces every given to be defined as a `Given`-wrapped value; cuts off
+the "promote/demote without touching the term" use case.
+
+## Decision
+
+We adopt **Option A: givenness is recorded as namespace metadata** on
+the (name, hash) binding, stored in or alongside `MdValues`. Term hashes
+are untouched by tagging; branch hashes change (already true for any
+metadata edit); the runtime sees nothing.
+
+## Consequences
+
+- Term hashes are stable across `mark.given` / `unmark.given`. Aliases,
+  history pointers, and dependent terms keep working unchanged.
+- Branch hashes legitimately change when givenness changes — this is
+  the same behavior any `MdValues` edit produces today, and is what
+  lets downstream namespaces fork their view of the given-set.
+- Two namespaces can disagree about whether the same hash is a given.
+  This is a feature (per ADR-005's "namespace = instance set") but
+  means UCM commands must always read givenness through the current
+  namespace, never by hash alone.
+- `MdValues` is currently a write-mostly schema slot. Phase 2.B must
+  thread metadata reads through name lookup, project APIs, view/find,
+  and any command that surfaces definitions. `grep MdValues unison-cli`
+  is empty today; this is real plumbing work.
+- ADR-020 inherits the storage decision (revive `causal_metadata`,
+  reuse `MdValues` with a sentinel `##Builtin.Given`, or new field).
+- ADR-021 inherits the merge story: namespace-metadata conflicts during
+  `unison-merge` need a defined resolution.
+- Sharing protocol (`unison-share-api`) must transmit the metadata
+  field; an API version bump is required and a coordinated server
+  release is required before client release.

--- a/docs/architecture/decisions/ADR-003-classes-are-ordinary-types.md
+++ b/docs/architecture/decisions/ADR-003-classes-are-ordinary-types.md
@@ -1,0 +1,84 @@
+# ADR-003: A "class" is an ordinary type; no new declaration kind
+
+**Status:** Accepted
+**Date:** 2026-05-01
+**Deciders:** core maintainers (per design discussion)
+**Related:** ADR-002, ADR-004, ADR-011; `docs/implicits-plan.md` §1.2 ("Declaring a class")
+
+## Context
+
+Languages with implicit/typeclass features split into two camps. One
+camp (Haskell, Idris, PureScript, Rust) introduces a dedicated `class`
+or `trait` declaration form whose bodies define methods, with `instance`
+declarations as the dual. The other camp (Scala 3, Coq) treats a "class"
+as just a type — usually a record — and instances as ordinary values of
+that type.
+
+Unison already has rich record-via-data-constructor syntax. The
+`unique type` form supports parameterised constructors with named
+fields, and pattern-matching on those constructors gives you method
+extraction for free. The `higher-rank.md` transcript
+(`unison-src/transcripts/idempotent/higher-rank.md` line 52) shows
+`unique type Functor f = Functor (forall a b . (a -> b) -> f a -> f b)`
+already type-checks today. Adding a separate `class`/`instance` system
+would either duplicate or clash with these mechanisms.
+
+## Options considered
+
+### Option A: Classes are ordinary types
+
+A "class" is a type declaration, typically a record:
+`unique type Show a = Show { show : a -> Text }`. An "instance" is just
+a value of that type, optionally tagged `given`. Pros: no new
+declaration kind to design, parse, hash, or store; subclassing falls
+out of records-containing-records (`Ord` carries a `functor : Functor
+m` field); existing typechecker, codegen, hashing, and UCM commands
+work unmodified; aligns with how community libraries already encode
+typeclass-shaped abstractions today. Cons: no `class`-specific syntax
+sugar (e.g., automatic method-projection by type); subclass coercion
+is manual record access rather than implicit.
+
+### Option B: Dedicated `class` and `instance` declarations (Haskell-style)
+
+Add new top-level forms: `class C a where method : Sig` and
+`instance C T where method = …`. Pros: methods can be projected by name
+without an explicit dictionary handle; superclasses can be
+implicitly-inserted upcasts; closer match to Haskell idioms. Cons:
+introduces a new declaration kind that has to flow through every
+codebase concern — parser, AST, typechecker, hashing, namespace
+storage, UCM `view`/`find`/`edit`, sharing protocol, pretty-printer,
+codebase migration. Doubles the surface area of the feature for a
+gain that records-with-`given`-values mostly already provide. Rules
+out a downstream user reclassifying an upstream record as a "class"
+without re-declaring it.
+
+## Decision
+
+We adopt **Option A: classes are ordinary types**, typically records.
+There is no dedicated `class` or `instance` declaration form. A given
+is simply a value of a record type with the `given` namespace tag.
+
+## Consequences
+
+- The whole feature ships without a new declaration kind. Parser, AST,
+  typechecker, hashing, codebase storage, and UCM commands carry over
+  unchanged for class/instance machinery — only the implicit-resolution
+  pass and the namespace `given` tag are new.
+- Method invocation goes through ordinary record field access, e.g.
+  `Show.show (summon (Show a)) x`. With implicit resolution this
+  collapses to the ergonomic form once the elaborator inserts the
+  dictionary, but the underlying mechanism is field projection.
+- Subclassing is composition of records. `Ord` containing a `functor :
+  Functor m` field is the entire mechanism — there is no "superclass
+  upcast" rule, the user calls the field. This is simpler but more
+  manual than Haskell's superclass inference.
+- Any existing `unique type` already in the wild can be retroactively
+  used as a class; existing record values can be retroactively tagged
+  `given`. There is no "class-ification" migration step.
+- Locks us out of class-only syntactic sugar (associated types,
+  defaults, automatic superclass coercion). ADR-011 already defers
+  associated types and functional dependencies; these would have been
+  natural to attach to a `class` form but must be revisited if added.
+- Keeps the door open for adding a `class` *abbreviation* later as
+  pure sugar over `unique type` + `given`, without re-architecting
+  anything.

--- a/docs/architecture/decisions/ADR-004-compile-time-resolution.md
+++ b/docs/architecture/decisions/ADR-004-compile-time-resolution.md
@@ -1,0 +1,92 @@
+# ADR-004: Resolution is purely compile-time; runtime/codegen untouched
+
+**Status:** Accepted
+**Date:** 2026-05-01
+**Deciders:** core maintainers (per design discussion)
+**Related:** ADR-002, ADR-014, ADR-019; `docs/implicits-plan.md` §1.1 principle 1, §1.1 principle 2
+
+## Context
+
+Implicit-parameter systems can run at one of two levels. Most ML-family
+languages (Haskell, Scala, Idris) elaborate implicits away at compile
+time, leaving ordinary function applications behind. A few systems
+(notably some dynamic languages and dependently-typed proof assistants
+with `auto`-tactics at runtime) defer instance lookup. Choosing affects
+which subsystems learn a new concept.
+
+Unison's runtime is content-addressed and built around term hashes that
+are baked into compiled output (ANF/MCode in `unison-runtime/`) and
+into the codebase store. Anything that has to vary across runtime
+contexts breaks the "the term hash *is* the program" model. Conversely,
+if elaborator output is plain `App` nodes referencing fully resolved
+dictionary hashes, the runtime sees nothing new at all.
+
+## Options considered
+
+### Option A: Compile-time-only resolution
+
+The elaborator runs after typechecking and before any runtime concern.
+It produces ordinary `App` nodes whose argument positions are filled
+with references to chosen given dictionaries. Term hashing
+(`unison-hashing-v2`) hashes those `App` nodes the same way it hashes
+hand-written applications. Runtime ANF/MCode in `unison-runtime/`
+sees only ordinary applications. Pros: zero changes to runtime,
+codegen, ABT, and term hashing; the feature is entirely "elaborator
+sugar"; resolution is frozen into the term hash, so a stored term
+will never silently re-resolve to a different given when the
+namespace changes. Cons: changing a given requires producing a new
+term (with a new hash) — ADR-016 has to define `update` semantics for
+this.
+
+### Option B: Runtime dictionary lookup
+
+Compiled terms reference givens by name or by some indirect handle;
+the runtime looks up the current dictionary at call time. Pros: a
+single term can dispatch differently depending on namespace context;
+allows late-binding of instances. Cons: the runtime
+(`unison-runtime/` ANF and MCode) gains a new instruction class;
+term hashes either become context-dependent (defeating
+content-addressing) or stop reflecting runtime behavior; the codebase
+store has to record dictionary-resolution metadata that travels with
+the term; the "two libraries with conflicting `Show.nat` ambiguate at
+the call site" coherence story becomes incoherent because the
+ambiguity is resolved at the wrong time.
+
+## Decision
+
+We adopt **Option A: resolution is purely compile-time.** The
+elaborator emits plain `App` nodes referencing fully resolved
+dictionary terms. Runtime, codegen, ABT, and term-hashing learn no
+new concept.
+
+This was verified by inspection of the codebase:
+`unison-runtime/`'s ANF/MCode pipeline operates on already-elaborated
+ABT and never inspects implicit-ness, and
+`unison-hashing-v2/src/Unison/Hashing/V2/Branch.hs` hashes branch
+contents (not term internals) so it is unaffected by the elaborator
+output as long as that output is plain `App` nodes. The whole feature
+lives in the elaborator pass.
+
+## Consequences
+
+- `unison-runtime/` is not touched by this feature. ANF, MCode, the
+  decompiler, and the runtime FFI all remain unchanged.
+- Term hashing is unchanged. An elaborated term with implicit slots
+  filled in hashes exactly like the equivalent hand-written term.
+  This is a guarantee downstream tooling can rely on.
+- Resolution is *frozen into the hash*: once a term is elaborated and
+  stored, it references specific dictionary hashes. Adding or
+  removing givens later cannot change what an existing stored term
+  computes.
+- Changing which given a function consumes requires a *new* term (new
+  hash). `update` semantics must be defined for the re-elaboration
+  case (ADR-016).
+- The elaborator pass's output must be deterministic given the same
+  typechecker output and the same given-set, or hashes will drift
+  across rebuilds. Phase 2.D locks this with golden-hash tests.
+- Forecloses the "single term that works in multiple namespaces with
+  different instances" use case. Users who want that must abstract
+  over the dictionary explicitly (writing the parameter, not relying
+  on `=>`).
+- Makes tooling unambiguous: a debugger, profiler, or decompiler
+  reading runtime values sees the same shape it has always seen.

--- a/docs/architecture/decisions/ADR-005-coherence.md
+++ b/docs/architecture/decisions/ADR-005-coherence.md
@@ -1,0 +1,88 @@
+# ADR-005: Coherence — ambiguity at call site, no global uniqueness
+
+**Status:** Accepted
+**Date:** 2026-05-01
+**Deciders:** core maintainers (per design discussion)
+**Related:** ADR-002, ADR-008, ADR-021; `docs/implicits-plan.md` §1.1 principle 3, §1.3
+
+## Context
+
+A typeclass-style implicit system has to decide what happens when two
+matching instances are visible. Haskell enforces *global coherence*:
+across the entire program (all transitive imports), at most one instance
+exists for each `(class, type)` pair. Violations are compile errors
+(orphan instances, overlapping instances). This requires a global
+registry, orphan-instance rules, and rejects programs that two libraries
+could otherwise compose.
+
+Unison's namespace model is incompatible with global registries. There
+is no transitive-import notion: a file pulls in exactly the names its
+namespace exposes, and two libraries' worth of names can sit alongside
+without conflict until a user calls into both. The `MdValues` slot lives
+per-namespace, not globally.
+
+## Options considered
+
+### Option A: Per-call-site ambiguity (no global uniqueness)
+
+The "instance set" at a given program point is exactly the set of
+visibly-tagged givens in scope. Resolution at a call site searches that
+set. If exactly one given matches, use it. If multiple match (and
+specificity per ADR-008 doesn't pick a winner), report ambiguity at the
+call site naming both candidates with their namespace paths and hash
+prefixes — the same UI TDNR already uses for ambiguous names. Pros:
+fits Unison's namespace model; zero global state; two libraries that
+each define `given Show.nat` compose freely until a third site sees
+both; downstream users can disambiguate by shadowing or by `@`-override
+(ADR-007); errors are local and actionable. Cons: a function might
+typecheck in one namespace and fail in another with strictly more
+visible givens; users must learn that "more imports can break me."
+
+### Option B: Haskell-style global coherence with orphan rules
+
+Maintain a global registry of `(class, type) -> instance` and reject
+duplicates. Pros: a function that typechecks anywhere typechecks
+everywhere; well-understood semantics; predictable. Cons: requires a
+global registry that doesn't exist in Unison and is incompatible with
+how namespaces, aliasing, and downstream reclassification (ADR-002)
+work; orphan rules are notoriously painful in Haskell and would need
+to be reinvented for Unison's name-based world; rules out the
+"namespace = view onto givens" property; requires defining what "the
+program" is in a UCM session that touches many namespaces.
+
+## Decision
+
+We adopt **Option A: coherence by call-site ambiguity. The namespace
+*is* the instance set.** Resolution searches visible givens; multiple
+matches that don't disambiguate via ADR-008's specificity rules are
+reported at the call site with both candidates. There is no global
+registry, no orphan rule, and no cross-namespace uniqueness check.
+
+## Consequences
+
+- Two libraries can each define `given Show.nat` and ship to Share
+  without a conflict. They only conflict when a user pulls both into
+  one namespace and writes a `Show Nat`-using term *in that
+  namespace*.
+- Ambiguity errors are reused from TDNR's existing machinery: same
+  formatting, same near-miss reporting, same "did you mean…"
+  affordances. Implementation effort is low.
+- A function written against a small namespace may fail to elaborate
+  when that namespace is enlarged. This is a real ergonomic cost.
+  Users learn to disambiguate via local `given` shadowing (ADR-010)
+  or `@`-override (ADR-007) at the call site.
+- ADR-008's specificity rules (subsumption + lexical-inner-wins) are
+  the only knob for resolving multi-candidate cases. Rejected:
+  GHC-style `OVERLAPPING`/`OVERLAPPABLE` pragmas — they encourage
+  fragile ordering tricks.
+- ADR-021 (merge semantics) inherits a defined story: when two
+  branches both add givens for the same type at the same name, the
+  merge tooling has to surface that and let the user pick.
+- Locks us into "which set of givens is in scope" being a
+  namespace-local question. Anything that wants global behavior
+  (e.g., a "canonical `Show Nat`" library lemma) has to be solved by
+  social convention or by Phase 5's stdlib seed, not by the
+  resolver.
+- A future reviewer who finds themselves wanting "global coherence"
+  should re-read this ADR and ADR-002 first; the answer is "by
+  design, no."

--- a/docs/architecture/decisions/ADR-006-summon-syntax.md
+++ b/docs/architecture/decisions/ADR-006-summon-syntax.md
@@ -1,0 +1,93 @@
+# ADR-006: `summon T` is the explicit summon form
+
+**Status:** Accepted
+**Date:** 2026-05-01
+**Deciders:** core maintainers (per design discussion)
+**Related:** ADR-001, ADR-007, ADR-022; `docs/implicits-plan.md` §1.2 ("Explicit summon and override"), §12 (lexer)
+
+## Context
+
+Most uses of givens never need an explicit "fetch the dictionary" form:
+calls insert constraint arguments automatically and the user writes
+`Show.show x` rather than `Show.show (the (Show a)) x`. Still, an
+explicit summon form is needed in three situations: (a) when the
+dictionary itself is the value being passed (`given local : Ord a =
+Ord.flip (summon (Ord a))`), (b) when writing a local given that wraps
+or transforms an ambient one, and (c) when teaching the resolver
+behavior in tests and docs.
+
+The choice is therefore about syntax for a relatively rare construct,
+but one that shows up in every nontrivial example in the design plan.
+The trigger for this ADR was discovering that the otherwise-attractive
+`?T` form clashes with Unison's existing `Char` literal syntax.
+
+## Options considered
+
+### Option A: `summon T`
+
+A keyword `summon` followed by the type. Pros: reads as English ("summon
+a `Show Nat`"); zero conflict with existing surface syntax (`summon` is
+not currently reserved per `unison-syntax/src/Unison/Syntax/ReservedWords.hs`);
+unambiguous in any expression context. Cons: `summon` is currently a
+legal identifier, so introducing it as a keyword breaks any program
+that names a binding `summon` (ADR-022 covers the migration).
+
+### Option B: `?T` prefix sigil
+
+Scala 3 / Idris-flavoured: `?T` reads "an instance of `T`, please."
+Compact, sigil-based, no keyword needed. **Rejected** because it
+clashes with Unison's `Char` literal syntax. The lexer at
+`unison-syntax/src/Unison/Syntax/Lexer/Unison.hs` line 489 reads
+`character = Character <$> (char '?' *> (spEsc <|> LP.charLiteral))`
+— `?` is the `Char` literal prefix. `?T` in expression context would
+be ambiguous with a malformed character literal, and tightening the
+disambiguation to handle "`?` followed by a type-shaped expression"
+would either break existing programs or require deep parser changes.
+
+### Option C: `the T` (Idris)
+
+Idris uses `the : (a : Type) -> a -> a` for type-ascription / explicit
+elaboration. Pros: established in another implicit-aware language;
+short. Cons: "the" is an extremely common English word and a frequent
+identifier choice (`the user`, `the request`); migration is painful;
+reads less actively than `summon`; the Idris meaning is closer to type
+ascription than implicit summoning, so importing the keyword imports
+confusion.
+
+### Option D: `given T` (Scala 3 expression form)
+
+Scala 3 uses `given` in expression position too: `summon[T]` with
+`given` declarations. Pros: keyword reuse with the declaration form.
+Cons: `given` already means "declare a given" in our top-level
+syntax; reusing it for "fetch a given" creates two unrelated meanings
+parsed by context; ambiguous when an in-let `given` declaration is
+parsed (Phase 2.A's parser would have to disambiguate
+`given X : T = …` from `given T` as an expression).
+
+## Decision
+
+We adopt **Option A: `summon T` as the explicit summon form.** It
+reads naturally, has no existing-syntax conflict, and is unambiguous
+in every expression context. The `?T` form is rejected on the basis
+of the `Char`-literal lexer clash discovered during design.
+
+## Consequences
+
+- `summon` becomes a reserved keyword. ADR-022 covers the migration
+  for any user code that currently names a binding `summon`. The
+  reserved-words list (`unison-syntax/src/Unison/Syntax/ReservedWords.hs`)
+  must add `summon`.
+- The form takes a type, not an expression: `summon (Show Nat)`,
+  `summon (Ord a)`. The parser knows it's in type context after
+  `summon`.
+- In every example in the design plan that needs an explicit
+  dictionary handle, `summon` reads naturally; reviewers report the
+  surface looks closer to English than to a sigil soup.
+- Locks us into "explicit summon is verbose by design." Users should
+  rarely need it; if surveys find frequent use, that's a signal the
+  *implicit* path has a hole, not a signal to add a sigil shortcut.
+- Forecloses repurposing `summon` for any other language feature.
+  Given how specific the word is, the loss is small.
+- Pretty-printer (Phase 4 / ADR-015) renders explicit summons as
+  `summon T`, including in verbose mode where `@d` overrides are
+  elaborated.

--- a/docs/architecture/decisions/ADR-007-explicit-override.md
+++ b/docs/architecture/decisions/ADR-007-explicit-override.md
@@ -1,0 +1,87 @@
+# ADR-007: `@`-positional explicit override at call sites
+
+**Status:** Accepted
+**Date:** 2026-05-01
+**Deciders:** core maintainers (per design discussion)
+**Related:** ADR-001, ADR-006, ADR-010; `docs/implicits-plan.md` §1.2 ("Explicit summon and override"), §12 (lexer/parser disambiguation)
+
+## Context
+
+Even with implicit resolution working, users need a way to pass a
+specific dictionary at a call site. The two main use cases are
+(a) testing — passing a mock `Show` to confirm a function calls
+`Show.show` with the expected formatting; and (b) breaking ambiguity
+locally — when two givens both match and the user wants this *one*
+call to use a particular one without introducing a `let`-bound local
+given.
+
+The form must read clearly, must compose with chains of implicit
+parameters (`f @ d1 @ d2 x`), and must not clash with the rest of the
+expression grammar — `@` is already used in patterns
+(`x @ Foo a`, `parser-typechecker/src/Unison/Syntax/TermParser.hs`
+line ~410) and as a doc-comment prefix
+(`parser-typechecker/src/Unison/Syntax/Parser/Doc.hs` line ~163).
+
+## Options considered
+
+### Option A: `@`-positional override (`f @ d x`)
+
+`f @ d x` parses as "apply `f` to `d` in its next implicit slot, then
+apply to `x`." Multiple `@`-overrides chain left-to-right:
+`f @ d1 @ d2 x` fills the first two implicit slots. Pros: terse, fits
+on one line; doesn't need a name for the implicit parameter; the
+`@`-token is already in the symbolic-keyword table; one-character
+visual cue that "this is non-standard arg passing." Cons: parser
+disambiguation needed against as-patterns and doc syntax — addressed
+by context (expression position vs pattern position vs doc position).
+
+### Option B: Named-argument syntax (`f (using = d) x`)
+
+Each implicit parameter gets a name; the override picks the name.
+Pros: unambiguous when a function has multiple implicits of unrelated
+types; survives reordering of implicits in the signature. Cons:
+implicit parameters typically have no good names — they're identified
+by their type, not by a label; introduces a new "named argument"
+machinery that doesn't exist elsewhere in Unison; verbose for the
+common case of one implicit; redundant with the type-based positional
+order that ADR-001 already establishes.
+
+### Option C: Apply by type (`f [Show Nat = d] x`)
+
+Bracket form keying on the type rather than the position. Pros: works
+under reordering of implicits. Cons: even more verbose; the type
+already determines which slot is filled, so the bracket adds no
+information at a typical call; brings new syntax for a corner case.
+
+## Decision
+
+We adopt **Option A: `@`-positional explicit override at call sites.**
+`f @ d` fills the next implicit slot of `f` with `d`; chained
+`@`-applications fill subsequent slots in order.
+
+## Consequences
+
+- Phase 2.A's parser must disambiguate three uses of `@` by context:
+  (1) as-patterns inside `cases`/`match` (existing); (2) doc-prefix
+  inside `Doc` blocks (existing); (3) explicit-override in expression
+  context (new). The lexer already produces `@` as a symboly keyword
+  (`unison-syntax/src/Unison/Syntax/Lexer/Unison.hs` line ~572); the
+  three meanings live in disjoint parser states.
+- `@`-overrides are positional, so changing the order of implicit
+  parameters in a function's signature is a breaking change for any
+  caller that uses `@`-override. This is acceptable because reordering
+  implicits in a signature is itself a breaking change (it's a
+  type-shape change), and `@` users will see the same error any other
+  caller would.
+- Testing pattern is straightforward: `myFunction @ mockShow input`.
+  No need to introduce a local `given` or unbind the ambient one.
+- Pretty-printer verbose mode renders implicit applications as
+  `f @ d1 @ d2 args`, the same form a user would write — verbose
+  output is parseable as source.
+- Forecloses adding "named implicit arguments" later without grammar
+  conflict. If demand surfaces, a `(name = value)` extension to
+  application-syntax could coexist with `@`-positional, but is not
+  planned.
+- Editor tooling (Phase 2.F LSP): hover on a synthesized `@d`
+  argument shows the resolved given's name and hash. Source-position
+  hover skips synthesized args because they don't exist in source.

--- a/docs/architecture/decisions/ADR-008-specificity.md
+++ b/docs/architecture/decisions/ADR-008-specificity.md
@@ -1,0 +1,109 @@
+# ADR-008: Specificity ordering — subsumption + lexical-inner-wins
+
+**Status:** Accepted
+**Date:** 2026-05-01
+**Deciders:** core maintainers (per design discussion)
+**Related:** ADR-005, ADR-009, ADR-010; `docs/implicits-plan.md` §1.3 ("Specificity ordering")
+
+## Context
+
+When more than one given matches a constraint goal, the resolver needs
+a deterministic rule to either pick a winner or report ambiguity. Two
+things happen frequently: (a) a generic given (`Show a => Show (List
+a)`) and a specific given (`Show (List Nat)`) both match — most users
+expect the specific one to win; (b) a local `given` declared in a `let`
+block matches alongside a top-level given — most users expect the local
+one to win.
+
+The choice of rule is observable in user code and is hard to change
+later: any change to the specificity rule reclassifies which programs
+typecheck and which terms hash to what. Conservative is right.
+
+## Options considered
+
+### Option A: Subsumption + lexical-inner-wins
+
+Two rules, applied in this order:
+1. **Subsumption.** Given `A` is strictly more specific than given `B`
+   iff there exists a substitution σ such that σ(B's *declared*
+   conclusion) = A's *declared* conclusion, where σ may substitute B's
+   quantified type variables only (A's quantified variables are treated
+   as rigid). σ ≠ identity. The comparison uses *alpha-renamed declared*
+   conclusions — not the post-unification specialised conclusions, since
+   those equal the goal by construction. **One-way matching, not full
+   unification.** If a unique most-specific candidate exists by
+   subsumption, pick it.
+2. **Lexical proximity.** Among candidates not separable by
+   subsumption, a `given` introduced by a closer (more-inner) `let`
+   binder wins over one introduced further out, regardless of type
+   shape.
+3. **Otherwise tie.** Report ambiguity, listing both candidates with
+   namespace path and hash prefix.
+
+> The "one-way matching, declared conclusions" detail was added after
+> the Phase 1 spike: the first implementation compared post-unification
+> conclusions and full-unified instead of one-way matched, producing
+> incorrect specificity orderings. The spike's `oneWayMatch` is the
+> reference implementation.
+
+Pros: matches what users expect from "specific beats generic"; lets
+local `given` shadow ambient givens as ADR-010 requires; deterministic
+and simple to implement; aligns with the resolution algorithm in
+`docs/implicits-plan.md` §1.3. Cons: subsumption-only ordering admits
+cases where two candidates are unrelated under subsumption but share
+common ground a human would consider "obviously equal" — these
+ambiguate, which can frustrate users until they add a local given or
+`@`-override.
+
+### Option B: Priority annotations (Scala 3 style)
+
+Allow givens to declare a priority level. A high-priority given beats
+a default given. Pros: explicit; user controls the ordering. Cons:
+introduces a new attribute on `given` declarations; prioritization
+reasoning is non-local (you have to know all candidates' priorities);
+encourages priority-tweaking battles when libraries disagree;
+incompatible with Unison's "namespace = instance set, no global
+arbiter" model from ADR-005.
+
+### Option C: GHC overlap pragmas (`OVERLAPPING`, `OVERLAPPABLE`,
+`INCOHERENT`)
+
+GHC-style annotations on instances controlling which overlaps the
+typechecker tolerates. **Rejected.** GHC's own users describe these
+pragmas as footguns; the documentation warns against them; they
+interact badly with cross-package coherence; they would import the
+worst part of Haskell's instance system into a language explicitly
+designed (ADR-005) to avoid that machinery.
+
+## Decision
+
+We adopt **Option A: subsumption + lexical-inner-wins, with
+otherwise-ties reporting ambiguity.** No priority annotations, no
+overlap pragmas.
+
+## Consequences
+
+- A specific given (`Show (List Nat)`) reliably wins over a generic
+  one (`Show a => Show (List a)`) when both match. This is the
+  textbook expected behavior and keeps stdlib design (Phase 5)
+  uncomplicated.
+- A local `given local : Ord a = …` reliably overrides any ambient
+  `Ord a` given for the rest of its scope. ADR-010's local-given
+  feature relies on this rule.
+- Two genuinely-unrelated candidates (neither subsumes the other,
+  same lexical depth) ambiguate. Users disambiguate via `@`-override
+  (ADR-007) or a local `given`. This is intentional — we surface
+  ambiguity rather than picking arbitrarily.
+- Locks the language out of priority annotations. Future work that
+  needs them (e.g. "default" instances) must either replace this ADR
+  or use a different mechanism.
+- Implementation: the spike (Phase 1) tests this on `Show (List Nat)`
+  vs `Show (List a)` as a success criterion. The full elaborator
+  (Phase 2.D) implements `mostSpecific` per the algorithm in
+  §1.3 of the plan.
+- Subsumption testing reuses unification machinery already in
+  `Unison.Typechecker.Context`; no new theory beyond what the
+  typechecker already has.
+- Error rendering (Phase 4) for the "tied" case shows both candidates
+  with enough information for the user to disambiguate; this is one
+  of the 20+ golden error scenarios.

--- a/docs/architecture/decisions/ADR-009-cycles-and-depth.md
+++ b/docs/architecture/decisions/ADR-009-cycles-and-depth.md
@@ -1,0 +1,90 @@
+# ADR-009: Cycle detection per branch; depth limit global, default 50
+
+**Status:** Accepted
+**Date:** 2026-05-01
+**Deciders:** core maintainers (per design discussion)
+**Related:** ADR-008; `docs/implicits-plan.md` §1.3 ("Cycle and depth handling")
+
+## Context
+
+Implicit resolution is a recursive search: a given for `Show (List a)`
+has a premise `Show a`, which must itself be resolved, and so on. Two
+things can go wrong with that search.
+
+First, **cycles.** A user can declare `given Foo : C => C` (or some
+chain of givens that loops). Naïve recursive search would diverge.
+Second, **explosion.** Even without cycles, a chain of premises can be
+deep (think `Show (Map (List (Optional Nat)) [Text])`), and pathological
+cases can blow up the search tree exponentially.
+
+The resolver needs defenses for both, and the defenses must distinguish
+"this branch is bad, try another candidate" (recoverable) from "the
+whole search is doomed" (hard error).
+
+## Options considered
+
+### Option A: Per-branch cycle detection + global depth limit (default 50, configurable)
+
+While exploring a candidate `g`, maintain a `stack` of types-being-resolved
+on this branch. If a sub-goal `T` unifies with anything on `stack`, fail
+*this branch* (try other candidates). Independently, maintain a global
+counter `depth`; if it exceeds a configured limit (default 50,
+overridable via project setting), error out the whole resolution with
+`DepthExceeded`, reporting the chain. Pros: cycles per-branch let
+alternative candidates succeed even when one alternative loops; depth
+limit catches non-cyclic explosions; `DepthExceeded` errors are
+actionable (the chain points at the offending givens); the algorithm
+matches the pseudocode in `docs/implicits-plan.md` §1.3 directly. Cons:
+two mechanisms instead of one; the depth bound is arbitrary and might
+need tuning.
+
+### Option B: Depth-only with no cycle detection
+
+Just rely on the depth limit; cycles will hit it eventually. **Rejected.**
+The error becomes "depth exceeded" for what is actually a structural
+cycle, masking the real bug. The chain in the error wouldn't reveal
+the loop because depth would terminate the search before the loop
+closed visibly. Diagnostics suffer.
+
+### Option C: Cycles as hard failure of the entire search
+
+If any sub-goal cycles, fail the whole top-level resolution with
+`Cycle` rather than failing only that candidate. **Rejected.** Kills
+valid alternative branches. Example: candidate `g1` cycles on its
+premise but candidate `g2` resolves cleanly — Option A picks `g2`,
+Option C errors. The latter is strictly worse.
+
+## Decision
+
+We adopt **Option A: per-branch cycle detection plus a global depth
+limit.** Cycles fail only the candidate that hit them; depth limit
+errors out the whole resolution with the chain. Default depth is 50,
+configurable via a project-level setting.
+
+## Consequences
+
+- The resolver maintains two pieces of state: a per-branch type-stack
+  (for cycle detection) and a global depth counter (for explosion
+  control). Both are threaded through the recursive `resolve` call,
+  exactly as shown in `docs/implicits-plan.md` §1.3.
+- Cycle detection is by *unification* against the stack, not by hash
+  identity. Two textually-different goals that unify to the same type
+  count as a cycle — this catches more loops than naive equality.
+- The default of 50 is generous for honest code (typical chains in
+  the spike test corpus are <10 deep) but small enough to terminate
+  pathological inputs in milliseconds. Users can raise it via a
+  project setting if they have a legitimate deep-chain use case.
+- Three structured error categories from §7.2: `NoGiven`,
+  `Ambiguous`, `DepthExceeded`. Cycles do *not* surface as a
+  user-visible error category — they are invisibly handled by
+  per-branch failure. If a cycle prevents *any* candidate from
+  succeeding, the user sees `NoGiven` (with near-misses including the
+  cycling candidate, ideally).
+- The spike (Phase 1) must demonstrate cycle termination and depth
+  behavior as success criteria.
+- `DepthExceeded` errors print the chain (truncated sensibly) and
+  mark the recursive step. Phase 4 has a golden test for this case.
+- Locks us into "no proof-search backtracking beyond what
+  per-candidate try-catch provides." Adding more sophisticated search
+  (e.g., dependent constraint solving) would require revisiting
+  this.

--- a/docs/architecture/decisions/ADR-010-local-givens.md
+++ b/docs/architecture/decisions/ADR-010-local-givens.md
@@ -1,0 +1,94 @@
+# ADR-010: Local `given` only inside `let`-blocks; no first-class implicit-function types
+
+**Status:** Accepted
+**Date:** 2026-05-01
+**Deciders:** core maintainers (per design discussion)
+**Related:** ADR-001, ADR-006, ADR-008; `docs/implicits-plan.md` §1.2 ("Local givens"), §1.4 ("not in v1")
+
+## Context
+
+Two related features can be folded into a "local implicit binding"
+story. The first is the ability to declare a `given` inside a function
+body — e.g. wrapping or transforming an ambient given for the rest of
+the block. The second, much heavier, is to have first-class
+implicit-function types: `(given x : T) => U`, with anonymous given
+lambdas, that can be passed around like any other function. Scala 3
+ships both; Idris ships variations.
+
+These features cost very different amounts. Local `given` in a `let`-
+block is a small, mechanical addition: it threads a binding through
+the lexical scope, where the elaborator already has to track scope.
+Anonymous given lambdas require `(given …)` as a binder form, type-
+inference for implicit-function types, and changes to how function
+values are formed. They also expand the surface area of what
+"specificity by lexical proximity" means.
+
+## Options considered
+
+### Option A: Local `given` in `let`-blocks only
+
+Allow `given name : T = expr` as a statement form inside a `let`
+block (and equivalent in do-notation). The binding is added to the
+lexical given environment for the rest of the block, shadowing any
+ambient given of the same type per ADR-008's lexical-inner-wins rule.
+No first-class implicit-function types, no anonymous given lambdas.
+Pros: small implementation; one new statement form; no changes to
+function-type theory; covers every use case in the design plan
+(e.g., reversed-order sort by introducing `given local : Ord a =
+Ord.flip (summon (Ord a))`); composes with `summon` (ADR-006) and
+`@`-override (ADR-007). Cons: users wanting to abstract over
+implicit-bearing functions must write the constraint explicitly in
+the function type; no `(given x : T) => …` lambda.
+
+### Option B: First-class implicit-function types deferred (current decision but worth naming)
+
+Allow `(given x : T) => U` as a type and `given x => body` as an
+expression. Pros: full Scala 3 / Coq parity; `given`-as-binder
+generalises uniformly. Cons: requires substantial new type theory
+(implicit-function types interact with effect rows, polymorphism,
+HKT); requires anonymous-lambda binder syntax; expands what "lexical
+inner wins" must reason about; usefulness in real code is small
+relative to cost. **Deferred.** Can be added in v2 without breaking
+the v1 surface.
+
+## Decision
+
+We adopt **Option A: local `given` only inside `let`-blocks (and
+equivalent block forms).** First-class implicit-function types and
+anonymous given-lambdas are deferred to a future revision. The local
+form is exactly the mechanism shown in `docs/implicits-plan.md`
+§1.2:
+
+```
+sortReversed : Ord a => [a] -> [a]
+sortReversed xs =
+  given local : Ord a = Ord.flip (summon (Ord a))
+  sort xs
+```
+
+## Consequences
+
+- Phase 2.A's parser learns `given <name> : <type> = <expr>` as a
+  statement form inside `let` and equivalent block contexts. No new
+  expression-position binder form.
+- The lexical given environment threaded through
+  `Unison.Typechecker.Context` (per `docs/implicits-plan.md` §5.4)
+  picks up local givens at the same point it picks up ordinary
+  bindings. This is mechanical but pervasive — every binding form
+  must extend the env.
+- Local givens compose with `summon` (ADR-006): wrapping an ambient
+  given is the canonical use case
+  (`given local : Ord a = Ord.flip (summon (Ord a))`).
+- ADR-008's lexical-inner-wins rule covers shadowing precisely.
+  Two locals at the same depth that both match still ambiguate.
+- Forecloses (for v1) abstracting over implicit-function-typed
+  values. A function that wants "give me a function that consumes a
+  `Show`" must take an explicit parameter, not an
+  implicit-function-typed argument. This is a real expressiveness
+  loss but the workarounds are well-known.
+- A future ADR can reintroduce first-class implicit-function types
+  on top of v1 without breaking existing code, because every v1
+  use of `given` is in binding position; expression-position uses
+  are still available namespace.
+- Pretty-printer (Phase 4) renders local givens with the same
+  syntax users wrote. Round-trip identity is required.

--- a/docs/architecture/decisions/ADR-011-hkt-scope.md
+++ b/docs/architecture/decisions/ADR-011-hkt-scope.md
@@ -1,0 +1,108 @@
+# ADR-011: HKT in v1; functional dependencies, associated types, kind-polymorphic givens deferred
+
+**Status:** Accepted
+**Date:** 2026-05-01
+**Deciders:** core maintainers (per design discussion)
+**Related:** ADR-003, ADR-004, ADR-019; `docs/implicits-plan.md` §1.4 ("What's not in v1"), §12 (kind inference and HKT baseline)
+
+## Context
+
+Typeclass-shaped features sit at different points on a complexity
+ladder: rank-1 classes over `Type` (`Eq a`, `Show a`), classes over
+type constructors of fixed kind `Type -> Type` (`Functor f`,
+`Monad m`), classes that abstract over kind shapes (`Bifunctor`,
+classes parameterised by both `Type -> Type` and `Type -> Type ->
+Type`), classes with functional dependencies relating parameters
+(`Mult a b c | a b -> c`), and classes with associated types (`type
+Item c` inside `class Container c`).
+
+Each step adds inference complexity, error-message complexity, and
+syntactic surface. Drawing the v1 line decides which patterns
+canonical libraries can express now and which patterns block on
+future work.
+
+Unison's actual kind system is documented in
+`parser-typechecker/src/Unison/KindInference/Generate.hs` line 451:
+
+```haskell
+data Kind = Type | Ability | Kind :-> Kind
+```
+
+There is no kind polymorphism — `Kind` is closed and finite-shape.
+The arrow form supports HKTs of any fixed shape. The transcript
+`unison-src/transcripts/idempotent/higher-rank.md` line 52 shows
+`unique type Functor f = Functor (forall a b . (a -> b) -> f a -> f
+b)` already type-checks, so `f : Type -> Type` works in current
+Unison without further kind-system changes.
+
+## Options considered
+
+### Option A: HKT yes; FDs, associated types, and kind-polymorphic givens deferred
+
+Givens may abstract over higher-kinded type constructors of fixed
+kind shape (`Functor f` where `f : Type -> Type`, `Monad m`, etc.).
+Givens that need functional dependencies, associated types, or
+kind variables (e.g., a `Bifunctor`-shaped premise where the kind
+shape itself is a parameter) are deferred. Pros: the existing kind
+system in `Unison.KindInference` already supports HKT without
+extension; the spike (Phase 1) can demonstrate `Functor List` and
+`Monad Optional`; the most common typeclass patterns work; no new
+kind theory required for v1. Cons: certain classes can't be
+expressed cleanly — `MonadReader r m | m -> r` requires FDs;
+`Container c` with `Item c` requires associated types — users
+write more parameters or duplicate code in the meantime.
+
+### Option B: HKT + FDs + associated types in v1
+
+Push everything into v1. Pros: maximally expressive; matches GHC's
+extensions in scope. Cons: each of these is a substantial typechecker
+project on its own; dramatically expands the elaborator surface
+(associated types interact with type-family normalization);
+multiplies error-rendering complexity (FD-violation errors are
+notoriously hard to render); pushes v1 ship date out by months;
+none are blocking for the headline use cases (`Eq`, `Ord`,
+`Functor`, `Monad`, `Traversable`).
+
+### Option C: Rank-1 only; no HKT
+
+Restrict v1 to classes over `Type`. Pros: simplest possible v1.
+Cons: rules out `Functor`, `Monad`, `Traversable`, the entire stdlib
+seed plan in Phase 5; cripples the feature for typed-functional
+idioms; would require a v2 to be useful for serious work.
+
+## Decision
+
+We adopt **Option A: HKT in v1; functional dependencies, associated
+types, and kind-polymorphic givens deferred to v2.** The kind system
+needs no extension to support v1 — the existing `Type | Ability |
+Kind :-> Kind` definition handles every v1 case.
+
+## Consequences
+
+- Phase 5's stdlib seed (`Eq`, `Ord`, `Show`, `Functor`,
+  `Applicative`, `Monad`, `Traversable`) can be authored in v1
+  without further language work. The HKT cases (`Functor`, `Monad`,
+  `Traversable`) reuse the kind machinery already in
+  `parser-typechecker/src/Unison/KindInference/`.
+- The spike (Phase 1) explicitly tests `Functor List` and `Monad
+  Optional` to confirm HKT given resolution works.
+  `unison-src/transcripts/idempotent/higher-rank.md` line 52 is the
+  baseline showing HKT already works at the language level.
+- Functional-dependency-shaped abstractions (state monads with
+  recoverable state type, `IsString`-style coercions) cannot be
+  expressed as cleanly in v1. Users either parameterise over the
+  related types explicitly or wait for v2.
+- Associated types similarly deferred. The `Ord` example in
+  `docs/implicits-plan.md` §1.2 sidesteps this by storing an `eq :
+  Eq a` *value* inside the record rather than declaring an
+  associated `type Item`.
+- Kind-polymorphic givens (e.g., a `Functor` instance parameterised
+  by the kind of the wrapped functor) are explicitly out. Standard
+  HKT — fixed kind shape — works.
+- Locks the v1 elaborator into "kind shape is determined by the
+  given's type signature; no kind variables are introduced during
+  resolution." Any future work that adds kind polymorphism must
+  revisit this assumption.
+- Documentation (Phase 6 migration guide) lists FDs and assoc types
+  as known omissions with examples of how to work around them in
+  v1.

--- a/docs/architecture/decisions/ADR-012-elaborator-placement.md
+++ b/docs/architecture/decisions/ADR-012-elaborator-placement.md
@@ -1,0 +1,89 @@
+# ADR-012: Elaborator pass placement vs inference
+
+**Status:** Proposed
+**Date:** 2026-05-01
+**Deciders:** core maintainers (pending ratification)
+**Related:** ADR-004, ADR-013, ADR-014, ADR-019; `docs/implicits-plan.md` §5.4, §5.5
+
+## Context
+
+Implicit-parameter elaboration must turn typechecker-recorded "constraint
+goals" — `(SourceLocation, Type, ScopeSnapshot)` triples — into concrete
+`App` nodes filled in with resolved dictionaries. The question is *when*
+this pass runs in the existing pipeline.
+
+The pipeline today already has a similar shape for type-directed name
+resolution (TDNR). `typeDirectedNameResolution` in
+`parser-typechecker/src/Unison/Typechecker.hs:262` runs a fixed-point loop
+over `InfoNote`s, and `applyTdnrDecisions` in
+`parser-typechecker/src/Unison/FileParsers.hs:329` walks the term and
+substitutes the chosen `Term v` for each recorded `Decision`. We can
+either fit implicit elaboration into the same shape or pick a different
+position in the pipeline.
+
+Inference itself lives in
+`parser-typechecker/src/Unison/Typechecker/Context.hs` (~3800 LoC of
+bidirectional inference). Whatever placement we choose has to interact
+cleanly with how that file threads its state.
+
+## Options considered
+
+### Option A: One-shot post-pass after TDNR's fixed point
+
+Run inference (with TDNR's fixed-point loop) to completion. The
+typechecker emits `InfoNote`s recording each implicit goal — type, scope
+snapshot, and a fresh `Implicit` blank in the term. Once TDNR reaches its
+fixed point, a single elaborator pass walks the goal list, runs
+resolution per ADR-008/009, and substitutes the chosen dictionary terms,
+mirroring `applyTdnrDecisions`. Pros: cheapest to implement, fits the
+existing extension pattern, no new fixed-point machinery. Cons: if
+implicit resolution itself produces a term whose type still has
+unresolved metavariables, we cannot feed those back into TDNR — but the
+spike (Phase 1) and the design contract (constraint goals carry pinned
+types) make this case rare and addressable with a localized re-check.
+
+### Option B: Interleaved within TDNR's fixed-point loop
+
+On each TDNR iteration, also resolve any newly added implicit goals;
+re-synthesize the type; iterate. Pros: handles the rare case where an
+implicit's resolution exposes a new TDNR opportunity (or vice versa).
+Cons: doubles the cost of the inner loop; couples two independently
+designed mechanisms; harder to debug when one of them oscillates.
+
+### Option C: Run before inference
+
+Resolve implicits at parse-to-AST time, before typechecking. Pros: keeps
+the typechecker unaware of implicits. Cons: untenable — resolution
+*requires* the inferred types of holes to know what to look up. The whole
+point of given resolution is type-directed.
+
+## Decision
+
+We recommend **Option A: a one-shot post-pass after TDNR's fixed point,**
+pending ratification. The pass mirrors `applyTdnrDecisions` and reuses
+the same `InfoNote`/`Decision`/blank-substitution shape. This is the
+minimum viable mechanism that fits the codebase, and the spike will
+confirm whether the rare TDNR-after-implicit case appears in practice. If
+it does, we can promote the pass into the TDNR fixed point as a follow-up
+without invalidating any consumer.
+
+## Consequences
+
+- **Unblocks** Phase 2.D (elaborator implementation) — the resolver lifts
+  out of the spike with a known place to be plugged in.
+- **Depends on** ADR-019 (so the typechecker can recognize implicit
+  arrows during inference), ADR-013 (so the pass has a given-set to read
+  from), and ADR-014 (for hashing the elaborated term).
+- ADR-016 (update semantics) presupposes deterministic, post-pass
+  elaboration: an `update` re-runs inference plus the post-pass and
+  compares hashes.
+- The elaborator output must be deterministic given the same goal list
+  and given-set; locked with golden-hash tests in Phase 2.E.
+- Required tests: (a) implicit goals appear and are resolved against
+  current TDNR test fixtures with no regressions; (b) a
+  TDNR-then-implicit case where TDNR pinning the type unlocks resolution;
+  (c) a "resolution surfaces a new TDNR candidate" case to confirm
+  whether Option B becomes necessary later.
+- Should the spike force Option B, the change is internal: only the
+  loop's driver in `Typechecker.hs` moves; ADRs 013/014/019 are
+  unaffected.

--- a/docs/architecture/decisions/ADR-013-given-set-storage.md
+++ b/docs/architecture/decisions/ADR-013-given-set-storage.md
@@ -1,0 +1,92 @@
+# ADR-013: Namespace given-set storage format
+
+**Status:** Proposed
+**Date:** 2026-05-01
+**Deciders:** core maintainers (pending ratification)
+**Related:** ADR-002, ADR-014, ADR-020, ADR-021; `docs/implicits-plan.md` §5.2
+
+## Context
+
+Per ADR-002, "givenness" is a tag attached to a hash inside a namespace,
+not part of the term itself. We need a concrete storage shape for the
+per-namespace set of given-tagged hashes. The choice has to fit the
+existing codebase model in
+`codebase2/codebase/U/Codebase/Branch/Type.hs:32`, which already records
+`MdValues = Set MetadataValue` per `(NameSegment, Referent)` for the
+existing metadata feature.
+
+The decision interacts with serialization (ADR-020), branch hashing
+(ADR-014), merge semantics (ADR-021), and migration. SQLite already has
+a dormant `causal_metadata` table at
+`codebase2/codebase-sqlite/sql/create.sql:113` that points at a different
+shape — per-causal rather than per-name — and is currently unused.
+
+Three storage options exist; each affects schema churn, migration cost,
+and how the merge code in `unison-merge/src/` will need to change.
+
+## Options considered
+
+### Option A: Reuse `MdValues` with a sentinel `Reference`
+
+Tag a name with given-ness by inserting a sentinel built-in `Reference`
+— call it `##Builtin.Given` — into the existing
+`Map Referent (m MdValues)` in `Branch m`. The schema, serialization,
+hashing, and read/write paths already exist; givenness becomes "a known
+metadata reference whose presence is significant." Pros: zero schema
+changes; piggy-backs on a slot already plumbed through codebase
+serialization (`unison-hashing-v2/src/Unison/Hashing/V2/Branch.hs`
+already includes `MdValues` in branch tokens, so causal hashing
+automatically tracks the change); aliases preserve the metadata
+naturally. Cons: needs every read path that surfaces metadata to know to
+filter or recognize the sentinel; the dormant `causal_metadata` table
+remains dormant; metadata semantics are stretched slightly (a sentinel
+is a flag dressed up as a value).
+
+### Option B: Revive the dormant `causal_metadata` table
+
+Use the existing-but-unused per-causal metadata table at
+`codebase2/codebase-sqlite/sql/create.sql:113` to record givenness keyed
+on causal id. Pros: gives metadata a real home rather than reusing a
+sentinel; the schema slot was designed for something like this. Cons:
+shape mismatch — `causal_metadata` is per-causal, but givenness is
+per-`(NameSegment, Referent)` within a branch; we would need a
+secondary lookup or a different schema; significantly more migration
+work; breaks the principle of fitting through the smallest possible
+hole.
+
+### Option C: New field on branch serialization
+
+Extend `U.Codebase.Branch.Type.Branch` with a new top-level `Set
+Referent` (or `Map NameSegment (Set Referent)`) recording givens. Pros:
+explicit, self-documenting, easy to read. Cons: invasive — touches
+serialization, hashing token list, sync/push, and every migration; new
+codebase format version; coordinated server release.
+
+## Decision
+
+We recommend **Option A: reuse `MdValues` with a sentinel
+`##Builtin.Given` reference,** pending ratification. The choice
+minimizes schema churn, exploits the metadata pathway that already
+participates in branch hashing, and matches the design principle
+(ADR-002) that givenness is a namespace-level tag. The dormant
+`causal_metadata` table stays dormant; ADR-020 makes that explicit.
+
+## Consequences
+
+- **Unblocks** Phase 2.B (namespace given-set storage) — work proceeds
+  against the existing `MdValues` slot rather than a new schema.
+- **Depends on** ADR-014 (which confirms branch-hash semantics for
+  metadata changes) and ADR-020 (which formalizes the on-disk encoding
+  and sharing-protocol bump).
+- **Forces** ADR-021 to teach `unison-merge/src/` how to diff and merge
+  the sentinel within `MdValues`; today the merge code has no
+  metadata-aware logic.
+- Sentinel choice locks us out of using `##Builtin.Given` for any other
+  purpose; document the reservation in the builtins module.
+- All read paths that surface metadata (UCM `find`, `view`, project APIs,
+  Share APIs) must filter or special-case the sentinel; failing to do so
+  exposes "Given" as a phantom metadata value to users.
+- Required tests: round-trip of a namespace through SQLite with
+  givens preserved; alias copies the sentinel; rename preserves it; a
+  migration test asserting existing namespaces have empty given-sets;
+  branch-hash determinism across mark/unmark.

--- a/docs/architecture/decisions/ADR-014-hashing.md
+++ b/docs/architecture/decisions/ADR-014-hashing.md
@@ -1,0 +1,99 @@
+# ADR-014: Hashing of givens and elaborated terms
+
+**Status:** Proposed
+**Date:** 2026-05-01
+**Deciders:** core maintainers (pending ratification)
+**Related:** ADR-002, ADR-004, ADR-013, ADR-019, ADR-020; `docs/implicits-plan.md` §1.1, §5.6
+
+## Context
+
+Implicit parameters interact with hashing in three places:
+
+1. **Given declarations.** A `given Show.nat : Show Nat = …` is just a
+   term whose namespace entry happens to carry a given-tag. Does the
+   declaration hash differently from an ordinary term?
+2. **Elaborated terms.** A caller `print x` becomes
+   `print @ Show.nat x` after elaboration. What does the term hash
+   against?
+3. **Branch (causal) hash.** Marking a definition `given` changes
+   namespace metadata. Does the branch hash reflect that?
+
+Each of these has a tempting "introduce a new hashing rule" answer. The
+goal of this ADR is the opposite: confirm that the existing
+infrastructure already does the right thing, so we add no new hashing
+rule.
+
+## Options considered
+
+### Option A: No new hashing rule — rely on existing infrastructure
+
+- Given declarations hash like ordinary terms. The body has a type
+  (per ADR-019, including any leading implicit-arrow parameters) and the
+  ABT `App`/`Lam`/`Ref` shape from `unison-core/src/Unison/Term.hs`. The
+  given-tag is *not* part of the term's hash — it lives in namespace
+  metadata per ADR-002/013.
+- Elaborated terms hash against resolved dictionary hashes. Once the
+  elaborator has filled in implicit arguments as plain `App` nodes
+  pointing at the chosen `Referent`s, the term reduces to ordinary
+  function application; the existing term-hash machinery already hashes
+  it correctly.
+- Branch hash already includes `MdValues` in its token list, see
+  `unison-hashing-v2/src/Unison/Hashing/V2/Branch.hs:34`. Storing the
+  given-tag inside `MdValues` (per ADR-013) means marking and unmarking
+  automatically changes the causal hash — the same mechanism that tracks
+  any other metadata edit.
+
+Pros: zero churn; consistent with ADR-004 ("runtime/codegen untouched");
+no new "given hashing" surface area in `unison-hashing-v2`. Cons: relies
+on ADR-019 settling cleanly so that a type containing `=>` hashes as a
+distinct type from one containing only `->`, and relies on ADR-013
+landing the tag inside `MdValues` rather than a new field.
+
+### Option B: Introduce a separate "given declaration" hashing rule
+
+Treat `given` declarations as a distinct hashable kind so the keyword is
+visible in the hash. Pros: hash carries the "this was declared given"
+signal even if metadata is lost. Cons: contradicts ADR-002 (givenness is
+namespace metadata, not term-level); makes alias/move/unmark operations
+semantically heavy; rules out demoting an upstream given without
+rehashing.
+
+### Option C: Hash elaborated terms against pre-elaboration form
+
+Strip implicit arguments before hashing the elaborated term so two
+namespaces with different givens but the same source produce the same
+hash. Pros: source-text identity. Cons: destroys content-addressing
+guarantees; old code's resolution would be hash-equivalent to new code
+with a different resolution; breaks the core "resolution is baked into
+the hash" principle (ADR-002, principle 2).
+
+## Decision
+
+We recommend **Option A: no new hashing rule,** pending ratification.
+Given declarations hash like ordinary terms; elaborated terms hash
+against resolved dictionary hashes via the existing `App` machinery; the
+branch hash captures givenness through the existing `MdValues`-in-tokens
+path. The change to `Type.F` decided in ADR-019 changes the type-hash
+namespace once but produces only new types going forward.
+
+## Consequences
+
+- **Unblocks** Phase 2.E (hashing and update semantics) — no new
+  `unison-hashing-v2` schema work.
+- **Depends on** ADR-013 (storage shape is `MdValues`-based so the
+  branch-hash path already covers tagging) and ADR-019 (so the
+  type-grammar change is the only new hash-affecting addition).
+- **Reinforces** ADR-016: an `update` that re-resolves to a different
+  given produces a different term hash, leaving old code's hash intact —
+  the foundation of the "ambiguity-free re-resolution silently produces
+  a new hash" rule.
+- Locks us into elaborator output that is *already* a plain `App`
+  (i.e. the elaborator does not introduce any new ABT constructor).
+- Required tests: golden-hash test fixing the hash of a representative
+  elaborated term; mark/unmark of a given changes the branch hash but
+  not the term hash; aliasing a given preserves the term hash; the
+  type-hash break for `=>` types is documented and golden-tested.
+- Should ADR-019 instead choose a side-table representation (its
+  Option B), this ADR's claim that elaborated terms hash via existing
+  `App` machinery still holds, but the "new types only" framing weakens;
+  ADR-019 must record any cross-impact.

--- a/docs/architecture/decisions/ADR-015-printer-default.md
+++ b/docs/architecture/decisions/ADR-015-printer-default.md
@@ -1,0 +1,82 @@
+# ADR-015: Pretty-printer default behavior
+
+**Status:** Proposed
+**Date:** 2026-05-01
+**Deciders:** core maintainers (pending ratification)
+**Related:** ADR-007, ADR-014, ADR-016, ADR-017; `docs/implicits-plan.md` §7.1
+
+## Context
+
+After elaboration, an implicit-bearing call site has explicit `App`
+nodes for each filled dictionary. The pretty-printer has to decide what
+to render: the resolved arguments (verbose, but transparent) or the
+source-style call without them (terse, but the resolution is invisible).
+
+Whichever default we pick has to satisfy the round-trip property: for any
+well-typed term `t`,
+`parse(print(elaborate(t))) == elaborate(t)` after re-elaborating in the
+namespace of origin. If the printer drops information the parser cannot
+recover, content addressing breaks at the source layer.
+
+## Options considered
+
+### Option A: Elide implicit arguments by default; verbose mode shows them
+
+Default `view`/`edit`/`find` output renders `print x`, not
+`print @Show.nat x`. The signature still shows `=>` so the reader knows
+implicits are involved. A verbose mode (CLI flag, UCM toggle, or LSP
+preference) prints `@<dict>` for each resolved implicit. Pros: matches
+how users wrote the code; matches the design intent ("givens are sugar
+for ordinary parameters"); aligns with ADR-007's claim that `@`-overrides
+are rare. Cons: source no longer carries the resolution, so
+re-elaboration must reproduce it. If the namespace's given-set changes
+between print and re-parse, re-elaboration may produce a different hash.
+
+### Option B: Always show resolved implicit arguments
+
+Every printed call site renders `@<dict>` arguments. Pros: hash-stable
+round-trip — the printed source contains exactly the resolution that was
+chosen, so re-parsing and elaborating recovers the same term regardless
+of namespace state. Cons: visually heavy; user-written code rarely looks
+this way; surfaces internal resolution choices that users intentionally
+hid; defeats the ergonomics motivating implicits.
+
+### Option C: Always elide
+
+Never print resolved implicits; no verbose mode. Pros: maximally terse.
+Cons: removes a debugging affordance; users have no way to ask "what did
+the elaborator pick here?" without invoking a separate command.
+
+## Decision
+
+We recommend **Option A: elide implicit arguments by default, with a
+verbose mode that shows `@<dict>` arguments,** pending ratification. The
+default matches user expectation; the verbose mode preserves the
+debugging affordance and gives a hash-stable form when needed.
+
+The round-trip property must hold in both modes. In verbose mode the
+property is trivial. In elide mode the printed source must re-elaborate
+to the same term in the same namespace — this is a constraint on the
+elaborator's determinism, not on the printer.
+
+## Consequences
+
+- **Unblocks** Phase 4 (pretty-printer and errors).
+- **Depends on** ADR-014 (so elaborator output is canonical and
+  re-elaboration is deterministic) and ADR-016 (which defines what
+  happens when re-elaboration changes hash).
+- **Constrains** Phase 2.D (elaborator) — given a fixed namespace and
+  fixed input, resolution must produce the same chosen dictionaries
+  every time. Already required by hashing; this ADR makes the printer
+  rely on it.
+- Verbose mode becomes part of the UCM surface (ADR-017). Naming and
+  flag spelling are decided there.
+- Required tests: round-trip property test (elide and verbose modes) on
+  a corpus including local givens, chained givens, HKT givens, and
+  explicit `@`-overrides; golden printer output for the canonical
+  examples in `docs/implicits-plan.md` §1.2; LSP hover renders verbose
+  form on synthesized arguments per Phase 2.F.
+- An elide-mode print that is then *re-elaborated in a different
+  namespace with different givens* may produce a different hash. This
+  is the user-facing meaning of "namespace = instance set"; ADR-016
+  governs the failure mode if the change becomes ambiguous.

--- a/docs/architecture/decisions/ADR-016-update-semantics.md
+++ b/docs/architecture/decisions/ADR-016-update-semantics.md
@@ -1,0 +1,95 @@
+# ADR-016: Update semantics on re-resolution
+
+**Status:** Proposed
+**Date:** 2026-05-01
+**Deciders:** core maintainers (pending ratification)
+**Related:** ADR-002, ADR-005, ADR-014, ADR-015, ADR-017; `docs/implicits-plan.md` §5.6, §10 (risk: "Update semantics surprise users")
+
+## Context
+
+`update` re-elaborates an edited term against the current namespace. If
+the visible given-set changed since the last elaboration — a new given
+appeared, an existing one was removed, or one was renamed — the
+elaborator may now resolve to a *different* dictionary than before. The
+old term retains its old hash and old resolution (content addressing is
+preserved by ADR-002 principle 2), but the new term has a different hash
+and different runtime behavior than the user might expect.
+
+Three scenarios matter:
+
+1. **Resolution unchanged.** Re-elaboration picks the same dictionary;
+   no semantic change; everything proceeds as ordinary update.
+2. **Resolution changed but unambiguous.** The new given-set exposes a
+   different unambiguous winner. The new term hashes differently. The
+   user may or may not have anticipated this.
+3. **Re-elaboration becomes ambiguous or fails.** The new given-set
+   surfaces two equally specific candidates, exceeds the depth limit, or
+   no candidate matches. The update cannot complete; we must report.
+
+## Options considered
+
+### Option A: Fail loud on any resolution change
+
+Treat (2) and (3) the same: any change in the resolved dictionary set
+aborts the update with an elaborator error listing the old and new
+resolution. Pros: zero surprises; users opt in explicitly. Cons:
+extremely chatty in normal workflows where users intentionally added a
+new given so it would take effect; punishes the mainline use case;
+arguably contradicts the design intent that "namespace = instance set"
+means changing the namespace changes resolution.
+
+### Option B: Silently re-resolve and produce a new hash
+
+Treat (2) as ordinary `update` semantics — new hash, new behavior, old
+code unaffected. Treat (3) as `update` failure (NoGiven, Ambiguous, or
+DepthExceeded) with structured error. Pros: matches the rest of `update`
+semantics (content addressing already means old dependents see old
+hash); aligns with the "resolution is part of the hash" principle;
+mainline workflow is uninterrupted. Cons: a user who changes a given
+unintentionally may not notice the resolution flipped; mitigated by the
+diff that `update` already presents.
+
+### Option C: Require an explicit `--allow-resolution-change` flag
+
+Default to refusal; require an explicit opt-in flag for any update that
+would change resolution. Pros: forces the user to acknowledge the
+change. Cons: as chatty as Option A in practice; flag fatigue;
+indistinguishable from Option A in most workflows.
+
+## Decision
+
+We recommend **Option B,** pending ratification:
+
+- For ambiguity-free, successful re-elaboration: silently re-resolve and
+  produce the new hash. The old term retains its old hash and its old
+  dependents. This is consistent with how every other kind of `update`
+  already works.
+- For re-elaboration that becomes ambiguous, exceeds depth, or has no
+  matching given: fail loud with a structured elaborator error
+  (`NoGiven`, `Ambiguous`, `DepthExceeded`) and abort the update.
+
+The `update` diff display already shows old vs new hash; the verbose
+printer mode (ADR-015) can show the chosen dictionaries when the user
+wants to inspect the change.
+
+## Consequences
+
+- **Unblocks** Phase 2.E exit criterion: "(a) working update through a
+  given changes hash; (b) breaking a given leaves dependent terms valid
+  but breaks new code; (c) introducing a second matching given causes
+  new code to fail with ambiguity but doesn't disturb existing code."
+- **Depends on** ADR-005 (ambiguity reporting machinery), ADR-009 (depth
+  errors), and ADR-014 (so the new hash is well-defined).
+- **Influences** ADR-015: an elide-mode pretty-printed term that
+  re-elaborates differently after a given-set change is exactly the
+  scenario this ADR governs; the printer must not silently drop
+  information that turns case (3) into case (2).
+- Required tests: golden hash round-trips for cases 1, 2, 3; an update
+  transcript showing a resolution flip with both old and new hash
+  visible in the diff; structured error fixtures for the three failure
+  categories; a regression test that breaking a given (deleting it)
+  leaves dependent terms hashable and runnable but breaks new code at
+  the same site.
+- Adds a documentation obligation: the migration guide (Phase 6) must
+  explain why `update`-after-given-edit can flip resolution and how to
+  inspect the diff.

--- a/docs/architecture/decisions/ADR-017-ucm-surface.md
+++ b/docs/architecture/decisions/ADR-017-ucm-surface.md
@@ -1,0 +1,103 @@
+# ADR-017: UCM command surface
+
+**Status:** Proposed
+**Date:** 2026-05-01
+**Deciders:** core maintainers (pending ratification)
+**Related:** ADR-013, ADR-015, ADR-016, ADR-018, ADR-021; `docs/implicits-plan.md` §6
+
+## Context
+
+UCM commands live in
+`unison-cli/src/Unison/CommandLine/InputPatterns.hs` (a flat ~4671-line
+table). Adding givens means (a) introducing commands that have no
+analogue today (toggling the namespace tag, listing givens) and
+(b) extending existing commands so that givenness is visible and
+preserved through every namespace operation.
+
+Implementations of these commands live in
+`unison-cli/src/Unison/Codebase/Editor/HandleInput/`, which is also
+where the `MdValues` plumbing must reach to honor ADR-013.
+
+## Options considered
+
+### Option A: Distinct `mark.given` / `unmark.given`, plus a `givens` lister; modify the natural surface of namespace commands
+
+**New commands.**
+
+- `givens [path]` — lists every given-tagged definition at `path`,
+  showing name, hash prefix, and inferred conclusion type. Mirrors
+  `find` in shape but filters to the given set.
+- `mark.given <name>` — toggles the namespace tag *on* without rehashing
+  the term. Per ADR-014, the term hash is unchanged; the branch hash
+  changes because `MdValues` participates in tokens.
+- `unmark.given <name>` — toggles the tag *off* with the same
+  hash-stability properties.
+
+**Modified commands.**
+
+- `view` — when the target is given-tagged, prepend the `given` keyword
+  in the printed form (Phase 4 wires this into the pretty-printer).
+- `find` — accept a `:given` filter; when the user types `find <type>`
+  and the type is a constraint, surface matching givens prominently.
+- `edit` — preserves the given tag on re-save; refusing to drop it
+  silently. Re-elaboration follows ADR-016.
+- `update` — same as `edit`, plus the ADR-016 failure modes for
+  resolution changes.
+- `move`, `alias` — copy the given tag to the destination by default.
+  Within a namespace, rename preserves givenness; cross-namespace alias
+  inherits-by-default per `docs/implicits-plan.md` §5.2.
+- `delete` — deleting a given-tagged definition removes both the
+  definition and the tag; if other names alias the same hash, the tag on
+  those aliases is unaffected (per-name tag, not per-hash).
+- `fork` — branch's given-set is forked along with everything else; this
+  falls out of `MdValues` already being copied.
+- `pull`, `push` — given-set travels with the namespace; depends on the
+  Sharing API version bump (ADR-020).
+
+Pros: the noun of the new behavior is "given," which gets its own
+verbs; existing commands stay shaped the way users expect. Cons: adds
+two commands to the already-long table; documentation and discovery
+load.
+
+### Option B: Single `given` command with subcommands
+
+`given list`, `given mark`, `given unmark`. Pros: one entry in the
+top-level table. Cons: inconsistent with the existing UCM convention of
+flat verbs (`view`, `find`, `update`); breaks tab-completion habits.
+
+### Option C: No new commands; expose marking only through an `edit`-time keyword
+
+Users never run a "mark this given" command; instead, the `given`
+keyword in source is the only way to set the tag. Pros: minimal
+surface. Cons: defeats the use case of demoting an upstream given
+locally without rewriting the source file (a stated design goal in
+`docs/implicits-plan.md` §1.1 principle 4); demands a re-edit of code to
+toggle a namespace property.
+
+## Decision
+
+We recommend **Option A,** pending ratification: add `givens`,
+`mark.given`, `unmark.given`; modify `view`, `find`, `edit`, `update`,
+`move`, `alias`, `delete`, `fork`, `pull`, `push` to flow givenness
+through their existing semantics. Naming follows the dotted convention
+already present in UCM (e.g. `pull.silent`).
+
+## Consequences
+
+- **Unblocks** Phase 3 (UCM integration).
+- **Depends on** ADR-013 (knows where the tag lives), ADR-016 (knows
+  what `update` does on re-resolution), ADR-018 (commands are
+  feature-gated until the flag flips), and ADR-021 (defines what
+  `pull`/`push`/`merge` do with conflicting given-sets).
+- Edits `InputPatterns.hs` and a corresponding handler in
+  `unison-cli/src/Unison/Codebase/Editor/HandleInput/` per command.
+  Wires `MdValues` through name-lookup and rendering paths that today
+  do not consult metadata (the plan notes `grep -rn MdValues unison-cli`
+  returns nothing).
+- Required tests: transcript tests for each new command and each
+  modified command; round-trip `mark.given` then `unmark.given`
+  preserves the term hash; `alias` propagates the tag; `delete` removes
+  only the local tag when the hash is multiply-named; help text
+  snapshots for every new and modified command.
+- LSP commands (Phase 2.F) parallel the UCM surface; this ADR doesn't
+  govern them but sets the names and semantics the LSP layer adopts.

--- a/docs/architecture/decisions/ADR-018-feature-flag.md
+++ b/docs/architecture/decisions/ADR-018-feature-flag.md
@@ -1,0 +1,89 @@
+# ADR-018: Feature-flag rollout
+
+**Status:** Proposed
+**Date:** 2026-05-01
+**Deciders:** core maintainers (pending ratification)
+**Related:** ADR-017, ADR-022; `docs/implicits-plan.md` §9
+
+## Context
+
+Implicit parameters are a major addition to a content-addressed,
+production-relied-on language. Even with a careful staged rollout
+(Phases 0–6), there are knowable unknowns: surprise interactions with
+TDNR, edge cases the spike did not exercise, ergonomics issues that
+only show up under real workloads, and cross-library effects in shared
+code. We want a way to make the feature available for experimentation
+*without* committing every user to its presence in the language.
+
+The design space is which dimension the flag operates on: per-project
+(opt-in via project config), per-binary (a compile-time switch baked
+into the UCM build), or just-ship-it (no flag at all). The answer
+shapes how Phase 6 rolls out and how the keyword migration in ADR-022
+interacts with code that does not opt in.
+
+## Options considered
+
+### Option A: Per-project feature flag in project config
+
+A project's config records whether implicits are enabled. UCM, the
+typechecker, the parser, and the printer all read the flag. With the
+flag off: `=>`, `given`, `summon`, and `@` in expression position
+remain unrecognized; `given` and `summon` continue to be legal
+identifiers (per ADR-022). With the flag on: implicits are fully
+available. Pros: gradual ecosystem rollout; library authors opt in when
+ready; users who depend on `given`/`summon` as identifiers are unaffected
+until they choose to upgrade; the flag flips to "on by default" in a
+later release without a binary change. Cons: requires a project-config
+schema bump and per-project state to thread through the typechecker;
+two code paths to keep working through Phase 5.
+
+### Option B: Compile-time flag in the UCM binary
+
+The flag is a Cabal/build setting. Production builds ship without the
+feature; nightly/dev builds ship with it. Pros: simplest to implement;
+no config plumbing. Cons: forces every user of a build to be either
+fully in or fully out; downstream packagers must choose; bug reports
+fragment by build flavor; mixing givens-using and givens-not-using
+projects in the same UCM session becomes impossible.
+
+### Option C: Immediate on, no flag
+
+Ship the feature enabled in the next release. Pros: simplest user
+story; no flag plumbing. Cons: leaves no path to recover from
+ecosystem-level surprises; conflicts with ADR-022's keyword migration
+(any code using `given` or `summon` as identifiers breaks day one); no
+soft landing if the resolver has performance regressions on large
+codebases.
+
+## Decision
+
+We recommend **Option A: a per-project feature flag in project
+config,** pending ratification. The flag defaults to *off* through one
+release cycle for library authors to experiment, then flips to *on by
+default* in the following release. Library authors who need the feature
+opt in; library consumers see no change until their dependencies start
+using it.
+
+## Consequences
+
+- **Unblocks** Phase 6 (release) — the rollout sequence has a clear
+  mechanism.
+- **Depends on** ADR-017 (the new commands respect the flag) and ADR-022
+  (the keyword reservation is gated on the flag for one release cycle,
+  so a project not opting in keeps the legacy meaning of `given` and
+  `summon`).
+- The typechecker, parser, and printer all need a single-bit "implicits
+  on" channel; plumbing this through is a Phase 2 task. Avoid the
+  temptation to spread the flag check through many sites — concentrate
+  it where parser modes branch (`unison-syntax`) and where elaboration
+  begins (Typechecker / FileParsers).
+- Required tests: a project with the flag off rejects `=>` syntax; the
+  same project with the flag on accepts it; a project with the flag off
+  still parses `given` and `summon` as identifiers; flipping the flag
+  on a project that uses those identifiers as definitions raises a
+  migration error per ADR-022; CI matrix runs both flag states until
+  the default flips.
+- Adds a permanent obligation: even after the default flips on,
+  documentation must call out how to opt out (e.g. for a library
+  pinned to legacy syntax for one more release). Removing the off-state
+  entirely is a future ADR.

--- a/docs/architecture/decisions/ADR-019-type-f-representation.md
+++ b/docs/architecture/decisions/ADR-019-type-f-representation.md
@@ -1,0 +1,121 @@
+# ADR-019: Implicit-arrow representation in `Type.F`
+
+**Status:** Proposed (foundational, blocking)
+**Date:** 2026-05-01
+**Deciders:** core maintainers (pending ratification)
+**Related:** ADR-001, ADR-004, ADR-014; `docs/implicits-plan.md` §3.3 (gate),
+§5.3, §12
+
+## Context
+
+`Type.F` at `unison-core/src/Unison/Type.hs:40` is the base functor
+for the type AST:
+
+```
+data F a
+  = Ref TypeReference
+  | Arrow a a
+  | Ann a K.Kind
+  | App a a
+  | Effect a a
+  | Effects [a]
+  | Forall a
+  | IntroOuter a
+```
+
+There is one arrow constructor: ordinary `Arrow a a`. Implicit
+parameters introduce a second flavor — the `=>` constructor parsed from
+ADR-001 — that the typechecker and elaborator must distinguish from `->`
+in order to know which leading parameters become implicit.
+
+This ADR is foundational. ADR-004 (settled) declares "runtime/codegen
+untouched"; that is true *only* if the type AST carries the implicit-vs-explicit distinction in a way the elaborator can read at typecheck time
+without leaking into runtime forms.
+
+## Options considered
+
+### Option A: Extend `Type.F` with `ImplicitArrow a a`
+
+Add a constructor:
+
+```
+| ImplicitArrow a a
+```
+
+`Show a => Show (List a)` parses as `ImplicitArrow (App Show a) (App Show
+(List a))`. The typechecker, elaborator, and pretty-printer pattern-match
+on it; runtime never sees it because `Type` is a compile-time artifact.
+Pros: self-describing; every reference site sees implicit-ness directly
+in the AST; aligns with how `Effect` is already a peer of `Arrow`; matches
+ADR-014's claim that "no new hashing rule" applies at the term level
+(the new type-AST constructor is the *only* hashing change needed). Cons:
+adds a constructor to a heavily pattern-matched ADT (every consumer must
+extend its `case` exhaustively); changes the type-hashing namespace —
+every type with `=>` hashes differently from a hypothetical `->` cousin.
+
+The type-hash break is acceptable: `=>` is new syntax; no existing types
+contain it; only types created going forward are affected.
+
+### Option B: Side-table on declarations
+
+Keep `Type.F` unchanged; maintain a separate map from `Reference` to
+"positions of arrows in this type that are implicit." Pros: preserves
+type-hash compatibility for existing types and the *form* of new
+implicit-bearing types (the `Type.F` shape is identical to a
+non-implicit equivalent). Cons: every consumer of a type must consult the
+side-table to know what to do — an effective globalization of the
+implicit-or-not signal; ad-hoc inheritance through type substitution
+(when a type variable is instantiated, which positions in the resulting
+type are implicit?); reverses the locality property that the ABT model
+gives us; makes ADR-014's framing weaker (hashing of types becomes
+contextually meaningful).
+
+### Option C: Wrapper type `Implicit a`
+
+Introduce a built-in type constructor `Implicit a` such that
+`Implicit T -> U` *means* `T => U`. Pros: no `Type.F` change. Cons: the
+wrapper leaks into surface syntax (users see `Implicit`); destroys the
+visual distinction `=>` was designed for; rejected upstream in
+`docs/implicits-plan.md` §5.3.
+
+## Decision
+
+We recommend **Option A: extend `Type.F` with `ImplicitArrow a a`,**
+pending ratification. The constructor lives next to `Arrow` and is
+treated by the elaborator as "Arrow whose leading parameter is filled by
+resolution." The type-hash break is a one-time cost paid only for new
+types written with `=>`.
+
+This ADR is **foundational**: it is what makes ADR-004's "runtime/codegen
+untouched" tractable, because the elaborator strips `ImplicitArrow` to
+ordinary `Arrow` (or never lets it reach runtime in the first place),
+and what makes ADR-014's "no new hashing rule" claim coherent.
+
+## Consequences
+
+- **Unblocks** Phase 1 spike (a real or stubbed `Type.F` shape is
+  available), Phase 2.C.1, and by transitivity Phase 2.C.2 / 2.D / 2.E.
+- **ADRs depending on this one:** 004 (presupposes implicits live in the
+  type AST and not in term-level wrappers), 012 (the elaborator pattern-matches on the new constructor), 014 (hashing claim depends on this
+  exact shape), 015 (printer renders the constructor as `=>`).
+- Every pattern-match on `Type.F` in the codebase must add a case for
+  `ImplicitArrow`; the compiler will flag exhaustiveness gaps. Plan a
+  sweep across `unison-core`, `parser-typechecker`, `unison-share-api`,
+  and the printer modules.
+- Type-hash break: any new type containing `=>` hashes differently from
+  the `->` form. Document this consequence in the migration guide.
+- Required tests: golden-hash tests for representative `=>` types;
+  exhaustiveness checks turned on across `Type.F` consumers; a
+  unification test confirming that `=>` and `->` do *not* unify (which
+  is what makes the elaborator capable of identifying implicit slots).
+- Locks in the ABT/`Type.F` extension as the canonical place for
+  implicit-vs-explicit. Any future "first-class implicit function
+  types" (out of scope per `docs/implicits-plan.md` §1.4) would build
+  on this constructor rather than re-litigate it.
+
+## Open question
+
+Whether `ImplicitArrow` should also encode an "implicit-ness arity" for
+multi-constraint signatures, or whether `(C1 a, C2 b) =>` desugars to
+nested `ImplicitArrow`s. Recommendation: nested form, matching how
+`Arrow` already represents curried functions; flag for ratification.

--- a/docs/architecture/decisions/ADR-020-metadata-serialization.md
+++ b/docs/architecture/decisions/ADR-020-metadata-serialization.md
@@ -1,0 +1,119 @@
+# ADR-020: Metadata serialization and `causal_metadata` migration
+
+**Status:** Proposed (foundational, blocking)
+**Date:** 2026-05-01
+**Deciders:** core maintainers (pending ratification)
+**Related:** ADR-002, ADR-013, ADR-014, ADR-021; `docs/implicits-plan.md` §3.3 (gate),
+§5.2
+
+## Context
+
+Givenness lives in namespace metadata (ADR-002). The codebase has *two*
+plausible homes for that metadata:
+
+- `MdValues = Set MetadataValue` per `(NameSegment, Referent)` defined
+  at `codebase2/codebase/U/Codebase/Branch/Type.hs:32-43`. Already
+  serialized; already participates in branch-hash tokens via
+  `unison-hashing-v2/src/Unison/Hashing/V2/Branch.hs`; already round-tripped through SQLite.
+- `causal_metadata` table at `codebase2/codebase-sqlite/sql/create.sql:113`. Defined in the schema, currently unused, keyed on
+  `causal_id × object_id × component_index`.
+
+Sharing makes the question concrete: any change to the metadata wire
+format requires bumping the protocol version in `unison-share-api` and
+`unison-share-projects-api`, plus a coordinated server release. We must
+pick *one* home and version it.
+
+ADR-013 already tentatively chose Option A (reuse `MdValues` with a
+sentinel `##Builtin.Given`). This ADR formalizes the on-disk
+serialization decision and disposes of the dormant table.
+
+## Options considered
+
+### Option A: Reuse `MdValues` (preferred)
+
+Encode given-ness as a sentinel `MetadataValue` (`##Builtin.Given`)
+inside the existing `MdValues` slot. No schema change. Wire-format
+change is *additive*: clients that don't know the sentinel see it as an
+opaque metadata reference and round-trip it through unchanged; clients
+that do know it interpret it as a tag. Pros: minimal churn; piggy-backs
+on serialization already used by sync; per-name resolution matches the
+shape of the data (givenness is per-name, not per-causal); branch
+hashing already includes it. Cons: requires a careful documentation that
+`##Builtin.Given` is a reserved metadata reference; the dormant
+`causal_metadata` table remains dormant and should be marked as such in
+the SQL.
+
+### Option B: Revive `causal_metadata`
+
+Use the `causal_metadata` table for given-set storage. Pros: gives the
+dormant table a purpose. Cons: shape mismatch — the table is keyed on
+causal id, but givenness is per `(NameSegment, Referent)`; a secondary
+table or column would be needed; new wire format; a new sync code path;
+client and server must both upgrade in lockstep without an additive
+fallback.
+
+### Option C: New schema
+
+Add a fresh table and a fresh wire field for given metadata. Pros:
+self-documenting. Cons: invasive — new SQL migration, new sync
+serialization, full protocol bump, no fallback for older clients.
+
+## Decision
+
+We recommend **Option A,** pending ratification, with these specifics:
+
+- The given-tag is a sentinel `MetadataValue` reference,
+  `##Builtin.Given`, recorded in `MdValues` for each given-tagged
+  `(NameSegment, Referent)`.
+- The `causal_metadata` SQL table is documented as deprecated/reserved
+  but **not dropped** in the same release; dropping it is a separate
+  schema-cleanup change with its own ADR if desired.
+- The Sharing wire format admits the addition of `##Builtin.Given` as
+  an opaque metadata reference with **no protocol version bump**. This
+  reverses an earlier draft of this ADR. The chunk B3 investigation
+  confirmed: `putLocalBranch`/`getLocalBranch` encode metadata as a
+  generic `Set Reference` (`putMetadataSetFormat = putWord8 0 *>
+  putFoldable putReference`), `putReference (ReferenceBuiltin t) =
+  putWord8 0 *> putVarInt t` is fully generic over the textId, and
+  SyncV2's `StreamInitInfo` is future-compatible at the schema level
+  (per its `Serialise` instance). Bumping the hard-coded `Version 1` in
+  `Unison.Share.SyncV2` would surface `SyncErrorUnsupportedVersion`
+  against existing servers — a breaking change for an additive feature
+  is the wrong tradeoff.
+- **Discoverability and feature gating** (which the earlier draft
+  called out as the reason to bump) instead use a
+  `StreamInitInfo`-style map-key entry like `"implicits"` introduced at
+  Phase 3 entry, since that struct is already future-compatible without
+  a version bump.
+- No coordinated server release is required for B-track delivery; the
+  sentinel travels through unmodified servers transparently.
+
+## Consequences
+
+- **Unblocks** Phase 2.B (storage subproject) and by transitivity every
+  later phase that needs to push/pull/merge given-sets.
+- **ADRs depending on this one:** 013 (storage shape), 014 (branch-hash
+  semantics rely on `MdValues` participating in tokens), 021 (the merge
+  code reads metadata from `MdValues`), 017 (UCM commands flow through
+  the same metadata path).
+- Locks `##Builtin.Given` as a reserved metadata reference; record this
+  in the builtins module and flag in any future metadata-feature
+  discussion.
+- Forces the read paths that today ignore metadata
+  (`grep -rn MdValues unison-cli` returns nothing per the plan §5.2) to
+  start consulting it. Implementation lands in
+  `unison-cli/src/Unison/Codebase/Editor/HandleInput/`.
+- Required tests: round-trip a namespace through SQLite and back with
+  givens preserved; round-trip across the Sharing API (no version
+  change required); an old-client/new-server compatibility test is
+  *not* required because the wire format already carries arbitrary
+  metadata references opaquely.
+- Sharing protocol: we incur a permanent obligation to negotiate
+  protocol version on connect; library code that relies on a specific
+  version must read the negotiated version, not assume one.
+
+## Open question
+
+Whether to ever revive `causal_metadata` for some other purpose, or
+schedule its eventual drop. Out of scope here; flag for a future
+schema-cleanup ADR.

--- a/docs/architecture/decisions/ADR-021-merge-semantics.md
+++ b/docs/architecture/decisions/ADR-021-merge-semantics.md
@@ -1,0 +1,103 @@
+# ADR-021: Merge semantics for given-set conflicts
+
+**Status:** Proposed
+**Date:** 2026-05-01
+**Deciders:** core maintainers (pending ratification)
+**Related:** ADR-002, ADR-013, ADR-017, ADR-020; `docs/implicits-plan.md` §5.2
+
+## Context
+
+`unison-merge/src/` performs three-way namespace merges. Today it has
+*no* metadata-aware logic: `grep -rn 'MdValues\|metadata' unison-merge/src/`
+returns nothing. Givens add a per-name tag (per ADR-013, encoded as the
+`##Builtin.Given` sentinel inside `MdValues`), so merges must learn how
+to combine the tag across LCA, "alice," and "bob" branches.
+
+Four cases must be defined explicitly. Each maps to either an existing
+merge code path with metadata threading added, or a new code path.
+
+## Options considered
+
+The cases below are not "options" in the usual sense — every merge
+implementation must decide each case. We list the cases and the chosen
+resolution; an Option A/B presentation would be artificial.
+
+### Case (a): Both branches mark the same hash given
+
+Alice's branch and Bob's branch both add the `##Builtin.Given` sentinel
+to the same `(NameSegment, Referent)`. Expected result: no-op. The
+merged namespace has the tag. No user prompt.
+
+### Case (b): One branch marks, the other does not
+
+Alice marks; Bob did not (or unmarked). LCA either had it or didn't.
+Resolution: **mark wins by default, user-confirmable.** Promoting a
+definition to a given is a strictly additive operation in the design
+(downstream users can demote locally per ADR-002 principle 4); a merge
+that drops a deliberate mark is more surprising than one that keeps it.
+The user gets a confirmable summary entry: "Alice marked Foo as given;
+Bob did not. Keep mark? [Y/n]." Non-interactive merges (CI) default to
+Y.
+
+### Case (c): Both branches rename the same given to different names
+
+Alice renames `Show.nat` to `ShowNat`; Bob renames it to `Show.Nat`.
+This routes through the existing rename-conflict path in
+`unison-merge/src/`. The givenness *travels with the hash*: whichever
+name resolution the user picks, the `##Builtin.Given` sentinel
+accompanies it. No new conflict category — the rename-conflict UI
+already prompts; we just preserve the metadata.
+
+### Case (d): One branch marks, the other deletes the definition
+
+Alice marks `Show.nat` as a given; Bob deletes `Show.nat`. This routes
+through the existing delete-conflict path (modify-vs-delete is already
+a known conflict category). Decision rule: same as Case (b) for the
+mark, but layered on top of the existing delete conflict. The user is
+prompted to either accept the deletion (the mark is moot) or restore
+the definition with the mark applied. No new conflict category.
+
+## Decision
+
+We recommend, pending ratification, that `unison-merge` add metadata
+awareness with these specific resolutions:
+
+| Case | Resolution                                                   |
+|------|--------------------------------------------------------------|
+| (a)  | No-op: mark survives.                                        |
+| (b)  | Mark wins by default; user-confirmable; CI default Y.        |
+| (c)  | Existing rename-conflict path; givenness travels with hash.  |
+| (d)  | Existing delete-conflict path; mark is preserved if the definition is restored. |
+
+## Consequences
+
+- **Unblocks** Phase 2.B exit criterion: "merge with given-set
+  conflicts" round-trip tests.
+- **Depends on** ADR-013 (storage shape determines what the merge code
+  reads) and ADR-020 (sentinel reservation).
+- **Forces** `unison-merge/src/` to grow metadata-aware diffing —
+  specifically `unison-merge/src/Unison/Merge/Diffblob.hs`,
+  `Diff.hs`, and `CombineDiffs.hs` need to project `MdValues` into the
+  diff representation, and `PartitionCombinedDiffs.hs` needs to
+  recognize the four cases above.
+- Adds a UCM prompt category for case (b) and a layered prompt for
+  case (d); ADR-017's `merge` command surface must show the prompts.
+- Required tests: transcript fixtures for each of (a)–(d); a regression
+  test that today's metadata-free merges still produce identical
+  results when no givens are involved (i.e. the new code path is a
+  no-op when `MdValues` is empty); a CI-mode test confirming default-Y
+  for (b) and the documented default for (d).
+- Locks "mark wins" as the default policy; reversing it later is
+  user-visible and would need a deprecation pass.
+
+## Open questions
+
+- Whether case (b) should default to *no prompt* in CI but *prompt* in
+  interactive mode (current recommendation), or always prompt and have
+  CI configure a non-interactive answer. Mostly a UX choice; flag for
+  ratification.
+- Whether the existing `unison-merge` types (`TwoWay`, `ThreeWay`,
+  `EitherWay`, etc.) need new variants to express "metadata change" or
+  whether metadata diffs ride alongside as a parallel structure. The
+  parallel-structure approach is cheaper to land first and is the
+  starting recommendation; document if the spike forces variants.

--- a/docs/architecture/decisions/ADR-022-keyword-migration.md
+++ b/docs/architecture/decisions/ADR-022-keyword-migration.md
@@ -1,0 +1,112 @@
+# ADR-022: Keyword migration plan for `given` and `summon`
+
+**Status:** Proposed
+**Date:** 2026-05-01
+**Deciders:** core maintainers (pending ratification)
+**Related:** ADR-001, ADR-006, ADR-018; `docs/implicits-plan.md` §10 (risk: "Keyword migration breaks existing code")
+
+## Context
+
+The implicits feature introduces two new keywords: `given` (declaration
+prefix and `let`-block form) and `summon` (explicit summon expression).
+Today neither is reserved: the `keywords` set in
+`unison-syntax/src/Unison/Syntax/ReservedWords.hs` does not contain
+either, so any user code can have a definition named `given` or `summon`,
+or use them as local variable names. Existing user code may currently
+do exactly that.
+
+The `=>` token is similar in shape but easier: it is purely symbolic
+and already disambiguated only against `==>` (currently in
+`reservedOperators`). `=>` does not collide with any user-writable
+identifier — only with potential operator definitions, of which `==>` is
+the existing precedent.
+
+This ADR addresses `given` and `summon` only; `=>` is governed by
+ADR-001's lexer ordering note.
+
+## Options considered
+
+### Option A: Hard break with a one-release deprecation warning
+
+The next release after the implicits feature stabilizes adds `given` and
+`summon` to the `keywords` set. The release *before* that ships a
+deprecation warning: any definition or local variable named `given` or
+`summon` parses successfully but emits a warning pointing to a migration
+note. Pros: user code gets one full release cycle to rename; the
+keyword space ends up clean; aligns with how mainstream languages
+handle reserved-word additions; per ADR-018, the feature flag delays
+the hard break until library authors have opted in. Cons: any user with
+a definition named `given` or `summon` must rename it within one
+release cycle; tooling must recognize and migrate (search-and-replace
+is straightforward).
+
+### Option B: Prefix sigils (`#given`, `#summon`)
+
+Use `#given` as the declaration prefix and `#summon` as the expression
+form. Pros: no keyword reservation needed; bare `given`/`summon` remain
+legal identifiers indefinitely. Cons: visually uglier; inconsistent
+with how `let`, `if`, `match`, `cases`, `handle` etc. read; awkward in
+documentation and tutorials; loses the "fits like a glove" goal.
+
+### Option C: Non-reserved with parser-level disambiguation
+
+Keep `given` and `summon` non-reserved in the lexer; rely on parser
+context to recognize them as keywords only where they syntactically
+make sense (top-level declaration position, expression-application
+position). Pros: zero migration cost; existing identifiers keep
+working. Cons: context-sensitive lexing/parsing is fragile;
+disambiguation rules become subtle (`let given = …` could be a local
+given declaration *or* a let-bound identifier called `given`); error
+messages get harder; precedent in other languages (Scala 3 itself)
+shows this is a long tail of edge cases.
+
+## Decision
+
+We recommend **Option A: hard break with a one-release deprecation
+warning,** pending ratification. Concretely:
+
+1. **Release N (implicits behind a flag, default off, per ADR-018).**
+   Lexer recognizes `given` and `summon` as reserved-when-flag-on.
+   When the flag is off, `given` and `summon` parse as identifiers as
+   today, but with a deprecation warning. The warning links to the
+   migration note.
+2. **Release N+1 (flag flips to on by default, per ADR-018).**
+   `given` and `summon` join the `keywords` set in
+   `unison-syntax/src/Unison/Syntax/ReservedWords.hs` unconditionally.
+   Code that still uses them as identifiers fails to parse with a
+   structured error directing the user to rename.
+
+The deprecation window is one release. The migration note (in
+`docs/implicits-plan.md` and the migration guide) provides a
+search-and-replace recipe.
+
+## Consequences
+
+- **Unblocks** Phase 6 (release) — the keyword reservation has a
+  defined timeline.
+- **Depends on** ADR-018 (the per-project flag is what allows the
+  deprecation warning to fire only against projects that *haven't* opted
+  in yet, while opted-in projects already use the keywords as
+  keywords).
+- **Forces** an edit to
+  `unison-syntax/src/Unison/Syntax/ReservedWords.hs`: the `keywords` set
+  grows by `"given"` and `"summon"`. (No change for `=>`/`==>`: per
+  ADR-001 the lexer ordering already handles symbolic precedence.)
+- Required tests: a deprecation-warning fixture for Release N (a file
+  with `given = …` or `let summon = …` produces a warning); a
+  hard-break fixture for Release N+1 (same file fails with a clear
+  error); a migration-script test if we ship one; a regression test
+  asserting `=>` still parses correctly when adjacent to `==>`.
+- Locks `given` and `summon` as keywords forever; freeing them later
+  would itself be a breaking change.
+- Documentation obligation: the migration guide must include the
+  search-and-replace recipe and a list of common identifier names that
+  conflict (e.g. functions called `given` in test fixtures).
+
+## Open question
+
+Whether to also reserve `using` proactively, even though the design
+chose `=>` over Scala-3 `using` (per ADR-001). If a future ADR
+introduces explicit `using`-bound parameter syntax, we would want the
+keyword available. Recommendation: defer; introduce only when needed,
+following the same one-release deprecation pattern.

--- a/docs/architecture/decisions/ADR-023-memoization-scope.md
+++ b/docs/architecture/decisions/ADR-023-memoization-scope.md
@@ -1,0 +1,107 @@
+# ADR-023: Memoization scope and cache key for given resolution
+
+**Status:** Proposed
+**Date:** 2026-05-01
+**Deciders:** core maintainers (pending ratification)
+**Related:** ADR-008 (specificity), ADR-009 (cycles and depth);
+`docs/implicits-plan.md` §1.3, §4.2#6, `spike/implicits/FINDINGS.md`
+
+## Context
+
+The Phase 1 spike validated `docs/implicits-plan.md` §4.2 success
+criterion #6 — "diamond dependencies don't blow up" — by memoizing
+sub-resolutions within a single top-level `resolve`. That worked, but
+the plan's text (§4.2#6 and §1.3) does not specify:
+
+1. **Scope.** Is the memo per-call-site (one top-level resolve), or
+   per-elaboration-pass (across all call sites in a file), or global?
+2. **Key.** Is the key the raw goal type, the substitution-applied
+   ("zonked") goal, or something else? How are free metavariables
+   treated?
+3. **What gets cached — successes only, failures only, both?**
+
+These are not bikesheds: getting them wrong produces either exponential
+blowup (the failure mode the spike's criterion #6 was meant to guard
+against) or incorrect resolutions (a sub-result reused in a context
+where the metavar bindings have changed).
+
+The spike's choice was "per top-level resolve, key = zonked goal,
+successes only," and it passed all 15 tests including the diamond cases.
+But the spike doesn't have free metavars from the *outer* type checker —
+in production, sub-goals will frequently contain metavars that are not
+yet pinned, since elaboration runs after TDNR but TDNR may itself emit
+goals containing existentials.
+
+## Options considered
+
+### Option A: Per top-level resolve, zonked key, cache both successes and failures
+
+Each invocation of `resolve T` allocates a fresh memo table. Keys are
+the substitution-applied (zonked) goal type. Both successful resolutions
+and `NoGiven`/`Cycle`/`DepthExceeded` outcomes are cached. The table is
+discarded when `resolve T` returns.
+
+**Pros:** matches what the spike implemented; clearly bounded memory
+(no cross-call-site leakage); caching failures is critical for the
+diamond case where the same dead-end is reached repeatedly. **Cons:**
+sub-goals containing un-pinned metavars hash to the same key as
+*different* sub-goals that happen to share the metavars — risk of
+false-positive cache hits if metavars are shared across the resolve.
+
+### Option B: Per elaboration-pass, zonked key
+
+A single memo table for the whole pass. Pros: more reuse across call
+sites in the same file. Cons: lifetime of cached resolutions outlives
+the metavar context they were resolved against. Risk of incorrect reuse
+when a later call site re-uses a key whose underlying metavars differ.
+Mitigation would require storing the metavar context with each cache
+entry, which approaches the cost of just re-resolving.
+
+### Option C: Per top-level resolve, key includes metavar context
+
+Like A, but the cache key is `(goal, snapshot of relevant metavar
+bindings)`. Pros: handles shared metavars correctly. Cons: complicated
+key; metavar-equivalence becomes a non-trivial computation; risk of
+making every cache lookup slower than the work it saves.
+
+### Option D: No memoization, accept O(2^n) on diamonds (rejected)
+
+Simplest. **Rejected** — fails plan §4.2#6.
+
+## Decision
+
+We recommend **Option A: per top-level resolve, zonked goal as key,
+cache successes and failures alike**, with the explicit qualification
+that the cache is **invalidated whenever a metavariable in the in-flight
+goal stack is bound** during sub-resolution. (In practice this means: if
+two sub-goals share a metavar and one resolution binds it, the other
+sub-goal's cached result is dropped.)
+
+This is the cheapest design that's correct for the diamond cases and
+honest about the metavar interaction.
+
+## Consequences
+
+- **Phase 2.D implementation:** the elaborator's resolver carries a
+  `Map ZonkedTy CachedResolution` allocated fresh per top-level resolve.
+  Cache is dropped when any metavar in the goal stack is bound; cheaper
+  than recomputing equivalence classes for each lookup.
+- **Phase 2.D test matrix:** add a property test for diamond resolution
+  with shared metavars across the diamond's two paths. The spike
+  doesn't cover this — its goals were ground.
+- **Performance:** memory is O(distinct sub-goals in one resolve), which
+  is small in practice. Time savings on diamonds are substantial: the
+  spike measured `Show (Map (List Nat) Nat)` solving exactly 3 distinct
+  sub-goals; without memoization, the same diamond would be O(2^depth).
+- **Failure caching is load-bearing.** Without it, a failed sub-goal
+  reached from N parent paths costs N × (full failure-search cost) —
+  enough to dominate runtime on realistic instance pools.
+- **Locks the language out of cross-call-site memoization** without a
+  follow-up ADR. Future work on speeding up large files (where many
+  call sites resolve the same constraints) may want to revisit this; if
+  so, Option C with a proper metavar-context key is the path forward.
+- **Open question for Phase 2.D:** the exact metavar-binding
+  invalidation rule. The recommendation here is "any binding within the
+  goal stack drops the cache," but a finer-grained rule may be possible
+  ("only drop entries whose key contains the just-bound metavar"). Test
+  matrix should include a benchmark distinguishing the two.

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -1,0 +1,47 @@
+# Architecture Decision Records
+
+This directory holds Architecture Decision Records (ADRs) for substantial,
+hard-to-reverse design choices in the Unison implementation.
+
+## Format
+
+Each ADR is one file: `ADR-NNN-short-title.md`. Use the template in
+[`TEMPLATE.md`](TEMPLATE.md). Status values:
+
+- **Proposed** — drafted, not yet ratified
+- **Accepted** — ratified by core maintainers; consequences are committed
+- **Deprecated** — superseded; see "Replaced by"
+- **Rejected** — considered and explicitly rejected
+
+## Index
+
+### Implicit parameters (`givens`)
+
+The plan that motivates ADRs 001–022 lives in
+[`docs/implicits-plan.md`](../../implicits-plan.md).
+
+| #   | Title                                                       | Status   |
+|-----|-------------------------------------------------------------|----------|
+| 001 | [Constraint syntax: Haskell-style `C =>`](ADR-001-constraint-syntax.md) | Accepted |
+| 002 | [Givenness as namespace metadata](ADR-002-givenness-namespace-metadata.md) | Accepted |
+| 003 | [No new "class" declaration kind](ADR-003-classes-are-ordinary-types.md) | Accepted |
+| 004 | [Resolution is compile-time only](ADR-004-compile-time-resolution.md) | Accepted |
+| 005 | [Coherence: per-call-site ambiguity](ADR-005-coherence.md)  | Accepted |
+| 006 | [`summon T` as the explicit summon form](ADR-006-summon-syntax.md) | Accepted |
+| 007 | [`@`-positional explicit override](ADR-007-explicit-override.md) | Accepted |
+| 008 | [Specificity ordering](ADR-008-specificity.md)              | Accepted |
+| 009 | [Cycle detection and depth limit](ADR-009-cycles-and-depth.md) | Accepted |
+| 010 | [Local givens scoping](ADR-010-local-givens.md)             | Accepted |
+| 011 | [HKT in v1; FDs/assoc-types deferred](ADR-011-hkt-scope.md) | Accepted |
+| 012 | [Elaborator pass placement vs inference](ADR-012-elaborator-placement.md) | Proposed |
+| 013 | [Namespace given-set storage format](ADR-013-given-set-storage.md) | Proposed |
+| 014 | [Hashing of givens and elaborated terms](ADR-014-hashing.md) | Proposed |
+| 015 | [Pretty-printer default behavior](ADR-015-printer-default.md) | Proposed |
+| 016 | [Update semantics on re-resolution](ADR-016-update-semantics.md) | Proposed |
+| 017 | [UCM command surface](ADR-017-ucm-surface.md)               | Proposed |
+| 018 | [Feature-flag rollout](ADR-018-feature-flag.md)             | Proposed |
+| 019 | [Implicit-arrow representation in `Type.F`](ADR-019-type-f-representation.md) | Proposed |
+| 020 | [Metadata serialization and `causal_metadata` migration](ADR-020-metadata-serialization.md) | Proposed |
+| 021 | [Merge semantics for given-set conflicts](ADR-021-merge-semantics.md) | Proposed |
+| 022 | [Keyword migration plan](ADR-022-keyword-migration.md)      | Proposed |
+| 023 | [Memoization scope and cache key](ADR-023-memoization-scope.md) | Proposed |

--- a/docs/architecture/decisions/TEMPLATE.md
+++ b/docs/architecture/decisions/TEMPLATE.md
@@ -1,0 +1,43 @@
+# ADR-NNN: Short title
+
+**Status:** Proposed | Accepted | Deprecated | Rejected
+**Date:** YYYY-MM-DD
+**Deciders:** (names or "core maintainers")
+**Related:** (other ADRs, plan sections, RFC issues)
+
+## Context
+
+What is the situation that demands a decision? What constraints are in
+play? What did we know about the codebase or the design space that
+forced this choice to be made now?
+
+Two to four short paragraphs.
+
+## Options considered
+
+### Option A: …
+
+How it works. Pros. Cons.
+
+### Option B: …
+
+How it works. Pros. Cons.
+
+### Option C: …
+
+How it works. Pros. Cons.
+
+## Decision
+
+The chosen option, and why. Be specific — name the option, summarise the
+reasoning in a paragraph.
+
+## Consequences
+
+What this commits us to. Both good and bad. Include:
+
+- Implementation work this enables / unblocks.
+- Implementation work this rules out.
+- Things that become harder to change later.
+- Things downstream code can now rely on.
+- Migration cost, if any.

--- a/docs/implicits-phase-2-chunks.md
+++ b/docs/implicits-phase-2-chunks.md
@@ -1,0 +1,273 @@
+# Phase 2 chunk catalog
+
+Each chunk is sized for ~1 week of focused work for a normal developer
+familiar with the relevant Unison subsystem. Each chunk has:
+
+- A clear deliverable (code + tests)
+- An explicit dependency list
+- An assigned implementer agent and reviewer agent (different agents)
+- A worktree branch that the reviewer reads
+
+Status legend: ⏳ queued · 🟡 implementing · 🟠 in review · ✅ done · ❌ blocked
+
+## Chunk dependency graph
+
+```
+A1 ──┐                     (parser: constraint syntax)
+A2 ──┤                     (parser: given decls + summon + let-given)
+A3 ──┘── A4                (parser: @-override · A4 = parser snapshot suite)
+
+B1 ──┬── B2                (UCM mark/unmark commands)
+     ├── B3                (sharing API + push/pull)
+     └── B4                (unison-merge conflict resolution)
+
+C1.1                       (Type.F ImplicitArrow extension — foundational)
+   └── C2.1                (thread lexical given env through Context.hs)
+        └── C2.2           (constraint-goal emission from inference)
+             └── C2.3      (given-decl validation)
+                  └── D1   (port spike resolver into parser-typechecker)
+                       └── D2  (adapt to real Type/unification)
+                            └── D3 (applyTdnrDecisions-shape post-pass)
+                                 └── D4 (errors + property tests)
+                                      ├── E1 (update + hashing tests)
+                                      ├── F1 (LSP hover + goto-def)
+                                      └── F2 (LSP diagnostics + code-actions)
+```
+
+## Wave plan
+
+**Wave 1 (parallel):** A1, B1, C1.1
+**Wave 2 (after Wave 1):** A2, B2, B3, B4, C2.1
+**Wave 3 (after Wave 2):** A3, C2.2
+**Wave 4 (after Wave 3):** A4, C2.3
+**Wave 5:** D1
+**Wave 6:** D2
+**Wave 7:** D3
+**Wave 8:** D4
+**Wave 9 (parallel):** E1, F1, F2
+
+Reviewer for each chunk runs immediately after that chunk's implementer.
+
+## Chunk specifications
+
+### A1 — Parse `=>` constraint syntax in type signatures
+
+**Deliverable:** lexer recognises `=>`; type parser accepts `(C1 a, C2 b) => T -> U` form; AST extends `Type.F` parsing path with constraint-bearing arrows. Snapshot tests for round-trip.
+**Files (estimated):** `unison-syntax/src/Unison/Syntax/Lexer/Unison.hs`, `unison-syntax/src/Unison/Syntax/ReservedWords.hs`, `parser-typechecker/src/Unison/Syntax/TypeParser.hs`.
+**Out of scope:** typechecker semantics (downstream chunks); printer (Phase 4); `given` keyword (chunk A2).
+**Dependencies:** none. Foundational. Use ADR-019's recommended `ImplicitArrow` shape but the AST hookup happens in C1.1; until then, A1 emits the closest existing form and tags the source range so C1.1 can rewire it.
+**Acceptance:** parser round-trips all signature forms in `docs/implicits-plan.md` §1.2; snapshot tests committed under `parser-typechecker/tests/`.
+
+### A2 — Parse `given` declarations, `summon T`, `let given`
+
+**Deliverable:** top-level `given` defs, `let given x = ...` blocks, `summon T` expressions, all parse to AST nodes that downstream phases can ignore (no semantics yet).
+**Files:** `unison-syntax/src/Unison/Syntax/Lexer/Unison.hs` (add keywords), `Syntax/{Term,File,Block}Parser.hs`.
+**Dependencies:** A1 must merge first to avoid lexer-edit conflicts.
+**Acceptance:** all three forms parse; snapshot tests. Keyword migration: hard-break is acceptable for the prototype (existing identifiers `given`/`summon` lex as `Reserved`, parse-failing). ADR-022's deprecation-cycle is a release-engineering concern that lands separately; it is *not* required for the RFC prototype. Document the choice in a code comment near the keyword promotion.
+
+### A3 — Parse `@`-positional explicit override
+
+**Deliverable:** `f @ d x` parses as explicit-implicit-override application; coexists with `@` in pattern (`Foo@Bar`) and doc (`@rewrite`) contexts.
+**Files:** `Syntax/TermParser.hs`, possibly `Syntax/Parser/Doc.hs`.
+**Dependencies:** A2 must merge first (lexer state).
+**Acceptance:** snapshot tests for override + as-pattern + doc `@` show no regression.
+
+### A4 — Parser snapshot suite consolidation
+
+**Deliverable:** consolidated test module covering A1+A2+A3, including parse-error scenarios for malformed `=>`, missing `given` body, etc.
+**Files:** new test module under `parser-typechecker/tests/`.
+**Dependencies:** A3.
+**Acceptance:** ≥30 snapshot tests; parse errors are helpful.
+
+**Carry-overs from A1 review (nice-to-haves, not blockers):**
+- Tighten the TODO comment in `TypeParser.hs:42-49` to say "C1.1 will replace `Type.arrow` with `Type.implicitArrow` at the call site" rather than the more abstract "post-pass" framing.
+- Add a positive test for `Show a => Show (List a)` (given-conclusion form, §1.2).
+- Add a positive test combining constraints with effect arrows: `(Monad m) => (a ->{e} m b) -> ...` (§1.2).
+- Add a negative test pinning that nested `=>` chains (`Show a => Eq a => T`) are rejected per ADR-001.
+
+**Carry-overs from A2 review:**
+- Add four negative tests to `ImplicitParser.hs`: (a) `given` with no body, (b) `summon` with no argument, (c) top-level `given x = …` with no `:` annotation, (d) `let given x = …` with no annotation.
+- Add one positive test exercising A1 ⊕ A2: `given x : Foo a => Bar a = …`.
+- Add lexer-level tests in `unison-syntax/test/Unison/Test/Unison.hs` pinning that `given` and `summon` lex as `Reserved`.
+- Fix the `label` helper in `ImplicitParser.hs` so multi-line `let-given` fixtures get distinct scope names (currently both display as `let-given.let`).
+- (Nice to have) Drop `P.try givenBinding` in `TermParser.hs:1096` and commit after the `given` keyword — current `P.try` produces unhelpful errors on malformed `given`.
+- (Nice to have) Tighten `summonExpr`'s docstring at `TermParser.hs:696-698` to match its actual greedy `valueType` parse.
+
+**Carry-overs from A3 review:**
+- Add a structural test that pulls out the second arg of a parsed `f @ d` and asserts the widened annotation actually distinguishes override args from regular args (e.g., `ann.start.column < ann d.start.column`). Otherwise a regression that drops the widening would silently pass.
+- Add negative tests for malformed override syntax: (a) `f @` with no following arg, (b) `@d` at term head (no preceding term), (c) `f @ @ x` (double `@`).
+- Use `ABT.annotate widened d` instead of record-update at `TermParser.hs:968` (cosmetic).
+- Same `label` collision noted in A2 carry-overs applies to the new doc-rewrite test cases.
+
+**Open architectural question (NOT for A4 — must settle before chunk D2):**
+- A3 used annotation-widening to mark override-arguments; the plan calls for an "AST node for implicit-application override." Settle: either (a) add a sentinel wrapper in `unison-core` so D2/D3 can match on it, or (b) keep the annotation-widening contract and add property tests proving the widened ann survives parse→print→parse round-trips. Track this as a D-stream prerequisite.
+
+### B1 — Givenness sentinel + `MdValues` plumbing
+
+**Deliverable:** built-in `##Builtin.Given` reference; `MdValues` reads and writes plumbed through `unison-cli/src/Unison/Codebase/Editor/HandleInput/` for `view`/`find`; helper module `Unison.Codebase.Givens` for predicate `isGiven :: Codebase -> Referent -> m Bool`.
+**Files:** `parser-typechecker/src/Unison/Builtin.hs`, new `Unison.Codebase.Givens`, edits in `HandleInput/View.hs`, `HandleInput/FindI.hs`.
+**Dependencies:** none.
+**Acceptance:** unit tests show `MdValues` round-trip; `view` on a given-tagged definition prints `given` keyword (parser side handled by A2 — for now, just the data flow).
+
+### B2 — UCM `mark.given`/`unmark.given` commands
+
+**Deliverable:** new commands in `InputPatterns.hs`; corresponding handlers; `givens` listing command.
+**Files:** `unison-cli/src/Unison/CommandLine/InputPatterns.hs`, `unison-cli/src/Unison/Codebase/Editor/HandleInput/`.
+**Dependencies:** B1.
+**Acceptance:** transcript tests under `unison-src/transcripts/` mark, list, unmark.
+
+**Carry-overs from B1 review (close as part of B2):**
+- Wire `Unison.Codebase.Givens.isGiven` into the `view` rendering path in `unison-cli/src/Unison/Codebase/Editor/HandleInput/ShowDefinition.hs` — surface the `given` keyword on definitions that have the sentinel. (Parser-side `given` keyword is from chunk A2; together this closes the round-trip.)
+- Wire `Unison.Codebase.Givens.metadataValuesFor` into the `find` filtering path in `HandleInput/FindAndReplace.hs` — let users filter for given-tagged definitions.
+- Reconcile the contradictory docstrings in `Givens.hs:15-16` vs `:60-66` — drop the "per-name granularity" bullet.
+- Strengthen the misnamed "term reference" test in `Unison.Test.Codebase.Givens` (parser-typechecker tests) to actually compute and compare term-hash before/after marking, validating ADR-014 empirically.
+
+### B3 — Sharing API push/pull verification
+
+**Deliverable:** verification that `MdValues` (and therefore the given sentinel) travels through push/pull intact via the existing wire format. **No protocol version bump** — chunk B3's investigation confirmed the wire format already carries metadata references opaquely (see amended ADR-020). Future feature gating uses the future-compatible `StreamInitInfo` map at Phase 3.
+**Files:** `unison-share-api/tests/Unison/Test/Sync/GivenRoundtrip.hs` (new).
+**Dependencies:** B1.
+**Acceptance:** new round-trip test confirms the sentinel survives the wire format; commit body documents why no bump is needed.
+
+### B4 — `unison-merge` given-set conflict resolution
+
+**Deliverable:** the four conflict cases from ADR-021 (both-mark, one-mark, rename-different, mark-vs-delete).
+**Files:** `unison-merge/src/`.
+**Dependencies:** B1.
+**Acceptance:** ≥4 unit tests covering each ADR-021 case (transcript tests deferred — see B4 carry-overs).
+
+**Carry-overs from B4 review:**
+- Add a TODO marker in `unison-merge/src/Unison/Merge/Mergeblob.hs` (or in the haddock of `GivenSet.hs`) pointing to where the merge engine will call `mergeGivenSets`/`applyGivenSet`. The module is currently sidecar — pipeline integration is a follow-up chunk.
+- Document alias-collapse behavior in `applyGivenSet` haddock, OR change `survivorByRef` to `Map Referent (NonEmpty Name)` so multiple surviving names of the same referent are preserved. Two-line haddock is sufficient if the engine doesn't yet exercise aliases.
+- Transcript tests covering the four cases through actual merges (vs. unit tests on `GivenSet`) — defer to a follow-up chunk after B4's pipeline integration lands.
+
+### C1.1 — Extend `Type.F` with `ImplicitArrow`
+
+**Deliverable:** `Type.F` gains `ImplicitArrow a a` per ADR-019; hashing-v2 tokens updated; all construction/destruction sites updated; existing `Arrow` cases unchanged in behavior.
+**Files:** `unison-core/src/Unison/Type.hs` (the central one), `unison-hashing-v2/src/Unison/Hashing/V2/Type.hs`, every `case` over `Type.F` across `parser-typechecker/`, `unison-runtime/` (where it just delegates to `Arrow`), `unison-cli/`.
+**Dependencies:** none. **Foundational** for C2.x and D1.
+**Acceptance:** existing test suite zero regressions; new tests confirm `ImplicitArrow` hashes distinctly from `Arrow`; round-trip serialization preserved.
+
+### C2.1 — Thread lexical given env through `Context.hs`
+
+**Deliverable:** new `Map TermReference Type` field on `Unison.Typechecker.Context.Context`; updated through `Lam`, `Let`, `LetRec`, `Match`-arm, top-level decl. No semantics — just plumbing.
+**Files:** `parser-typechecker/src/Unison/Typechecker/Context.hs`.
+**Dependencies:** none architecturally, but easier after C1.1 lands.
+**Acceptance:** zero regressions on existing typechecker test suite; ad-hoc test confirms env propagates through nested binders.
+
+**Implementation note (recorded post-landing):** the field landed on `Env` (the typechecker's monad state), not on `Context` (the `newtype` over a finger-tree of `Element`s). Save/restore via `withLexicalGivens` mirrors the `markThenRetract` pattern. Trade-off: avoids touching the `Measured`/finger-tree machinery at the cost of requiring binder additions to remember the wrapper. Helpers `getLexicalGivens` / `extendLexicalGiven` / `withLexicalGivens` are exported for C2.2/C2.3.
+
+**Carry-overs from C1.1 review (close before this chunk lands):**
+- Add `Type.ImplicitArrow' i o -> wellformedType c i && wellformedType c o` clause in `Context.hs:748` to keep `wellformedType` total — currently falls through to a `Match failure` `error` for `ImplicitArrow`.
+- Add `ImplicitArrow'` arms to `unArrows` and `unEffectfulArrows` in `unison-core/src/Unison/Type.hs:223–240`. These are consumed by `DeclPrinter`, `TypePrinter`, `Variance.split`, `Context.checkWanted`'s argument-extractor; missing arms silently break declaration-field counting and printing.
+- Add `ImplicitArrow'` traversal to `existentializeArrows` and `purifyArrows` (`unison-core/src/Unison/Type.hs:706-735`) so effect-attach/strip behavior matches `Arrow`.
+- Add `-- TODO Phase 4: render ImplicitArrow as =>` comment at `TypePrinter.hs:127` and `PrintError.hs:1438` so the printer gap is grep-able. (Don't implement the rendering — Phase 4.)
+- Consider adding `AppImplicitArrow` constructor to `KindInference.Generate.hs` `Provenance` so kind errors point at `=>`. (Nice to have; defer if scope-creep.)
+
+### C2.2 — Emit constraint goals from inference
+
+**Deliverable:** new `InfoNote` variant `ConstraintGoal { loc, type, scope }`; inference emits one for each `ImplicitArrow` parameter at apply sites; `Blank.Recorded` gains `Implicit loc` variant.
+**Files:** `unison-core/src/Unison/Blank.hs`, `parser-typechecker/src/Unison/Typechecker/Context.hs`.
+**Dependencies:** C1.1, C2.1.
+**Acceptance:** typechecker accepts test programs with `=>` signatures, emitting the right number of constraint goals at the right locations. No resolution yet — goals are reported, not filled.
+
+**Carry-over from C2.1 review:** strengthen the `lexicalGivensThreading` test (now placeholder per C2.1) so it actually verifies env propagation: e.g., assert `getLexicalGivens` returns a populated map inside a binder body. The C2.2 hook for emitting `ConstraintGoal` notes captures the env, so this test gains a real observation point.
+
+**Carry-overs from C2.2 review (close in next C-stream chunk or a polish pass):**
+- Add a multi-constraint emission test: `(C1 a, C2 b) =>` should emit exactly 2 goals in order. C2.2's recursion handles this implicitly but no test pins the property.
+- Replace the test's `mapMaybe'` reimplementation with `Data.Maybe.mapMaybe`.
+- Add `-- TODO chunk D1+` comment markers at `Context.hs:3009` (`subtype`) and `Context.hs:3121` (`equate0`) — neither has an `ImplicitArrow'` clause; not needed for C2.2 (apply-sites peel off ImplicitArrow first) but D1+ should close.
+
+**C1.1 carry-over actually closed in C2.2 (recorded for posterity):**
+- `Context/Structure.hs apply'` totality fix (added `ImplicitArrow'` clause). This was a latent gap from the original C1.1 carry-over commit, surfaced when `ConstraintGoal` types started flowing through `substituteSolved`.
+
+### C2.3 — Validate `given` declarations
+
+**Deliverable:** when typechecker encounters a `given` declaration, validates body's type matches conclusion of declared signature. Hooks into `mark.given` namespace tagging from B1.
+**Files:** `parser-typechecker/src/Unison/FileParsers.hs`, `Typechecker.hs`.
+**Dependencies:** C2.2, B1.
+**Acceptance:** valid given decls pass; mismatched ones produce helpful errors.
+
+**Carry-overs from C2.3 review (nice-to-haves, defer to a polish pass):**
+- `unImplicitArrows` haddock at `unison-core/src/Unison/Type.hs:266-272` mentions a `vs` list that the implementation doesn't return; tighten the doc to match the actual `([Type v a], Type v a)` shape.
+- `noteGivenDeclLet` (`Context.hs:1292`) takes `_inferredType` that's never used; drop it or note why it's there (callsite-symmetry with `noteTopLevelType`).
+- `emitGivenDeclNote` and `noteGivenDeclLet` are nearly identical with different binding-shape destructuring; can be unified via a shared helper.
+- Add a `-- TODO chunk B2/D3:` marker at `givenDeclVars`'s call-out site (currently no in-tree consumer; downstream chunks consume it).
+
+### D1 — Port spike resolver into `parser-typechecker`
+
+**Deliverable:** new module `Unison.Typechecker.GivenResolver` containing the spike's algorithm, adapted to use `Unison.Type.Type v loc` and the existing unification primitives in `Context.hs`. Does NOT yet run end-to-end — exercised via unit tests.
+**Files:** new `parser-typechecker/src/Unison/Typechecker/GivenResolver.hs` and unit tests.
+**Dependencies:** C1.1.
+**Acceptance:** unit-tested resolver passes the spike's 15-test matrix on real `Unison.Type.Type` values.
+
+### D2 — Adapt resolver to real unification context
+
+**Deliverable:** resolver consumes the constraint goals emitted by C2.2 and the lexical given env from C2.1; produces resolution decisions analogous to TDNR's `SolvedBlank`.
+**Files:** `Unison.Typechecker.GivenResolver`, `Typechecker.hs`.
+**Dependencies:** C2.2, D1.
+**Acceptance:** integration tests on small files with `=>` signatures produce correct resolutions.
+
+**Carry-over from D1 review:**
+- `cycleHit` in D1 uses `unify mempty Set.empty` (no flex) — equivalent to structural equality up to annotations, not the alpha-renamed-cycles semantics the docstring claims. In D1 with closed monotypes this is unobservable; D2 will see metavars and the discrepancy will surface. Either widen flex to all free vars of either side, or rephrase the docstring honestly.
+- D2 must decide on shared-metavar awareness for both unification and memoization (per ADR-023's metavar-invalidation rule), and may want to revisit whether to fold the resolver into the `M v loc` monad at that point or keep it standalone.
+
+### D3 — Apply resolved givens via post-pass
+
+**Deliverable:** `applyGivenDecisions` analogous to `applyTdnrDecisions`; walks the term and substitutes implicit applications into `App` nodes.
+**Files:** `parser-typechecker/src/Unison/FileParsers.hs`, `Typechecker.hs`.
+**Dependencies:** D2.
+**Acceptance:** end-to-end: file with `=>` signatures and matching givens typechecks and elaborates; the resulting term has plain `App` nodes pointing at dictionary hashes.
+
+**Resolution of A3 architectural question (was: AST wrapper vs annotation-widening for `@`-overrides):** **chosen option (b) — annotation-widening contract.** D3 walks the term and threads `SolvedImplicit` decisions into `App` nodes. When D3 encounters an apply site whose next argument has a widened annotation (per A3's `Term.apps` convention — start column of the arg's range begins before the arg's leaf token, indicating an `@`-prefixed override), D3 must:
+1. NOT consume a `SolvedImplicit` decision for that slot.
+2. Leave the user-supplied argument in place.
+3. Continue walking — the next `App`'s argument may or may not be widened; each is checked independently.
+
+Add a property test: `parse(print(elaborate(t)))` preserves the override marker, since D3 must not strip the widened annotation when threading decisions.
+
+### D4 — Error categories and property tests
+
+**Deliverable:** structured `NoGiven`, `Ambiguous`, `DepthExceeded`, `Cycle` errors; property tests for cycle/metavar interaction and diamond/shared-metavar correctness (see `spike/implicits/FINDINGS.md` and ADR-023).
+**Files:** `Unison.Typechecker.GivenResolver`, error-rendering hooks.
+**Dependencies:** D3.
+**Acceptance:** ≥4 distinct error scenarios with golden-file output; property tests pass.
+
+**Carry-overs from D2 review:**
+- Add elaborator-level tests for the `Ambiguous` and `DepthExceeded` categories (D2 only proved `NoGiven` end-to-end). Each should set up a small test program that exercises that specific failure category through the full elaborator path.
+- Add a cycle/metavar regression test: a mutually-recursive given pair where one resolution path induces a metavar in the goal. Should exercise the now-fixed `cycleHit` widened-flex behavior.
+- When a goal's existential is unsolved at end of inference, the resolver currently treats it as rigid and can produce a "no given" failure where "type can't be inferred" would be more accurate. D4 should detect this and produce a clearer error category (perhaps a fifth variant `UnresolvedMetavarInGoal` or special-case rendering of `NoGiven`).
+
+**Carry-overs from D3 review:**
+- `GivenApply.aeLocalTypes` is never extended for `Abs`-introduced bindings; either thread the env through `Abs` in `rewrite` or drop the "traversal-introduced bindings" wording in the doc.
+- `interleave` handles bare `f` (no args) at an `ImplicitArrow'` slot by NOT inserting the dictionary (`GivenApply.hs:288-289`). For partial applications like `let g = f in g 42` this silently drops the implicit. Add a regression test and either insert the dict at the partial-app site or document the constraint.
+- Effect arrows on the spine break the walker (`GivenApply.hs:313`). `Effect1' es (Arrow' i o)` falls into the catch-all. Functionally OK at the moment (no implicits after an effect arrow at the spine in well-typed surface types) but the walker should peek through `Effect1'` to keep the apply chain coherent.
+- Decision queue (`collectDecisions` in `GivenApply.hs:167`) is order-dependent on synthesis traversal order; if the C-stream's traversal order ever changes, this passes silently with wrong dictionaries. Switch to a `loc`-keyed `Map` for hardening.
+- Surface "wrap leaf overrides in parens" guidance from D3's `GivenApply.hs:82-85` haddock into a user-facing diagnostic when an unparenthesized `@`-leaf override is silently ignored.
+- Cosmetic: `outerAnn` is reused for every dictionary's `Term.ref` annotation, collapsing nested-dict ranges. Consider deriving from the function's annotation per layer.
+
+**Carry-overs from D4 review (deferred polish):**
+- `Cycle` constructor at `GivenResolver.hs:163-170` is documented as emitted "for self-referential goals with no escape hatch" but no construction site exists. Either implement the explicit hard-cycle detection, or update the docstring to "Reserved for future use; not currently emitted."
+- Thread `candSubst` into `NearMiss` so the renderer can show "tried `Show.list` with `a := Nat`" — the substitution is computed in the resolver but not surfaced.
+- Diamond property test docstring at `GivenResolverProperties.hs:191-263` claims to exercise ADR-023's metavar-invalidation rule but the goal uses a ground `a`. Either rename the test or build a goal where `a` is a genuine existential bound during resolution.
+
+### E1 — Update + hashing semantics tests
+
+**Deliverable:** transcript tests for ADR-016's three cases — (a) working update through given changes hash; (b) breaking given leaves dependent terms valid but breaks new code; (c) new ambiguous given fails new code without disturbing old.
+**Files:** `unison-src/transcripts/`.
+**Dependencies:** D4.
+**Acceptance:** all three cases produce expected transcripts.
+
+### F1 — LSP hover and goto-definition on synthesized args
+
+**Deliverable:** hover on `@d` shows "implicit; resolved from given <name> (#hash)"; goto-def jumps to the resolved given.
+**Files:** `unison-cli/src/Unison/LSP/`.
+**Dependencies:** D4.
+**Acceptance:** manual test in VSCode + scripted protocol-level test.
+
+### F2 — LSP diagnostics and code actions
+
+**Deliverable:** NoGiven/Ambiguous/DepthExceeded surface as diagnostics; code actions for "define given X" and "shadow with local given".
+**Files:** `unison-cli/src/Unison/LSP/`.
+**Dependencies:** D4.
+**Acceptance:** scripted protocol-level test for each diagnostic.

--- a/docs/implicits-plan.md
+++ b/docs/implicits-plan.md
@@ -1,0 +1,682 @@
+# Implicit parameters for Unison — design and execution plan
+
+**Status:** draft / pre-RFC. Working name: `givens`.
+
+This document captures the design and the staged execution plan for adding
+Scala-3-style `given`/`using` implicit parameters to Unison. It is the source
+of truth that the ADRs in `docs/architecture/decisions/` (to be created in
+Phase 0) will refine.
+
+---
+
+## 1. Design summary
+
+### 1.1 Guiding principles
+
+Five things are load-bearing for the design "fitting like a glove":
+
+1. **Givens are sugar for ordinary parameters.** After elaboration, a
+   constraint parameter is an ordinary positional argument. Runtime,
+   codegen, ABT, and hashing learn no new concept. The whole feature lives
+   in the elaborator.
+
+2. **Resolution is baked into the hash.** A term that referenced a
+   constraint resolves the dictionary at typecheck time and freezes the
+   chosen hash into the term. Old terms never change instance — content
+   addressing makes implicits coherent for already-elaborated code by
+   construction.
+
+3. **Namespace = instance set.** The visible givens in your current
+   namespace *are* your instance dictionary. No orphan rules, no global
+   registry. Two libraries that each define `given Show.nat` produce an
+   ambiguity at any call site that sees both, surfaced through the same
+   machinery TDNR uses today.
+
+4. **Givenness is a namespace-level tag on a hash.** Marking a definition
+   `given` is recorded in namespace metadata, not in the term itself. The
+   underlying *term hash* is unchanged by tagging — aliases, dependent
+   terms, and history pointers all keep working. The *branch (causal)
+   hash* of the namespace does change, since it summarises namespace
+   contents including metadata. A downstream user can promote an upstream
+   definition to a given locally, or demote an upstream given they don't
+   want, all without touching term hashes.
+
+5. **Givens extend TDNR rather than replace it.** TDNR resolves "which
+   named definition fits this type"; given resolution adds "which value of
+   this type exists, with chaining." Same elaborator, same ambiguity
+   reporting, same "did you mean…" affordances.
+
+### 1.2 Surface syntax
+
+#### Declaring a "class"
+
+There is no class declaration. A class is just a type — typically a record.
+
+```unison
+unique type Show a = Show { show : a -> Text }
+unique type Ord a  = Ord  { compare : a -> a -> Ordering, eq : Eq a }
+unique type Functor f = Functor { fmap : ∀ a b. (a -> b) -> f a -> f b }
+unique type Monad m   = Monad   { pure : ∀ a. a -> m a
+                                , bind : ∀ a b. m a -> (a ->{} m b) ->{} m b
+                                , functor : Functor m }
+```
+
+Subclassing falls out of records-containing-records.
+
+#### Declaring a given
+
+```unison
+given Show.nat : Show Nat = Show Nat.toText
+
+given Show.list : Show a => Show (List a) =
+  Show (xs -> "[" ++ Text.join ", " (List.map Show.show xs) ++ "]")
+
+given Functor.optional : Functor Optional = Functor Optional.map
+```
+
+The keyword `given` is a namespace tag: it records that this hash is
+eligible for implicit resolution in this namespace. `Show a => Show (List
+a)` desugars to `Show a -> Show (List a)` with the first parameter marked
+as a `using` parameter.
+
+#### Consuming givens
+
+```unison
+print : Show a => a ->{IO} ()
+print a = printLine (Show.show a)
+
+sort : Ord a => [a] -> [a]
+
+mapM : (Monad m, Traversable t) => (a ->{e} m b) -> t a ->{e} m (t b)
+```
+
+#### Local givens
+
+```unison
+sortReversed : Ord a => [a] -> [a]
+sortReversed xs =
+  given local : Ord a = Ord.flip (summon (Ord a))
+  sort xs
+```
+
+Local givens shadow ambient ones (lexically inner wins).
+
+#### Explicit summon and override
+
+`summon T` is the explicit summon expression — rare in practice because
+constraint arguments are inserted automatically at every call. Used when
+the dictionary itself is needed as a value.
+
+`f @ d x` passes `d` explicitly to the next implicit slot of `f`, useful
+for testing and for breaking ambiguity without introducing a local given.
+
+### 1.3 Resolution algorithm
+
+```
+resolve(T, stack, depth) =
+  if depth > maxDepth: error DepthExceeded(stack)
+  if any(unifies(T, S)) for S in stack: fail this branch (cycle)
+
+  candidates = { g ∈ visibleGivens
+               | conclusion(g) unifies with T under σ }
+
+  results = []
+  for (g, σ) in candidates:
+      premises = σ(premises(g))
+      try:
+          subs = [resolve(p, stack ∪ {T}, depth+1) for p in premises]
+          results += (g, σ, subs)
+      catch: continue   -- this candidate didn't pan out
+
+  case results of
+    []  → error NoGiven(T, near = nearMisses(T))
+    [r] → r
+    rs  → case mostSpecific(rs) of
+            Just r  → r
+            Nothing → error Ambiguous(rs)
+```
+
+#### Specificity ordering
+- **Subsumption.** A's conclusion is strictly more specific than B's iff
+  there is a substitution σ with σ(B) = A and σ ≠ identity.
+- **Lexical proximity.** Local `given` beats outer `given` regardless of
+  type specificity.
+- **Otherwise tie.** Report ambiguity with both candidates.
+
+#### Cycle and depth handling
+- Cycles detected per branch via `stack`. Hitting a cycle fails *that
+  candidate*; other candidates may still succeed.
+- Depth limit global per top-level resolution. Default 50, configurable
+  via project setting. Hitting the limit always errors.
+- The error reports the chain.
+
+### 1.4 What's *not* in v1
+
+- Functional dependencies / associated types.
+- Implicit conversions (givens fill explicit holes only).
+- Default parameters.
+- Macro/derivation (`deriving Show`).
+- Anonymous given lambdas / first-class implicit-function types.
+- **Kind-polymorphic givens.** Unison's kind system has only `Type`,
+  `Ability`, and arrow kinds (`Kind :-> Kind`). There is no kind
+  polymorphism. Givens that abstract over kinds (rare —
+  `Bifunctor`-shaped premises with kind variables) won't work in v1.
+  Standard HKT — `Functor f`, `Monad m` where `f, m :: Type -> Type` —
+  works fine.
+
+---
+
+## 2. Phasing at a glance
+
+```
+Phase 0  Design freeze      ADRs ratified, RFC drafted
+Phase 1  Spike              throwaway prototype validates resolution
+Phase 2  Core               parser, namespace, typechecker, elaborator
+Phase 3  UCM integration    view/find/edit/update for givens
+Phase 4  Pretty + errors    polished diagnostics, printer modes
+Phase 5  Stdlib seed        Show, Ord, Functor, Monad, Traversable
+Phase 6  Release            RFC merged, behind a flag → on by default
+```
+
+Each phase has a gate that must close before the next opens. Phase 2's
+subprojects run partly in parallel, gated internally.
+
+---
+
+## 3. Phase 0 — Design freeze
+
+**Goal:** every contentious decision recorded as an ADR and ratified by
+core maintainers. No code yet.
+
+### 3.1 ADRs to author
+
+| #   | Title                                                                  | Status     |
+|-----|------------------------------------------------------------------------|------------|
+| 001 | Constraint syntax: Haskell-style `C =>`                                | settled    |
+| 002 | Givenness is namespace metadata, not a term-level tag                  | settled    |
+| 003 | A "class" is an ordinary type; no new declaration kind                 | settled    |
+| 004 | Resolution is purely compile-time; runtime/codegen untouched           | settled    |
+| 005 | Coherence: ambiguity at call site, no global uniqueness                | settled    |
+| 006 | `summon T` is the explicit summon form                                 | settled    |
+| 007 | `@`-positional explicit override at call sites                         | settled    |
+| 008 | Specificity ordering: subsumption + lexical inner > outer              | settled    |
+| 009 | Cycle detection per branch; depth limit global, default 50             | settled    |
+| 010 | Local `given` in `let`-blocks; no first-class implicit functions       | settled    |
+| 011 | HKT support in v1; functional dependencies and assoc types deferred    | settled    |
+| 012 | Where the elaborator pass sits relative to inference                   | open       |
+| 013 | Storage format for a namespace's given-set (and how it's diffed/pushed)| open       |
+| 014 | Hash treatment of given declarations and elaborated terms              | open       |
+| 015 | Pretty-printer default: elide implicit args; verbose mode shows them   | open       |
+| 016 | Update semantics when a re-typecheck would re-resolve differently      | open       |
+| 017 | UCM surface: new commands and modifications to existing ones           | open       |
+| 018 | Feature flag rollout: gated by project config until stable             | open       |
+| 019 | Representation of implicit arrows in `Type.F` (extend / side-table / wrapper) | **open, blocking** |
+| 020 | Metadata serialization format and migration from dormant `causal_metadata` table | **open, blocking** |
+| 021 | Merge semantics for given-set conflicts in `unison-merge`              | open       |
+| 022 | Keyword migration plan for `given`/`summon` (currently legal identifiers) | open    |
+| 023 | Memoization scope and cache key for resolution (Phase-1 spike output) | open       |
+
+### 3.2 Phase 0 deliverables
+- All 18 ADRs in `docs/architecture/decisions/`.
+- A public RFC issue/PR linking to the ADR set, soliciting community input
+  for ~2 weeks.
+- A "what doesn't change" companion doc that codifies the
+  runtime/hashing/codegen non-changes.
+
+### 3.3 Gate to Phase 1
+- All ADRs marked *Accepted* (not *Proposed*).
+- RFC has at least one round of feedback addressed.
+- Two core maintainers sign off.
+- ADRs **012, 013, 014, 016, 019, 020** specifically have *no open
+  questions*. These six block the spike. ADR 019 is foundational because
+  the "settled" ADR 004 (runtime/codegen untouched) presupposes its
+  answer; ADR 020 is foundational because the dormant `causal_metadata`
+  table forces a choice on serialization shape.
+
+---
+
+## 4. Phase 1 — Spike
+
+**Goal:** prove the resolution algorithm works on a toy implementation, in
+a throwaway branch, *without touching the parser or main typechecker.*
+
+### 4.1 Scope
+- A standalone Haskell module that takes a hand-written AST of
+  "elaboration goals" plus a "given pool" and runs the resolution
+  algorithm.
+- Inputs: list of mock givens with type-shaped premises and conclusions,
+  list of constraint goals.
+- Output: resolution tree or error.
+- Test harness covering chaining, HKT, ambiguity, cycles, depth blowup.
+
+### 4.2 Success criteria
+1. Resolution terminates on cycles (per-branch detection).
+2. Specificity ordering produces the expected winner on `Show (List Nat)`
+   vs `Show (List a)`.
+3. HKT cases resolve: `Functor List`, `Monad Optional`.
+4. Ambiguity errors include both candidates with enough context.
+5. Performance acceptable for ~1000 givens with ~20-deep chains.
+6. **Diamond dependencies don't blow up.** Resolution of compound
+   instances like `Show (Map (List a) Nat)` — where the same sub-goal
+   (`Show Nat`) is reached by multiple chain paths — completes without
+   exponential blowup or duplicate sub-resolution. Memoize sub-results by
+   type within a single top-level resolution.
+
+### 4.3 Out of scope
+- No parser changes. AST is hand-built.
+- No real Unison types — mock representation just rich enough for
+  unification + HKT.
+- No TDNR integration.
+- No namespace concept; givens flat list.
+
+### 4.4 Gate to Phase 2
+- All six spike-success criteria demonstrated.
+- A 1-page writeup: what we learned, what surprised us, what we now know
+  we got wrong in the ADRs.
+- *If the spike surfaces an ADR-level issue, return to Phase 0.*
+
+---
+
+## 5. Phase 2 — Core implementation
+
+Six subprojects. Numbered in topological order, but 2.B and 2.C overlap
+heavily and 2.E starts as soon as 2.D has a working stub. 2.C is split
+into 2.C.1 (foundational, blocks 2.D) and 2.C.2 (parallel with 2.D).
+
+### 5.1 Subproject 2.A — Parser & AST extensions
+- Lex/parse `=>` in type signatures.
+- Lex/parse `given` as a definition prefix.
+- Lex/parse `given` in `let`-blocks.
+- Lex/parse `summon T` expression.
+- Lex/parse `@`-positional explicit-override at call sites.
+- AST nodes for: constraint-bearing function types, given declarations,
+  summon expressions, implicit-application override.
+- No semantics yet — parser produces nodes, downstream phases ignore them.
+
+**Exit:** parser round-trips every example in the RFC. Snapshot tests for
+both success and helpful parse errors.
+
+### 5.2 Subproject 2.B — Namespace given-set storage
+- Schema change: a namespace tracks `Set Hash` of givens. Likely fits in
+  the existing `MdValues` slot in `U.Codebase.Branch.Type` rather than a
+  new schema field — pending ADR 020.
+- Codebase format: per ADR 020, decide between (a) reviving the dormant
+  `causal_metadata` table, (b) reusing `MdValues` with a sentinel
+  built-in `Reference` like `##Builtin.Given`, or (c) a new field on
+  branch serialization.
+- Migration: existing namespaces have empty given-sets.
+- Push/pull: given-set travels with its namespace. Sharing servers learn
+  the new field; bump the relevant API version in `unison-share-api` and
+  `unison-share-projects-api`. Coordinate with a server release.
+- Aliasing/move/delete: hash being given-tagged in namespace X doesn't
+  imply given in namespace Y. Aliases inherit by default; rename within a
+  namespace preserves givenness.
+- **Merge semantics (per ADR 021):** extend `unison-merge` with
+  given-set conflict resolution. Cases to define: both branches mark a
+  hash given (no-op), one marks and the other doesn't (mark wins —
+  user-confirmable), both branches rename the same given to different
+  names (existing rename-conflict path, with givenness preserved on the
+  resulting hash).
+- **Plumbing for read sites.** `MdValues` schema exists but is not
+  currently read by user-facing flows (`grep -rn MdValues unison-cli`
+  returns nothing). Wire it through name lookup, project APIs, and any
+  command that surfaces definitions.
+
+**Exit:** existing UCM round-trip tests pass with no diff. New round-trip
+tests cover marking, unmarking, aliasing, push/pull, fork, **merge with
+given-set conflicts**. Sharing API version bumped and a coordinated
+server build available.
+
+### 5.3 Subproject 2.C.1 — Type-AST representation of implicit arrows
+
+**Blocks 2.D.** Per ADR 019, choose how implicit-ness is represented in
+the type AST. Three options:
+
+- (a) **Extend `Type.F`** with `ImplicitArrow a a`. Pros: self-describing,
+  every reference site sees implicit-ness directly. Cons: changes
+  type-hashing — every existing type with `=>` (none yet, but every type
+  added going forward) hashes differently than its `->` cousin would.
+- (b) **Side-table on declarations.** `Type.F` keeps only `Arrow`; a map
+  from `Reference` to "positions of this declaration's arrows that are
+  implicit" lives alongside. Pros: preserves type-hash compatibility.
+  Cons: every reference site must consult the side-table to know what to
+  elaborate.
+- (c) **Wrapper type `Implicit a`.** Surface syntax leaks; rejected.
+
+Recommended starting point: (a) with the type-hash break documented as a
+v1 consequence (acceptable since `=>` is new syntax and creates only new
+types). Final choice in ADR 019.
+
+**Exit:** `Type.F` modified per ADR 019; type-hashing tests updated;
+parser+typechecker can synthesize and check the new arrow form.
+
+### 5.4 Subproject 2.C.2 — Typechecker integration
+- Recognize `=>` in signatures: desugar (or directly type-check, per
+  2.C.1) to function with leading parameters tagged `Implicit`.
+- Recognize `given` declarations: validate body's type matches conclusion;
+  flag in namespace metadata.
+- During inference, record `Implicit` parameter slots as constraint goals
+  with types pinned by surrounding inference.
+- Do not resolve them yet — that's 2.D.
+- New typechecker output: `[(SourceLocation, Type, ScopeSnapshot)]` of
+  constraint goals.
+- **Lexical given environment.** Thread a `Map Hash Type` (or similar) of
+  in-scope local givens through every binding form in
+  `Unison.Typechecker.Context` — `Lam`, `Let`, `LetRec`, `Match`-arm,
+  top-level decl. This is mechanical but pervasive (the file is ~3800
+  lines). Plan for it explicitly; do not undercount.
+- **Loop ordering vs TDNR.** Decide whether implicit resolution runs as a
+  post-pass after TDNR's fixed point, or interleaved within TDNR's loop
+  (per ADR 012). One-shot post-pass is the cheaper starting point and
+  likely suffices.
+
+**Exit:** typechecker accepts all examples in the RFC's "consuming givens"
+section, producing constraint-goal lists. Lexical given environment is
+threaded through every binder. TDNR test suite passes unchanged.
+
+### 5.5 Subproject 2.D — Elaborator pass
+- Lift the spike resolver into the real codebase. Reference
+  implementation: `spike/implicits/`.
+- Input: typechecker output + namespace given-set.
+- Output: term with implicit arguments filled in, constraint goals erased.
+- Specificity (per refined ADR 008: one-way matching of declared
+  conclusions, B's variables flexible, A's rigid), lexical-inner-wins,
+  cycle detection, depth limit, memoization (per ADR 023: per-resolve,
+  zonked-goal key, cache successes and failures, invalidate on metavar
+  binding in the goal stack).
+- **Four** structured error categories: `NoGiven`, `Ambiguous`,
+  `DepthExceeded`, `Cycle [Ty]`. The spike used `NoGiven` as a stand-in
+  for cycle hits but this conflates "no instance" with "instance exists
+  but cyclic". Distinguish for diagnostics.
+- `NearMiss` carries the unifying substitution alongside the candidate
+  given, so error messages can say "tried `Show.list` with `a := Nat`,
+  failed because: …" instead of just naming the candidate.
+- **Output mechanism mirrors TDNR.** Today TDNR records its decisions as
+  `SolvedBlank` info notes that `applyTdnrDecisions` walks and substitutes
+  (`FileParsers.hs`). Implicit resolution should produce analogous
+  decision records — "fill this implicit hole with this term" — and a
+  post-pass walks the term to substitute. Reuses the existing pattern.
+
+**Subgate:**
+- 50+ positive cases (chaining, HKT, locals, overrides).
+- 30+ negative cases (cycles, ambiguity, depth, missing).
+- Property test: elaborated terms typecheck as ordinary terms (round-trip
+  through inference unchanged).
+- **Property test: cycle detection with metavars.** The spike's cycle
+  hits use `unify` rather than `==`, which can spuriously fire when an
+  outer goal carries unresolved metavars. Cover this with a property
+  test using an inference state that mirrors what TDNR will produce.
+- **Property test: diamond resolution with shared metavars.** The spike
+  validated diamonds with ground goals only. Phase 2.D goals routinely
+  have un-pinned metavars; ensure memoization invalidation (ADR 023) is
+  correct when two diamond paths share a metavar that one of them binds.
+
+**Exit:** existing test suite passes (zero regressions). New tests pass.
+
+### 5.6 Subproject 2.E — Hashing and update semantics
+- Confirm: elaborated term hashes against resolved dictionary hashes.
+- Confirm: given declaration hashes against its body; givenness not in
+  *term* hash (but does change *branch* hash, per §1.1 principle 4).
+- `update` with re-elaborated term: failures comprehensible.
+- `update` that changes resolution silently: new term has new hash, old
+  term retains its old hash and old resolution.
+
+**Exit:** update tests show: (a) working update through a given changes
+hash; (b) breaking a given leaves dependent terms valid (hashed against
+the old) but breaks new code; (c) introducing a second matching given
+causes new code to fail with ambiguity but doesn't disturb existing code.
+
+### 5.7 Subproject 2.F — LSP integration
+
+Not previously planned; surfaced by codebase review.
+
+`unison-cli/src/Unison/LSP/` consumes typechecker info notes
+(`VarBinding`, `VarMention`, etc.) to produce hover, goto-definition,
+document-symbols, and diagnostics. Implicit-resolution synthesizes
+arguments that didn't appear in source, so the existing flows have
+undefined behavior on them.
+
+- Hover on a synthesized `@d` argument: show "implicit; resolved from
+  given `<name>` (#hash)". Source-position hover skips synthesized args.
+- Goto-definition through an implicit: jumps to the resolved given.
+- Document-symbols: givens appear with a distinct icon/marker.
+- Diagnostics: NoGiven/Ambiguous/DepthExceeded errors surface as LSP
+  diagnostics with code-actions ("define given `Show Nat`", "shadow with
+  local given").
+
+**Exit:** the four LSP flows have a defined, tested behavior on terms
+containing resolved implicit arguments. Editor integration tested in
+VSCode and at least one other editor.
+
+### 5.8 Phase 2 gate
+- 2.A, 2.B, 2.C.1, 2.C.2, 2.D, 2.E, 2.F all green.
+- Full test suite green on a branch with the feature flag enabled.
+- Performance: typechecking unison-base codebase no slower than ±5% with
+  flag on (no givens used yet).
+
+---
+
+## 6. Phase 3 — UCM integration
+
+- `view <name>` on a given shows the `given` keyword.
+- `find` learns a `:given` filter.
+- `find <type>` notices when type is a constraint and surfaces matching
+  givens specially.
+- `edit` on a given works exactly like editing any definition; re-saving
+  preserves the given tag.
+- New command `givens` lists givens in current namespace.
+- New commands `mark.given <name>` and `unmark.given <name>` to toggle the
+  namespace tag without rehashing the term (the branch hash will change).
+- `move`, `alias`, `delete`, `fork` updated per ADR 013.
+- `pull` and `push` carry the given-set.
+
+**Exit:** every UCM command's help text and behavior updated. Manual smoke
+test against a real project. CI tests cover new commands.
+
+---
+
+## 7. Phase 4 — Pretty-printer and errors
+
+### 7.1 Printer
+- Default: elide implicit arguments; render `=>` in signatures; render
+  `given` on declarations.
+- Verbose mode: print resolved implicit arguments inline as `@<dict>`.
+- Round-trip identity in both modes.
+- **Round-trip property test:** for any well-typed term `t`,
+  `parse(print(elaborate(t))) == elaborate(t)` in both verbose and elide
+  modes, including local givens and explicit `@`-overrides. Elide mode
+  must produce source that re-elaborates to the same term (same chosen
+  givens), since the printed source no longer carries the explicit
+  arguments.
+
+### 7.2 Errors
+
+Structured output for the existing error-rendering machinery:
+
+- **NoGiven**: requested type, scope summary, near-misses, hint.
+- **Ambiguous**: candidates with namespace path and hash prefix, hint.
+- **DepthExceeded**: print chain (truncated sensibly), mark recursive
+  step, hint.
+
+Run errors through real users before signing off.
+
+**Exit:** golden-file tests for 20+ distinct error scenarios. Recorded
+session showing realistic debug flow under each error category.
+
+---
+
+## 8. Phase 5 — Stdlib seed
+
+- `Eq`, `Ord` for primitives + collections.
+- `Show` for primitives + collections.
+- `Functor`, `Applicative`, `Monad` for `Optional`, `Either`, `List`,
+  common containers.
+- `Traversable` for the same.
+- One *non-trivial* given showing chaining: `Show (Map k v)` requiring
+  `Show k` and `Show v`.
+- One example program in the docs using 3+ givens together.
+
+**Exit:** stdlib givens reviewed and accepted on their own merits. Example
+program in tutorial form.
+
+---
+
+## 9. Phase 6 — Release
+
+- Feature flag *off by default* through one release cycle for library
+  authors to experiment.
+- Documentation: language tour section, reference docs, ADR index linked
+  from the docs.
+- Migration guide: how to add givens to existing libraries; how to *not*.
+- Flip default to *on* in the following release.
+
+**Exit:** flag flipped, no rollback for one full release cycle, no
+critical bugs filed.
+
+---
+
+## 10. Risk register
+
+| Risk                                                       | Mitigation                                                  |
+|------------------------------------------------------------|-------------------------------------------------------------|
+| Resolution algorithm too slow on large codebases           | Spike microbenchmark + Phase 2 perf gate                    |
+| Errors are inscrutable (Haskell-failure mode)              | Phase 4 dedicated; user-tested before sign-off              |
+| HKT inference interacts badly with TDNR                    | Spike covers HKT; Phase 2.C explicit HKT tests              |
+| Update semantics surprise users                            | ADR 016 + Phase 2.E explicit testing                        |
+| Ecosystem fragmentation (every library defines its `Show`) | Phase 5 stdlib givens establish canonical types early       |
+| Hash drift: elaborator changes silently re-hash code       | Elaborator output deterministic; lock with golden-hash tests |
+| Feature creep (defaults, conversions, deriving)            | ADR set explicitly defers; reject in review                 |
+| TDNR and given-resolution disagree at the same call site   | ADR 012 defines precedence; test matrix covers both kinds at one site |
+| Keyword migration breaks existing code (`given`, `summon`) | ADR 022; deprecation cycle or use prefix sigils as fallback |
+| Sharing API protocol drift between client and server       | ADR 020 versions the protocol; coordinated server release in Phase 2.B |
+| `Unison.Typechecker.Context` (~3800 LoC) bloats further    | Threading lexical given env is pervasive — budget Phase 2.C.2 accordingly; refactor incrementally |
+| `unison-merge` lacks given-set conflict story              | ADR 021 + Phase 2.B explicit subtask                        |
+
+---
+
+## 11. Deliberate omissions
+
+- A timeline. Effort estimates require knowing capacity.
+- A "deriving" mechanism. Belongs in v2.
+- A migration of TDNR-as-typeclass-illusion code. The illusion keeps
+  working; users opt into givens.
+
+---
+
+## 11A. Open questions surfaced during ADR authoring
+
+Each item below is called out in a specific ADR's "Open question" or
+"Consequences" section. They aren't blocking the spike, but should be
+resolved before the corresponding implementation phase.
+
+1. **ADR-019 multi-constraint encoding.** Should `(C1 a, C2 b) =>` desugar
+   to nested single-implicit arrows or to a multi-arg implicit
+   constructor? Affects pattern-matching ergonomics across every `Type.F`
+   consumer. *Settle before Phase 2.C.1.*
+2. **ADR-020 fate of `causal_metadata`.** Recommended to leave dormant
+   rather than drop. Documentation/cleanup obligation; not currently in
+   the risk register.
+3. **ADR-021 merge prompt UX in CI.** Case (b) "mark wins,
+   user-confirmable" needs an explicit policy for non-interactive runs.
+   Current recommendation: default Y in CI. *Pin before Phase 2.B.*
+4. **ADR-021 `unison-merge` type shape.** Whether existing types need new
+   metadata-diff variants or a parallel structure suffices. Starting
+   recommendation: parallel structure for cheaper landing; revisit after
+   spike.
+5. **ADR-022 proactive reservation of `using`.** Even though ADR-001
+   chose `=>`, future ADRs may want it. Track so a future syntax addition
+   isn't blocked by another deprecation cycle.
+6. **ADR-018 eventual removal of off-state.** Once the flag flips to
+   default-on, the codebase carries two parser modes indefinitely. Track
+   when (or if) the off-state retires.
+7. **ADR-015 / ADR-016 round-trip precondition.** Elide mode plus a
+   namespace whose given-set has shifted produces the deterministic
+   failure path of ADR-016. The §7.1 round-trip property assumes "same
+   namespace" — make that precondition explicit.
+8. **ADR-017 `delete` on aliased hash with one-name-given-tagged.** ADR
+   specifies per-name tag (deletion only removes the local tag); this can
+   contradict a "givenness is per-hash" reader expectation. Worth a docs
+   note in Phase 3.
+
+---
+
+## 12. Codebase reference index
+
+Critical files identified during the codebase-validation review. Use as a
+navigation map for implementers; line numbers are accurate at the
+review's snapshot but will drift.
+
+### TDNR and the typechecker
+- `parser-typechecker/src/Unison/Typechecker.hs` — `typeDirectedNameResolution`
+  (~line 262) drives the TDNR fixed-point loop. Implicit resolution will
+  be a sibling pass with the same `SolvedBlank`/`Decision` shape.
+- `parser-typechecker/src/Unison/FileParsers.hs` — `applyTdnrDecisions`
+  (~line 329) walks the term and substitutes TDNR results. Implicit
+  substitution can mirror this.
+- `parser-typechecker/src/Unison/Typechecker/Context.hs` — ~3800 LoC of
+  bidirectional inference. The lexical given environment must be threaded
+  through every binder here. `InfoNote` (~line 388) is where new
+  constraint-goal records will live. `Element` (~line 131) defines
+  context shape; resist adding new forms unless required.
+- `parser-typechecker/src/Unison/KindInference/` — full kind inference
+  pipeline (`Generate`, `Solve`, `Constraint`, `Error`, `UVar`). Already
+  supports arrow kinds (`Type | Ability | Kind :-> Kind`); HKT givens
+  work without extension.
+
+### Term and type AST
+- `unison-core/src/Unison/Term.hs` — ABT `F` functor (~line 64). `App` is
+  generic; elaborator output uses ordinary `App` nodes.
+- `unison-core/src/Unison/Type.hs` — `Type.F` (~line 40). ADR 019 picks
+  whether to extend with `ImplicitArrow` (changes type hashing) or use a
+  side-table.
+- `unison-core/src/Unison/Blank.hs` — `Recorded` (~line 21) is the
+  parser-emitted hole. Add an `Implicit` variant.
+
+### Codebase storage and metadata
+- `codebase2/codebase/U/Codebase/Branch/Type.hs` — `MdValues = Set
+  MetadataValue` (~line 32) per `(NameSegment, Referent)`. Likely home
+  for the given tag; ADR 020 confirms.
+- `codebase2/codebase-sqlite/sql/create.sql` — schema. Existing
+  `causal_metadata` table (~line 113) is dormant; ADR 020 decides
+  revival vs. alternative.
+- `unison-merge/src/` — currently no metadata-aware logic. ADR 021 +
+  Phase 2.B add given-set conflict resolution here.
+
+### Hashing
+- `unison-hashing-v2/src/Unison/Hashing/V2/Branch.hs` — branch hash
+  derivation (~line 18). Includes `MdValues` in tokens, so givenness
+  changes the branch hash even though term hashes are stable.
+
+### Lexer and parser
+- `unison-syntax/src/Unison/Syntax/ReservedWords.hs` — reserved word
+  list. `given`, `summon`, `using`, `=>` not yet taken.
+- `unison-syntax/src/Unison/Syntax/Lexer/Unison.hs` — the lexer.
+  - `?` delimiter at ~line 489 (Char literal prefix; explains the
+    rejected `?T` syntax).
+  - `@` symboly keyword at ~line 572 (currently used for as-patterns and
+    `@rewrite`; expression-context `@` for explicit override needs
+    parser disambiguation).
+  - Order of `==>` vs `=>` in keyword alternatives matters
+    (`symbolyKw` at ~line 586).
+- `parser-typechecker/src/Unison/Syntax/TermParser.hs` — `@`-pattern
+  parsing (~line 410). Confirm coexistence with new expression-context
+  `@`.
+- `parser-typechecker/src/Unison/Syntax/Parser/Doc.hs` — `@`-prefixed
+  doc syntax (~line 163). Another disambiguation point.
+
+### UCM and editor integration
+- `unison-cli/src/Unison/CommandLine/InputPatterns.hs` — flat table of
+  commands (~4671 lines). Add `givens`, `mark.given`, `unmark.given`;
+  modify existing commands as needed.
+- `unison-cli/src/Unison/Codebase/Editor/HandleInput/` — actual command
+  implementations; metadata plumbing lands here.
+- `unison-cli/src/Unison/LSP/` — language-server flows; Phase 2.F.
+
+### Sharing
+- `unison-share-api/` and `unison-share-projects-api/` — wire format
+  versioning when metadata field is added.
+
+### Test corpora
+- `unison-src/transcripts/idempotent/higher-rank.md` — confirms HKT
+  works in current Unison (`unique type Functor f` + polymorphic use).
+  Use as a baseline for HKT given tests.

--- a/parser-typechecker/package.yaml
+++ b/parser-typechecker/package.yaml
@@ -81,6 +81,7 @@ tests:
       - containers
       - easytest
       - text
+      - time
       - unison-core
       - unison-core1
       - unison-hash

--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -12,6 +12,8 @@ module Unison.Builtin
     builtinTypes,
     builtinTermsByType,
     builtinTermsByTypeMention,
+    givenSentinelName,
+    givenSentinelRef,
     intrinsicTermReferences,
     intrinsicTypeReferences,
     isBuiltinType,
@@ -284,6 +286,25 @@ intrinsicTypeReferences = foldl' go mempty builtinTypesSrc
 
 intrinsicTermReferences :: Set R.Reference
 intrinsicTermReferences = Map.keysSet termRefTypes
+
+-- | The textual name of the sentinel builtin reference used to mark a
+-- definition as a "given" via namespace metadata. This corresponds to the
+-- hash-prefix syntax @##Builtin.Given@.
+--
+-- See ADR-013 (given-set storage) and ADR-002 (givenness namespace
+-- metadata).
+givenSentinelName :: Text
+givenSentinelName = "Builtin.Given"
+
+-- | The sentinel builtin reference used to mark a definition as a "given"
+-- when present in its 'MdValues' metadata set. The reference is *not*
+-- registered as a callable term (it has no type and is not in
+-- 'termRefTypes'); it exists solely as a tag carried by namespace
+-- metadata, where its presence indicates givenness.
+--
+-- See @docs/architecture/decisions/ADR-013-given-set-storage.md@.
+givenSentinelRef :: R.Reference
+givenSentinelRef = R.Builtin givenSentinelName
 
 builtinConstructorType :: Map R.Reference CT.ConstructorType
 builtinConstructorType = Map.fromList [(R.Builtin r, ct) | B' r ct <- builtinTypesSrc]

--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -13,6 +13,8 @@ module Unison.Builtin
     builtinTermsByType,
     builtinTermsByTypeMention,
     givenSentinelName,
+    classSentinelName,
+    classSentinelRef,
     givenSentinelRef,
     intrinsicTermReferences,
     intrinsicTypeReferences,
@@ -306,6 +308,21 @@ givenSentinelName = "Builtin.Given"
 givenSentinelRef :: R.Reference
 givenSentinelRef = R.Builtin givenSentinelName
 
+-- | The textual name of the sentinel builtin reference used to mark a
+-- /type/ declaration as having originated from the @class@ keyword.
+-- See ADR-013 (the same storage strategy as 'givenSentinelName').
+-- 'view' inspects this marker to decide whether to render the
+-- declaration with the @class@ keyword and record-field syntax.
+classSentinelName :: Text
+classSentinelName = "Builtin.Class"
+
+-- | The sentinel builtin reference used to tag a type declaration as
+-- a class. Carried by namespace metadata on the type ref (parallel to
+-- 'givenSentinelRef' for terms). Not registered as a callable term;
+-- only a tag.
+classSentinelRef :: R.Reference
+classSentinelRef = R.Builtin classSentinelName
+
 builtinConstructorType :: Map R.Reference CT.ConstructorType
 builtinConstructorType = Map.fromList [(R.Builtin r, ct) | B' r ct <- builtinTypesSrc]
 
@@ -400,6 +417,13 @@ typeOf a f r = maybe a f (Map.lookup r termRefTypes)
 builtinsSrc :: [BuiltinDSL]
 builtinsSrc =
   [ B "Any.unsafeExtract" $ forall1 "a" (\a -> anyt --> a),
+    -- ADR-006: the @summon@ builtin. Type @forall a. a => a@ — the
+    -- leading @=>@ makes the typechecker emit a 'ConstraintGoal' at
+    -- every reference and the resolver fills it from the surrounding
+    -- type context. Runtime behaviour is the identity function
+    -- (defined in 'Unison.Runtime.Builtin'). No longer a reserved
+    -- word; the name parser accepts @summon@ as an ordinary segment.
+    B "summon" $ forall1 "a" (\a -> a ==> a),
     B "Int.+" $ int --> int --> int,
     B "Int.-" $ int --> int --> int,
     B "Int.*" $ int --> int --> int,
@@ -1326,6 +1350,12 @@ pair l r = DD.pairType () `app` l `app` r
 a --> b = Type.arrow () a b
 
 infixr 9 -->
+
+-- | The implicit-arrow constructor (ADR-019) used in builtin signatures.
+(==>) :: Type -> Type -> Type
+a ==> b = Type.implicitArrow () a b
+
+infixr 9 ==>
 
 io, iof :: Type -> Type
 socket, threadId, handle, phandle, unit :: Type

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -346,6 +346,7 @@ installUcmDependencies c = do
             [Builtin.builtinTermsSrc Parser.Intrinsic]
             mempty
             mempty
+            mempty
         )
   addDefsToCodebase c uf
 

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -345,6 +345,7 @@ installUcmDependencies c = do
             (Map.fromList Builtin.builtinEffectDecls)
             [Builtin.builtinTermsSrc Parser.Intrinsic]
             mempty
+            mempty
         )
   addDefsToCodebase c uf
 

--- a/parser-typechecker/src/Unison/Codebase/Classes.hs
+++ b/parser-typechecker/src/Unison/Codebase/Classes.hs
@@ -1,0 +1,87 @@
+-- | Helpers for marking type declarations as @class@ via the
+-- @##Builtin.Class@ sentinel reference stored in namespace metadata.
+-- Mirrors 'Unison.Codebase.Givens' but operates on type references
+-- (the 'types_' Star of a 'Branch0' instead of 'terms_').
+--
+-- A type declaration is a /class/ if its associated metadata-value
+-- set contains 'classSentinel'. The sentinel is the builtin reference
+-- @##Builtin.Class@; it has no runtime behaviour and is never invoked.
+--
+-- The marker is purely surface-syntax sugar: the underlying data
+-- declaration is unchanged. @view@ inspects this marker to decide
+-- whether to render the declaration with the @class@ keyword and
+-- record-field syntax, completing the round-trip from source written
+-- with @class@ back through @view@.
+module Unison.Codebase.Classes
+  ( -- * Sentinel reference
+    classSentinel,
+
+    -- * Querying
+    isClassAt,
+    isClass,
+    namesMarkedClass,
+    metadataValuesForType,
+
+    -- * Marking and unmarking
+    markClassAt,
+    unmarkClassAt,
+  )
+where
+
+import Control.Lens (over, view)
+import Data.Set qualified as Set
+import Unison.Builtin qualified as Builtin
+import Unison.Codebase.Branch.Type (Branch0, types_)
+import Unison.Codebase.Metadata qualified as Metadata
+import Unison.NameSegment (NameSegment)
+import Unison.Reference (TermReference, TypeReference)
+import Unison.Util.Relation qualified as Relation
+import Unison.Util.Star2 qualified as Star2
+
+-- | The sentinel metadata value whose presence on a type's metadata
+-- indicates the type was declared with the @class@ keyword.
+classSentinel :: TermReference
+classSentinel = Builtin.classSentinelRef
+
+-- | @True@ if the type reference @r@ is present at the given name
+-- segment in the branch and carries 'classSentinel' in its metadata.
+isClassAt :: TypeReference -> NameSegment -> Branch0 m -> Bool
+isClassAt r n b =
+  Star2.memberD1 (r, n) (view types_ b) && hasClassSentinel r b
+
+-- | @True@ if the type reference @r@ has 'classSentinel' in its
+-- metadata anywhere in the supplied branch.
+isClass :: TypeReference -> Branch0 m -> Bool
+isClass = hasClassSentinel
+
+-- | All name segments at which the supplied type reference appears
+-- and is marked as a class.
+namesMarkedClass :: TypeReference -> Branch0 m -> Set.Set NameSegment
+namesMarkedClass r b
+  | hasClassSentinel r b = Relation.lookupDom r (Star2.d1 (view types_ b))
+  | otherwise = Set.empty
+
+-- | Mark the type reference at the given name as a class by adding
+-- 'classSentinel' to its metadata. If the reference is not present at
+-- the name, the branch is returned unchanged.
+markClassAt :: TypeReference -> NameSegment -> Branch0 m -> Branch0 m
+markClassAt r n b
+  | Star2.memberD1 (r, n) (view types_ b) =
+      over types_ (Metadata.insert (r, classSentinel)) b
+  | otherwise = b
+
+-- | Remove 'classSentinel' from the type reference's metadata,
+-- unmarking it as a class. Other metadata values are preserved.
+unmarkClassAt :: TypeReference -> NameSegment -> Branch0 m -> Branch0 m
+unmarkClassAt r _n =
+  over types_ (Metadata.delete (r, classSentinel))
+
+hasClassSentinel :: TypeReference -> Branch0 m -> Bool
+hasClassSentinel r b =
+  Set.member classSentinel (metadataValuesForType r b)
+
+-- | The full set of metadata values currently associated with the
+-- given type reference in the supplied branch.
+metadataValuesForType :: TypeReference -> Branch0 m -> Set.Set TermReference
+metadataValuesForType r b =
+  Relation.lookupDom r (Star2.d2 (view types_ b))

--- a/parser-typechecker/src/Unison/Codebase/Givens.hs
+++ b/parser-typechecker/src/Unison/Codebase/Givens.hs
@@ -1,0 +1,115 @@
+-- | Helpers for marking definitions as "givens" via the
+-- @##Builtin.Given@ sentinel reference stored in namespace metadata.
+--
+-- A definition is a /given/ if its associated metadata-value set
+-- ('Unison.Codebase.Branch.Type.MdValues' in V2, or the @d2@ dimension
+-- of 'Unison.Util.Star2.Star2' in V1) contains 'givenSentinel'. The
+-- sentinel itself is the builtin reference @##Builtin.Given@; it has no
+-- runtime behaviour and is never invoked.
+--
+-- Per ADR-013, this gives us:
+--
+--   * No schema change: 'MdValues' is already serialised in the SQLite
+--     codebase and included in the namespace (causal) hash via
+--     'Unison.Hashing.V2.Branch.Branch'\'s 'Tokenizable' instance.
+--   * The term reference itself is unchanged when (un)marking a name,
+--     so its content hash and any dependents are unaffected; only the
+--     enclosing namespace hash changes.
+--
+-- Per-referent (not per-name) granularity: V1's 'Star2' metadata is
+-- keyed on the referent, so marking one name marks every alias of the
+-- same referent within that namespace. See 'isGivenAt' for details.
+--
+-- Higher-level UCM commands (@given@, @find :given@, etc.) live in
+-- chunk B2 and consume the helpers in this module.
+module Unison.Codebase.Givens
+  ( -- * Sentinel reference
+    givenSentinel,
+
+    -- * Querying
+    isGivenAt,
+    isGiven,
+    namesMarkedGiven,
+    metadataValuesFor,
+
+    -- * Marking and unmarking
+    markGivenAt,
+    unmarkGivenAt,
+  )
+where
+
+import Control.Lens (over, view)
+import Data.Set qualified as Set
+import Unison.Builtin qualified as Builtin
+import Unison.Codebase.Branch.Type (Branch0, terms_)
+import Unison.Codebase.Metadata qualified as Metadata
+import Unison.NameSegment (NameSegment)
+import Unison.Reference (TermReference)
+import Unison.Referent (Referent)
+import Unison.Util.Relation qualified as Relation
+import Unison.Util.Star2 qualified as Star2
+
+-- | The sentinel metadata value whose presence in a definition's
+-- 'MdValues' indicates the definition is a /given/. This is exactly
+-- 'Unison.Builtin.givenSentinelRef'; re-exported here so callers
+-- typically only need to import 'Unison.Codebase.Givens'.
+givenSentinel :: TermReference
+givenSentinel = Builtin.givenSentinelRef
+
+-- | @True@ if the referent @r@ is present at the given name segment in
+-- the branch and carries 'givenSentinel' in its metadata.
+--
+-- Note: the V1 'Unison.Util.Star2.Star2' schema stores metadata per
+-- referent rather than per (referent, name) pair, so adding the
+-- sentinel for a referent that is published under multiple names will
+-- affect every name it appears at. This matches existing metadata
+-- semantics; the V2 schema in 'Unison.Codebase.Branch.Type.MdValues'
+-- has the same shape (metadata is keyed on the referent within each
+-- name-segment\'s map).
+isGivenAt :: Referent -> NameSegment -> Branch0 m -> Bool
+isGivenAt r n b =
+  Star2.memberD1 (r, n) (view terms_ b) && hasGivenSentinel r b
+
+-- | @True@ if the term referent @r@ has 'givenSentinel' in its
+-- metadata anywhere in the supplied branch.
+isGiven :: Referent -> Branch0 m -> Bool
+isGiven = hasGivenSentinel
+
+-- | All name segments at which the supplied term referent appears and
+-- is marked as a given. Useful for @find :given@-style filters
+-- (chunk B2).
+namesMarkedGiven :: Referent -> Branch0 m -> Set.Set NameSegment
+namesMarkedGiven r b
+  | hasGivenSentinel r b = Relation.lookupDom r (Star2.d1 (view terms_ b))
+  | otherwise = Set.empty
+
+-- | Mark the term referent at the given name as a given by adding
+-- 'givenSentinel' to its metadata. If the referent is not present at
+-- the name, the branch is returned unchanged.
+markGivenAt :: Referent -> NameSegment -> Branch0 m -> Branch0 m
+markGivenAt r n b
+  | Star2.memberD1 (r, n) (view terms_ b) =
+      over terms_ (Metadata.insert (r, givenSentinel)) b
+  | otherwise = b
+
+-- | Remove 'givenSentinel' from the term referent\'s metadata,
+-- unmarking it as a given. Other metadata values are preserved. The
+-- @NameSegment@ argument is accepted for symmetry with 'markGivenAt'
+-- and to leave room for a future per-name representation; it is
+-- currently ignored because V1 metadata is per-referent.
+unmarkGivenAt :: Referent -> NameSegment -> Branch0 m -> Branch0 m
+unmarkGivenAt r _n =
+  over terms_ (Metadata.delete (r, givenSentinel))
+
+hasGivenSentinel :: Referent -> Branch0 m -> Bool
+hasGivenSentinel r b =
+  Set.member givenSentinel (metadataValuesFor r b)
+
+-- | The full set of metadata values currently associated with the
+-- given term referent in the supplied branch. This is the read-side
+-- entry point that 'view' / 'find' query paths can consume; callers
+-- testing for givenness should prefer 'isGiven' but may use this
+-- function when displaying or filtering on a richer set of tags.
+metadataValuesFor :: Referent -> Branch0 m -> Set.Set TermReference
+metadataValuesFor r b =
+  Relation.lookupDom r (Star2.d2 (view terms_ b))

--- a/parser-typechecker/src/Unison/Codebase/Runtime.hs
+++ b/parser-typechecker/src/Unison/Codebase/Runtime.hs
@@ -182,6 +182,7 @@ evaluateTerm' codeLookup cache ppe prof rt tm = do
               mempty
               [(WK.RegularWatch, [(Var.nameds "result", mempty, tm, mempty <$> mainType rt)])]
               mempty
+              mempty
       r <- evaluateWatches (void codeLookup) ppe prof cache rt (void tuf)
       pure $
         r <&> \(_, errs, map) ->

--- a/parser-typechecker/src/Unison/Codebase/Runtime.hs
+++ b/parser-typechecker/src/Unison/Codebase/Runtime.hs
@@ -181,6 +181,7 @@ evaluateTerm' codeLookup cache ppe prof rt tm = do
               mempty
               mempty
               [(WK.RegularWatch, [(Var.nameds "result", mempty, tm, mempty <$> mainType rt)])]
+              mempty
       r <- evaluateWatches (void codeLookup) ppe prof cache rt (void tuf)
       pure $
         r <&> \(_, errs, map) ->

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Conversions.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Conversions.hs
@@ -359,6 +359,8 @@ type2to1' convertRef =
       V2.Type.Effects as -> V1.Type.Effects as
       V2.Type.Forall a -> V1.Type.Forall a
       V2.Type.IntroOuter a -> V1.Type.IntroOuter a
+      -- ADR-019: implicit arrows round-trip between V1 and V2 representations.
+      V2.Type.ImplicitArrow i o -> V1.Type.ImplicitArrow i o
       where
         convertKind = \case
           V2.Kind.Star -> V1.Kind.Star
@@ -386,6 +388,8 @@ type1to2' convertRef =
       V1.Type.Effects as -> V2.Type.Effects as
       V1.Type.Forall a -> V2.Type.Forall a
       V1.Type.IntroOuter a -> V2.Type.IntroOuter a
+      -- ADR-019: implicit arrows round-trip between V1 and V2 representations.
+      V1.Type.ImplicitArrow i o -> V2.Type.ImplicitArrow i o
       where
         convertKind = \case
           V1.Kind.Star -> V2.Kind.Star

--- a/parser-typechecker/src/Unison/DataDeclaration/Dependencies.hs
+++ b/parser-typechecker/src/Unison/DataDeclaration/Dependencies.hs
@@ -30,6 +30,7 @@ import Unison.Term (Term)
 import Unison.Type (Type)
 import Unison.Type qualified as Type
 import Unison.Typechecker qualified as Typechecker
+import Unison.Typechecker.GivenResolver qualified as GivenResolver
 import Unison.Typechecker.TypeLookup (TypeLookup (..))
 import Unison.Typechecker.Variance (defaultVariances)
 import Unison.Util.Tuple qualified as Tuple
@@ -126,5 +127,7 @@ hashFieldAccessors ppe declName vars declRef dd = do
           termsByShortname = mempty,
           freeNameToFuzzyTermsByShortName = Map.empty,
           topLevelComponents = Map.empty,
-          variances = defaultVariances
+          variances = defaultVariances,
+          ambientGivens = GivenResolver.poolFromList [],
+          givenBindings = mempty
         }

--- a/parser-typechecker/src/Unison/DataDeclaration/Dependencies.hs
+++ b/parser-typechecker/src/Unison/DataDeclaration/Dependencies.hs
@@ -15,7 +15,7 @@ import Data.Map qualified as Map
 import Data.Set qualified as Set
 import Data.Set.Lens (setOf)
 import Unison.DataDeclaration qualified as DD
-import Unison.DataDeclaration.Records (generateRecordAccessors)
+import Unison.DataDeclaration.Records (RecordKind (..), generateRecordAccessors)
 import Unison.Hashing.V2.Convert qualified as Hashing
 import Unison.LabeledDependency qualified as LD
 import Unison.Prelude
@@ -91,7 +91,7 @@ hashFieldAccessors ::
 hashFieldAccessors ppe declName vars declRef dd = do
   let accessors :: [(v, (), Term v ())]
       accessors =
-        generateRecordAccessors Var.namespaced id (map (,()) vars) declName declRef
+        generateRecordAccessors TypeRecord Var.namespaced id (map (,()) vars) declName declRef
 
   typecheckedAccessors <-
     for accessors \(v, _a, term) -> do

--- a/parser-typechecker/src/Unison/DataDeclaration/Dependencies.hs
+++ b/parser-typechecker/src/Unison/DataDeclaration/Dependencies.hs
@@ -7,6 +7,7 @@ module Unison.DataDeclaration.Dependencies
     DD.labeledDeclDependenciesIncludingSelf,
     labeledDeclDependenciesIncludingSelfAndFieldAccessors,
     hashFieldAccessors,
+    hashClassFieldAccessors,
   )
 where
 
@@ -27,6 +28,7 @@ import Unison.Referent qualified as Referent
 import Unison.Result qualified as Result
 import Unison.Syntax.Var qualified as Var (namespaced)
 import Unison.Term (Term)
+import Unison.Term qualified as Term
 import Unison.Type (Type)
 import Unison.Type qualified as Type
 import Unison.Typechecker qualified as Typechecker
@@ -112,6 +114,83 @@ hashFieldAccessors ppe declName vars declRef dd = do
       -- type. We do so here using `Type.cleanup`, mirroring what's
       -- done when typechecking a whole file and ensuring we get the
       -- same inferred type.
+      Just (Type.cleanup typ)
+
+    typecheckingEnv :: Typechecker.Env v ()
+    typecheckingEnv =
+      Typechecker.Env
+        { ambientAbilities = mempty,
+          typeLookup =
+            TypeLookup
+              { typeOfTerms = mempty,
+                dataDecls = Map.singleton declRef (void dd),
+                effectDecls = mempty
+              },
+          termsByShortname = mempty,
+          freeNameToFuzzyTermsByShortName = Map.empty,
+          topLevelComponents = Map.empty,
+          variances = defaultVariances,
+          ambientGivens = GivenResolver.poolFromList [],
+          givenBindings = mempty
+        }
+
+-- | Like 'hashFieldAccessors' but for /class/ accessors: wraps each
+-- generated getter with the @=>@-bearing annotation that
+-- 'annotateClassAccessor' attaches at parse time, so the resulting
+-- hashes match what's stored in the codebase for a class declaration.
+hashClassFieldAccessors ::
+  forall v.
+  (Var.Var v) =>
+  PrettyPrintEnv ->
+  v ->
+  [v] ->
+  TypeReference ->
+  DD.DataDeclaration v () ->
+  Maybe (Map v (TermReferenceId, Term v (), Type v ()))
+hashClassFieldAccessors ppe declName vars declRef dd = do
+  -- Records (and classes) have exactly one constructor.
+  [(_, ctorType)] <- Just (DD.constructors dd)
+  let ctorBody = case ctorType of
+        Type.ForallsNamed' _ t -> t
+        t -> t
+  ts <- Type.unArrows ctorBody
+  let fieldTypes = init ts
+  guard (length fieldTypes == length vars)
+  let tyvars = DD.bound dd
+      ann = ()
+      classRefT = Type.ref ann declRef
+      classApp = foldl' (\acc tyv -> Type.app ann acc (Type.var ann tyv)) classRefT tyvars
+      annotateAccessor fieldType (v, _a, body) =
+        let implicit = Type.implicitArrow ann classApp fieldType
+            quantified = Type.foralls ann tyvars implicit
+         in (v, ann, Term.ann ann body quantified)
+      rawAccessors :: [(v, (), Term v ())]
+      rawAccessors =
+        generateRecordAccessors ClassRecord Var.namespaced id (map (,()) vars) declName declRef
+      annotated = zipWith annotateAccessor fieldTypes rawAccessors
+
+  typecheckedAccessors <-
+    for annotated \(v, _a, term) -> do
+      typ <- typecheck term
+      Just (v, (term, typ, ()))
+
+  typecheckedAccessors
+    & Map.fromList
+    & Hashing.hashTermComponents
+    & Hashing.crashOnHashingWarning
+    & Map.map Tuple.drop4th
+    & Just
+  where
+    typecheck :: Term v () -> Maybe (Type v ())
+    typecheck term = do
+      typ <-
+        Result.result
+          ( Typechecker.synthesize
+              ppe
+              Typechecker.PatternMatchCoverageCheckAndKindInferenceSwitch'Disabled
+              typecheckingEnv
+              term
+          )
       Just (Type.cleanup typ)
 
     typecheckingEnv :: Typechecker.Env v ()

--- a/parser-typechecker/src/Unison/FileParsers.hs
+++ b/parser-typechecker/src/Unison/FileParsers.hs
@@ -343,9 +343,9 @@ synthesizeFile env0 uf = do
                   Reference.Builtin ("Local.given." <> Var.name (Var.reset v)),
                 GivenElaborator.ambientType = t
               }
-            | tlc <- topLevelComponents,
-              (v, _, t) <- tlc,
-              Set.member (Var.reset v) (UF.givenBindings uf)
+          | tlc <- topLevelComponents,
+            (v, _, t) <- tlc,
+            Set.member (Var.reset v) (UF.givenBindings uf)
           ]
         ambient =
           GivenElaborator.mergePool

--- a/parser-typechecker/src/Unison/FileParsers.hs
+++ b/parser-typechecker/src/Unison/FileParsers.hs
@@ -31,6 +31,7 @@ import Unison.Parser.Ann (Ann)
 import Unison.Prelude
 import Unison.PrettyPrintEnv.Names qualified as PPE
 import Unison.Reference (TermReference, TypeReference)
+import Unison.Reference qualified as Reference
 import Unison.Referent (Referent)
 import Unison.Referent qualified as Referent
 import Unison.Result (CompilerBug (..), Note (..), ResultT, pattern Result)
@@ -324,7 +325,32 @@ synthesizeFile env0 uf = do
     -- trees into 'App' nodes. The ambient pool comes from
     -- 'env0.ambientGivens', built by 'computeTypecheckingEnvironment'
     -- from the namespace's 'given'-tagged definitions (L1 wiring).
-    let ambient = Typechecker.ambientGivens env0
+    --
+    -- We additionally promote every file-local @given@-tagged
+    -- top-level binding into the ambient pool. The per-binding
+    -- 'extendLexicalGivenFromBinding' machinery only makes a given
+    -- visible to siblings that 'minimize' happened to order /after/
+    -- it in the resulting let-chain; siblings that come earlier in
+    -- the chain (because 'minimize' reordered independent SCCs) have
+    -- a 'ConstraintGoal' whose 'pgScope' snapshot is missing the
+    -- given. Top-level givens are conceptually file-global, so we
+    -- expose them to every goal via the ambient pool, sidestepping
+    -- minimize's ordering entirely.
+    let fileLocalGivens :: [GivenElaborator.AmbientGiven v Ann]
+        fileLocalGivens =
+          [ GivenElaborator.AmbientGiven
+              { GivenElaborator.ambientName =
+                  Reference.Builtin ("Local.given." <> Var.name (Var.reset v)),
+                GivenElaborator.ambientType = t
+              }
+            | tlc <- topLevelComponents,
+              (v, _, t) <- tlc,
+              Set.member (Var.reset v) (UF.givenBindings uf)
+          ]
+        ambient =
+          GivenElaborator.mergePool
+            (GivenElaborator.ambientPool fileLocalGivens)
+            (Typechecker.ambientGivens env0)
     let infosWithImplicits = GivenElaborator.elaborateInfoNotes ambient infos
     -- Phase-2 chunk D4: surface implicit-resolution failures as user
     -- diagnostics. Each 'SolvedImplicit' note whose decision is
@@ -400,6 +426,7 @@ synthesizeFile env0 uf = do
         terms'
         (map tlcKind watches')
         uf.givenBindings
+        uf.classBindings
   where
     applyTdnrDecisions ::
       [Context.InfoNote v Ann] ->

--- a/parser-typechecker/src/Unison/FileParsers.hs
+++ b/parser-typechecker/src/Unison/FileParsers.hs
@@ -350,35 +350,36 @@ synthesizeFile env0 uf = do
           ]
     for_ solvedImplicitNotes (Result.tell1 . Result.TypeInfo)
     let doTdnr = applyTdnrDecisions infos
-    let doImplicits =
-          GivenApply.applyGivenDecisions
+    -- Apply TDNR first, then implicit-dictionary insertion. The
+    -- implicit insertion runs over /all/ bindings as a single pass
+    -- so the decision queue stays aligned with the typechecker's
+    -- emission order — per-binding fresh queues caused bindings to
+    -- pop decisions intended for a sibling and inject the sibling's
+    -- locally-bound dictionary into a scope where it isn't bound.
+    let tdnredTerms :: [[(v, Term v, Type v)]]
+        tdnredTerms =
+          (fmap . fmap) (\(v, t, tp) -> (v, doTdnr t, tp)) topLevelComponents
+        flatBindings :: [(Int, (v, Term v, Type v))]
+        flatBindings = zip [0 ..] (concat tdnredTerms)
+        (rewrittenTerms, implicitNotesAll) =
+          GivenApply.applyGivenDecisionsAll
             infosWithImplicits
             (Typechecker.typeLookup env0)
-    -- Chunk F1: 'doImplicits' also produces 'ImplicitArgRef' info
-    -- notes recording each synthesized dictionary insertion. Collect
-    -- them so the LSP can build a position-indexed lookup.
-    let doTdnrInComponent (v, t, tp) =
-          let (t', implicitNotes) = doImplicits (doTdnr t)
-           in ((v, t', tp), implicitNotes)
-    let tlcsWithImplicitNotes =
-          topLevelComponents
-            & (fmap . fmap)
-              ( \vtt ->
-                  let (vtt', notes) = vtt & doTdnrInComponent
-                   in ( vtt'
-                          & \(v, t, tp) ->
-                            ( v,
-                              fromMaybe
-                                (error $ "Symbol from typechecked file not present in parsed file" <> show v)
-                                (definitionLocation v uf),
-                              t,
-                              tp
-                            ),
-                        notes
-                      )
-              )
-    let tdnredTlcs = (fmap . fmap) fst tlcsWithImplicitNotes
-    let implicitNotesAll = concatMap (concatMap snd) tlcsWithImplicitNotes
+            (map (\(_, (_, t, _)) -> t) flatBindings)
+        idxToRewritten :: Map Int (Term v)
+        idxToRewritten = Map.fromList (zip (map fst flatBindings) rewrittenTerms)
+    let tdnredTlcs :: [[(v, Ann, Term v, Type v)]]
+        tdnredTlcs =
+          let go i (v, _t, tp) =
+                let t' = idxToRewritten Map.! i
+                    a = fromMaybe (error $ "Symbol from typechecked file not present in parsed file" <> show v) (definitionLocation v uf)
+                 in (v, a, t', tp)
+              indexed :: [[(Int, (v, Term v, Type v))]]
+              indexed = snd $ List.mapAccumL stepComp 0 tdnredTerms
+              stepComp i comp =
+                let n = length comp
+                 in (i + n, zip [i .. i + n - 1] comp)
+           in (fmap . fmap) (\(i, vtt) -> go i vtt) indexed
     -- Emit the 'ImplicitArgRef' notes as 'TypeInfo' so that
     -- 'FileAnalysis' (and any other 'Note'-consumer) can pick them up.
     for_ implicitNotesAll (Result.tell1 . Result.TypeInfo)
@@ -398,6 +399,7 @@ synthesizeFile env0 uf = do
         (UF.effectDeclarationsId uf)
         terms'
         (map tlcKind watches')
+        uf.givenBindings
   where
     applyTdnrDecisions ::
       [Context.InfoNote v Ann] ->

--- a/parser-typechecker/src/Unison/FileParsers.hs
+++ b/parser-typechecker/src/Unison/FileParsers.hs
@@ -2,10 +2,12 @@ module Unison.FileParsers
   ( ShouldUseTndr (..),
     computeTypecheckingEnvironment,
     synthesizeFile,
+    givenDeclVars,
   )
 where
 
 import Control.Lens
+import Control.Monad.Fail qualified as Fail
 import Control.Monad.State (evalStateT)
 import Data.Foldable qualified as Foldable
 import Data.List (partition)
@@ -40,6 +42,8 @@ import Unison.Type qualified as Type
 import Unison.Typechecker qualified as Typechecker
 import Unison.Typechecker.Context qualified as Context
 import Unison.Typechecker.Extractor (RedundantTypeAnnotation)
+import Unison.Typechecker.GivenApply qualified as GivenApply
+import Unison.Typechecker.GivenElaborator qualified as GivenElaborator
 import Unison.Typechecker.TypeLookup qualified as TL
 import Unison.Typechecker.Variance qualified as Variance
 import Unison.UnisonFile (definitionLocation)
@@ -89,9 +93,16 @@ computeTypecheckingEnvironment ::
   ShouldUseTndr m ->
   [Type v] ->
   (DefnsF Set TermReference TypeReference -> m (TL.TypeLookup v Ann)) ->
+  -- | Ambient givens harvested from the namespace (chunk L1). Each
+  -- entry is a top-level term tagged via
+  -- 'Unison.Codebase.Givens.givenSentinel' together with its declared
+  -- type; 'ambientPool' decomposes the type into the resolver's
+  -- @(tyVars, premises, conclusion)@ shape. Pass @[]@ when there is no
+  -- namespace context (e.g. a fresh test environment).
+  [GivenElaborator.AmbientGiven v Ann] ->
   UnisonFile v ->
   m (Typechecker.Env v Ann)
-computeTypecheckingEnvironment shouldUseTndr ambientAbilities typeLookupf uf =
+computeTypecheckingEnvironment shouldUseTndr ambientAbilities typeLookupf ambientGivens uf =
   case shouldUseTndr of
     ShouldUseTndr'No -> do
       tl <- typeLookupf (UF.dependencies uf)
@@ -102,7 +113,11 @@ computeTypecheckingEnvironment shouldUseTndr ambientAbilities typeLookupf uf =
             termsByShortname = Map.empty,
             freeNameToFuzzyTermsByShortName = Map.empty,
             topLevelComponents = Map.empty,
-            variances = Variance.fromTypeLookup tl
+            variances = Variance.fromTypeLookup tl,
+            ambientGivens = GivenElaborator.ambientPool ambientGivens,
+            -- ADR-010 / chunk L2 fixup: thread the parser-collected
+            -- @given@-bound variable names through to the typechecker.
+            givenBindings = uf.givenBindings
           }
     ShouldUseTndr'Yes parsingEnv -> do
       let resolveName :: Name -> Relation Name (ResolvesTo Referent)
@@ -195,7 +210,11 @@ computeTypecheckingEnvironment shouldUseTndr ambientAbilities typeLookupf uf =
             termsByShortname,
             freeNameToFuzzyTermsByShortName,
             topLevelComponents = Map.empty,
-            variances = Variance.fromTypeLookup typeLookup
+            variances = Variance.fromTypeLookup typeLookup,
+            ambientGivens = GivenElaborator.ambientPool ambientGivens,
+            -- ADR-010 / chunk L2 fixup: thread the parser-collected
+            -- @given@-bound variable names through to the typechecker.
+            givenBindings = uf.givenBindings
           }
 
 -- | 'fuzzyFindByEditDistanceRanked' finds matches for the given 'name' within 'names' by edit distance.
@@ -299,16 +318,70 @@ synthesizeFile env0 uf = do
             -- The Var.reset removes any freshening added during typechecking
             pure (Var.reset v, tm, typ)
        in traverse (traverse addTypesToTopLevelBindings) tlcsFromTypechecker
+    -- Phase-2 chunks D2 + D3 + L1: drive given-resolution from the
+    -- 'ConstraintGoal' info notes the typechecker emitted (chunk
+    -- C2.2), then walk each top-level term and substitute resolution
+    -- trees into 'App' nodes. The ambient pool comes from
+    -- 'env0.ambientGivens', built by 'computeTypecheckingEnvironment'
+    -- from the namespace's 'given'-tagged definitions (L1 wiring).
+    let ambient = Typechecker.ambientGivens env0
+    let infosWithImplicits = GivenElaborator.elaborateInfoNotes ambient infos
+    -- Phase-2 chunk D4: surface implicit-resolution failures as user
+    -- diagnostics. Each 'SolvedImplicit' note whose decision is
+    -- 'Left _' becomes a 'Result.UnresolvedImplicit' note. We tell
+    -- them all and fail the result if any were emitted, so the
+    -- compiler does not silently proceed with an under-applied term.
+    let implicitFailures =
+          [ Result.UnresolvedImplicit loc ty err
+          | (loc, ty, Left err) <- GivenElaborator.implicitDecisions infosWithImplicits
+          ]
+    Result.tellNotes (Seq.fromList implicitFailures)
+    when (not (null implicitFailures)) (Fail.fail "implicit resolution failed")
+    -- Chunk L1: surface 'SolvedImplicit' info notes as 'TypeInfo' so
+    -- downstream consumers (LSP, tests, transcripts) can observe which
+    -- given was chosen for each apply-site. The 'GivenElaborator'
+    -- adds these as plain 'Context.InfoNote's appended to the
+    -- typechecker's stream; they need an explicit 'tell' here to
+    -- become part of the file's 'Result' notes.
+    let solvedImplicitNotes =
+          [ note'
+          | note'@(Context.SolvedImplicit {}) <-
+              drop (length infos) infosWithImplicits
+          ]
+    for_ solvedImplicitNotes (Result.tell1 . Result.TypeInfo)
     let doTdnr = applyTdnrDecisions infos
-    let doTdnrInComponent (v, t, tp) = (v, doTdnr t, tp)
-    let tdnredTlcs =
+    let doImplicits =
+          GivenApply.applyGivenDecisions
+            infosWithImplicits
+            (Typechecker.typeLookup env0)
+    -- Chunk F1: 'doImplicits' also produces 'ImplicitArgRef' info
+    -- notes recording each synthesized dictionary insertion. Collect
+    -- them so the LSP can build a position-indexed lookup.
+    let doTdnrInComponent (v, t, tp) =
+          let (t', implicitNotes) = doImplicits (doTdnr t)
+           in ((v, t', tp), implicitNotes)
+    let tlcsWithImplicitNotes =
           topLevelComponents
             & (fmap . fmap)
               ( \vtt ->
-                  vtt
-                    & doTdnrInComponent
-                    & \(v, t, tp) -> (v, fromMaybe (error $ "Symbol from typechecked file not present in parsed file" <> show v) (definitionLocation v uf), t, tp)
+                  let (vtt', notes) = vtt & doTdnrInComponent
+                   in ( vtt'
+                          & \(v, t, tp) ->
+                            ( v,
+                              fromMaybe
+                                (error $ "Symbol from typechecked file not present in parsed file" <> show v)
+                                (definitionLocation v uf),
+                              t,
+                              tp
+                            ),
+                        notes
+                      )
               )
+    let tdnredTlcs = (fmap . fmap) fst tlcsWithImplicitNotes
+    let implicitNotesAll = concatMap (concatMap snd) tlcsWithImplicitNotes
+    -- Emit the 'ImplicitArgRef' notes as 'TypeInfo' so that
+    -- 'FileAnalysis' (and any other 'Note'-consumer) can pick them up.
+    for_ implicitNotesAll (Result.tell1 . Result.TypeInfo)
     let (watches', terms') = partition isWatch tdnredTlcs
         isWatch = all (\(v, _, _, _) -> Set.member v watchedVars)
         watchedVars = Set.fromList [v | (v, _a, _) <- UF.allWatches uf]
@@ -341,3 +414,41 @@ synthesizeFile env0 uf = do
                 -- Decision
                 Just $ replacement
           _ -> Nothing
+
+-- | ADR-019 / chunk C2.3: extract the @given@-declaration metadata
+-- from the typechecker's info-notes stream.
+--
+-- A 'Context.GivenDecl' note is emitted for every top-level binding
+-- whose declared type begins (after stripping any leading 'Forall')
+-- with one or more @=>@ constraint parameters. This helper projects
+-- those notes into a @Map v (declaredType, conclusion)@, with
+-- 'Var.reset' applied so callers see the user-written variable name
+-- (un-freshened).
+--
+-- Consumers: chunk B2's UCM command surface, which marks each named
+-- definition as a given via 'Unison.Codebase.Givens.markGivenAt'
+-- after the file's hashes are computed; chunk D3's elaborator, which
+-- substitutes resolved dictionary terms into apply sites.
+--
+-- Per ADR-005 the namespace is the instance set; this helper does
+-- not itself touch any namespace metadata. It only provides the data
+-- the caller needs to do the marking.
+givenDeclVars ::
+  (Var v) =>
+  [Context.InfoNote v Ann] ->
+  Map v (Type v, Type v)
+givenDeclVars infos =
+  -- The typechecker's 'GivenDecl' note carries 'Context.Type'
+  -- (TypeVar-tagged), so lower each type back to surface form before
+  -- handing the map to consumers — they will compare it against
+  -- 'Type.Type v Ann'-shaped values from the parser / namespace.
+  -- 'generalizeAndUnTypeVar' is the same lowering 'TopLevelComponent'
+  -- uses for the publicly-exposed type field.
+  Map.fromList
+    [ ( Var.reset v,
+        ( Context.generalizeAndUnTypeVar declared,
+          Context.generalizeAndUnTypeVar conclusion
+        )
+      )
+    | Context.GivenDecl _ v declared conclusion <- infos
+    ]

--- a/parser-typechecker/src/Unison/Hashing/V2/Convert.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/Convert.hs
@@ -280,6 +280,8 @@ m2hType = ABT.transform \case
   Memory.Type.Effects a1s -> Hashing.TypeEffects a1s
   Memory.Type.Forall a1 -> Hashing.TypeForall a1
   Memory.Type.IntroOuter a1 -> Hashing.TypeIntroOuter a1
+  -- ADR-019: implicit arrows hash with a distinct tag from regular arrows.
+  Memory.Type.ImplicitArrow a1 a1' -> Hashing.TypeImplicitArrow a1 a1'
 
 m2hKind :: Memory.Kind.Kind -> Hashing.Kind
 m2hKind = \case
@@ -318,6 +320,8 @@ h2mType = ABT.transform \case
   Hashing.TypeEffects a1s -> Memory.Type.Effects a1s
   Hashing.TypeForall a1 -> Memory.Type.Forall a1
   Hashing.TypeIntroOuter a1 -> Memory.Type.IntroOuter a1
+  -- ADR-019: implicit arrows round-trip back to memory representation.
+  Hashing.TypeImplicitArrow a1 a1' -> Memory.Type.ImplicitArrow a1 a1'
 
 h2mKind :: Hashing.Kind -> Memory.Kind.Kind
 h2mKind = \case

--- a/parser-typechecker/src/Unison/KindInference/Constraint/Context.hs
+++ b/parser-typechecker/src/Unison/KindInference/Constraint/Context.hs
@@ -12,6 +12,13 @@ data ConstraintContext v loc
   = AppAbs !(UVar v loc) !(UVar v loc)
   | AppArg !(UVar v loc) !(UVar v loc) !(UVar v loc)
   | AppArrow loc !(Type v loc) !(Type v loc)
+  | -- | ADR-019 / chunk C2.1: kind constraint introduced by an
+    -- 'Type.ImplicitArrow' (the @=>@ form). Distinguished from
+    -- 'AppArrow' so kind-error messages can point at @=>@ rather than
+    -- @->@. Currently the kind structure is identical to that of
+    -- 'AppArrow' (both sides must be of kind @Type@); the distinction
+    -- exists for diagnostic precision.
+    AppImplicitArrow loc !(Type v loc) !(Type v loc)
   | Annotation
   | EffectsList
   | ScopeReference

--- a/parser-typechecker/src/Unison/KindInference/Error.hs
+++ b/parser-typechecker/src/Unison/KindInference/Error.hs
@@ -109,6 +109,12 @@ improveError' generatedConstraint constraintConflict constraintMap =
         AppAbs abs arg -> pure (UnexpectedArgument loc abs arg constraintMap)
         AppArg abs expected actual -> pure (ArgumentMismatch abs expected actual constraintMap)
         AppArrow loc dom cod -> pure (ArgumentMismatchArrow (loc, dom, cod) constraintConflict constraintMap)
+        -- ADR-019 / chunk C2.1: 'AppImplicitArrow' folds into the same
+        -- 'ArgumentMismatchArrow' error variant as 'AppArrow' so kind
+        -- errors over @=>@ get the same diagnostic shape. Phase 4 may
+        -- introduce a dedicated error variant once @=>@ rendering is
+        -- distinguished from @->@.
+        AppImplicitArrow loc dom cod -> pure (ArgumentMismatchArrow (loc, dom, cod) constraintConflict constraintMap)
         EffectsList -> pure (EffectListMismatch constraintConflict constraintMap)
         _ -> pure (ConstraintConflict generatedConstraint constraintConflict constraintMap)
 

--- a/parser-typechecker/src/Unison/KindInference/Generate.hs
+++ b/parser-typechecker/src/Unison/KindInference/Generate.hs
@@ -67,6 +67,25 @@ typeConstraintTree resultVar term@ABT.Term {annotation, out} = do
                   ParentConstraint (IsType k2 (Provenance ctx $ ABT.annotation cod)) codConstraints
                 ]
             )
+      -- ADR-019: 'ImplicitArrow' has the same kind structure as 'Arrow'
+      -- (both sides must be of kind Type). Chunk C2.1 carry-over: tag
+      -- the resulting constraint with 'AppImplicitArrow' so kind errors
+      -- can point at @=>@ rather than @->@. Divergent typechecker
+      -- treatment beyond this is added in chunks D2/D3.
+      Type.ImplicitArrow dom cod -> do
+        let ctx = AppImplicitArrow annotation dom cod
+        k1 <- freshVar dom
+        domConstraints <- typeConstraintTree k1 dom
+        k2 <- freshVar cod
+        codConstraints <- typeConstraintTree k2 cod
+        pure $
+          Constraint
+            (IsType resultVar (Provenance ctx annotation))
+            ( Node
+                [ ParentConstraint (IsType k1 (Provenance ctx $ ABT.annotation dom)) domConstraints,
+                  ParentConstraint (IsType k2 (Provenance ctx $ ABT.annotation cod)) codConstraints
+                ]
+            )
       Type.App abs arg -> do
         absVar <- freshVar abs
         absArgVar <- freshVar arg
@@ -307,6 +326,8 @@ withInstantiatedConstructorType declType tyParams0 constructorType0 k =
       goArrow :: Type.Type v loc -> Gen v loc [GeneratedConstraint v loc]
       goArrow = \case
         Type.Arrow' _ o -> goArrow o
+        -- ADR-019: 'ImplicitArrow' walks the result spine like 'Arrow'.
+        Type.ImplicitArrow' _ o -> goArrow o
         Type.Effect' es _ -> goEffs es
         resultTyp@(Type.Apps' f xs)
           | f == declType -> unifyVars resultTyp xs

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -68,6 +68,7 @@ import Unison.Term qualified as Term
 import Unison.Type (Type)
 import Unison.Type qualified as Type
 import Unison.Typechecker.Context qualified as C
+import Unison.Typechecker.GivenResolver qualified as GR
 import Unison.Typechecker.TypeError
 import Unison.Typechecker.TypeVar qualified as TypeVar
 import Unison.UnisonFile.Error qualified as UF
@@ -1433,6 +1434,19 @@ renderType env f t = renderType0 env f (0 :: Int) (cleanup t)
     curly = wrap "{" "}"
     renderType0 env f p t = f (ABT.annotation t) $ case t of
       Type.Ref' r -> showTypeRef env r
+      -- ADR-019 / chunk P1: a leading chain of 'ImplicitArrow's renders
+      -- as a @=>@ constraint context. Walk the spine to collect every
+      -- leading constraint, emit them as a single @=>@ tuple (single
+      -- constraints print bare; two or more print as a parenthesised
+      -- comma list), then recurse on the conclusion. The conclusion is
+      -- rendered at precedence 0 so it is /not/ parenthesised: @=>@
+      -- binds looser than @->@. Mirrors the helper in @TypePrinter.hs@.
+      _
+        | (cs@(_ : _), conclusion) <- splitImplicitConstraints t ->
+            let renderedCs = case cs of
+                  [c] -> go 0 c
+                  _ -> "(" <> commas (go 0) cs <> ")"
+             in paren (p >= 1) $ renderedCs <> " => " <> go 0 conclusion
       Type.Arrow' i (Type.Effect1' e o) ->
         paren (p >= 2) $ go 2 i <> " ->{" <> go 1 e <> "} " <> go 1 o
       Type.Arrow' i o -> paren (p >= 2) $ go 2 i <> " -> " <> go 1 o
@@ -1472,6 +1486,18 @@ spaces = intercalateMap " "
 
 commas :: (IsString a, Monoid a) => (b -> a) -> [b] -> a
 commas = intercalateMap ", "
+
+-- | Walk the leading chain of 'Type.ImplicitArrow's, returning the list
+-- of constraint types and the conclusion. ADR-019: @(C1, C2) => T@ is
+-- encoded as @ImplicitArrow C1 (ImplicitArrow C2 T)@; this peels the
+-- chain so the error renderer can emit it as a single @=>@ context.
+-- Mirrors 'Unison.Syntax.TypePrinter.splitImplicitConstraints'.
+splitImplicitConstraints :: Type.Type v loc -> ([Type.Type v loc], Type.Type v loc)
+splitImplicitConstraints t = case t of
+  Type.ImplicitArrow' c rest ->
+    let (cs, conclusion) = splitImplicitConstraints rest
+     in (c : cs, conclusion)
+  _ -> ([], t)
 
 renderVar :: (IsString a, Var v) => v -> a
 renderVar = fromString . Text.unpack . Var.name
@@ -1579,6 +1605,147 @@ printNoteWithSource env s (CompilerBug (Result.TypecheckerBug c)) =
   renderCompilerBug env s c
 printNoteWithSource _env _s (CompilerBug c) =
   fromString $ "Compiler bug: " <> show c
+printNoteWithSource env s (Result.UnresolvedImplicit loc goal err) =
+  renderImplicitResolutionError env s loc goal err
+
+-- | Render a 'GR.ResolveError' produced by implicit resolution
+-- (chunk D4). The four primary categories ('NoGiven', 'Ambiguous',
+-- 'DepthExceeded', 'Cycle') and the goal-metavar refinement
+-- ('UnresolvedMetavarInGoal') each get a distinct, helpful header
+-- and supporting context. NearMisses on 'NoGiven' show /why/ each
+-- candidate didn't work, threading the same renderer recursively.
+renderImplicitResolutionError ::
+  forall v a.
+  (Var v, Annotated a, Show a, Ord a) =>
+  Env ->
+  String ->
+  a ->
+  Type v a ->
+  GR.ResolveError v a ->
+  Pretty ColorText
+renderImplicitResolutionError env src loc _goal err =
+  Pr.lines
+    [ headerFor err,
+      "",
+      annotatedAsErrorSite src loc,
+      "",
+      bodyFor err
+    ]
+  where
+    -- Top-line summary, color-keyed to error category.
+    headerFor :: GR.ResolveError v a -> Pretty ColorText
+    headerFor = \case
+      GR.NoGiven g _ ->
+        Pr.wrap $
+          "I couldn't find a "
+            <> style ErrorSite "given"
+            <> " for "
+            <> style Type1 (renderType' env g)
+            <> "."
+      GR.Ambiguous g _ ->
+        Pr.wrap $
+          "I found multiple "
+            <> style ErrorSite "given"
+            <> " candidates for "
+            <> style Type1 (renderType' env g)
+            <> "; the choice is ambiguous."
+      GR.DepthExceeded _ ->
+        Pr.wrap $
+          "Implicit resolution gave up: the chain "
+            <> "exceeded the maximum depth."
+      GR.Cycle _ ->
+        Pr.wrap $
+          "Implicit resolution detected a "
+            <> style ErrorSite "cycle"
+            <> " between givens."
+      GR.UnresolvedMetavarInGoal g ->
+        Pr.wrap $
+          "I can't pick a "
+            <> style ErrorSite "given"
+            <> " for "
+            <> style Type1 (renderType' env g)
+            <> " because the goal type still contains an "
+            <> "unsolved type variable. Add a type annotation "
+            <> "and try again."
+
+    -- Detail body — varies by category.
+    bodyFor :: GR.ResolveError v a -> Pretty ColorText
+    bodyFor = \case
+      GR.NoGiven _ [] ->
+        Pr.wrap "No matching givens are in scope."
+      GR.NoGiven _ misses ->
+        Pr.lines
+          [ Pr.wrap "These candidates head-matched but their premises did not resolve:",
+            "",
+            Pr.indentN 2 (Pr.lines (map renderNearMiss misses))
+          ]
+      GR.Ambiguous _ candidates ->
+        Pr.lines
+          [ Pr.wrap "Candidates:",
+            "",
+            Pr.indentN 2 (Pr.lines (map renderCandidate candidates))
+          ]
+      GR.DepthExceeded chain ->
+        Pr.lines
+          [ Pr.wrap "The chain (truncated to the first few links):",
+            "",
+            Pr.indentN 2 (Pr.lines (map renderChainStep (truncateChain chain)))
+          ]
+      GR.Cycle chain ->
+        Pr.lines
+          [ Pr.wrap "The cycle (outermost first):",
+            "",
+            Pr.indentN 2 (Pr.lines (map renderChainStep chain))
+          ]
+      GR.UnresolvedMetavarInGoal _ ->
+        Pr.wrap $
+          "Implicit resolution needs a fully-determined goal type."
+
+    renderNearMiss :: GR.NearMiss v a -> Pretty ColorText
+    renderNearMiss (GR.NearMiss g why) =
+      Pr.lines
+        [ "- "
+            <> style Identifier (givenLabelString g)
+            <> ", failed because:",
+          Pr.indentN 4 (renderNestedReason why)
+        ]
+
+    renderNestedReason :: GR.ResolveError v a -> Pretty ColorText
+    renderNestedReason = \case
+      GR.NoGiven g _ ->
+        Pr.wrap $
+          "no given for " <> style Type1 (renderType' env g)
+      GR.Ambiguous g _ ->
+        Pr.wrap $
+          "ambiguous candidates for " <> style Type1 (renderType' env g)
+      GR.DepthExceeded _ ->
+        Pr.wrap "depth limit exceeded in this branch"
+      GR.Cycle _ ->
+        Pr.wrap "cycle detected in this branch"
+      GR.UnresolvedMetavarInGoal g ->
+        Pr.wrap $
+          "goal type "
+            <> style Type1 (renderType' env g)
+            <> " contains an unresolved metavariable"
+
+    renderCandidate :: GR.Given v a -> Pretty ColorText
+    renderCandidate g = "- " <> style Identifier (givenLabelString g)
+
+    givenLabelString :: GR.Given v a -> String
+    givenLabelString g = Text.unpack (R.toText (GR.givenName g))
+
+    renderChainStep :: Type v a -> Pretty ColorText
+    renderChainStep t = "- " <> style Type1 (renderType' env t)
+
+    -- Show at most ~12 chain steps (head + tail) to keep depth-exceeded
+    -- diagnostics readable.
+    truncateChain :: [Type v a] -> [Type v a]
+    truncateChain xs
+      | length xs <= 12 = xs
+      | otherwise =
+          let (front, back) = splitAt 6 xs
+              tail6 = drop (length back - 6) back
+           in front ++ tail6
 
 _printPosRange :: String -> L.Pos -> L.Pos -> String
 _printPosRange s (L.Pos startLine startCol) _end =

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -1565,6 +1565,7 @@ annotatedToEnglish a = case ann a of
   External -> "<external>"
   GeneratedFrom a -> "generated from: " <> annotatedToEnglish a
   Synthetic a -> "synthesized at: " <> annotatedToEnglish a
+  Lowered a -> annotatedToEnglish a
   Ann start end -> rangeToEnglish $ Range start end
 
 rangeForAnnotated :: (Annotated a) => a -> Maybe Range
@@ -1573,6 +1574,7 @@ rangeForAnnotated a = case ann a of
   External -> Nothing
   GeneratedFrom a -> rangeForAnnotated a
   Synthetic a -> rangeForAnnotated a
+  Lowered a -> rangeForAnnotated a
   Ann start end -> Just $ Range start end
 
 showLexerOutput :: Bool

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -1564,6 +1564,7 @@ annotatedToEnglish a = case ann a of
   Intrinsic -> "<intrinsic>"
   External -> "<external>"
   GeneratedFrom a -> "generated from: " <> annotatedToEnglish a
+  Synthetic a -> "synthesized at: " <> annotatedToEnglish a
   Ann start end -> rangeToEnglish $ Range start end
 
 rangeForAnnotated :: (Annotated a) => a -> Maybe Range
@@ -1571,6 +1572,7 @@ rangeForAnnotated a = case ann a of
   Intrinsic -> Nothing
   External -> Nothing
   GeneratedFrom a -> rangeForAnnotated a
+  Synthetic a -> rangeForAnnotated a
   Ann start end -> Just $ Range start end
 
 showLexerOutput :: Bool

--- a/parser-typechecker/src/Unison/Result.hs
+++ b/parser-typechecker/src/Unison/Result.hs
@@ -10,7 +10,9 @@ import Unison.Names.ResolutionResult qualified as Names
 import Unison.Prelude
 import Unison.Syntax.Parser qualified as Parser
 import Unison.Term (Term)
+import Unison.Type (Type)
 import Unison.Typechecker.Context qualified as Context
+import Unison.Typechecker.GivenResolver qualified as GR
 
 type Result notes = ResultT notes Identity
 
@@ -23,6 +25,19 @@ data Note v loc
   | TypeError (Context.ErrorNote v loc)
   | TypeInfo (Context.InfoNote v loc)
   | CompilerBug (CompilerBug v loc)
+  | -- | ADR-019 / chunk D4: an implicit-resolution failure. Surfaced
+    -- by 'Unison.FileParsers.synthesizeFile' after running the
+    -- 'Unison.Typechecker.GivenElaborator' over the typechecker's
+    -- 'Context.ConstraintGoal' info notes. The 'GR.ResolveError'
+    -- payload is the structured failure from
+    -- 'Unison.Typechecker.GivenResolver': 'NoGiven', 'Ambiguous',
+    -- 'DepthExceeded', 'Cycle', or 'UnresolvedMetavarInGoal'.
+    --
+    -- The first 'loc' is the apply-site source location (copied from
+    -- the originating 'ConstraintGoal'); the 'Type' is the goal as
+    -- the resolver saw it (post-substitution from inference); the
+    -- 'GR.ResolveError' carries the structured reason.
+    UnresolvedImplicit loc (Type v loc) (GR.ResolveError v loc)
   deriving (Show)
 
 data CompilerBug v loc
@@ -68,6 +83,10 @@ toEither r = ExceptT (go <$> runResultT r)
 
 tell1 :: (Monad f) => note -> ResultT (Seq note) f ()
 tell1 = tell . pure
+
+-- | Like 'tell1' but accepts a sequence of notes.
+tellNotes :: (Monad f) => Seq note -> ResultT (Seq note) f ()
+tellNotes = tell
 
 fromParsing :: (Monad f) => Either (Parser.Err v) a -> ResultT (Seq (Note v loc)) f a
 fromParsing (Left e) = do

--- a/parser-typechecker/src/Unison/Syntax/DeclParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/DeclParser.hs
@@ -53,7 +53,17 @@ data SynDataDecl v = SynDataDecl
     fields :: !(Maybe [(L.Token v, Type v Ann)]),
     modifier :: !DataDeclaration.Modifier,
     name :: !(L.Token v),
-    tyvars :: ![v]
+    tyvars :: ![v],
+    -- | 'True' iff this declaration was parsed with the @class@
+    -- keyword instead of @type@. Class declarations are sugared
+    -- record types whose accessors take the record as an /implicit/
+    -- parameter (an @=>@ arrow per ADR-001) and emit only the
+    -- getters — no setters or modifiers — so a method call like
+    -- @Monoid.op acc x@ relies on the resolver to thread the chosen
+    -- 'Monoid' dictionary in. See @generateRecordAccessors@ for the
+    -- accessor-emission split. Always 'False' for ordinary @type@
+    -- declarations.
+    isClass :: !Bool
   }
   deriving stock (Generic)
 
@@ -101,7 +111,14 @@ synDeclP = do
 
 synDataDeclP :: forall m v. (Monad m, Var v) => Maybe (L.Token UnresolvedModifier) -> P v m (SynDataDecl v)
 synDataDeclP modifier0 = do
-  typeToken <- fmap void (reserved "type") <|> openBlockWith "type"
+  -- A @class T a = { ... }@ declaration is sugared to the same
+  -- record-style data declaration as @type T a = { ... }@; downstream
+  -- accessor emission (see 'generateRecordAccessors') consults the
+  -- 'isClass' flag to emit getters with an implicit ('=>') dictionary
+  -- parameter and to omit setters/modifiers.
+  let typeKw = (False,) <$> (fmap void (reserved "type") <|> openBlockWith "type")
+      classKw = (True,) <$> (fmap void (reserved "class") <|> openBlockWith "class")
+  (classFlag, typeToken) <- typeKw <|> classKw
   (name, typeArgs) <- (,) <$> prefixVar <*> many prefixVar
   let tyvars = L.payload <$> typeArgs
   eq <- reserved "="
@@ -150,7 +167,8 @@ synDataDeclP modifier0 = do
             fields = Nothing,
             modifier,
             name,
-            tyvars
+            tyvars,
+            isClass = classFlag
           }
     Just (constructor, fields, closingAnn) -> do
       _ <- closeBlock
@@ -162,7 +180,8 @@ synDataDeclP modifier0 = do
             fields,
             modifier,
             name,
-            tyvars
+            tyvars,
+            isClass = classFlag
           }
   where
     prefixVar :: P v m (L.Token v)

--- a/parser-typechecker/src/Unison/Syntax/DeclParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/DeclParser.hs
@@ -120,6 +120,13 @@ synDataDeclP modifier0 = do
       classKw = (True,) <$> (fmap void (reserved "class") <|> openBlockWith "class")
   (classFlag, typeToken) <- typeKw <|> classKw
   (name, typeArgs) <- (,) <$> prefixVar <*> many prefixVar
+  -- ADR-007: when the user used the @class@ keyword, record the type
+  -- name in the parser's side-channel so the @add@ / @update@ command
+  -- can mark the namespace metadata with 'classSentinel'. This makes
+  -- the @class@ keyword recoverable on the @view@ round-trip even
+  -- though the underlying data declaration is the same as if it were
+  -- written with @type@.
+  when classFlag $ recordClassDeclVar (L.payload name)
   let tyvars = L.payload <$> typeArgs
   eq <- reserved "="
   let -- go gives the type of the constructor, given the types of

--- a/parser-typechecker/src/Unison/Syntax/DeclPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/DeclPrinter.hs
@@ -3,7 +3,14 @@ module Unison.Syntax.DeclPrinter
     prettyDeclW,
     prettyDeclHeader,
     prettyDeclOrBuiltinHeader,
+    prettyDeclWithClasses,
+    prettyDeclWWithClasses,
+    prettyDeclHeaderWithClasses,
+    prettyDeclOrBuiltinHeaderWithClasses,
     getFieldAndAccessorNames,
+    getClassFieldNames,
+    IsClassRef,
+    noClasses,
     AccessorName,
     RenderUniqueTypeGuids (..),
   )
@@ -51,6 +58,18 @@ type SyntaxText = S.SyntaxText' Reference
 
 type AccessorName = Name
 
+-- | Predicate: is a given TypeReference known to be a class
+-- declaration in the surrounding context? Threaded through the
+-- pretty-printer so that class types get rendered with the
+-- @class@ keyword and record-style field syntax instead of the
+-- default @type T = T <fields>@ rendering. The default for callers
+-- that have no class information is 'noClasses' (always 'False').
+type IsClassRef = TypeReference -> Bool
+
+-- | Default 'IsClassRef' that treats no type as a class.
+noClasses :: IsClassRef
+noClasses _ = False
+
 -- | Should we render unique type guids? Usually no, but in `merge` it's helpful.
 data RenderUniqueTypeGuids
   = RenderUniqueTypeGuids'No
@@ -64,9 +83,20 @@ prettyDeclW ::
   HQ.HashQualified Name ->
   DD.Decl v a ->
   Writer (Set AccessorName) (Pretty SyntaxText)
-prettyDeclW ppe guid r hq = \case
+prettyDeclW = prettyDeclWWithClasses noClasses
+
+prettyDeclWWithClasses ::
+  (Var v) =>
+  IsClassRef ->
+  PrettyPrintEnvDecl ->
+  RenderUniqueTypeGuids ->
+  TypeReference ->
+  HQ.HashQualified Name ->
+  DD.Decl v a ->
+  Writer (Set AccessorName) (Pretty SyntaxText)
+prettyDeclWWithClasses isClassRef ppe guid r hq = \case
   Left e -> pure $ prettyEffectDecl ppe guid r hq e
-  Right dd -> prettyDataDecl ppe guid r hq dd
+  Right dd -> prettyDataDecl isClassRef ppe guid r hq dd
 
 prettyDecl ::
   (Var v) =>
@@ -76,7 +106,19 @@ prettyDecl ::
   HQ.HashQualified Name ->
   DD.Decl v a ->
   Pretty SyntaxText
-prettyDecl ppe guid r hq d = fst . runWriter $ prettyDeclW ppe guid r hq d
+prettyDecl = prettyDeclWithClasses noClasses
+
+prettyDeclWithClasses ::
+  (Var v) =>
+  IsClassRef ->
+  PrettyPrintEnvDecl ->
+  RenderUniqueTypeGuids ->
+  TypeReference ->
+  HQ.HashQualified Name ->
+  DD.Decl v a ->
+  Pretty SyntaxText
+prettyDeclWithClasses isClassRef ppe guid r hq d =
+  fst . runWriter $ prettyDeclWWithClasses isClassRef ppe guid r hq d
 
 prettyEffectDecl ::
   (Var v) =>
@@ -155,16 +197,53 @@ orderConstructors ppe r dd ctype =
 prettyDataDecl ::
   forall v a.
   (Var v) =>
+  IsClassRef ->
   PrettyPrintEnvDecl ->
   RenderUniqueTypeGuids ->
   TypeReference ->
   HQ.HashQualified Name ->
   DataDeclaration v a ->
   Writer (Set AccessorName) (Pretty SyntaxText)
-prettyDataDecl (PrettyPrintEnvDecl unsuffixifiedPPE suffixifiedPPE) guid r name dd =
-  (header <>) . P.sep (fmt S.DelimiterChar (" | " `P.orElse` "\n  | "))
-    <$> constructor `traverse` (orderConstructors unsuffixifiedPPE r dd CT.Data)
+prettyDataDecl isClassRef (PrettyPrintEnvDecl unsuffixifiedPPE suffixifiedPPE) guid r name dd =
+  if isClass
+    then renderClass
+    else renderDefault
   where
+    isClass = isClassRef r
+
+    renderDefault =
+      (header <>) . P.sep (fmt S.DelimiterChar (" | " `P.orElse` "\n  | "))
+        <$> constructor `traverse` (orderConstructors unsuffixifiedPPE r dd CT.Data)
+
+    -- 'class' types render as @class T tyvars = { f : T1, g : T2 }@.
+    -- They have exactly one constructor; if the field-name lookup
+    -- fails for any reason, we keep the @class@ header and fall back
+    -- to the positional constructor body so we still surface the
+    -- class-ness of the declaration on @view@.
+    renderClass = case getClassFieldNames unsuffixifiedPPE r name dd of
+      Nothing ->
+        (classHeader <>) . P.sep (fmt S.DelimiterChar (" | " `P.orElse` "\n  | "))
+          <$> constructor `traverse` (orderConstructors unsuffixifiedPPE r dd CT.Data)
+      Just (fieldNames, ts) -> do
+        tell $
+          Set.fromList $
+            [ declName `Name.joinDot` fieldName
+            | HQ.NameOnly declName <- [name],
+              fieldName <- fieldNames
+            ]
+        let body =
+              P.group $
+                fmt S.DelimiterChar "{ "
+                  <> P.sep
+                    (fmt S.DelimiterChar "," <> " " `P.orElse` "\n      ")
+                    (field <$> zip fieldNames ts)
+                  <> fmt S.DelimiterChar " }"
+        pure (classHeader <> body)
+
+    classHeader =
+      prettyDataHeaderWithClasses isClassRef guid r name dd
+        <> fmt S.DelimiterChar (" = " `P.orElse` "\n  = ")
+
     constructor (n, (_, _, Type.ForallsNamed' _ t)) = constructor' n t
     constructor (n, (_, _, t)) = constructor' n t
     constructor' n t = case Type.unArrows t of
@@ -299,6 +378,66 @@ getFieldAndAccessorNames env r hqTypename dd = do
         )
     else Nothing
 
+-- | Like 'getFieldAndAccessorNames' but for class declarations: the
+-- accessor hashes carry the @=>@-bearing type annotation that
+-- 'annotateClassAccessor' added at parse time, so we use
+-- 'hashClassFieldAccessors' to reproduce them. Classes have only
+-- getters (no setter / modifier), so we return the field names and
+-- the field types (already resolved through the constructor).
+getClassFieldNames ::
+  forall v a.
+  (Var v) =>
+  PrettyPrintEnv ->
+  TypeReference ->
+  HQ.HashQualified Name ->
+  DataDeclaration v a ->
+  Maybe ([Name], [Type.Type v a])
+getClassFieldNames env r hqTypename dd = do
+  typename <- HQ.toName hqTypename
+  [(_, typ)] <- Just (DD.constructors dd)
+
+  let vars :: [v]
+      vars = [Var.freshenId (fromIntegral n) (Var.named ("_" <> Text.pack (show n))) | n <- [0 .. Type.arity typ - 1]]
+
+  hashes <- DD.hashClassFieldAccessors env (Name.toVar typename) vars r (void dd)
+
+  let accessorNamesByHash =
+        hashes
+          & Map.elems
+          & map \(refId, _term, _typ) ->
+            (refId, HQ.toText (PPE.termName env (Referent.fromTermReferenceId refId)))
+
+  let fieldNamesByHash =
+        Map.fromList
+          [ (ref, f)
+          | (ref, n) <- accessorNamesByHash,
+            let typenameText = Name.toText typename,
+            typenameText `Text.isPrefixOf` n,
+            let rest = Text.drop (Text.length typenameText + 1) n,
+            (f, suffix) <- pure $ Text.span (/= '.') rest,
+            suffix == ""
+          ]
+
+  -- All accessors must have resolved to field names (no trailing
+  -- @.set@/@.modify@ are expected for classes).
+  guard (Map.size fieldNamesByHash == length accessorNamesByHash)
+
+  -- Pull the field types from the constructor's arrow chain.
+  ts <- case typ of
+    Type.ForallsNamed' _ inner -> Type.unArrows inner
+    _ -> Type.unArrows typ
+  let fieldTypes = init ts
+
+  let fieldNames =
+        [ Name.unsafeParseText name
+        | v <- vars,
+          Just (ref, _, _) <- [Map.lookup (Var.namespaced (Name.toVar typename :| [v])) hashes],
+          Just name <- [Map.lookup ref fieldNamesByHash]
+        ]
+
+  guard (length fieldNames == length fieldTypes)
+  Just (fieldNames, fieldTypes)
+
 prettyModifier :: RenderUniqueTypeGuids -> DD.Modifier -> Pretty SyntaxText
 prettyModifier _ DD.Structural = fmt S.DataTypeModifier "structural"
 prettyModifier RenderUniqueTypeGuids'No (DD.Unique _guid) = mempty
@@ -314,6 +453,26 @@ prettyDataHeader guid name dd =
       styleHashQualified'' (fmt $ S.HashQualifier name) name,
       P.sep " " (fmt S.DataTypeParams . P.text . Var.name <$> DD.bound dd)
     ]
+
+-- | Like 'prettyDataHeader' but emits the @class@ keyword instead of
+-- @type@ when @isClassRef r@ is 'True'.
+prettyDataHeaderWithClasses ::
+  (Var v) =>
+  IsClassRef ->
+  RenderUniqueTypeGuids ->
+  TypeReference ->
+  HQ.HashQualified Name ->
+  DD.DataDeclaration v a ->
+  Pretty SyntaxText
+prettyDataHeaderWithClasses isClassRef guid r name dd =
+  let keyword = if isClassRef r then "class" else "type"
+   in P.sepNonEmpty
+        " "
+        [ prettyModifier guid (DD.modifier dd),
+          fmt S.DataTypeKeyword keyword,
+          styleHashQualified'' (fmt $ S.HashQualifier name) name,
+          P.sep " " (fmt S.DataTypeParams . P.text . Var.name <$> DD.bound dd)
+        ]
 
 prettyEffectHeader ::
   (Var v) =>
@@ -342,6 +501,18 @@ prettyDeclHeader guid name = \case
   Left e -> prettyEffectHeader guid name e
   Right d -> prettyDataHeader guid name d
 
+prettyDeclHeaderWithClasses ::
+  (Var v) =>
+  IsClassRef ->
+  RenderUniqueTypeGuids ->
+  TypeReference ->
+  HQ.HashQualified Name ->
+  Either (DD.EffectDeclaration v a) (DD.DataDeclaration v a) ->
+  Pretty SyntaxText
+prettyDeclHeaderWithClasses isClassRef guid r name = \case
+  Left e -> prettyEffectHeader guid name e
+  Right d -> prettyDataHeaderWithClasses isClassRef guid r name d
+
 prettyDeclOrBuiltinHeader ::
   (Var v) =>
   RenderUniqueTypeGuids ->
@@ -352,6 +523,19 @@ prettyDeclOrBuiltinHeader guid name = \case
   Builtin CT.Data -> fmt S.DataTypeKeyword "builtin type " <> styleHashQualified'' (fmt $ S.HashQualifier name) name
   Builtin CT.Effect -> fmt S.DataTypeKeyword "builtin ability " <> styleHashQualified'' (fmt $ S.HashQualifier name) name
   NotBuiltin e -> prettyDeclHeader guid name e
+
+prettyDeclOrBuiltinHeaderWithClasses ::
+  (Var v) =>
+  IsClassRef ->
+  RenderUniqueTypeGuids ->
+  TypeReference ->
+  HQ.HashQualified Name ->
+  DD.DeclOrBuiltin v a ->
+  Pretty SyntaxText
+prettyDeclOrBuiltinHeaderWithClasses isClassRef guid r name = \case
+  Builtin CT.Data -> fmt S.DataTypeKeyword "builtin type " <> styleHashQualified'' (fmt $ S.HashQualifier name) name
+  Builtin CT.Effect -> fmt S.DataTypeKeyword "builtin ability " <> styleHashQualified'' (fmt $ S.HashQualifier name) name
+  NotBuiltin e -> prettyDeclHeaderWithClasses isClassRef guid r name e
 
 fmt :: S.Element r -> Pretty (S.SyntaxText' r) -> Pretty (S.SyntaxText' r)
 fmt = P.withSyntax

--- a/parser-typechecker/src/Unison/Syntax/FileParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/FileParser.hs
@@ -116,7 +116,7 @@ file = do
           ( \case
               SynDecl'Data decl
                 | Just fields <- decl.fields,
-                  Just (ref, _) <-
+                  Just (ref, dataDecl) <-
                     Map.lookup (maybe id Var.namespaced2 maybeNamespaceVar decl.name.payload) (UF.datas env) ->
                     let kind = if decl.isClass then ClassRecord else TypeRecord
                         rawAccessors =
@@ -130,14 +130,29 @@ file = do
                      in case kind of
                           TypeRecord -> rawAccessors
                           ClassRecord ->
-                            map
-                              ( annotateClassAccessor
-                                  decl.name.payload
-                                  decl.tyvars
-                                  ref
-                                  fields
-                              )
-                              rawAccessors
+                            -- The fields-with-resolved-types pair the
+                            -- field name from the parsed declaration
+                            -- with its type as it appears in the
+                            -- /resolved/ constructor — references in
+                            -- the resolved type have been bound to
+                            -- the namespace (e.g. @Text@ resolves to
+                            -- its builtin), which the typechecker
+                            -- needs when checking the accessor's
+                            -- generated body against our @=>@
+                            -- annotation. Falling back to the parsed
+                            -- field type would leave external types
+                            -- as free vars and fail with
+                            -- "I don't know about the type Text".
+                            let resolvedFieldTypes =
+                                  resolveClassFieldTypes dataDecl fields
+                             in map
+                                  ( annotateClassAccessor
+                                      decl.name.payload
+                                      decl.tyvars
+                                      ref
+                                      resolvedFieldTypes
+                                  )
+                                  rawAccessors
               _ -> []
           )
           unNamespacedSynDecls
@@ -450,6 +465,34 @@ annotateClassAccessor className tyvars classRef classFields (vname, a, body) =
 
     qualifyField :: v -> v -> v
     qualifyField cn fn = Var.namespaced (cn :| [fn])
+
+-- | Pair each parsed field name with its corresponding type as it
+-- appears in the /resolved/ data-declaration's constructor — that
+-- form has every type reference bound to the namespace (e.g.
+-- @Text@ → its builtin reference), which is what the typechecker
+-- needs when validating the accessor's generated body against the
+-- class's @=>@-bearing annotation. Records have exactly one
+-- constructor and its declared type is
+-- @forall tyvars. T1 -> T2 -> … -> Tn -> Self@; the inputs of that
+-- arrow chain are the field types in the same order the record
+-- syntax declared them.
+resolveClassFieldTypes ::
+  forall v.
+  (Var v) =>
+  DataDeclaration v Ann ->
+  [(L.Token v, Type v Ann)] ->
+  [(L.Token v, Type v Ann)]
+resolveClassFieldTypes dataDecl fields =
+  case DataDeclaration.constructors' dataDecl of
+    [(_, _, ctorType)] ->
+      let (inputs, _) = peelInputs (Type.unforall' ctorType)
+       in zipWith (\(tok, _) ty -> (tok, ty)) fields inputs
+    _ -> fields
+  where
+    peelInputs ty = case ty of
+      (_vs, Type.Arrow' i o) ->
+        let (rest, conc) = peelInputs ([], o) in (i : rest, conc)
+      (_, t) -> ([], t)
 
 stanza :: (Monad m, Var v) => P v m (Stanza v (Term v Ann))
 stanza = watchExpression <|> unexpectedAction <|> binding

--- a/parser-typechecker/src/Unison/Syntax/FileParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/FileParser.hs
@@ -364,6 +364,11 @@ checkForDuplicateTermsAndConstructors fn datas effects terms watches = do
   -- bindings nested inside term bodies (both invoke 'givenBindingBody'
   -- which calls 'recordGivenVar').
   gbs <- getGivenVars
+  -- ADR-007: also pull the @class@-keyword names so the @add@/@update@
+  -- command can mark them in namespace metadata via
+  -- 'Unison.Codebase.Classes.markClassAt'. Without this the
+  -- declaration round-trips through @view@ as a plain @type@.
+  cbs <- getClassDeclVars
   pure
     UnisonFileId
       { fileNamespace = fn,
@@ -371,7 +376,8 @@ checkForDuplicateTermsAndConstructors fn datas effects terms watches = do
         effectDeclarationsId = effects,
         terms = List.foldl (\acc (v, ann, term) -> Map.insert v (ann, term) acc) Map.empty terms,
         watches,
-        givenBindings = gbs
+        givenBindings = gbs,
+        classBindings = cbs
       }
   where
     effectDecls :: [DataDeclaration v Ann]

--- a/parser-typechecker/src/Unison/Syntax/FileParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/FileParser.hs
@@ -287,7 +287,7 @@ applyNamespaceToStanza namespace locallyBoundTerms = \case
 
 -- | Final validations and sanity checks to perform before finishing parsing.
 validateUnisonFile ::
-  (Ord v) =>
+  (Monad m, Ord v) =>
   Maybe (Ann, Name.Name) ->
   Map v (TypeReferenceId, DataDeclaration v Ann) ->
   Map v (TypeReferenceId, EffectDeclaration v Ann) ->
@@ -302,7 +302,7 @@ validateUnisonFile fn datas effects terms watches =
 -- constructors and verify that no duplicates exist in the file, triggering an error if needed.
 checkForDuplicateTermsAndConstructors ::
   forall m v.
-  (Ord v) =>
+  (Monad m, Ord v) =>
   Maybe (Ann, Name.Name) ->
   Map v (TypeReferenceId, DataDeclaration v Ann) ->
   Map v (TypeReferenceId, EffectDeclaration v Ann) ->
@@ -317,13 +317,21 @@ checkForDuplicateTermsAndConstructors fn datas effects terms watches = do
             & fmap Set.toList
             & Map.toList
     P.customFailure (DuplicateTermNames dupeList)
+  -- ADR-010 / chunk L2 fixup: pull the parser-side @given@-keyword
+  -- names out of the parser's state side channel and stamp them onto
+  -- the 'UnisonFile' so the typechecker can recognise @given@ origins
+  -- by name. Includes both file-level @given@ decls and @let given@
+  -- bindings nested inside term bodies (both invoke 'givenBindingBody'
+  -- which calls 'recordGivenVar').
+  gbs <- getGivenVars
   pure
     UnisonFileId
       { fileNamespace = fn,
         dataDeclarationsId = datas,
         effectDeclarationsId = effects,
         terms = List.foldl (\acc (v, ann, term) -> Map.insert v (ann, term) acc) Map.empty terms,
-        watches
+        watches,
+        givenBindings = gbs
       }
   where
     effectDecls :: [DataDeclaration v Ann]

--- a/parser-typechecker/src/Unison/Syntax/FileParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/FileParser.hs
@@ -7,6 +7,7 @@ import Control.Lens
 import Control.Monad.Reader (asks, local)
 import Data.Foldable (foldlM)
 import Data.List qualified as List
+import Data.List.NonEmpty (pattern (:|))
 import Data.Map qualified as Map
 import Data.Set qualified as Set
 import Data.Text qualified as Text
@@ -14,7 +15,7 @@ import Text.Megaparsec qualified as P
 import Unison.ABT qualified as ABT
 import Unison.DataDeclaration (DataDeclaration (..), EffectDeclaration)
 import Unison.DataDeclaration qualified as DataDeclaration
-import Unison.DataDeclaration.Records (generateRecordAccessors)
+import Unison.DataDeclaration.Records (RecordKind (..), generateRecordAccessors)
 import Unison.Name qualified as Name
 import Unison.NameSegment qualified as NameSegment
 import Unison.Names qualified as Names
@@ -23,6 +24,7 @@ import Unison.Parser.Ann (Ann)
 import Unison.Parser.Ann qualified as Ann
 import Unison.Prelude
 import Unison.Reference (TypeReferenceId)
+import Unison.Reference qualified as Reference
 import Unison.Syntax.DeclParser (SynDataDecl (..), SynDecl (..), SynEffectDecl (..), synDeclConstructors, synDeclName, synDeclsP)
 import Unison.Syntax.Lexer qualified as L
 import Unison.Syntax.Name qualified as Name (toText, toVar, unsafeParseVar)
@@ -99,6 +101,15 @@ file = do
   --
   -- we want to rename `Bar.baz` to `foo.Bar.baz`, and it seems easier to first generate un-namespaced accessors like
   -- `Bar.baz`, rather than rip off the namespace from accessors like `foo.Bar.baz` (though not by much).
+  --
+  -- For @class@ declarations we additionally wrap each accessor in a
+  -- 'Term.Ann' that declares the dictionary parameter as implicit
+  -- (an @=>@ arrow). The typechecker's @=>I@ rule then binds the
+  -- getter's leading lambda variable as a /lexical given/ for the
+  -- body, so a method call like @Monoid.op acc x@ resolves the
+  -- dictionary against any enclosing @=>@-parameter or namespace
+  -- given. See 'classAccessorType' below and the @=>I@ clause in
+  -- @Unison.Typechecker.Context.checkWanted@.
   let unNamespacedAccessors :: [(v, Ann, Term v Ann)]
       unNamespacedAccessors =
         foldMap
@@ -107,12 +118,26 @@ file = do
                 | Just fields <- decl.fields,
                   Just (ref, _) <-
                     Map.lookup (maybe id Var.namespaced2 maybeNamespaceVar decl.name.payload) (UF.datas env) ->
-                    generateRecordAccessors
-                      Var.namespaced
-                      Ann.GeneratedFrom
-                      (toPair <$> fields)
-                      decl.name.payload
-                      ref
+                    let kind = if decl.isClass then ClassRecord else TypeRecord
+                        rawAccessors =
+                          generateRecordAccessors
+                            kind
+                            Var.namespaced
+                            Ann.GeneratedFrom
+                            (toPair <$> fields)
+                            decl.name.payload
+                            ref
+                     in case kind of
+                          TypeRecord -> rawAccessors
+                          ClassRecord ->
+                            map
+                              ( annotateClassAccessor
+                                  decl.name.payload
+                                  decl.tyvars
+                                  ref
+                                  fields
+                              )
+                              rawAccessors
               _ -> []
           )
           unNamespacedSynDecls
@@ -377,6 +402,54 @@ getVars = \case
   WatchExpression _ guid _ _ -> [Var.unnamedTest guid]
   Binding ((_, v), _) -> [v]
   Bindings bs -> [v | ((_, v), _) <- bs]
+
+-- | Wrap a @class@ accessor term with a 'Term.Ann' that declares the
+-- dictionary parameter as implicit. The accessor's getter body is
+-- already a lambda taking the dictionary; this annotation pins the
+-- leading parameter as an @=>@ arrow so the typechecker's @=>I@ rule
+-- registers the binder as a lexical given for the body.
+--
+-- The resulting type is
+-- @
+--   forall tyvars... . T tyvars... => FieldType
+-- @
+-- where @T@ is the class type, @tyvars@ are its parameters, and
+-- @FieldType@ is the field's declared type. The @FieldType@ is
+-- copied verbatim from the field declaration, so existing type
+-- variables continue to bind to the class's @forall@.
+annotateClassAccessor ::
+  forall v.
+  (Var v) =>
+  -- | Class type name (e.g. @Monoid@).
+  v ->
+  -- | Class type parameters (e.g. @[m]@).
+  [v] ->
+  -- | Reference of the class type, used to construct @T tyvars@.
+  Reference.Reference ->
+  -- | Class field declarations: @[(name, fieldType)]@.
+  [(L.Token v, Type v Ann)] ->
+  -- | The raw accessor produced by 'generateRecordAccessors'.
+  (v, Ann, Term v Ann) ->
+  (v, Ann, Term v Ann)
+annotateClassAccessor className tyvars classRef classFields (vname, a, body) =
+  case List.find (\(tok, _) -> matchesField (L.payload tok)) classFields of
+    Nothing -> (vname, a, body)
+    Just (_, fieldType) ->
+      let classRefT = Type.ref a classRef
+          classApp = foldl' (\acc tyv -> Type.app a acc (Type.var a tyv)) classRefT tyvars
+          implicit = Type.implicitArrow a classApp fieldType
+          quantified = Type.foralls a tyvars implicit
+       in (vname, a, Term.ann a body quantified)
+  where
+    -- The accessor's variable name is @ClassName.fieldName@. Pull
+    -- out the field name and match against the declaration's tokens.
+    matchesField :: v -> Bool
+    matchesField fieldName =
+      let target = qualifyField className fieldName
+       in vname == target
+
+    qualifyField :: v -> v -> v
+    qualifyField cn fn = Var.namespaced (cn :| [fn])
 
 stanza :: (Monad m, Var v) => P v m (Stanza v (Term v Ann))
 stanza = watchExpression <|> unexpectedAction <|> binding

--- a/parser-typechecker/src/Unison/Syntax/TermParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermParser.hs
@@ -667,7 +667,6 @@ termLeaf :: forall m v. (Monad m, Var v) => TermP v m
 termLeaf =
   asum
     [ force,
-      summonExpr,
       hashQualifiedPrefixTerm,
       text,
       char,
@@ -683,35 +682,6 @@ termLeaf =
       bang,
       doc2Block <&> \(spanAnn, trm) -> trm {ABT.annotation = ABT.annotation trm <> spanAnn}
     ]
-
--- | Parse a `summon T` expression (chunk A2; ADR-006).
---
--- `summon` is followed by a type. It desugars (for now) to a typed
--- hole `_ : T` so that downstream phases can ignore the new node:
--- the elaborator (chunk D) will recognise the source range and
--- replace it with the resolved dictionary; until then the typechecker
--- will report an unfilled blank, which is the correct behaviour for
--- a parser-only landing.
---
--- The argument is a full 'TypeParser.valueType', which greedily
--- consumes everything that 'valueType' accepts: type atoms, prefix
--- applications (`summon Show Nat`), parenthesized forms
--- (`summon (Show Nat)`), arrows, foralls, and the new constraint
--- arrow `=>` from chunk A1. Both unparenthesized and parenthesized
--- forms appear in @docs/implicits-plan.md@ §1.2; the greedy parse
--- accepts both without disambiguation.
-summonExpr :: forall m v. (Monad m, Var v) => TermP v m
-summonExpr = do
-  kw <- reserved "summon"
-  -- A type signature parser consumes everything up to the next
-  -- expression-context terminator. We call into 'TypeParser.valueType'
-  -- which already handles parens, applications, forall, and the
-  -- new constraint-arrow form (chunk A1). The blank's annotation
-  -- spans the whole `summon T`, so the source range is recoverable
-  -- by downstream passes.
-  ty <- TypeParser.valueType
-  let spanAnn = ann kw <> ann ty
-  pure $ Term.ann spanAnn (Term.blank spanAnn) ty
 
 -- | Gives a parser an explicit stream to parse, so that it consumes nothing from the original stream when it runs.
 --
@@ -939,37 +909,25 @@ force = P.label "force" $ P.try do
 
 term4 :: (Monad m, Var v) => TermP v m
 term4 = do
-  func <- termLeaf
-  args <- many appArg
+  func <- giveExpr <|> termLeaf
+  args <- many termLeaf
   pure case args of
     [] -> func
     _ -> Term.apps func ((\a -> (ann func <> ann a, a)) <$> args)
   where
-    -- An argument in an application chain. May be either an ordinary
-    -- term-leaf, or an explicit @-positional override of the form
-    -- @ d (chunk A3; ADR-007).
-    --
-    -- Disambiguation:
-    --   - In *expression* context (here): a `Reserved "@"` token in
-    --     argument position introduces an override.
-    --   - In *pattern* context (`pHqNamey` ~line 410): the same token
-    --     produces an as-pattern. Patterns are parsed by a different
-    --     entry point so the two grammars do not interfere.
-    --   - In *doc* context (`Syntax/Parser/Doc.hs:keyedInline`): the
-    --     `@` is matched at the raw-string level, before tokens reach
-    --     this parser.
-    --
-    -- For chunk A3 the override desugars to ordinary positional
-    -- application: `f @ d` parses as `Term.app f d`. The argument's
-    -- annotation is widened to include the leading `@` token so that
-    -- downstream chunks (D2/D3) can recognise overrides by source
-    -- range and skip implicit-resolution at that slot.
-    appArg = overrideArg <|> termLeaf
-    overrideArg = do
-      atTok <- reserved "@"
-      d <- termLeaf
-      let widened = ann atTok <> ann d
-      pure (ABT.annotate widened d)
+    -- ADR-007: @give f@ is a prefix syntactic transformation that
+    -- demotes f's leading `=>` arrows to `->`. The result is f with
+    -- its outer annotation wrapped in 'Ann.Lowered'; the typechecker
+    -- ('synthesizeWanted', Var/Ref clauses) checks this flag and
+    -- skips 'peelLeadingImplicits', then converts each leading
+    -- 'ImplicitArrow' to a regular 'Arrow'. Subsequent application
+    -- supplies the dictionary positionally as an ordinary explicit
+    -- argument.
+    giveExpr = do
+      kw <- reserved "give"
+      f <- termLeaf
+      let widened = Ann.Lowered (ann kw <> ann f)
+      pure (ABT.annotate widened f)
 
 data InfixParse v
   = InfixOp (L.Token (HQ.HashQualified Name)) (Term v Ann) (InfixParse v) (InfixParse v)

--- a/parser-typechecker/src/Unison/Syntax/TermParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermParser.hs
@@ -667,6 +667,7 @@ termLeaf :: forall m v. (Monad m, Var v) => TermP v m
 termLeaf =
   asum
     [ force,
+      summonExpr,
       hashQualifiedPrefixTerm,
       text,
       char,
@@ -682,6 +683,35 @@ termLeaf =
       bang,
       doc2Block <&> \(spanAnn, trm) -> trm {ABT.annotation = ABT.annotation trm <> spanAnn}
     ]
+
+-- | Parse a `summon T` expression (chunk A2; ADR-006).
+--
+-- `summon` is followed by a type. It desugars (for now) to a typed
+-- hole `_ : T` so that downstream phases can ignore the new node:
+-- the elaborator (chunk D) will recognise the source range and
+-- replace it with the resolved dictionary; until then the typechecker
+-- will report an unfilled blank, which is the correct behaviour for
+-- a parser-only landing.
+--
+-- The argument is a full 'TypeParser.valueType', which greedily
+-- consumes everything that 'valueType' accepts: type atoms, prefix
+-- applications (`summon Show Nat`), parenthesized forms
+-- (`summon (Show Nat)`), arrows, foralls, and the new constraint
+-- arrow `=>` from chunk A1. Both unparenthesized and parenthesized
+-- forms appear in @docs/implicits-plan.md@ §1.2; the greedy parse
+-- accepts both without disambiguation.
+summonExpr :: forall m v. (Monad m, Var v) => TermP v m
+summonExpr = do
+  kw <- reserved "summon"
+  -- A type signature parser consumes everything up to the next
+  -- expression-context terminator. We call into 'TypeParser.valueType'
+  -- which already handles parens, applications, forall, and the
+  -- new constraint-arrow form (chunk A1). The blank's annotation
+  -- spans the whole `summon T`, so the source range is recoverable
+  -- by downstream passes.
+  ty <- TypeParser.valueType
+  let spanAnn = ann kw <> ann ty
+  pure $ Term.ann spanAnn (Term.blank spanAnn) ty
 
 -- | Gives a parser an explicit stream to parse, so that it consumes nothing from the original stream when it runs.
 --
@@ -908,10 +938,38 @@ force = P.label "force" $ P.try do
   pure $ DD.forceTerm (ann fn <> ann close) (tok <> ann close) fn
 
 term4 :: (Monad m, Var v) => TermP v m
-term4 = f <$> some termLeaf
+term4 = do
+  func <- termLeaf
+  args <- many appArg
+  pure case args of
+    [] -> func
+    _ -> Term.apps func ((\a -> (ann func <> ann a, a)) <$> args)
   where
-    f (func : args) = Term.apps func ((\a -> (ann func <> ann a, a)) <$> args)
-    f [] = error "'some' shouldn't produce an empty list"
+    -- An argument in an application chain. May be either an ordinary
+    -- term-leaf, or an explicit @-positional override of the form
+    -- @ d (chunk A3; ADR-007).
+    --
+    -- Disambiguation:
+    --   - In *expression* context (here): a `Reserved "@"` token in
+    --     argument position introduces an override.
+    --   - In *pattern* context (`pHqNamey` ~line 410): the same token
+    --     produces an as-pattern. Patterns are parsed by a different
+    --     entry point so the two grammars do not interfere.
+    --   - In *doc* context (`Syntax/Parser/Doc.hs:keyedInline`): the
+    --     `@` is matched at the raw-string level, before tokens reach
+    --     this parser.
+    --
+    -- For chunk A3 the override desugars to ordinary positional
+    -- application: `f @ d` parses as `Term.app f d`. The argument's
+    -- annotation is widened to include the leading `@` token so that
+    -- downstream chunks (D2/D3) can recognise overrides by source
+    -- range and skip implicit-resolution at that slot.
+    appArg = overrideArg <|> termLeaf
+    overrideArg = do
+      atTok <- reserved "@"
+      d <- termLeaf
+      let widened = ann atTok <> ann d
+      pure (ABT.annotate widened d)
 
 data InfixParse v
   = InfixOp (L.Token (HQ.HashQualified Name)) (Term v Ann) (InfixParse v) (InfixParse v)
@@ -1060,49 +1118,102 @@ binding ::
       Term v Ann
     )
 binding = label "binding" do
-  typ <- optional typedecl
-  -- a ++ b = ...
-  let infixLhs = do
-        (arg1, op) <-
-          P.try $
-            (,) <$> prefixDefinitionName <*> symbolyDefinitionName
-        arg2 <- prefixDefinitionName
-        pure (ann arg1, op, [arg1, arg2])
-  let prefixLhs = do
-        v <- prefixTermName
-        vs <- many prefixTermName
-        pure (ann v, v, vs)
-  let lhs :: P v m (Ann, L.Token v, [L.Token v])
-      lhs = infixLhs <|> prefixLhs
-  case typ of
-    Nothing -> do
-      -- we haven't seen a type annotation, so lookahead to '=' before commit
-      (lhsLoc, name, args) <- P.try (lhs <* P.lookAhead (openBlockWith "="))
-      (_eqAnn, _bodySpanAnn, body) <- block "="
-      verifyRelativeName' (fmap Name.unsafeParseVar name)
-      let binding = mkBinding lhsLoc args body
-      -- We don't actually use the span annotation from the block (yet) because it
-      -- may contain a bunch of white-space and comments following a top-level-definition.
-      -- let spanAnn = ann lhsLoc <> ann binding
-      pure $ ((ann name, (L.payload name)), binding)
-    Just (nameT, typ) -> do
-      (lhsLoc, name, args) <- lhs
-      verifyRelativeName' (fmap Name.unsafeParseVar name)
-      when (L.payload name /= L.payload nameT) $
-        customFailure $
-          SignatureNeedsAccompanyingBody nameT
-      (_eqAnn, _bodySpanAnn, body) <- block "="
-      let binding = mkBinding lhsLoc args body
-      -- We don't actually use the span annotation from the block (yet) because it
-      -- may contain a bunch of white-space and comments following a top-level-definition.
-      let spanAnn = ann nameT <> ann binding
-      pure $ ((ann nameT, L.payload name), Term.ann spanAnn binding typ)
+  -- A `given` declaration is a one-line binding form:
+  --
+  -- > given name : T = body
+  --
+  -- We commit as soon as we see the `given` keyword (no `P.try`); a
+  -- malformed `given` is a hard parse error rather than a backtrack
+  -- to `regularBinding`, which would otherwise produce a confusing
+  -- "expected binding got `given`" message. See chunk A2;
+  -- ADR-010, ADR-022.
+  P.optional (reserved "given") >>= \case
+    Just kw -> givenBindingBody kw
+    Nothing -> regularBinding
   where
+    regularBinding = do
+      typ <- optional typedecl
+      -- a ++ b = ...
+      let infixLhs = do
+            (arg1, op) <-
+              P.try $
+                (,) <$> prefixDefinitionName <*> symbolyDefinitionName
+            arg2 <- prefixDefinitionName
+            pure (ann arg1, op, [arg1, arg2])
+      let prefixLhs = do
+            v <- prefixTermName
+            vs <- many prefixTermName
+            pure (ann v, v, vs)
+      let lhs :: P v m (Ann, L.Token v, [L.Token v])
+          lhs = infixLhs <|> prefixLhs
+      case typ of
+        Nothing -> do
+          -- we haven't seen a type annotation, so lookahead to '=' before commit
+          (lhsLoc, name, args) <- P.try (lhs <* P.lookAhead (openBlockWith "="))
+          (_eqAnn, _bodySpanAnn, body) <- block "="
+          verifyRelativeName' (fmap Name.unsafeParseVar name)
+          let bnd = mkBinding lhsLoc args body
+          -- We don't actually use the span annotation from the block (yet) because it
+          -- may contain a bunch of white-space and comments following a top-level-definition.
+          -- let spanAnn = ann lhsLoc <> ann bnd
+          pure $ ((ann name, (L.payload name)), bnd)
+        Just (nameT, typ') -> do
+          (lhsLoc, name, args) <- lhs
+          verifyRelativeName' (fmap Name.unsafeParseVar name)
+          when (L.payload name /= L.payload nameT) $
+            customFailure $
+              SignatureNeedsAccompanyingBody nameT
+          (_eqAnn, _bodySpanAnn, body) <- block "="
+          let bnd = mkBinding lhsLoc args body
+          -- We don't actually use the span annotation from the block (yet) because it
+          -- may contain a bunch of white-space and comments following a top-level-definition.
+          let spanAnn = ann nameT <> ann bnd
+          pure $ ((ann nameT, L.payload name), Term.ann spanAnn bnd typ')
     mkBinding :: Ann -> [L.Token v] -> Term.Term v Ann -> Term.Term v Ann
     mkBinding _lhsLoc [] body = body
     mkBinding lhsLoc args body =
       let annotatedArgs = args <&> \arg -> (ann arg, L.payload arg)
        in Term.lam' (lhsLoc <> ann body) annotatedArgs body
+
+-- | Parse the body of a `given` declaration after the leading `given`
+-- keyword has already been consumed. Used at the top level and inside
+-- block contexts (i.e., `let given name : T = body`). The remaining
+-- form is: name, `:`, type, `=`, body.
+--
+-- For now (chunk A2) the parser produces an ordinary type-annotated
+-- binding. The `given` tag itself is namespace metadata (chunk B1),
+-- not part of the term AST. The leading-keyword source range is
+-- preserved by the binding's annotation so downstream phases can
+-- recognise the statement when wiring up implicit resolution.
+--
+-- The caller commits to this branch as soon as it sees `given`; this
+-- function does NOT use `P.try`, so a malformed body produces a
+-- targeted error (e.g., "expected `:` after `given <name>`") rather
+-- than a confusing backtrack into the regular-binding grammar.
+givenBindingBody ::
+  forall m v.
+  (Monad m, Var v) =>
+  L.Token String ->
+  P
+    v
+    m
+    ( (Ann, v),
+      Term v Ann
+    )
+givenBindingBody kw = label "given" do
+  name <- prefixTermName
+  verifyRelativeName' (fmap Name.unsafeParseVar name)
+  -- ADR-010 / chunk L2 fixup: record this variable name in the parser's
+  -- given-binding side channel so the typechecker can identify @given@
+  -- origins by name rather than inspecting type shape. This makes the
+  -- canonical premise-free form @given local : Ord a = …@ work without
+  -- relying on the type beginning with @=>@.
+  recordGivenVar (L.payload name)
+  _ <- reserved ":"
+  ty <- TypeParser.valueType
+  (_eqAnn, _bodySpanAnn, body) <- block "="
+  let spanAnn = ann kw <> ann body
+  pure ((ann kw <> ann name, L.payload name), Term.ann spanAnn body ty)
 
 customFailure :: (P.MonadParsec e s m) => e -> m a
 customFailure = P.customFailure

--- a/parser-typechecker/src/Unison/Syntax/TermParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermParser.hs
@@ -1108,6 +1108,41 @@ destructuringBind = do
 -- binding) and the entire body.
 -- * If the binding is a lambda, the  lambda node includes the entire LHS of the binding,
 -- including the name as well.
+-- | When a binding's declared type begins with one or more @=>@
+-- constraint arrows (after any leading @forall@ binders), wrap the
+-- binding's body with a leading lambda for each implicit parameter
+-- so that the dictionary is accessible at runtime. Each fresh binder
+-- is also registered via 'recordGivenVar' so the typechecker's
+-- letrec wiring (@annotateLetRecBindings'@) lifts it into the lexical
+-- given environment for the body. The introduced variables are named
+-- @_implicit_<baseName>_<index>@ — the base name (typically the
+-- bound variable's name) makes diagnostics traceable, and the index
+-- distinguishes multiple constraints on the same signature.
+--
+-- See chunk L2 / ADR-010 for the lexical-given convention. The
+-- companion @=>I@ rule in @Unison.Typechecker.Context.checkWanted@
+-- recognises the injected lambda when checking against an
+-- 'ImplicitArrow' and finishes the binding by registering the binder
+-- as a local lexical given.
+wrapImplicitParams ::
+  forall m v.
+  (Monad m, Var v) =>
+  v ->
+  Type v Ann ->
+  Term v Ann ->
+  P v m (Term v Ann)
+wrapImplicitParams baseName ty body0 =
+  case Type.unImplicitArrows ty of
+    ([], _) -> pure body0
+    (implicits, _) -> do
+      let baseText = Var.name (Var.reset baseName)
+          mk i = Var.named ("_implicit_" <> baseText <> "_" <> Text.pack (show (i :: Int)))
+          vs = zipWith (\i _ -> mk i) [0 ..] implicits
+      for_ vs recordGivenVar
+      let bodyAnn = ABT.annotation body0
+          wrap v body = Term.lam bodyAnn (bodyAnn, v) body
+      pure (foldr wrap body0 vs)
+
 binding ::
   forall m v.
   (Monad m, Var v) =>
@@ -1164,7 +1199,15 @@ binding = label "binding" do
             customFailure $
               SignatureNeedsAccompanyingBody nameT
           (_eqAnn, _bodySpanAnn, body) <- block "="
-          let bnd = mkBinding lhsLoc args body
+          let bnd0 = mkBinding lhsLoc args body
+          -- If the declared type begins with one or more @=>@ arrows
+          -- (after any leading 'forall' binders), inject leading
+          -- lambdas for the implicit dictionary parameters so the
+          -- elaborator and runtime see them. The fresh binders are
+          -- also recorded as given-bound-vars so the typechecker
+          -- lifts them into the lexical given environment for the
+          -- body. See 'wrapImplicitParams'.
+          bnd <- wrapImplicitParams (L.payload name) typ' bnd0
           -- We don't actually use the span annotation from the block (yet) because it
           -- may contain a bunch of white-space and comments following a top-level-definition.
           let spanAnn = ann nameT <> ann bnd
@@ -1211,7 +1254,12 @@ givenBindingBody kw = label "given" do
   recordGivenVar (L.payload name)
   _ <- reserved ":"
   ty <- TypeParser.valueType
-  (_eqAnn, _bodySpanAnn, body) <- block "="
+  (_eqAnn, _bodySpanAnn, body0) <- block "="
+  -- A @given@ binding may itself declare implicit parameters
+  -- (@given foo : C a => D a = ...@): wrap the body with leading
+  -- lambdas so the implicit dictionaries are available at runtime
+  -- exactly as in 'regularBinding'.
+  body <- wrapImplicitParams (L.payload name) ty body0
   let spanAnn = ann kw <> ann body
   pure ((ann kw <> ann name, L.payload name), Term.ann spanAnn body ty)
 

--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -451,11 +451,12 @@ pretty0
             -- Render that as the @give@ keyword so the source
             -- round-trips back to a parse with the matching
             -- 'Ann.Lowered' annotation.
-            Apps' (Ann' inner t) args | isGiveMarkerType t ->
-              paren (p >= Application) <$> do
-                inner' <- pretty0 (ac (InfixOp Highest) Normal im doc) inner
-                args' <- PP.spacedTraverse (pretty0 (ac Application Normal im doc)) args
-                pure (fmt S.ControlKeyword "give " <> PP.hang inner' args')
+            Apps' (Ann' inner t) args
+              | isGiveMarkerType t ->
+                  paren (p >= Application) <$> do
+                    inner' <- pretty0 (ac (InfixOp Highest) Normal im doc) inner
+                    args' <- PP.spacedTraverse (pretty0 (ac Application Normal im doc)) args
+                    pure (fmt S.ControlKeyword "give " <> PP.hang inner' args')
             _ -> notDoc go
         where
           notDoc go = do

--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -79,6 +79,14 @@ etaReduce :: (Var v) => Term3 v a -> Term3 v a
 etaReduce (LamNamed' v (App' f (Var' v'))) | v == v' && Var.name v == "_eta" = f
 etaReduce tm = tm
 
+-- | True if the type is the 'Type.giveMarkerRef' sentinel injected
+-- by 'GivenApply.stripImplicitArgsByType' to mark an apply-chain
+-- head whose @=>@ slots were user-supplied via @give@.
+isGiveMarkerType :: Type v a -> Bool
+isGiveMarkerType ty = case ABT.out ty of
+  ABT.Tm (Type.Ref r) -> r == Type.giveMarkerRef
+  _ -> False
+
 goPretty :: (Var v) => PrettyPrintEnv -> Term2 v at ap v a -> Pretty SyntaxText
 goPretty ppe tm = runPretty (avoidShadowing tm ppe) $ pretty0 emptyAc $ printAnnotate ppe tm
 
@@ -422,6 +430,12 @@ pretty0
                         fmt S.ControlKeyword " with" `PP.hang` pbs
                       ]
                   else (fmt S.ControlKeyword "match " <> ps <> fmt S.ControlKeyword " with") `PP.hang` pbs
+          -- ADR-007: when 'stripImplicitArgsByType' decides the
+          -- leading @=>@ slot(s) of an application were user-supplied
+          -- (rather than resolver-picked), it tags the head with a
+          -- 'Type.giveMarkerRef' ascription. Render that as the @give@
+          -- keyword so the source round-trips back to a parse with
+          -- the matching 'Ann.Lowered' annotation.
           Apps' f args -> paren (p >= Application) <$> (PP.hang <$> goNormal (InfixOp Highest) f <*> PP.spacedTraverse (goNormal Application) args)
           t -> pure $ l "error: " <> l (show t)
     where
@@ -429,7 +443,20 @@ pretty0
       specialCases term go = do
         prettyDoc2_ a term >>= \case
           Just d -> pure d
-          Nothing -> notDoc go
+          Nothing -> case term of
+            -- ADR-007: when 'stripImplicitArgsByType' decides the
+            -- leading @=>@ slot(s) of an application were
+            -- user-supplied (rather than resolver-picked), it tags
+            -- the head with a 'Type.giveMarkerRef' ascription.
+            -- Render that as the @give@ keyword so the source
+            -- round-trips back to a parse with the matching
+            -- 'Ann.Lowered' annotation.
+            Apps' (Ann' inner t) args | isGiveMarkerType t ->
+              paren (p >= Application) <$> do
+                inner' <- pretty0 (ac (InfixOp Highest) Normal im doc) inner
+                args' <- PP.spacedTraverse (pretty0 (ac Application Normal im doc)) args
+                pure (fmt S.ControlKeyword "give " <> PP.hang inner' args')
+            _ -> notDoc go
         where
           notDoc go = do
             env <- ask

--- a/parser-typechecker/src/Unison/Syntax/TypeParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/TypeParser.hs
@@ -30,8 +30,53 @@ type TypeP v m = P v m (Type v Ann)
 -- Value types cannot have effects, unless those effects appear to
 -- the right of a function arrow:
 --   valueType ::= Int | Text | App valueType valueType | Arrow valueType computationType
+--              | Constraint+ '=>' valueType
 valueType :: (Monad m, Var v) => TypeP v m
-valueType = forAll type1 <|> type1
+valueType = constrainedType <|> forAll (constrainedType <|> type1) <|> type1
+
+-- | Parse the implicit-parameter constraint-arrow form introduced by
+-- ADR-001:
+--
+-- > Show a => a -> Text
+-- > (Monad m, Traversable t) => (a -> m b) -> t a -> m (t b)
+-- > Functor f => (a -> b) -> f a -> f b
+--
+-- Per ADR-019, multi-constraint signatures @(C1 a, C2 b) => T@ desugar
+-- to a right-folded chain of 'ImplicitArrow's:
+-- @ImplicitArrow C1a (ImplicitArrow C2b T)@. This distinguishes the
+-- constraint arrow @=>@ from the explicit function arrow @->@ in the
+-- type AST, and the printer (chunk P1) renders @ImplicitArrow@ chains
+-- back as @=>@ tuples so signatures round-trip.
+constrainedType :: (Monad m, Var v) => TypeP v m
+constrainedType = do
+  cs <- P.try constraintContext
+  body <- forAll (constrainedType <|> type1) <|> type1
+  -- Right-fold: (C1, C2, ..., Cn) => T  ===>
+  --   ImplicitArrow C1 (ImplicitArrow C2 (... (ImplicitArrow Cn T))).
+  -- Each step preserves the source range of the constraint by combining
+  -- annotations.
+  pure $ foldr (\c t -> Type.implicitArrow (ann c <> ann t) c t) body cs
+
+-- | Parses one of:
+--
+-- > C        -- a single constraint, e.g. @Show a@
+-- > (C1, ..., Cn)  -- a parenthesised list of constraints, n >= 1
+--
+-- followed by the @=>@ arrow. Wrapped in 'P.try' at the call site so
+-- non-constrained types fall back to the regular grammar without
+-- consuming input.
+constraintContext :: (Monad m, Var v) => P v m [Type v Ann]
+constraintContext = do
+  cs <- parenthesisedConstraints <|> ((: []) <$> type2)
+  _ <- reserved "=>"
+  pure cs
+  where
+    parenthesisedConstraints = do
+      _ <- openBlockWith "("
+      -- A constraint context cannot be empty; @() => T@ is rejected.
+      cs <- sepBy1 (reserved ",") type2
+      _ <- closeBlock
+      pure cs
 
 -- Computation
 -- computationType ::= [{effect*}] valueType

--- a/parser-typechecker/src/Unison/Syntax/TypePrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TypePrinter.hs
@@ -124,6 +124,27 @@ prettyRaw im p tp = go im p tp
             if p < 0 && not Settings.debugRevealForalls && all Var.universallyQuantifyIfFree vs
               then ifM (willCaptureType vs) (prettyForall p) (go im p body)
               else paren (p >= 0) <$> prettyForall (-1)
+      -- ADR-019 / chunk P1: a leading chain of 'ImplicitArrow's prints
+      -- as a @=>@ constraint context. Walk the spine to collect /all/
+      -- leading constraints, then emit them as a single @=>@ tuple
+      -- followed by the conclusion. A single constraint prints bare
+      -- (e.g. @Show a => a -> Text@); two or more print as a parenthesised
+      -- comma list (e.g. @(Show a, Eq a) => [a] -> [a]@).
+      --
+      -- The conclusion is printed at precedence -1 so an inner @->@ chain
+      -- is /not/ parenthesised; the @=>@ constraint context binds looser
+      -- than @->@. The whole expression is parenthesised when the
+      -- ambient precedence is @>= 0@, mirroring the @Arrow'@ branch.
+      t@(ImplicitArrow' _ _) ->
+        let (cs, conclusion) = splitImplicitConstraints t
+            renderConstraints = case cs of
+              [c] -> go im 0 c
+              _ -> PP.parenthesizeCommas <$> traverse (go im 0) cs
+         in PP.parenthesizeIf (p >= 0)
+              <$> ( (\lhs rhs -> lhs <> " " <> fmt S.TypeOperator "=>" <> " " <> rhs)
+                      <$> renderConstraints
+                      <*> go im (-1) conclusion
+                  )
       t@(Arrow' _ _) -> case t of
         EffectfulArrows' (Ref' DD.UnitRef) rest ->
           PP.parenthesizeIf (p >= 10) <$> arrows True True rest
@@ -180,6 +201,21 @@ prettyRaw im p tp = go im p tp
 
     parenNoGroup True s = fmt S.Parenthesis "(" <> s <> fmt S.Parenthesis ")"
     parenNoGroup False s = s
+
+-- | Walk the leading chain of 'ImplicitArrow' premises, returning the list
+-- of constraint types and the (non-implicit-arrow) conclusion. A type with
+-- no implicit arrows at the head returns @([], t)@ unchanged.
+--
+-- ADR-019: @(C1 a, C2 b) => T@ is encoded as
+-- @ImplicitArrow C1a (ImplicitArrow C2b T)@. This function unfolds that
+-- chain so the printer can emit it as a single @=>@ context, matching
+-- the surface syntax in @docs/implicits-plan.md@ §1.2.
+splitImplicitConstraints :: Type v a -> ([Type v a], Type v a)
+splitImplicitConstraints t = case t of
+  ImplicitArrow' c rest ->
+    let (cs, conclusion) = splitImplicitConstraints rest
+     in (c : cs, conclusion)
+  _ -> ([], t)
 
 fmt :: S.Element r -> Pretty (S.SyntaxText' r) -> Pretty (S.SyntaxText' r)
 fmt = PP.withSyntax

--- a/parser-typechecker/src/Unison/Typechecker.hs
+++ b/parser-typechecker/src/Unison/Typechecker.hs
@@ -36,6 +36,7 @@ import Unison.Blank qualified as B
 import Unison.Builtin.Decls qualified as BuiltinDecls
 import Unison.Codebase.BuiltinAnnotation (BuiltinAnnotation)
 import Unison.Name qualified as Name
+import Unison.Parser.Ann qualified as Ann
 import Unison.Prelude
 import Unison.PrettyPrintEnv (PrettyPrintEnv)
 import Unison.Reference (Reference)
@@ -128,7 +129,7 @@ data Env v loc = Env
 -- a function to resolve the type of @Ref@ constructors
 -- contained in that term.
 synthesize ::
-  (Monad f, Var v, BuiltinAnnotation loc, Ord loc, Show loc, Semigroup loc) =>
+  (Monad f, Var v, BuiltinAnnotation loc, Ord loc, Show loc, Semigroup loc, Ann.IsLoweredAnn loc) =>
   PrettyPrintEnv ->
   Context.PatternMatchCoverageCheckAndKindInferenceSwitch ->
   Env v loc ->
@@ -238,6 +239,7 @@ synthesizeAndResolve ::
   (BuiltinAnnotation loc) =>
   (Ord loc) =>
   (Show loc) =>
+  (Ann.IsLoweredAnn loc) =>
   PrettyPrintEnv ->
   Env v loc ->
   TDNR f v loc (Type v loc)
@@ -288,7 +290,7 @@ liftResult = lift . MaybeT . WriterT . pure . runIdentity . runResultT
 -- 3. No match at all. Throw an unresolved symbol at the user.
 typeDirectedNameResolution ::
   forall v loc f.
-  (Monad f, Var v, BuiltinAnnotation loc, Ord loc, Monoid loc, Show loc) =>
+  (Monad f, Var v, BuiltinAnnotation loc, Ord loc, Monoid loc, Show loc, Ann.IsLoweredAnn loc) =>
   PrettyPrintEnv ->
   Notes v loc ->
   Type v loc ->
@@ -465,7 +467,7 @@ typeDirectedNameResolution ppe oldNotes oldType env = do
 -- contained in the term. Returns @typ@ if successful,
 -- and a note about typechecking failure otherwise.
 check ::
-  (Monad f, Var v, BuiltinAnnotation loc, Ord loc, Show loc, Semigroup loc) =>
+  (Monad f, Var v, BuiltinAnnotation loc, Ord loc, Show loc, Semigroup loc, Ann.IsLoweredAnn loc) =>
   PrettyPrintEnv ->
   Env v loc ->
   Term v loc ->
@@ -495,6 +497,7 @@ wellTyped ::
   (Ord loc) =>
   (Show loc) =>
   (Semigroup loc) =>
+  (Ann.IsLoweredAnn loc) =>
   PrettyPrintEnv ->
   Env v loc ->
   Term v loc ->

--- a/parser-typechecker/src/Unison/Typechecker.hs
+++ b/parser-typechecker/src/Unison/Typechecker.hs
@@ -47,6 +47,7 @@ import Unison.Term qualified as Term
 import Unison.Type (Type)
 import Unison.Type qualified as Type
 import Unison.Typechecker.Context qualified as Context
+import Unison.Typechecker.GivenResolver qualified as GR
 import Unison.Typechecker.TypeLookup qualified as TL
 import Unison.Typechecker.TypeVar qualified as TypeVar
 import Unison.Typechecker.Variance (Variance (..))
@@ -103,7 +104,23 @@ data Env v loc = Env
     -- For each free name, a separate mapping with the same type as termsByShortname is provided.
     freeNameToFuzzyTermsByShortName :: Map Name.Name (Map Name.Name [Either Name.Name (NamedReference v loc)]),
     topLevelComponents :: Map Name.Name (NamedReference v loc),
-    variances :: Map Reference [Variance]
+    variances :: Map Reference [Variance],
+    -- | Phase-2 chunk L1: the ambient pool of namespace-level givens
+    -- (terms tagged via 'Unison.Codebase.Givens.givenSentinel' that the
+    -- typechecker can use to satisfy 'ImplicitArrow' constraints in
+    -- the file under elaboration). Populated by 'computeTypecheckingEnvironment'
+    -- from the namespace; defaults to an empty pool when typechecking
+    -- contexts that don't have a namespace (e.g. some test setups).
+    ambientGivens :: GR.Pool v loc,
+    -- | ADR-010 / chunk L2 fixup: variable names bound via the @given@
+    -- keyword in the file under elaboration. Populated by the parser's
+    -- side channel (see 'Unison.Syntax.Parser') and surfaced via
+    -- 'UF.UnisonFile.givenBindings'. Replaces the previous shape-based
+    -- predicate ('Type.unImplicitArrows' . declared type) which
+    -- silently dropped premise-free givens like
+    -- @given local : Ord a = …@. The set covers both file-level and
+    -- block-scoped @let given@ bindings.
+    givenBindings :: Set v
   }
   deriving stock (Generic)
 
@@ -125,6 +142,16 @@ synthesize ppe pmccSwitch env t =
             pmccSwitch
             env.variances
             (TypeVar.liftType <$> env.ambientAbilities)
+            -- ADR-010 / chunk C2.1: lexical given environment is empty
+            -- at the top of the typechecker pipeline. Chunk C2.3 will
+            -- thread top-level @given@ decls into 'Env' so this picks
+            -- them up.
+            Map.empty
+            -- ADR-010 / chunk L2 fixup: thread the parser-collected
+            -- @given@-keyword names into the typechecker so the
+            -- letrec/let predicates can recognise @given@ origins by
+            -- name rather than by type shape.
+            env.givenBindings
             env.typeLookup
             (TypeVar.liftTerm t)
    in Result.hoist (pure . runIdentity) $ fmap TypeVar.lowerType result

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -811,6 +811,36 @@ withLexicalGivens act = do
   modEnv (\e -> e {lexicalGivens = saved})
   pure a
 
+-- | Peel leading @=>@ arrows (and any intervening 'Forall' binders)
+-- off a synthesised type, emitting a 'ConstraintGoal' info note for
+-- each. The returned type is the conclusion after every implicit
+-- has been stripped, so subsequent typechecking sees the function
+-- as if its implicit arguments had been applied already. The
+-- corresponding dictionary insertions are performed by
+-- 'Unison.Typechecker.GivenApply' as a post-pass: it visits each
+-- 'Var'\'@/@'Ref'\'' leaf in the elaborated term, looks up its
+-- /original/ type, and wraps the leaf with @App leaf <dict>@ for
+-- each @=>@ found there.
+--
+-- 'goalLoc_' is the source location reported on each
+-- 'ConstraintGoal'; pass the location of the reference itself.
+peelLeadingImplicits ::
+  (Var v, Ord loc) =>
+  loc ->
+  Type v loc ->
+  M v loc (Type v loc)
+peelLeadingImplicits goalLoc_ = go
+  where
+    go ty = case ty of
+      Type.ImplicitArrow' i conc -> do
+        ctx <- getContext
+        scope_ <- getLexicalGivens
+        let goalTy = apply ctx i
+            goalScope = apply ctx <$> scope_
+        btw $ ConstraintGoal goalLoc_ goalTy goalScope
+        go conc
+      _ -> pure ty
+
 -- | ADR-010 / chunk L2 fixup: ask whether a variable name was bound via
 -- the @given@ keyword. The lookup compares against 'Var.reset' of @v@
 -- because the parser-side set holds the un-freshened names while the
@@ -1506,10 +1536,22 @@ synthesizeWanted trm@(Term.Var' v) = do
         -- early.
         (vs, t) <- ungeneralize' t
         vars <- getVariances
-        pure (discardCovariant vars (Set.fromList vs) t, [])
+        -- ADR-001 / chunk D-eager: when a variable's declared type
+        -- begins with one or more @=>@ arrows, peel each one off
+        -- eagerly here and emit a 'ConstraintGoal' info note for the
+        -- elaborator. This handles the case where the user references
+        -- a function with implicit parameters in a /non-application/
+        -- context — e.g. @Monoid.zero@ used directly as a value. The
+        -- D3 'GivenApply' rewrite walks each 'Term.Var\'' leaf and
+        -- wraps it with the resolved dictionary, so the runtime sees
+        -- the dictionaries applied positionally. When the var IS in
+        -- an application context, the implicit-arrows have already
+        -- been stripped here, so 'synthesizeApp' doesn't double-emit.
+        t' <- peelLeadingImplicits (ABT.annotation trm) t
+        pure (discardCovariant vars (Set.fromList vs) t', [])
 synthesizeWanted (Term.Ref' h) =
   compilerCrash $ UnannotatedReference h
-synthesizeWanted (Term.Ann' (Term.Ref' _) t)
+synthesizeWanted trm@(Term.Ann' (Term.Ref' _) t)
   -- innermost Ref annotation assumed to be correctly provided by
   -- `synthesizeClosed`
   --
@@ -1518,6 +1560,10 @@ synthesizeWanted (Term.Ann' (Term.Ref' _) t)
       t <- existentializeArrows t
       -- See note about ungeneralizing above in the Var case.
       t <- ungeneralize t
+      -- Mirror the 'Var\'' branch: peel leading @=>@ arrows eagerly
+      -- so that a top-level reference used outside an application
+      -- gets its implicit dictionaries inserted by 'GivenApply'.
+      t <- peelLeadingImplicits (ABT.annotation trm) t
       (,[]) <$> discard t
   | otherwise = compilerCrash $ FreeVarsInTypeAnnotation s
   where
@@ -3104,6 +3150,31 @@ checkWanted exact want m (Type.Forall' body) = do
     x <- extendUniversal v
     checkWanted exact want m $
       ABT.bindInheritAnnotation body (universal' () x)
+-- ADR-019 / chunk C2.2 +I: =>I on the check side. When the term is
+-- a lambda whose binder corresponds to the leading 'ImplicitArrow'
+-- (i.e. the parser injected a leading lambda for an implicit
+-- dictionary; see 'Unison.Syntax.TermParser.wrapImplicitParams'), we
+-- treat this as the introduction rule for implicit parameters: bind
+-- the lambda's variable to the constraint type and register it as a
+-- local lexical given before recursing on the body against the
+-- conclusion. This makes the implicit dictionary visible to any
+-- constraint goal raised inside the body so polymorphic constraints
+-- like @Monoid m@ can be discharged against the function's own
+-- @=>@ parameter rather than relying on an ambient given that does
+-- not exist for arbitrary @m@.
+checkWanted exact want (Term.Lam' boundVarAnn body) (Type.ImplicitArrow' i conc) = do
+  x <- ABT.freshen body freshenVar
+  markThenRetract0 x . withLexicalGivens $ do
+    extendContext (Ann x boundVarAnn i)
+    -- The synthetic reference shape matches
+    -- 'extendLexicalGivenFromBinding' so that the elaborator's
+    -- 'GivenApply.buildDictionary' strips the @Local.given.@ prefix
+    -- and emits a 'Term.var' pointing at this lambda's binder.
+    let ref = Reference.Builtin ("Local.given." <> Var.name (Var.reset x))
+    extendLexicalGiven ref i
+    body <- pure $ ABT.bindInheritAnnotation body (Term.var () x)
+    checkWanted exact want body conc
+  pure want
 -- ADR-019 / chunk C2.2: =>App on the check side. Checking a term
 -- against an 'ImplicitArrow' type doesn't ask the user to write the
 -- implicit argument; the elaborator (chunk D1+) fills it. We emit a

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -99,6 +99,7 @@ import Unison.Pattern qualified as Pattern
 import Unison.PatternMatchCoverage (checkMatch)
 import Unison.PatternMatchCoverage.Class (EnumeratedConstructors (..), Pmc, traverseConstructorTypes)
 import Unison.PatternMatchCoverage.Class qualified as Pmc
+import Unison.Parser.Ann qualified as Ann
 import Unison.PatternMatchCoverage.ListPat qualified as ListPat
 import Unison.Prelude
 import Unison.PrettyPrintEnv (PrettyPrintEnv)
@@ -841,6 +842,19 @@ peelLeadingImplicits goalLoc_ = go
         go conc
       _ -> pure ty
 
+-- | ADR-007: demote /every/ leading 'ImplicitArrow' to a regular
+-- 'Arrow'. Used to elaborate the @give@ keyword: writing @give f@
+-- converts all leading @=>@ slots in f's type into plain explicit
+-- parameters, so the user can supply each dictionary positionally
+-- at the call site instead of leaving them to the resolver. Stops
+-- at the first non-@=>@ constructor. For finer-grained overrides,
+-- the user uses @let given@ shadowing instead.
+lowerLeadingImplicit :: (Ord v) => Type v loc -> Type v loc
+lowerLeadingImplicit ty = case ty of
+  Type.ImplicitArrow' i o ->
+    Type.arrow (ABT.annotation ty) i (lowerLeadingImplicit o)
+  _ -> ty
+
 -- | ADR-010 / chunk L2 fixup: ask whether a variable name was bound via
 -- the @given@ keyword. The lookup compares against 'Var.reset' of @v@
 -- because the parser-side set holds the un-freshened names while the
@@ -1217,7 +1231,7 @@ withEffects handled act = do
   pruneWanted [] want handled
 
 synthesizeApps ::
-  (Foldable f, Var v, Ord loc, Semigroup loc) =>
+  (Foldable f, Var v, Ord loc, Semigroup loc, Ann.IsLoweredAnn loc) =>
   Term v loc ->
   Type v loc ->
   f (Term v loc) ->
@@ -1235,7 +1249,7 @@ synthesizeApps fun ft args =
 -- the process.
 -- e.g. in `(f:t) x` -- finds the type of (f x) given t and x.
 synthesizeApp ::
-  (Var v, Ord loc, Semigroup loc) =>
+  (Var v, Ord loc, Semigroup loc, Ann.IsLoweredAnn loc) =>
   Term v loc ->
   Type v loc ->
   (Term v loc, Int) ->
@@ -1331,14 +1345,19 @@ generalizeExistentials' t =
     isExistential _ = False
 
 noteTopLevelType ::
-  (Ord loc, Var v, Semigroup loc) =>
+  (Ord loc, Var v, Semigroup loc, Ann.IsLoweredAnn loc) =>
   ABT.Subst f v a ->
   Term v loc ->
   Type v loc ->
   M v loc ()
 noteTopLevelType e binding typ = case binding of
   Term.Ann' strippedBinding _ -> do
-    inferred <- (Just <$> synthesizeTop strippedBinding) `orElse` pure Nothing
+    -- Redundancy-detection synthesis: discard info notes so that
+    -- 'ConstraintGoal' notes from this annotation-less pass don't
+    -- reach the resolver. Without the user's annotation '=>I' never
+    -- fires, so any goal raised here carries an incomplete
+    -- lexical-given snapshot and would spuriously fail to resolve.
+    inferred <- (Just <$> discardInfoNotes (synthesizeTop strippedBinding)) `orElse` pure Nothing
     case inferred of
       Nothing -> do
         btw $
@@ -1428,10 +1447,17 @@ noteGivenDeclLet e binding _inferredType = do
 -- discipline matters.
 extendLexicalGivenFromBinding ::
   (Var v, Ord loc) =>
+  -- | Whether this binding is at file top level. Top-level givens are
+  -- already promoted to the resolver's ambient pool by 'FileParsers',
+  -- so registering them here as lexical too would tie with truly-local
+  -- givens (e.g. an inner @=>I@-injected @_implicit_*@) on the
+  -- 'Lexical 0' scope tag and surface a spurious "ambiguous" diagnostic.
+  -- Only register lexically when the binding is genuinely nested.
+  Bool ->
   ABT.Subst f v loc ->
   Term v loc ->
   M v loc Bool
-extendLexicalGivenFromBinding e binding = do
+extendLexicalGivenFromBinding isTop e binding = do
   -- ADR-010 / chunk L2 fixup: register a lexical given iff the parser
   -- tagged this variable as originating from the @given@ keyword. The
   -- previous predicate (begins with @=>@ after stripping foralls)
@@ -1439,7 +1465,7 @@ extendLexicalGivenFromBinding e binding = do
   -- @given local : Ord a = …@, which is the canonical ADR-010 example.
   isGiven <- isGivenBoundVar (ABT.variable e)
   case binding of
-    Term.Ann' _stripped declared | isGiven -> do
+    Term.Ann' _stripped declared | isGiven && not isTop -> do
       let v = Var.reset (ABT.variable e)
           ref = Reference.Builtin ("Local.given." <> Var.name v)
       extendLexicalGiven ref declared
@@ -1457,7 +1483,7 @@ noteVarMention v loc = do
   btw $ VarMention v loc
 
 synthesizeTop ::
-  (Var v, Semigroup loc) =>
+  (Var v, Semigroup loc, Ann.IsLoweredAnn loc) =>
   (Ord loc) =>
   Term v loc ->
   M v loc (Type v loc)
@@ -1476,7 +1502,7 @@ synthesizeTop tm = do
 -- the process.  Also collect wanted abilities.
 -- | Figure 11 from the paper
 synthesize ::
-  (Var v, Semigroup loc) =>
+  (Var v, Semigroup loc, Ann.IsLoweredAnn loc) =>
   (Ord loc) =>
   Term v loc ->
   M v loc (Type v loc, Wanted v loc)
@@ -1509,8 +1535,9 @@ wantRequest loc ty =
 -- The return value is the synthesized type together with a list of
 -- wanted abilities.
 synthesizeWanted ::
-  (Var v, Semigroup loc) =>
+  (Var v, Semigroup loc, Ann.IsLoweredAnn loc) =>
   (Ord loc) =>
+  (Ann.IsLoweredAnn loc) =>
   Term v loc ->
   M v loc (Type v loc, Wanted v loc)
 synthesizeWanted trm@(Term.Var' v) = do
@@ -1547,7 +1574,17 @@ synthesizeWanted trm@(Term.Var' v) = do
         -- the dictionaries applied positionally. When the var IS in
         -- an application context, the implicit-arrows have already
         -- been stripped here, so 'synthesizeApp' doesn't double-emit.
-        t' <- peelLeadingImplicits (ABT.annotation trm) t
+        --
+        -- ADR-007: if the reference is the operand of @give@ (parser
+        -- wraps its annotation with 'Ann.Lowered'), we /skip/
+        -- 'peelLeadingImplicits' and instead demote leading @=>@
+        -- arrows to @->@ in the type. The resulting type behaves
+        -- like a regular function and the dictionary becomes an
+        -- ordinary positional argument supplied at the call site.
+        t' <-
+          if Ann.isLoweredAnn (ABT.annotation trm)
+            then pure (lowerLeadingImplicit t)
+            else peelLeadingImplicits (ABT.annotation trm) t
         pure (discardCovariant vars (Set.fromList vs) t', [])
 synthesizeWanted (Term.Ref' h) =
   compilerCrash $ UnannotatedReference h
@@ -1563,7 +1600,12 @@ synthesizeWanted trm@(Term.Ann' (Term.Ref' _) t)
       -- Mirror the 'Var\'' branch: peel leading @=>@ arrows eagerly
       -- so that a top-level reference used outside an application
       -- gets its implicit dictionaries inserted by 'GivenApply'.
-      t <- peelLeadingImplicits (ABT.annotation trm) t
+      -- ADR-007: if the surface reference was wrapped with @give@,
+      -- demote leading @=>@ to @->@ instead of peeling them.
+      t <-
+        if Ann.isLoweredAnn (ABT.annotation trm)
+          then pure (lowerLeadingImplicit t)
+          else peelLeadingImplicits (ABT.annotation trm) t
       (,[]) <$> discard t
   | otherwise = compilerCrash $ FreeVarsInTypeAnnotation s
   where
@@ -1596,7 +1638,7 @@ synthesizeWanted (Term.Let1Top' top binding boundVarAnn e) = do
   -- guaranteeing lexical-only visibility per ADR-010.
   (t, w) <-
     withLexicalGivens $ do
-      _ <- extendLexicalGivenFromBinding e binding
+      _ <- extendLexicalGivenFromBinding top e binding
       synthesize (ABT.bindInheritAnnotation e (Term.var () v'))
   t <- applyM t
   when top $ noteTopLevelType e binding tbinding
@@ -1820,7 +1862,7 @@ synthesizeWanted _e = compilerCrash PatternMatchFailure
 -- can be refined later. This is a bit unusual for the algorithm we
 -- use, but it seems like it should be safe.
 synthesizeBinding ::
-  (Var v, Semigroup loc) =>
+  (Var v, Semigroup loc, Ann.IsLoweredAnn loc) =>
   (Ord loc) =>
   Bool ->
   Term v loc ->
@@ -1969,7 +2011,7 @@ ensurePatternCoverage theMatch _theMatchType _scrutinee scrutineeType cases = do
   checkUncovered *> checkRedundant
 
 checkCases ::
-  (Var v, Semigroup loc) =>
+  (Var v, Semigroup loc, Ann.IsLoweredAnn loc) =>
   (Ord loc) =>
   Type v loc ->
   Type v loc ->
@@ -2033,7 +2075,7 @@ requestType ps =
 
 checkCase ::
   forall v loc.
-  (Var v, Ord loc, Semigroup loc) =>
+  (Var v, Ord loc, Semigroup loc, Ann.IsLoweredAnn loc) =>
   Type v loc ->
   Type v loc ->
   Term.MatchCase loc (Term v loc) ->
@@ -2258,6 +2300,25 @@ resetContextAfter x a = do
   setContext ctx
   pure a
 
+-- | Run an action and discard any info notes it emits. Used to
+-- suppress notes from speculative typechecking passes that aren't
+-- part of the official typecheck (e.g. the annotation-free second
+-- pass in 'annotateLetRecBindings' used purely for redundancy
+-- detection). Without this, that pass's 'ConstraintGoal' notes
+-- carry incomplete lexical-given snapshots — '=>I' never fires when
+-- the user's annotation is ignored, so any constraint goal raised
+-- inside such a body lacks the implicit-dictionary binder that the
+-- annotated pass registered, and the resolver fails on bogus
+-- "missing given" diagnostics that have no surface cause.
+discardInfoNotes :: M v loc a -> M v loc a
+discardInfoNotes (MT m) =
+  MT $ \ppe pmc vars datas effects defs env ->
+    clear (m ppe pmc vars datas effects defs env)
+  where
+    clear (Success _ a) = Success mempty a
+    clear (TypeError e _) = TypeError e mempty
+    clear (CompilerBug c e _) = CompilerBug c e mempty
+
 type LetRecInfo v loc =
   (v -> M v loc v) -> M v loc ([((loc, v), Term v loc)], Term v loc)
 
@@ -2266,7 +2327,7 @@ type LetRecInfo v loc =
 -- their type. Also returns the freshened version of `body`.
 -- See usage in `synthesize` and `check` for `LetRec'` case.
 annotateLetRecBindings ::
-  (Var v, Ord loc, Semigroup loc) =>
+  (Var v, Ord loc, Semigroup loc, Ann.IsLoweredAnn loc) =>
   Term.IsTop -> LetRecInfo v loc -> M v loc (Term v loc)
 annotateLetRecBindings isTop letrec =
   -- If this is a top-level letrec, then emit a TopLevelComponent note,
@@ -2275,13 +2336,22 @@ annotateLetRecBindings isTop letrec =
     then do
       -- First, typecheck (using annotateLetRecBindings') the bindings with any
       -- user-provided annotations.
-      (body, vts) <- annotateLetRecBindings' letrec True
+      (body, vts) <- annotateLetRecBindings' isTop letrec True
       -- Then, try typechecking again, but ignoring any user-provided annotations.
       -- This will infer whatever type.  If it altogether fails to typecheck here
       -- then, ...(1)
+      --
+      -- 'discardInfoNotes' is required: without the user's annotation
+      -- '=>I' (the introduction rule for ImplicitArrow) never fires on
+      -- a binding like @given f : C => T = body@, so any
+      -- 'ConstraintGoal' raised inside @body@ during this pass would
+      -- be emitted with an incomplete lexical-given snapshot and
+      -- silently poison the resolver. The pass exists solely to
+      -- detect whether the user's annotations were redundant; its
+      -- side-effect notes are not part of the official typecheck.
       withoutAnnotations <-
-        resetContextAfter Nothing $
-          Just <$> annotateLetRecBindings' letrec False
+        resetContextAfter Nothing . discardInfoNotes $
+          Just <$> annotateLetRecBindings' isTop letrec False
       -- convert from typechecker TypeVar back to regular `v` vars
       let unTypeVar (v, t) = (v, generalizeAndUnTypeVar t)
       case withoutAnnotations of
@@ -2295,7 +2365,7 @@ annotateLetRecBindings isTop letrec =
       pure body
     else do
       -- If this isn't a top-level letrec, then we don't have to do anything special
-      (body, _vts) <- annotateLetRecBindings' letrec True
+      (body, _vts) <- annotateLetRecBindings' isTop letrec True
       pure body
 
 -- A wrapper type for demuxed binding information in a let. Only used
@@ -2354,11 +2424,15 @@ namedBindings bs = bndVars bs `zip` bnds bs
 -- can be immediately completed to `a ->{} b ->{} c ->{E} d` instead
 -- of making up variables for the two positions that must be pure.
 annotateLetRecBindings' ::
-  (Var v, Ord loc, Semigroup loc) =>
+  (Var v, Ord loc, Semigroup loc, Ann.IsLoweredAnn loc) =>
+  -- | Whether the enclosing letrec is at file top level. See the
+  -- comment on 'extendLexicalGivenFromBinding' for why top-level
+  -- givens must not be added to the lexical pool.
+  Bool ->
   LetRecInfo v loc ->
   Bool ->
   M v loc (Term v loc, [(v, Type v loc)])
-annotateLetRecBindings' letrec useAnn = do
+annotateLetRecBindings' isTop letrec useAnn = do
   (binds, body) <- letrec freshenVar
 
   ((allbnds, abnds, ubnds), ctx) <-
@@ -2449,7 +2523,7 @@ annotateLetRecBindings' letrec useAnn = do
   -- ADR-010 example.
   Foldable.for_ vTypes \(v, t) -> do
     isGiven <- isGivenBoundVar v
-    when isGiven $ do
+    when (isGiven && not isTop) $ do
       let ref = Reference.Builtin ("Local.given." <> Var.name (Var.reset v))
       extendLexicalGiven ref t
 
@@ -2780,7 +2854,7 @@ variableP _ = Nothing
 -- See its usage in `synthesize` and `annotateLetRecBindings`.
 checkScoped ::
   forall v loc.
-  (Var v, Ord loc, Semigroup loc) =>
+  (Var v, Ord loc, Semigroup loc, Ann.IsLoweredAnn loc) =>
   Term v loc ->
   Type v loc ->
   M v loc (Type v loc, Wanted v loc)
@@ -2797,7 +2871,7 @@ checkScoped e t = do
   (t,) <$> check e t
 
 checkScopedWith ::
-  (Var v, Semigroup loc) =>
+  (Var v, Semigroup loc, Ann.IsLoweredAnn loc) =>
   (Ord loc) =>
   Term v loc ->
   Type v loc ->
@@ -3103,7 +3177,7 @@ relax' vars nonArrow fv = rebuild True
 -- The boolean argument is for exact ability match cases explained in
 -- the documentation for `checkWanted`.
 checkWantedScoped ::
-  (Var v, Semigroup loc) =>
+  (Var v, Semigroup loc, Ann.IsLoweredAnn loc) =>
   (Ord loc) =>
   Bool ->
   Wanted v loc ->
@@ -3136,7 +3210,7 @@ checkWantedScoped exact want m ty =
 -- If the Maybe is a Just, the suspicious condition emits a warning,
 -- with the given term as the problem location.
 checkWanted ::
-  (Var v, Semigroup loc) =>
+  (Var v, Semigroup loc, Ann.IsLoweredAnn loc) =>
   (Ord loc) =>
   Maybe (Term v loc) ->
   Wanted v loc ->
@@ -3227,7 +3301,7 @@ checkWanted exact want (Term.Let1Top' top binding boundVarAnn m) t = do
   -- 'extendLexicalGivenFromBinding'), registers it before checking the
   -- body. Mirrors the symmetric synthesis path.
   markThenRetractWanted v . withLexicalGivens $ do
-    _ <- extendLexicalGivenFromBinding m binding
+    _ <- extendLexicalGivenFromBinding top m binding
     when (Var.isAction (ABT.variable m)) . scope InActionRestriction $
       -- enforce that actions in a block have type ()
       subtype tbinding (DDB.unitType (ABT.annotation binding))
@@ -3293,7 +3367,7 @@ checkWanted _ want e t = do
 -- The result specifies whether the wanted abilities are a proper
 -- subset of the specified available abilities.
 checkWithAbilities ::
-  (Var v, Semigroup loc) =>
+  (Var v, Semigroup loc, Ann.IsLoweredAnn loc) =>
   (Ord loc) =>
   Maybe (Term v loc) ->
   [Type v loc] ->
@@ -3326,7 +3400,7 @@ exactAbilitiesWarning _ _ _ _ = pure ()
 --     `m` has type `t`
 -- updating the context in the process.
 check ::
-  (Var v, Semigroup loc) =>
+  (Var v, Semigroup loc, Ann.IsLoweredAnn loc) =>
   (Ord loc) =>
   Term v loc ->
   Type v loc ->
@@ -4084,7 +4158,7 @@ verifyDataDeclarations decls = forM_ (Map.toList decls) $ \(_ref, decl) -> do
 -- binding form ('Lam', 'Let1', 'LetRec', match arm) saves and
 -- restores it via 'withLexicalGivens'.
 synthesizeClosed ::
-  (BuiltinAnnotation loc, Var v, Ord loc, Show loc, Semigroup loc) =>
+  (BuiltinAnnotation loc, Var v, Ord loc, Show loc, Semigroup loc, Ann.IsLoweredAnn loc) =>
   PrettyPrintEnv ->
   PatternMatchCoverageCheckAndKindInferenceSwitch ->
   Map Reference [Variance] ->
@@ -4194,7 +4268,7 @@ run ppe pmcSwitch vars datas effects m =
     $ Env 1 context0 Map.empty Set.empty
 
 synthesizeClosed' ::
-  (Var v, Ord loc, Semigroup loc) =>
+  (Var v, Ord loc, Semigroup loc, Ann.IsLoweredAnn loc) =>
   [Type v loc] ->
   Term v loc ->
   M v loc (Type v loc)

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -40,6 +40,12 @@ module Unison.Typechecker.Context
     Unknown (..),
     relax,
     generalizeAndUnTypeVar,
+    -- ADR-010 / chunk C2.1: lexical given environment plumbing.
+    -- Exported so chunks C2.2 / C2.3 can populate the env without
+    -- needing to add new helpers.
+    getLexicalGivens,
+    extendLexicalGiven,
+    withLexicalGivens,
   )
 where
 
@@ -110,6 +116,7 @@ import Unison.Typechecker.Context.Structure hiding
     partition,
   )
 import Unison.Typechecker.Context.Structure qualified as Ctx
+import Unison.Typechecker.GivenResolver qualified as GR
 import Unison.Typechecker.TypeLookup qualified as TL
 import Unison.Typechecker.TypeVar qualified as TypeVar
 import Unison.Typechecker.Variance (Variance (..), defaultVariances)
@@ -146,8 +153,36 @@ existentialp a = existential' a B.Blank
 universal' :: (Ord v) => a -> v -> Type.Type (TypeVar v loc) a
 universal' a v = ABT.annotatedVar a (TypeVar.Universal v)
 
--- The typechecking state
-data Env v loc = Env {freshId :: Word64, ctx :: Context v loc}
+-- | The typechecking state.
+--
+-- ADR-010 / chunk C2.1: 'lexicalGivens' threads the in-scope givens
+-- (top-level @given@ declarations and, eventually, local @let given@
+-- bindings — see ADR-010) through every binding form. The keys are
+-- term references identifying the given's binding; the values are the
+-- given's full type. The map is consulted by the resolver in chunks
+-- D1+; chunk C2.1 only ensures the field exists and is correctly
+-- saved/restored across lexical scopes.
+data Env v loc = Env
+  { freshId :: Word64,
+    ctx :: Context v loc,
+    -- | In-scope given references with their declared types. See
+    -- ADR-010 (\"Local givens\") and 'docs\/implicits-plan.md' §5.4
+    -- (\"Lexical given environment\"). Populated by 'synthesizeClosed'
+    -- from the caller's top-level given set; extended by every
+    -- binding form via 'withLexicalGivens'. No semantics yet — the
+    -- resolver in chunks D1+ consumes this.
+    lexicalGivens :: Map Reference (Type v loc),
+    -- | ADR-010 / chunk L2 fixup: variable names that the parser
+    -- recorded as originating from the @given@ keyword. Consulted by
+    -- 'extendLexicalGivenFromBinding', 'noteGivenDeclLet', and the
+    -- letrec hook in 'annotateLetRecBindings'' to identify @given@
+    -- bindings without inspecting type shape, so premise-free
+    -- declarations like @given local : Ord a = …@ are recognised
+    -- correctly. Seeded by 'synthesizeClosed' from the caller (which in
+    -- turn is fed by the parser's side channel via
+    -- 'UF.UnisonFile.givenBindings').
+    givenBindings :: Set v
+  }
 
 type DataDeclarations v loc = Map Reference (DataDeclaration v loc)
 
@@ -398,6 +433,102 @@ data InfoNote v loc
     VarBinding v loc (Type v loc)
   | -- | The usage of a particular variable. We report the variable and its location so we can match a given source location with a specific symbol later in the LSP.
     VarMention v loc
+  | -- | ADR-019 / chunk C2.2: a constraint goal emitted at an
+    -- 'ImplicitArrow' apply-site. The elaborator (chunk D1+) consumes
+    -- these notes, runs given-resolution per the algorithm in
+    -- 'docs/implicits-plan.md' §1.3, and substitutes the chosen
+    -- dictionary term back into the AST. Mirrors the
+    -- 'SolvedBlank'/'Decision'/'applyTdnrDecisions' pattern that TDNR
+    -- already uses (see 'parser-typechecker/src/Unison/FileParsers.hs:329').
+    --
+    -- 'goalLoc' is the source location of the apply-site (the function
+    -- whose type begins with @=>@).
+    -- 'goalType' is the constraint type to resolve — the LHS of the
+    -- 'ImplicitArrow' at the moment the goal was emitted (so it carries
+    -- whatever type-information surrounding inference has pinned).
+    -- 'goalScope' is a snapshot of the lexical given environment at
+    -- the apply-site (see 'getLexicalGivens'); the resolver consults
+    -- this for local @given@ bindings introduced by enclosing scopes.
+    ConstraintGoal
+      { goalLoc :: loc,
+        goalType :: Type v loc,
+        goalScope :: Map Reference (Type v loc)
+      }
+  | -- | ADR-019 / chunk D2: the result of running given-resolution
+    -- ('Unison.Typechecker.GivenResolver') on a 'ConstraintGoal'.
+    --
+    -- 'implicitGoalLoc' is the apply-site location copied from the
+    -- corresponding 'ConstraintGoal' (so the D3 post-pass knows where
+    -- to substitute the resolved dictionary term back into the AST).
+    --
+    -- 'implicitGoalType' is the (post-substitution) constraint type
+    -- the resolver was asked to satisfy. Stored on the note so D3
+    -- (and error rendering in D4) does not need to re-derive it from
+    -- the surrounding context.
+    --
+    -- 'implicitDecision' records the resolver's verdict: a winning
+    -- 'GR.ResolutionTree' on success, or a structured
+    -- 'GR.ResolveError' on failure. D3 walks 'Right' decisions and
+    -- substitutes them into the AST; D4 renders 'Left' decisions
+    -- alongside other type errors.
+    --
+    -- Mirrors the 'SolvedBlank'/'Decision'/'applyTdnrDecisions' shape
+    -- used by TDNR (see 'parser-typechecker/src/Unison/FileParsers.hs:329').
+    SolvedImplicit
+      { implicitGoalLoc :: loc,
+        implicitGoalType :: Type.Type v loc,
+        implicitDecision ::
+          Either (GR.ResolveError v loc) (GR.ResolutionTree v loc)
+      }
+  | -- | ADR-019 / chunk F1: a record left behind by D3's
+    -- 'applyGivenDecisions' identifying a synthesized implicit
+    -- argument. The LSP consumes these notes to render hover and
+    -- goto-definition responses for synthesized 'App' nodes.
+    --
+    -- 'implicitArgLoc' is the source location of the function being
+    -- applied (i.e. the head of the apply chain whose type begins
+    -- with @=>@). This is the position the user can place a cursor
+    -- on; the synthesized dictionary argument itself has no source
+    -- range.
+    --
+    -- 'implicitArgRef' is the 'Reference' of the resolved given
+    -- (the root of the 'ResolutionTree'). For a derived hash, the
+    -- LSP can resolve to a name and definition location; for a
+    -- builtin given, the LSP shows a builtin marker.
+    ImplicitArgRef
+      { implicitArgLoc :: loc,
+        implicitArgRef :: Reference
+      }
+  | -- | ADR-019 / chunk C2.3: emitted when the typechecker validates
+    -- a top-level binding whose declared type begins (after stripping
+    -- 'Forall') with one or more 'ImplicitArrow' constructors — the
+    -- shape of a @given@ declaration's signature, i.e.
+    -- @C1 a, C2 b => T@. The note records the variable, its source
+    -- location, the declared type, and the /conclusion/ type
+    -- (declared type with all leading 'ImplicitArrow' parameters
+    -- stripped). 'synthesizeFile' (chunk C2.3) consumes this note to
+    -- identify which top-level definitions should be marked as givens
+    -- in the namespace metadata via 'Unison.Codebase.Givens.markGivenAt'
+    -- (the actual marking happens in the UCM command surface, B2).
+    --
+    -- Per ADR-005, there is no global registry; the namespace is the
+    -- instance set. The note exists only to plumb a @v -> conclusion@
+    -- mapping out of the typechecker so callers can do the marking;
+    -- nothing in the typechecker itself is sensitive to it.
+    --
+    -- Body validation: inference checks the body against the declared
+    -- type via the existing 'Term.Ann\'' path. C2.2's
+    -- @checkWanted exact want m (Type.ImplicitArrow' i conc)@ clause
+    -- recurses on the conclusion, so the body's inferred type is
+    -- already required to match the conclusion. C2.3 emits this note
+    -- after that check has succeeded, so its presence is itself the
+    -- positive signal of a valid given declaration.
+    GivenDecl
+      { givenLoc :: loc,
+        givenVar :: v,
+        givenDeclaredType :: Type v loc,
+        givenConclusion :: Type v loc
+      }
   deriving (Show)
 
 topLevelComponent :: (Var v) => [(v, Type.Type v loc, RedundantTypeAnnotation)] -> InfoNote v loc
@@ -423,6 +554,19 @@ substituteSolved ::
 substituteSolved ctx = \case
   (SolvedBlank b v t) -> SolvedBlank b v (apply ctx t)
   VarBinding v loc t -> VarBinding v loc (apply ctx t)
+  -- ADR-019 / chunk C2.2: propagate context substitution into the
+  -- constraint goal's type and into the captured given-scope so that
+  -- later inference (TDNR, additional unification) can refine the
+  -- types the resolver will eventually look at.
+  ConstraintGoal loc t scope ->
+    ConstraintGoal loc (apply ctx t) (apply ctx <$> scope)
+  -- ADR-019 / chunk C2.3: like 'ConstraintGoal', a given-decl note
+  -- records types that may still contain unsolved existentials at
+  -- emission time; later inference may refine them. Apply the context
+  -- substitution to both the declared type and the conclusion so
+  -- consumers downstream see fully-solved shapes.
+  GivenDecl loc v declared conc ->
+    GivenDecl loc v (apply ctx declared) (apply ctx conc)
   i -> i
 
 -- The typechecker generates synthetic type variables as part of type inference.
@@ -640,6 +784,41 @@ getContext = gets ctx
 setContext :: Context v loc -> M v loc ()
 setContext ctx = modEnv (\e -> e {ctx = ctx})
 
+-- | ADR-010 / chunk C2.1: read the lexical given environment.
+-- The map is keyed by the term reference of each in-scope given.
+-- Currently consulted only by code that will land in chunks D1+;
+-- present here so the field is observable from the typechecker monad.
+getLexicalGivens :: M v loc (Map Reference (Type v loc))
+getLexicalGivens = gets lexicalGivens
+
+-- | ADR-010 / chunk C2.1: extend the lexical given environment with a
+-- single given binding. No-op semantics in C2.1 (the field is plumbed
+-- but not yet consulted); chunks C2.2 / C2.3 / D1+ light it up.
+extendLexicalGiven :: Reference -> Type v loc -> M v loc ()
+extendLexicalGiven r ty =
+  modEnv (\e -> e {lexicalGivens = Map.insert r ty (lexicalGivens e)})
+
+-- | ADR-010 / chunk C2.1: run an action in a scope that may extend the
+-- lexical given environment, restoring the prior environment on exit.
+-- Wraps every binding form ('Lam', 'Let1', 'LetRec', match arm) so
+-- that lexical scoping of givens is correctly modeled even though
+-- the field is not yet semantically consulted. The save/restore
+-- pattern matches how 'Context' is mark/retracted in the typechecker.
+withLexicalGivens :: M v loc a -> M v loc a
+withLexicalGivens act = do
+  saved <- getLexicalGivens
+  a <- act
+  modEnv (\e -> e {lexicalGivens = saved})
+  pure a
+
+-- | ADR-010 / chunk L2 fixup: ask whether a variable name was bound via
+-- the @given@ keyword. The lookup compares against 'Var.reset' of @v@
+-- because the parser-side set holds the un-freshened names while the
+-- typechecker may pass in freshened or non-freshened variants.
+isGivenBoundVar :: (Var v) => v -> M v loc Bool
+isGivenBoundVar v =
+  gets (Set.member (Var.reset v) . givenBindings)
+
 modifyContext :: (Context v loc -> M v loc (Context v loc)) -> M v loc ()
 modifyContext f = do
   c <- getContext
@@ -746,6 +925,10 @@ wellformedType c t = case t of
   Type.Var' (TypeVar.Universal v) -> Set.member v (universals c)
   Type.Ref' _ -> True
   Type.Arrow' i o -> wellformedType c i && wellformedType c o
+  -- ADR-019 / chunk C2.1 carry-over: 'ImplicitArrow' is well-formed iff
+  -- both sides are. Falling through to the @Match failure@ catchall would
+  -- crash the typechecker on any signature containing @=>@.
+  Type.ImplicitArrow' i o -> wellformedType c i && wellformedType c o
   Type.Ann' t' _ -> wellformedType c t'
   Type.App' x y -> wellformedType c x && wellformedType c y
   Type.Effect1' e a -> wellformedType c e && wellformedType c a
@@ -1053,6 +1236,22 @@ synthesizeApp fun (Type.stripIntroOuters -> Type.Effect'' es ft) argp@(arg, argN
             | Term.Apps' (Term.Var' f) _ <- fun = any (== f) defs
             | otherwise = False
       (o,) <$> checkWantedScoped exact ((Just fun,) <$> es) arg i
+    -- ADR-019 / chunk C2.2: =>App. The user did *not* supply this
+    -- argument; the elaborator (chunk D1+) will fill it by given-resolution. We emit a 'ConstraintGoal' info note carrying the
+    -- implicit parameter's type plus a snapshot of the in-scope givens,
+    -- then recurse on the conclusion with the *same* user argument.
+    -- (Mirrors how 'Forall1App' instantiates and recurses without
+    -- consuming the surface argument.) Multi-constraint signatures
+    -- — nested 'ImplicitArrow's per ADR-019 — are handled by repeated
+    -- recursion: each step emits one goal and peels one arrow.
+    go (Type.ImplicitArrow' i conc) = do
+      ctx <- getContext
+      scope_ <- getLexicalGivens
+      let goalTy = apply ctx i
+          goalScope = apply ctx <$> scope_
+          goalLoc_ = loc ft
+      btw $ ConstraintGoal goalLoc_ goalTy goalScope
+      synthesizeApp fun conc argp
     go (Type.Var' (TypeVar.Existential b a)) = do
       -- a^App
       [i, e, o] <- traverse freshenVar [Var.named "i", Var.inferAbility, Var.named "o"]
@@ -1125,6 +1324,97 @@ noteTopLevelType e binding typ = case binding of
     btw $
       topLevelComponent
         [(Var.reset (ABT.variable e), generalizeAndUnTypeVar typ, True)]
+
+-- | ADR-019 / chunk C2.3: emit a 'GivenDecl' info note when the
+-- binding's user-provided type begins (after stripping any leading
+-- 'Forall' binders) with one or more 'ImplicitArrow' parameters.
+--
+-- A binding without an explicit type annotation cannot be a @given@
+-- declaration in the surface syntax (the parser at chunk A2 always
+-- generates @Term.Ann'@ for @given@ decls), so the no-annotation
+-- branch is a no-op.
+--
+-- The body has just been checked against the annotated type @t@
+-- (via 'synthesizeBinding' → 'synthesize' → 'checkScoped'). C2.2's
+-- 'checkWanted' clause for 'ImplicitArrow' recurses into the
+-- conclusion type, so the body's inferred type already matches the
+-- conclusion when this function runs. The note's @declaredType@ is
+-- the user-written annotation; the @conclusion@ is that annotation
+-- with its leading 'Forall' / 'ImplicitArrow' prefix stripped.
+--
+-- 'synthesizeFile' (and downstream tooling — UCM commands wired in
+-- chunk B2) consume these notes to identify candidates for
+-- @mark.given@ namespace tagging via
+-- 'Unison.Codebase.Givens.markGivenAt'. Per ADR-005 there is no
+-- global registry; the namespace metadata is the instance set.
+noteGivenDeclLet ::
+  (Var v, Ord loc) =>
+  ABT.Subst f v loc ->
+  Term v loc ->
+  Type v loc ->
+  M v loc ()
+noteGivenDeclLet e binding _inferredType = do
+  -- ADR-010 / chunk L2 fixup: the binding is a @given@ declaration iff
+  -- the parser tagged its variable, regardless of whether the type
+  -- begins with @=>@. (The shape check 'unImplicitArrows' previously
+  -- gated this branch and silently dropped premise-free givens such
+  -- as @given local : Ord a = …@.)
+  isGiven <- isGivenBoundVar (ABT.variable e)
+  case binding of
+    Term.Ann' _stripped declared
+      | isGiven ->
+          let (_premises, conc) = Type.unImplicitArrows declared
+           in btw $
+                GivenDecl
+                  (ABT.annotation binding)
+                  (Var.reset (ABT.variable e))
+                  declared
+                  conc
+    _ -> pure ()
+
+-- | ADR-010 / chunk L2: detect a @let given@ binding and extend the
+-- lexical given environment so the body of the @let@ sees the binding
+-- as a candidate for implicit resolution.
+--
+-- A binding qualifies as a @given@ if its declared type (after
+-- stripping any leading 'Forall' binders) begins with one or more
+-- 'ImplicitArrow' parameters — exactly the test 'noteGivenDeclLet'
+-- uses to emit 'GivenDecl' info notes. This is the same shape produced
+-- by the parser's 'givenBindingBody' (chunk A2): @let given x : T = ...@
+-- desugars to a regular type-annotated let-binding whose annotation
+-- type begins with @=>@.
+--
+-- The 'Reference' is synthesized from the bound variable. Local
+-- lexical givens never become codebase 'Reference's — they can't be
+-- referenced from outside the @let@'s scope — so a 'Reference.Builtin'
+-- tag suffices for the resolver to identify which given was chosen.
+-- The chunk D3 'GivenApply' rewriter does not yet substitute local
+-- vars for these synthetic refs (see ADR-010 Option B; that wiring is
+-- a future chunk), but the 'SolvedImplicit' info note carries the
+-- correct identification, which is what the L2 tests assert on.
+--
+-- Returns 'True' iff a lexical given was registered. Callers can use
+-- the return value for diagnostic logging; today only the 'when'
+-- discipline matters.
+extendLexicalGivenFromBinding ::
+  (Var v, Ord loc) =>
+  ABT.Subst f v loc ->
+  Term v loc ->
+  M v loc Bool
+extendLexicalGivenFromBinding e binding = do
+  -- ADR-010 / chunk L2 fixup: register a lexical given iff the parser
+  -- tagged this variable as originating from the @given@ keyword. The
+  -- previous predicate (begins with @=>@ after stripping foralls)
+  -- silently dropped premise-free givens like
+  -- @given local : Ord a = …@, which is the canonical ADR-010 example.
+  isGiven <- isGivenBoundVar (ABT.variable e)
+  case binding of
+    Term.Ann' _stripped declared | isGiven -> do
+      let v = Var.reset (ABT.variable e)
+          ref = Reference.Builtin ("Local.given." <> Var.name v)
+      extendLexicalGiven ref declared
+      pure True
+    _ -> pure False
 
 -- | Take note of the types and locations of all bindings, including let bindings, letrec
 -- bindings, lambda argument bindings and top-level bindings.
@@ -1250,15 +1540,41 @@ synthesizeWanted (Term.Let1Top' top binding boundVarAnn e) = do
     -- enforce that actions in a block have type ()
     subtype tbinding (DDB.unitType (ABT.annotation binding))
   appendContext [Ann v' boundVarAnn tbinding]
-  (t, w) <- synthesize (ABT.bindInheritAnnotation e (Term.var () v'))
+  -- ADR-010 / chunk C2.1 + chunk L2: 'withLexicalGivens' opens a fresh
+  -- lexical scope for the body. If the binding is a @given@ declaration
+  -- (recognised by 'extendLexicalGivenFromBinding' via the same
+  -- shape-check 'noteGivenDeclLet' uses) we register it before
+  -- synthesizing the body, so the resolver at any 'ConstraintGoal' in
+  -- the body sees the local given as a candidate. The 'withLexicalGivens'
+  -- wrapper restores the prior environment when the body finishes,
+  -- guaranteeing lexical-only visibility per ADR-010.
+  (t, w) <-
+    withLexicalGivens $ do
+      _ <- extendLexicalGivenFromBinding e binding
+      synthesize (ABT.bindInheritAnnotation e (Term.var () v'))
   t <- applyM t
   when top $ noteTopLevelType e binding tbinding
+  -- ADR-019 / chunk C2.3: emit a 'GivenDecl' info note for the
+  -- top-level binding when its declared type has the shape of a
+  -- @given@ signature. After 'minimize' (in 'Unison.Typechecker.Components')
+  -- a singleton non-recursive top-level letrec is rewritten as a
+  -- 'singleLet' (i.e. 'Let1Top''), so this branch is the one that
+  -- fires for parsed @given f : C => T = body@ files. The annotated
+  -- type carries the original 'ImplicitArrow's; 'tbinding' is the
+  -- inferred type after 'addAbilities' / 'existentializeArrows' and
+  -- ability-row insertion, which preserves the leading constraint
+  -- chain — we use the user-written annotation when available so the
+  -- conclusion is reported in surface shape.
+  when top $ noteGivenDeclLet e binding tbinding
   want <- coalesceWanted w wb
   -- doRetract $ Ann v' tbinding
   pure (t, want)
 synthesizeWanted (Term.LetRecNamed' [] body) = synthesizeWanted body
 synthesizeWanted (Term.LetRecAnnotatedTop' isTop letrec) = do
-  ((t, want), ctx2) <- markThenRetract (Var.named "let-rec-marker") $ do
+  -- ADR-010 / chunk C2.1: each letrec opens a lexical given scope; any
+  -- @given@ statements introduced inside the cycle (chunk C2.2+) must
+  -- not leak past the surrounding term.
+  ((t, want), ctx2) <- markThenRetract (Var.named "let-rec-marker") . withLexicalGivens $ do
     e <- annotateLetRecBindings isTop letrec
     synthesize e
   want <- substAndDefaultWanted want ctx2
@@ -1378,9 +1694,16 @@ synthesizeWanted e
         -- here's where the typechecker assumes this must be of type 'thunkArgType'
         subtype it (DDB.thunkArgType l)
       body' <- pure $ ABT.bindInheritAnnotation body (Term.var () arg)
-      if Term.isLam body'
-        then checkWithAbilities Nothing [] body' ot
-        else checkWithAbilities Nothing [et] body' ot
+      -- ADR-010 / chunk C2.1: a lambda body opens a fresh lexical
+      -- given scope. The body cannot currently introduce its own
+      -- givens (no @given@ binder is available in expression position
+      -- — see ADR-010 Option B), but threading the env here keeps the
+      -- shape uniform with let / letrec / match arms and prepares for
+      -- ADR-010-relaxation if it ever lands.
+      withLexicalGivens $
+        if Term.isLam body'
+          then checkWithAbilities Nothing [] body' ot
+          else checkWithAbilities Nothing [et] body' ot
       ctx <- getContext
       let t = apply ctx $ Type.arrow l it (Type.effect l [et] ot)
 
@@ -1672,7 +1995,11 @@ checkCase ::
 checkCase scrutineeType outputType (Term.MatchCase pat guard rhs) = do
   scrutineeType <- applyM scrutineeType
   outputType <- applyM outputType
-  markThenRetractWanted Var.inferOther $ do
+  -- ADR-010 / chunk C2.1: each match arm opens its own lexical scope
+  -- for givens. Pattern-introduced bindings are not themselves givens
+  -- (ADR-010 reserves @given@ to top-level decls and let-blocks) but
+  -- a future arm-body @let given@ must not leak across arms.
+  markThenRetractWanted Var.inferOther . withLexicalGivens $ do
     let peel t = case t of
           ABT.AbsN' vars bod -> (vars, bod)
         (rhsvs, rhsbod) = peel rhs
@@ -2007,6 +2334,17 @@ annotateLetRecBindings' letrec useAnn = do
         when (Var.isAction v) . scope InActionRestriction $
           subtype t (DDB.unitType (ABT.annotation b))
         insideDef v $ checkScopedWith b t []
+        -- ADR-019 / chunk C2.3: emit a 'GivenDecl' info note for
+        -- bindings whose declared type begins with one or more
+        -- 'ImplicitArrow' parameters (after stripping any leading
+        -- 'Forall'). Bindings that landed in 'ubnds' rather than
+        -- 'abnds' did so because the type carried free existential
+        -- variables introduced by 'addAbilities' /
+        -- 'existentializeArrows' (which 'prepare' runs before its
+        -- closedness check) — that does not change the structural
+        -- shape of the leading constraint chain. See the symmetric
+        -- emission below in the 'abnds' loop.
+        emitGivenDeclNote v b t
 
       pure (allbnds, abnds, ubnds)
 
@@ -2029,12 +2367,45 @@ annotateLetRecBindings' letrec useAnn = do
       when (Var.isAction v) . scope InActionRestriction $
         subtype t (DDB.unitType (ABT.annotation b))
       insideDef v $ checkScopedWith b t []
+      -- ADR-019 / chunk C2.3: emit a 'GivenDecl' info note when the
+      -- declared type has the shape of a @given@ signature — i.e.
+      -- begins (after an optional 'Forall' prefix) with one or more
+      -- 'ImplicitArrow' parameters. The body has just been checked
+      -- against @t@; C2.2's 'checkWanted' clause for 'ImplicitArrow'
+      -- recursed into the conclusion, so the body's inferred type
+      -- already matches that conclusion. The note exists so
+      -- 'synthesizeFile' (and ultimately the UCM command surface
+      -- B2 wires up) can identify this binding as a candidate for
+      -- namespace-level @mark.given@ tagging via
+      -- 'Unison.Codebase.Givens.markGivenAt'. Per ADR-005 there is no
+      -- global registry; we only plumb the (var, conclusion) pair.
+      emitGivenDeclNote v b t
 
   ensureGuardedCycle (namedBindings allbnds)
 
   let vTypes =
         zip (bndVars ubnds) gbndTyps
           ++ zip (bndVars abnds) (bndTyps abnds)
+
+  -- ADR-010 / chunk L2 (+ L2 fixup): register every binding whose
+  -- variable was tagged by the parser as a @given@ origin into the
+  -- lexical given environment so the body (synthesised by the caller
+  -- after we return) sees them as candidates. This handles both
+  -- file-internal top-level @given@ declarations (the whole file
+  -- becomes a top-level letrec) and @given@ bindings inside
+  -- mutually-recursive blocks. The surrounding 'withLexicalGivens' in
+  -- the caller of 'annotateLetRecBindings'' restores the prior
+  -- environment when the letrec scope closes.
+  --
+  -- Predicate is by parser-tagged name (per the L2 fixup), not by
+  -- type shape, so premise-free declarations like
+  -- @given local : Ord a = …@ are recognised — the canonical
+  -- ADR-010 example.
+  Foldable.for_ vTypes \(v, t) -> do
+    isGiven <- isGivenBoundVar v
+    when isGiven $ do
+      let ref = Reference.Builtin ("Local.given." <> Var.name (Var.reset v))
+      extendLexicalGiven ref t
 
   pure (body, vTypes)
   where
@@ -2063,6 +2434,36 @@ annotateLetRecBindings' letrec useAnn = do
       | otherwise = do
           vt <- extendExistential v
           pure $ Left (binding, existential' (loc binding) B.Blank vt, v, vloc)
+
+-- | ADR-019 / chunk C2.3: helper for 'annotateLetRecBindings''. Emit
+-- a 'GivenDecl' info note when @t@ begins (after an optional 'Forall'
+-- prefix) with one or more 'ImplicitArrow' parameters — that is, the
+-- shape of a @given@ declaration's signature. No-op for bindings
+-- whose declared type has no leading @=>@ constraints.
+--
+-- Body validation: the body has already been checked against the
+-- declared type @t@ at the call site (via 'checkScopedWith'). C2.2's
+-- 'checkWanted' clause for 'ImplicitArrow' recursed into the
+-- conclusion, so the body's inferred type already matches the
+-- stripped conclusion type when @emitGivenDeclNote@ runs. The note
+-- carries the conclusion verbatim for the convenience of
+-- 'synthesizeFile' and downstream consumers.
+emitGivenDeclNote ::
+  (Var v, Ord loc) =>
+  v ->
+  Term v loc ->
+  Type v loc ->
+  M v loc ()
+emitGivenDeclNote v b t = do
+  -- ADR-010 / chunk L2 fixup: emit the note iff the parser tagged the
+  -- bound variable as a @given@ origin. The conclusion is computed by
+  -- stripping any leading @=>@ premises (which may be absent for
+  -- premise-free givens like @given local : Ord a = …@; in that case
+  -- 'unImplicitArrows' returns @([], t)@ so @conc == t@).
+  isGiven <- isGivenBoundVar v
+  when isGiven $
+    let (_premises, conc) = Type.unImplicitArrows t
+     in btw $ GivenDecl (loc b) v t conc
 
 ensureGuardedCycle :: (Var v) => [(v, Term v loc)] -> M v loc ()
 ensureGuardedCycle bindings =
@@ -2703,11 +3104,26 @@ checkWanted exact want m (Type.Forall' body) = do
     x <- extendUniversal v
     checkWanted exact want m $
       ABT.bindInheritAnnotation body (universal' () x)
+-- ADR-019 / chunk C2.2: =>App on the check side. Checking a term
+-- against an 'ImplicitArrow' type doesn't ask the user to write the
+-- implicit argument; the elaborator (chunk D1+) fills it. We emit a
+-- 'ConstraintGoal' info note for the implicit slot and continue
+-- checking the term against the conclusion.
+checkWanted exact want m ty@(Type.ImplicitArrow' i conc) = do
+  ctx <- getContext
+  scope_ <- getLexicalGivens
+  let goalTy = apply ctx i
+      goalScope = apply ctx <$> scope_
+      goalLoc_ = loc ty
+  btw $ ConstraintGoal goalLoc_ goalTy goalScope
+  checkWanted exact want m conc
 -- =>I
 -- Lambdas are pure, so they add nothing to the wanted set
 checkWanted exact want (Term.Lam' boundVarAnn body) (Type.Arrow'' i es o) = do
   x <- ABT.freshen body freshenVar
-  markThenRetract0 x $ do
+  -- ADR-010 / chunk C2.1: lambda body opens a fresh lexical given
+  -- scope; symmetric with the synthesis path above.
+  markThenRetract0 x . withLexicalGivens $ do
     extendContext (Ann x boundVarAnn i)
     body <- pure $ ABT.bindInheritAnnotation body (Term.var () x)
     checkWithAbilities exact es body o
@@ -2735,7 +3151,12 @@ checkWanted exact want (Term.Let1Top' top binding boundVarAnn m) t = do
   (tbinding, wbinding) <- synthesizeBinding top binding
   want <- coalesceWanted wbinding want
   v <- ABT.freshen m freshenVar
-  markThenRetractWanted v $ do
+  -- ADR-010 / chunk C2.1 + chunk L2: opens a fresh lexical given scope
+  -- for the body and, when the binding is a @given@ declaration (per
+  -- 'extendLexicalGivenFromBinding'), registers it before checking the
+  -- body. Mirrors the symmetric synthesis path.
+  markThenRetractWanted v . withLexicalGivens $ do
+    _ <- extendLexicalGivenFromBinding m binding
     when (Var.isAction (ABT.variable m)) . scope InActionRestriction $
       -- enforce that actions in a block have type ()
       subtype tbinding (DDB.unitType (ABT.annotation binding))
@@ -2745,7 +3166,9 @@ checkWanted exact want (Term.LetRecNamed' [] m) t =
   checkWanted exact want m t
 -- letrec can't have effects, so it doesn't extend the wanted set
 checkWanted exact want (Term.LetRecAnnotatedTop' isTop lr) t =
-  markThenRetractWanted (Var.named "let-rec-marker") $ do
+  -- ADR-010 / chunk C2.1: opens a fresh lexical given scope for the
+  -- letrec cycle.
+  markThenRetractWanted (Var.named "let-rec-marker") . withLexicalGivens $ do
     e <- annotateLetRecBindings isTop lr
     checkWanted exact want e t
 checkWanted _ want e@(Term.Match' scrut cases) t = do
@@ -3583,16 +4006,30 @@ verifyDataDeclarations decls = forM_ (Map.toList decls) $ \(_ref, decl) -> do
   forM_ ctors $ \(_ctorName, typ) -> verifyClosed typ id
 
 -- | public interface to the typechecker
+--
+-- ADR-010 / chunk C2.1: 'givens' is the initial lexical given
+-- environment seeded from the caller's top-level @given@ declarations
+-- (currently always empty — chunks C2.3 / D1+ light it up). Every
+-- binding form ('Lam', 'Let1', 'LetRec', match arm) saves and
+-- restores it via 'withLexicalGivens'.
 synthesizeClosed ::
   (BuiltinAnnotation loc, Var v, Ord loc, Show loc, Semigroup loc) =>
   PrettyPrintEnv ->
   PatternMatchCoverageCheckAndKindInferenceSwitch ->
   Map Reference [Variance] ->
   [Type v loc] ->
+  -- | Initial lexical given environment (top-level givens in scope).
+  -- Pass 'Map.empty' until chunk C2.3 wires up @given@ declaration
+  -- collection.
+  Map Reference (Type v loc) ->
+  -- | ADR-010 / chunk L2 fixup: parser-collected names of @given@-bound
+  -- variables. The letrec / let predicates consult this instead of
+  -- inspecting type shape so premise-free givens are recognised.
+  Set v ->
   TL.TypeLookup v loc ->
   Term v loc ->
   Result v loc (Type v loc)
-synthesizeClosed ppe pmcSwitch vars abilities lookupType term0 =
+synthesizeClosed ppe pmcSwitch vars abilities givens gbs lookupType term0 =
   let datas = TL.dataDecls lookupType
       effects = TL.effectDecls lookupType
       term = annotateRefs (TL.typeOfTerm' lookupType) term0
@@ -3600,6 +4037,10 @@ synthesizeClosed ppe pmcSwitch vars abilities lookupType term0 =
         Left missingRef ->
           compilerCrashResult (UnknownTermReference missingRef)
         Right term -> run ppe pmcSwitch vars datas effects $ do
+          -- Seed the lexical given environment from the caller before
+          -- recursing into the term. The save/restore in every binder
+          -- preserves this seed at the outermost lexical scope.
+          modEnv (\e -> e {lexicalGivens = givens, givenBindings = gbs})
           liftResult $
             verifyDataDeclarations datas
               *> verifyDataDeclarations (DD.toDataDecl <$> effects)
@@ -3672,7 +4113,14 @@ run ::
 run ppe pmcSwitch vars datas effects m =
   fmap fst
     . runM m ppe pmcSwitch vars datas effects []
-    $ Env 1 context0
+    -- ADR-010 / chunk C2.1: the lexical given environment starts empty;
+    -- 'synthesizeClosed' seeds it from the caller's top-level given set
+    -- before invoking 'synthesizeClosed''. Every binding form then
+    -- threads it via 'withLexicalGivens'.
+    --
+    -- ADR-010 / chunk L2 fixup: 'givenBindings' likewise starts empty
+    -- and is seeded from the parser side channel by 'synthesizeClosed'.
+    $ Env 1 context0 Map.empty Set.empty
 
 synthesizeClosed' ::
   (Var v, Ord loc, Semigroup loc) =>

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -94,12 +94,12 @@ import Unison.DataDeclaration qualified as DD
 import Unison.DataDeclaration.ConstructorId (ConstructorId)
 import Unison.KindInference qualified as KindInference
 import Unison.Name (Name)
+import Unison.Parser.Ann qualified as Ann
 import Unison.Pattern (Pattern)
 import Unison.Pattern qualified as Pattern
 import Unison.PatternMatchCoverage (checkMatch)
 import Unison.PatternMatchCoverage.Class (EnumeratedConstructors (..), Pmc, traverseConstructorTypes)
 import Unison.PatternMatchCoverage.Class qualified as Pmc
-import Unison.Parser.Ann qualified as Ann
 import Unison.PatternMatchCoverage.ListPat qualified as ListPat
 import Unison.Prelude
 import Unison.PrettyPrintEnv (PrettyPrintEnv)

--- a/parser-typechecker/src/Unison/Typechecker/Context/Structure.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context/Structure.hs
@@ -329,6 +329,11 @@ apply' solved t = go t
       Type.Var' (TypeVar.Existential _ v) ->
         maybe t (\(Type.Monotype t') -> go t') (Map.lookup v solved)
       Type.Arrow' i o -> Type.arrow a (go i) (go o)
+      -- ADR-019 / chunk C2.2 (carry-over from C1.1): 'ImplicitArrow'
+      -- substitution mirrors 'Arrow'. Without this clause 'apply'' would
+      -- crash on any type containing @=>@ — including the constraint
+      -- goals emitted by 'synthesizeApp'.
+      Type.ImplicitArrow' i o -> Type.implicitArrow a (go i) (go o)
       Type.App' x y -> Type.app a (go x) (go y)
       Type.Ann' v k -> Type.ann a (go v) k
       Type.Effect1' e t -> Type.effect1 a (go e) (go t)

--- a/parser-typechecker/src/Unison/Typechecker/GivenApply.hs
+++ b/parser-typechecker/src/Unison/Typechecker/GivenApply.hs
@@ -97,21 +97,32 @@
 module Unison.Typechecker.GivenApply
   ( -- * Top-level entry point
     applyGivenDecisions,
+    applyGivenDecisionsAll,
 
     -- * Building dictionary terms
     buildDictionary,
 
     -- * Override detection (exposed for tests)
     isOverrideArg,
+
+    -- * Stripping for surface rendering
+    stripSyntheticArgs,
+    stripImplicitArgsByType,
+    stripLeadingImplicitLambdas,
   )
 where
 
 import Control.Monad.State.Strict (State, gets, modify', runState)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
+import Data.Maybe (fromMaybe)
+import Data.Text qualified as Text
 import Unison.ABT qualified as ABT
 import Unison.Lexer.Pos qualified as L
 import Unison.Parser.Ann (Ann (..))
+import Unison.Parser.Ann qualified as Ann
+import Unison.Reference (Reference)
+import Unison.Reference qualified as Reference
 import Unison.Term (Term)
 import Unison.Term qualified as Term
 import Unison.Type (Type)
@@ -121,6 +132,7 @@ import Unison.Typechecker.GivenResolver qualified as GR
 import Unison.Typechecker.TypeLookup (TypeLookup)
 import Unison.Typechecker.TypeLookup qualified as TL
 import Unison.Var (Var)
+import Unison.Var qualified as Var
 
 ------------------------------------------------------------------------------
 -- Top-level entry point
@@ -156,15 +168,65 @@ applyGivenDecisions ::
   -- synthesized dictionary insertion.
   (Term v Ann, [Context.InfoNote v Ann])
 applyGivenDecisions notes typeLookup tm =
-  let queue = collectDecisions notes
+  let (queue, byLoc) = collectDecisionsAndIndex notes
       tlcEnv = collectTopLevelTypes notes
       env0 =
         AppEnv
           { aeTypeLookup = typeLookup,
-            aeLocalTypes = tlcEnv
+            aeLocalTypes = tlcEnv,
+            aeByLoc = byLoc
           }
       (tm', st) = runState (rewrite env0 tm) (DState queue [])
    in (tm', reverse (dsImplicitNotes st))
+
+-- | Variant of 'applyGivenDecisions' that walks a sequence of
+-- top-level bindings as a single pass. The location-indexed
+-- decisions table ensures every dictionary insertion uses the
+-- decision emitted /at the same source location/, so a per-binding
+-- traversal order doesn't matter.
+applyGivenDecisionsAll ::
+  forall v.
+  (Var v) =>
+  [Context.InfoNote v Ann] ->
+  TypeLookup v Ann ->
+  -- | List of bindings to rewrite.
+  [Term v Ann] ->
+  -- | Rewritten terms (same order) and a flat list of
+  -- 'ImplicitArgRef' notes for the LSP.
+  ([Term v Ann], [Context.InfoNote v Ann])
+applyGivenDecisionsAll notes typeLookup terms =
+  let (queue, byLoc) = collectDecisionsAndIndex notes
+      tlcEnv = collectTopLevelTypes notes
+      env0 =
+        AppEnv
+          { aeTypeLookup = typeLookup,
+            aeLocalTypes = tlcEnv,
+            aeByLoc = byLoc
+          }
+      (tms', st) = runState (traverse (rewrite env0) terms) (DState queue [])
+   in (tms', reverse (dsImplicitNotes st))
+
+-- | Build both the legacy flat decision queue and a
+-- location-indexed map of decisions. The map keys each successful
+-- 'SolvedImplicit' decision by the source-position of the goal that
+-- produced it; the value is a list of decisions /in emission order/
+-- for that location (multiple emissions at one location are
+-- possible when a reference's type carries more than one @=>@).
+collectDecisionsAndIndex ::
+  [Context.InfoNote v Ann] ->
+  ([GR.ResolutionTree v Ann], Map Ann [GR.ResolutionTree v Ann])
+collectDecisionsAndIndex notes =
+  let flat = collectDecisions notes
+      indexed =
+        foldr
+          ( \n acc -> case n of
+              Context.SolvedImplicit loc _ (Right tree) ->
+                Map.insertWith (++) loc [tree] acc
+              _ -> acc
+          )
+          Map.empty
+          notes
+   in (flat, indexed)
 
 ------------------------------------------------------------------------------
 -- Collecting inputs from the info-note stream
@@ -199,7 +261,12 @@ collectTopLevelTypes = foldr step Map.empty
 -- | Read-only environment for the rewrite.
 data AppEnv v = AppEnv
   { aeTypeLookup :: !(TypeLookup v Ann),
-    aeLocalTypes :: !(Map v (Type v Ann))
+    aeLocalTypes :: !(Map v (Type v Ann)),
+    -- | Map from each goal's source location to the decision(s)
+    -- emitted there, in emission order. Used by 'wrapImplicitLeaves'
+    -- to look up the correct decision for a leaf without relying on
+    -- queue order alignment across multiple top-level bindings.
+    aeByLoc :: !(Map Ann [GR.ResolutionTree v Ann])
   }
 
 -- | Mutable state: the queue of decisions still to consume, plus a
@@ -258,13 +325,50 @@ rewrite ::
 rewrite env tt =
   let a = ABT.annotation tt :: Ann
    in case ABT.out tt of
-        ABT.Var _ -> pure tt
+        -- A bare 'Term.Var\'' or 'Term.Ref\'' may stand for a value
+        -- whose declared type begins with one or more @=>@ arrows
+        -- (e.g. a class accessor like @Monoid.zero@). The synthesis
+        -- pass eagerly emitted a 'ConstraintGoal' for each of those
+        -- arrows; we pop the corresponding decisions from the queue
+        -- here and wrap the leaf with @App leaf <dict>@ for each.
+        ABT.Var _ -> wrapImplicitLeaves env tt
         ABT.Cycle body -> ABT.cycle' a <$> rewrite env body
         ABT.Abs v body -> ABT.abs' a v <$> rewrite env body
         ABT.Tm body -> case body of
           -- Apply-site: this is where we may insert dictionaries.
           Term.App f x -> rewriteApply env tt f [x]
+          Term.Ref _ -> wrapImplicitLeaves env tt
           other -> ABT.tm' a <$> traverse (rewrite env) other
+
+-- | Pop one dictionary from the decision queue for each leading
+-- @=>@ in the leaf's declared type, then wrap the leaf with
+-- left-leaning 'App' nodes. Returns the leaf unchanged when it has
+-- no implicit prefix.
+wrapImplicitLeaves ::
+  forall v.
+  (Var v) =>
+  AppEnv v ->
+  Term v Ann ->
+  M v (Term v Ann)
+wrapImplicitLeaves env tm = case headType env tm of
+  Nothing -> pure tm
+  Just ty -> do
+    let leafAnn = ABT.annotation tm
+        decisions = fromMaybe [] (Map.lookup leafAnn (aeByLoc env))
+    peel tm (Type.unforall ty) decisions
+  where
+    peel ::
+      Term v Ann ->
+      Type v Ann ->
+      [GR.ResolutionTree v Ann] ->
+      M v (Term v Ann)
+    peel acc ty ds = case (ty, ds) of
+      (Type.ImplicitArrow' _ conc, tree : restDs) -> do
+        recordImplicit (ABT.annotation tm) tree
+        let dictTm = buildDictionary (ABT.annotation tm) tree
+            acc' = Term.app (ABT.annotation acc <> ABT.annotation dictTm) acc dictTm
+        peel acc' (Type.unforall conc) restDs
+      _ -> pure acc
 
 -- | Handle a chain of applications. We collect the spine
 -- (function and explicit args), then re-emit it with dictionary
@@ -369,13 +473,181 @@ rebuildApps a f args = case args of
 --
 -- becomes the term @Show.list Show.nat@: a 'Term.app' applying the
 -- chosen given to its premise dictionaries.
+--
+-- For /local/ givens — declared file-internally via @given x = ...@ or
+-- inside a @let given@ block — the resolver attaches a synthetic
+-- 'Reference.Builtin' of the form @Local.given.<name>@ (see
+-- 'Unison.Typechecker.Context.extendLexicalGivenFromBinding'). Such
+-- refs are not real builtins; the runtime can't evaluate them. We
+-- detect that prefix here and substitute a 'Term.var' that references
+-- the source-level binding by name, which the surrounding letrec
+-- scope makes available.
+--
+-- The /outermost/ node of the produced term is annotated with
+-- 'Ann.Synthetic' so the term printer can detect that the argument
+-- was inserted by the elaborator (not written by the user) and elide
+-- it from surface output — see ADR-015. Inner premise dictionaries
+-- keep their non-synthetic annotations because they may already
+-- correspond to user-named givens.
 buildDictionary :: (Var v) => Ann -> GR.ResolutionTree v Ann -> Term v Ann
 buildDictionary a tree =
-  let head_ = Term.ref a (GR.givenName (GR.rtGiven tree))
+  let head_ = headTermFor a (GR.givenName (GR.rtGiven tree))
       premises = map (buildDictionary a) (GR.rtChildren tree)
-   in case premises of
+      raw = case premises of
         [] -> head_
         _ -> Term.apps head_ (map (\p -> (a, p)) premises)
+   in markSyntheticTop raw
+
+-- | Replace the outermost annotation of a term with 'Ann.Synthetic'
+-- wrapping the original. Used to flag elaborator-inserted terms so
+-- the printer can elide them from surface output.
+markSyntheticTop :: Term v Ann -> Term v Ann
+markSyntheticTop t = ABT.annotate (Ann.Synthetic (ABT.annotation t)) t
+
+-- | Walk a term and drop every 'App' argument whose top annotation
+-- is 'Ann.Synthetic'. This recovers the user's original surface
+-- shape (modulo formatting) for terms whose implicit slots were
+-- filled in by 'applyGivenDecisions' / 'wrapImplicitLeaves' /and/
+-- whose synthesized markers have survived in memory (i.e. the term
+-- hasn't been round-tripped through the codebase, which strips
+-- annotations). Use this just before handing a term to a surface
+-- pretty-printer so @> foo@ watches render without the
+-- resolved-dictionary arguments.
+--
+-- For terms loaded /back/ from the codebase (e.g. via @view@), the
+-- 'Ann.Synthetic' marker is no longer present; use
+-- 'stripImplicitArgsByType' instead, which derives the implicit slots
+-- from the function's declared type.
+stripSyntheticArgs :: (Var v) => Term v Ann -> Term v Ann
+stripSyntheticArgs = go
+  where
+    go t = case ABT.out t of
+      ABT.Var _ -> t
+      ABT.Cycle body -> ABT.cycle' (ABT.annotation t) (go body)
+      ABT.Abs v body -> ABT.abs' (ABT.annotation t) v (go body)
+      ABT.Tm body -> case body of
+        Term.App f x
+          | Ann.isSynthetic (ABT.annotation x) -> go f
+          | otherwise -> ABT.tm' (ABT.annotation t) (Term.App (go f) (go x))
+        other -> ABT.tm' (ABT.annotation t) (fmap go other)
+
+-- | Drop leading 'Lam' binders from a term, one for each leading
+-- @=>@ in its declared type. Used when rendering a top-level
+-- binding whose body the parser wrapped with synthetic
+-- @\\_implicit_<name>_<i> -> …@ lambdas: the user wrote
+-- @foldMap f = body@, the typechecker sees
+-- @foldMap = \\_implicit_foldMap_0 -> \\f -> body@, and at print
+-- time we want the user's surface form back.
+stripLeadingImplicitLambdas ::
+  forall v.
+  (Var v, Ord v) =>
+  -- | The binding's declared type.
+  Type v Ann ->
+  -- | The binding's term.
+  Term v Ann ->
+  Term v Ann
+stripLeadingImplicitLambdas ty0 tm0 =
+  let n = countLeadingImplicits (Type.unforall ty0) :: Int
+   in go n tm0
+  where
+    countLeadingImplicits :: Type v Ann -> Int
+    countLeadingImplicits ty = case ty of
+      Type.ImplicitArrow' _ conc -> 1 + countLeadingImplicits conc
+      _ -> 0
+
+    go :: Int -> Term v Ann -> Term v Ann
+    go 0 t = t
+    go n t = case ABT.out t of
+      ABT.Tm (Term.Lam body) -> case ABT.out body of
+        ABT.Abs _v inner -> go (n - 1) inner
+        _ -> t
+      -- Unison stores type annotations as 'Term.Ann e t' nodes
+      -- around bindings. Recurse into the inner term but preserve
+      -- the surrounding 'Ann' so the printer keeps the type
+      -- signature in its output.
+      ABT.Tm (Term.Ann inner ty) ->
+        let inner' = go n inner
+         in Term.ann (ABT.annotation t) inner' ty
+      _ -> t
+
+-- | Walk a term and drop every apply-site argument that fills a
+-- leading @=>@ slot in the function's declared type. Unlike
+-- 'stripSyntheticArgs', this version derives "which slot is
+-- implicit" from a type lookup — so it works on terms loaded back
+-- from the codebase, whose source annotations have been stripped.
+--
+-- @lookupTermType@ receives the head of an apps chain (a 'Term.Ref'
+-- or 'Term.Var') and returns its declared type, if known. Heads
+-- that aren't found (e.g. inferred-type let-bound vars in scope)
+-- pass through unchanged.
+stripImplicitArgsByType ::
+  forall v.
+  (Var v) =>
+  (Term v Ann -> Maybe (Type v Ann)) ->
+  Term v Ann ->
+  Term v Ann
+stripImplicitArgsByType lookupTermType = go
+  where
+    go :: Term v Ann -> Term v Ann
+    go t = case ABT.out t of
+      ABT.Var _ -> t
+      ABT.Cycle body -> ABT.cycle' (ABT.annotation t) (go body)
+      ABT.Abs v body -> ABT.abs' (ABT.annotation t) v (go body)
+      ABT.Tm (Term.App _ _) -> stripApps t
+      ABT.Tm other -> ABT.tm' (ABT.annotation t) (fmap go other)
+
+    -- | Collect the apps spine, find the head, look up its declared
+    -- type, and skip args for each leading @=>@ in that type.
+    stripApps :: Term v Ann -> Term v Ann
+    stripApps tm =
+      let (head_, args) = collect tm []
+          recurseArgs xs = map (\(a, x) -> (a, go x)) xs
+       in case lookupTermType head_ of
+            Just ty ->
+              let nImplicits = countLeadingImplicits ty
+                  args' = drop nImplicits args
+               in rebuild (ABT.annotation tm) (go head_) (recurseArgs args')
+            Nothing ->
+              rebuild (ABT.annotation tm) (go head_) (recurseArgs args)
+
+    collect :: Term v Ann -> [(Ann, Term v Ann)] -> (Term v Ann, [(Ann, Term v Ann)])
+    collect t acc = case ABT.out t of
+      ABT.Tm (Term.App f x) -> collect f ((ABT.annotation t, x) : acc)
+      _ -> (t, acc)
+
+    rebuild :: Ann -> Term v Ann -> [(Ann, Term v Ann)] -> Term v Ann
+    rebuild outerAnn f = \case
+      [] -> f
+      args -> Term.apps f (map (\(a, x) -> (a, x)) args) `withTopAnn` outerAnn
+
+    withTopAnn :: Term v Ann -> Ann -> Term v Ann
+    withTopAnn t _outer = t
+
+    countLeadingImplicits :: Type v Ann -> Int
+    countLeadingImplicits ty0 =
+      let ty1 = Type.unforall ty0
+       in case ty1 of
+            Type.ImplicitArrow' _ conc -> 1 + countLeadingImplicits conc
+            _ -> 0
+
+-- | Pick the right surface form for a chosen given's reference. Local
+-- givens are encoded by 'extendLexicalGivenFromBinding' as the synthetic
+-- @Local.given.<name>@ builtin reference; replace those with a
+-- 'Term.var' so the runtime can resolve them through the enclosing
+-- letrec. All other references go through unchanged as 'Term.ref'.
+headTermFor :: (Var v) => Ann -> Reference -> Term v Ann
+headTermFor a r = case r of
+  Reference.Builtin name
+    | Just localName <- Text.stripPrefix localGivenPrefix name ->
+        Term.var a (Var.named localName)
+  _ -> Term.ref a r
+
+-- | Prefix used by 'Unison.Typechecker.Context' to mint synthetic
+-- references for file-internal givens. Kept in sync with the literal
+-- in @extendLexicalGivenFromBinding@ / the letrec hook in
+-- @annotateLetRecBindings'@.
+localGivenPrefix :: Text.Text
+localGivenPrefix = "Local.given."
 
 ------------------------------------------------------------------------------
 -- Override detection
@@ -396,21 +668,56 @@ buildDictionary a tree =
 -- The widening shifts the outer annotation's start strictly to the
 -- left of the inner term's natural start. We detect this by
 -- comparing the outer annotation's start position to the start of
--- the leftmost annotation among the term's sub-children. If the
--- outer is strictly earlier, the term was widened.
+-- the leftmost annotation among the term's sub-children.
 --
--- For terms with no inner sub-children (a single 'Var', 'Ref',
--- 'Builtin', or literal), we cannot reliably tell from annotations
--- alone — see the module-level comment for the limitation. We
--- return 'False' in that case (treat as non-override).
+-- This detection is unsafe when the term is itself a structural
+-- composite (a list literal @[1,2,3]@, a parenthesised expression,
+-- a constructor application, etc.) because the surrounding brackets
+-- /also/ shift the outer annotation strictly before the first inner
+-- child. Such terms must never be treated as overrides — they are
+-- the user's own explicit arguments at non-implicit slots.
+--
+-- The 'termLeaf'-only restriction below mirrors the parser's
+-- @overrideArg@: only single-leaf terms (Var, Ref, Builtin, literal,
+-- TermLink, TypeLink, Blank) can be @\@@-widened. Composite terms
+-- with sub-children are never overrides.
 isOverrideArg :: Term v Ann -> Bool
-isOverrideArg t =
-  case ABT.annotation t of
-    Ann outerStart _ ->
-      case innerLeftmostStart t of
-        Just innerStart -> outerStart < innerStart
-        Nothing -> False
+isOverrideArg t
+  | isLeafForOverride t,
+    Ann outerStart _ <- ABT.annotation t,
+    Just innerStart <- innerLeftmostStart t,
+    outerStart < innerStart =
+      True
+  | otherwise = False
+
+-- | Restricted predicate matching the same surface forms 'termLeaf'
+-- accepts for an @\@@-override (see
+-- @parser-typechecker/src/Unison/Syntax/TermParser.hs:overrideArg@).
+-- Returns 'True' only for atomic surface terms whose AST has no
+-- structural children; this is what lets us trust an outer-vs-inner
+-- annotation gap as a real override marker.
+--
+-- NOTE: As of this writing, single-leaf overrides (e.g. @f @ d@ where
+-- @d@ is a bare identifier) cannot be detected via annotation
+-- widening — the inner annotation is unavailable, so
+-- 'innerLeftmostStart' returns 'Nothing' for these and
+-- 'isOverrideArg' falls back to 'False'. Composite-leaf overrides
+-- like @f @ (g x)@ also do not match this predicate because the
+-- inner term has structural children, which would falsely conflict
+-- with structural composites like list literals @[1,2,3]@. Until the
+-- override path is rewired with an explicit AST marker, override
+-- detection is effectively disabled: every implicit slot is filled
+-- by the resolver. Users who want to override resolution must use
+-- the @let given@ shadowing form (ADR-010).
+isLeafForOverride :: Term v Ann -> Bool
+isLeafForOverride t = case ABT.out t of
+  ABT.Var _ -> True
+  ABT.Tm body -> case body of
+    Term.Ref _ -> True
+    Term.Constructor _ -> True
+    Term.Request _ -> True
     _ -> False
+  _ -> False
 
 -- | Find the leftmost source-position start among the term's direct
 -- structural children, if any. Returns 'Nothing' for a leaf.

--- a/parser-typechecker/src/Unison/Typechecker/GivenApply.hs
+++ b/parser-typechecker/src/Unison/Typechecker/GivenApply.hs
@@ -596,7 +596,7 @@ stripImplicitArgsByType lookupTermType = go
       ABT.Tm (Term.App _ _) -> stripApps t
       ABT.Tm other -> ABT.tm' (ABT.annotation t) (fmap go other)
 
-    -- | Collect the apps spine, find the head, look up its declared
+    -- \| Collect the apps spine, find the head, look up its declared
     -- type, and skip args for each leading @=>@ in that type.
     stripApps :: Term v Ann -> Term v Ann
     stripApps tm =

--- a/parser-typechecker/src/Unison/Typechecker/GivenApply.hs
+++ b/parser-typechecker/src/Unison/Typechecker/GivenApply.hs
@@ -1,0 +1,433 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | Phase-2 chunk D3: post-typecheck pass that walks a term and
+-- substitutes resolved implicit arguments into 'App' nodes, mirroring
+-- the @applyTdnrDecisions@ pattern (see
+-- @parser-typechecker/src/Unison/FileParsers.hs:329@).
+--
+-- ## Inputs
+--
+-- * The list of 'Context.InfoNote' values produced by inference.
+--   The relevant ones are:
+--
+--     * 'Context.SolvedImplicit': one per resolved implicit slot,
+--       carrying either a 'GR.ResolutionTree' (success) or a
+--       'GR.ResolveError' (failure). Errors are left in place for
+--       chunk D4 to surface; D3 only consumes successes.
+--
+--     * 'Context.TopLevelComponent': the inferred types of let-rec
+--       bindings, used to look up the types of locally-defined
+--       functions referenced by 'Term.Var''.
+--
+-- * A 'TL.TypeLookup': the typechecker's view of every 'Term.Ref''
+--   the term mentions. Used to compute how many leading
+--   'Type.ImplicitArrow's a function carries before its first explicit
+--   argument.
+--
+-- ## Strategy
+--
+-- The typechecker emits 'SolvedImplicit' notes in left-to-right
+-- /synthesis/ order: that is, the order in which 'synthesizeApp'
+-- peeled 'ImplicitArrow' arrows during inference. Apply-sites are
+-- visited top-down, function-first, then arguments left-to-right.
+--
+-- D3 walks the term in the same order, holding a queue of pending
+-- decisions. At each apply-site @Apps' f args@:
+--
+--  1. Look up the type of @f@. For 'Ref'' we consult the supplied
+--     'TL.TypeLookup'; for 'Ann'' we use the annotation's type; for
+--     'Var'' we consult a local environment built from the
+--     'TopLevelComponent' notes plus traversal-introduced bindings.
+--
+--  2. Walk that type, peeling 'ImplicitArrow' before each user arg
+--     and 'Arrow' as we consume args. For each 'ImplicitArrow' we
+--     pop a 'SolvedImplicit' decision from the queue (matching the
+--     order in which the typechecker emitted them).
+--
+--  3. **Override skip (per A3's annotation-widening contract).**
+--     Before consuming a decision, examine the /next user-supplied
+--     argument/. If its annotation has been widened by A3's
+--     @\@@-positional override syntax (i.e. the outer 'Ann' starts at
+--     a column strictly /before/ the start of the leftmost annotation
+--     among its sub-terms), the user has already supplied this
+--     implicit explicitly. We do /not/ pop a decision, leave the arg
+--     untouched, and move on.
+--
+--  4. Otherwise, build a 'Term.Term' for the resolution tree (a
+--     left-leaning chain of 'Term.app' nodes terminating in
+--     'Term.ref' for each chosen given) and insert it into the
+--     argument list at the correct position. The resulting 'Apps''
+--     has plain 'App' nodes pointing at dictionary hashes — exactly
+--     what the runtime expects.
+--
+-- ## Errors and overrides
+--
+-- D3 leaves error decisions ('Left ResolveError') untouched: the term
+-- keeps the original arity, and a downstream rendering pass (chunk
+-- D4) translates the error into a user-facing diagnostic. This is
+-- the same separation TDNR uses today: 'applyTdnrDecisions' silently
+-- skips 'SolvedBlank' notes whose 'Resolution' yielded no
+-- substitution; the user-facing error surfaces from the stored
+-- 'Suggestion's via 'Result.Note'.
+--
+-- ## Limitations
+--
+-- * The override detection works only when the override-argument has
+--   sub-term annotations to compare against. For a single-leaf
+--   override (e.g. @f \@ d@ where @d@ is a bare identifier) the
+--   inner annotation is unavailable and we fall back to /not/
+--   treating the slot as overridden. The user-visible effect is the
+--   same as before A3 landed: the resolver's chosen dictionary will
+--   be used. To force an override on a single leaf, the user can
+--   wrap the argument in parentheses (@f \@ (d)@) — the parens
+--   produce a non-leaf node whose inner annotation is recoverable.
+--   This limitation is recorded in chunks.md as a follow-up for
+--   chunk A4.
+--
+-- * For function expressions whose type cannot be looked up
+--   syntactically (e.g. a higher-order callback, a complex
+--   expression head), D3 leaves the apply site alone. In practice
+--   such functions cannot have implicit parameters in their
+--   /surface/ type, since 'ImplicitArrow' is only valid in declared
+--   signatures (per ADR-019); inferred types of expressions never
+--   contain 'ImplicitArrow'. So this is not a soundness gap, just a
+--   reminder that D3 is syntax-directed.
+module Unison.Typechecker.GivenApply
+  ( -- * Top-level entry point
+    applyGivenDecisions,
+
+    -- * Building dictionary terms
+    buildDictionary,
+
+    -- * Override detection (exposed for tests)
+    isOverrideArg,
+  )
+where
+
+import Control.Monad.State.Strict (State, gets, modify', runState)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Unison.ABT qualified as ABT
+import Unison.Lexer.Pos qualified as L
+import Unison.Parser.Ann (Ann (..))
+import Unison.Term (Term)
+import Unison.Term qualified as Term
+import Unison.Type (Type)
+import Unison.Type qualified as Type
+import Unison.Typechecker.Context qualified as Context
+import Unison.Typechecker.GivenResolver qualified as GR
+import Unison.Typechecker.TypeLookup (TypeLookup)
+import Unison.Typechecker.TypeLookup qualified as TL
+import Unison.Var (Var)
+
+------------------------------------------------------------------------------
+-- Top-level entry point
+------------------------------------------------------------------------------
+
+-- | Walk the typechecked term and substitute resolution trees into
+-- 'App' nodes, consuming 'SolvedImplicit' decisions in synthesis
+-- order.
+--
+-- The result is a term in which every implicit slot whose decision
+-- succeeded has been filled with a dictionary application; every
+-- explicit override (per A3) is preserved unchanged; every implicit
+-- whose decision failed is left as-is, with the failure surfaced via
+-- the original info-note (D4).
+--
+-- Alongside the rewritten term we return a list of
+-- 'Context.ImplicitArgRef' notes (one per inserted dictionary), so
+-- downstream consumers (chunk F1's LSP integration) can detect
+-- synthesized arguments at a given source position. The notes are
+-- anchored at the source location of the function head, since the
+-- synthesized argument has no surface range.
+applyGivenDecisions ::
+  forall v.
+  (Var v) =>
+  -- | The typechecker's info notes (in emission order).
+  [Context.InfoNote v Ann] ->
+  -- | The codebase's view of the types of every 'Ref'' the term
+  -- mentions. Used to count how many implicits each function carries.
+  TypeLookup v Ann ->
+  -- | The term to rewrite.
+  Term v Ann ->
+  -- | The rewritten term plus one 'ImplicitArgRef' note per
+  -- synthesized dictionary insertion.
+  (Term v Ann, [Context.InfoNote v Ann])
+applyGivenDecisions notes typeLookup tm =
+  let queue = collectDecisions notes
+      tlcEnv = collectTopLevelTypes notes
+      env0 =
+        AppEnv
+          { aeTypeLookup = typeLookup,
+            aeLocalTypes = tlcEnv
+          }
+      (tm', st) = runState (rewrite env0 tm) (DState queue [])
+   in (tm', reverse (dsImplicitNotes st))
+
+------------------------------------------------------------------------------
+-- Collecting inputs from the info-note stream
+------------------------------------------------------------------------------
+
+-- | Extract every successful 'SolvedImplicit' decision in the order
+-- the typechecker emitted them. Failures are dropped here; they
+-- stay in the original info-note list for D4 to render.
+collectDecisions :: [Context.InfoNote v Ann] -> [GR.ResolutionTree v Ann]
+collectDecisions = foldr step []
+  where
+    step (Context.SolvedImplicit _ _ (Right tree)) acc = tree : acc
+    step _ acc = acc
+
+-- | Build a map from variable names to their inferred top-level
+-- types. The typechecker emits 'TopLevelComponent' notes for every
+-- top-level binding cluster after inference completes.
+collectTopLevelTypes ::
+  (Var v) =>
+  [Context.InfoNote v Ann] ->
+  Map v (Type v Ann)
+collectTopLevelTypes = foldr step Map.empty
+  where
+    step (Context.TopLevelComponent xs) acc =
+      foldr (\(v, t, _) -> Map.insert v t) acc xs
+    step _ acc = acc
+
+------------------------------------------------------------------------------
+-- The traversal monad
+------------------------------------------------------------------------------
+
+-- | Read-only environment for the rewrite.
+data AppEnv v = AppEnv
+  { aeTypeLookup :: !(TypeLookup v Ann),
+    aeLocalTypes :: !(Map v (Type v Ann))
+  }
+
+-- | Mutable state: the queue of decisions still to consume, plus a
+-- collected list of 'ImplicitArgRef' info notes (chunk F1) recording
+-- each synthesized insertion. Notes are pushed in reverse order; the
+-- caller of 'applyGivenDecisions' reverses them.
+data DState v = DState
+  { dsQueue :: [GR.ResolutionTree v Ann],
+    dsImplicitNotes :: [Context.InfoNote v Ann]
+  }
+
+type M v = State (DState v)
+
+-- | Pop one decision from the head of the queue. Returns 'Nothing'
+-- when the queue is empty (which only happens if an apply site
+-- has more implicits than the typechecker reported — a bug; see
+-- @Note [drained queue]@).
+popDecision :: M v (Maybe (GR.ResolutionTree v Ann))
+popDecision = do
+  q <- gets dsQueue
+  case q of
+    [] -> pure Nothing
+    (x : xs) -> do
+      modify' (\s -> s {dsQueue = xs})
+      pure (Just x)
+
+-- | Record an 'ImplicitArgRef' note for a synthesized insertion.
+-- Anchored at the location of the function being applied (the head
+-- of the apply chain whose type begins with @=>@), since the
+-- synthesized argument has no surface range.
+recordImplicit :: Ann -> GR.ResolutionTree v Ann -> M v ()
+recordImplicit headLoc tree =
+  modify' \s ->
+    s
+      { dsImplicitNotes =
+          Context.ImplicitArgRef
+            { Context.implicitArgLoc = headLoc,
+              Context.implicitArgRef = GR.givenName (GR.rtGiven tree)
+            }
+            : dsImplicitNotes s
+      }
+
+------------------------------------------------------------------------------
+-- The walker
+------------------------------------------------------------------------------
+
+-- | Recursive top-down rewrite. We hand-roll the recursion (rather
+-- than using 'ABT.visitPure') because we need stateful sequencing of
+-- decisions across siblings.
+rewrite ::
+  forall v.
+  (Var v) =>
+  AppEnv v ->
+  Term v Ann ->
+  M v (Term v Ann)
+rewrite env tt =
+  let a = ABT.annotation tt :: Ann
+   in case ABT.out tt of
+        ABT.Var _ -> pure tt
+        ABT.Cycle body -> ABT.cycle' a <$> rewrite env body
+        ABT.Abs v body -> ABT.abs' a v <$> rewrite env body
+        ABT.Tm body -> case body of
+          -- Apply-site: this is where we may insert dictionaries.
+          Term.App f x -> rewriteApply env tt f [x]
+          other -> ABT.tm' a <$> traverse (rewrite env) other
+
+-- | Handle a chain of applications. We collect the spine
+-- (function and explicit args), then re-emit it with dictionary
+-- arguments interleaved per the function's type.
+rewriteApply ::
+  (Var v) =>
+  AppEnv v ->
+  Term v Ann ->
+  Term v Ann ->
+  [Term v Ann] ->
+  M v (Term v Ann)
+rewriteApply env outer f args = case ABT.out f of
+  ABT.Tm (Term.App f' x') -> rewriteApply env outer f' (x' : args)
+  _ -> do
+    -- f is the head; args are the explicit user arguments left-to-right.
+    f' <- rewrite env f
+    args' <- traverse (rewrite env) args
+    case headType env f' of
+      Nothing ->
+        -- No type info; leave the apply chain alone (no implicits to insert).
+        pure (rebuildApps (ABT.annotation outer) f' args')
+      Just ft ->
+        interleave (ABT.annotation outer) f' ft args'
+
+-- | Try to infer the type of the apply-chain's head from syntactic
+-- information alone.
+headType :: (Var v) => AppEnv v -> Term v Ann -> Maybe (Type v Ann)
+headType env t = case ABT.out t of
+  ABT.Tm (Term.Ref r) -> Map.lookup r (TL.typeOfTerms (aeTypeLookup env))
+  ABT.Tm (Term.Ann _ ty) -> Just ty
+  ABT.Var v -> Map.lookup v (aeLocalTypes env)
+  _ -> Nothing
+
+-- | Walk the function's type, alternating implicit-peeling with
+-- explicit-arg consumption. At each implicit slot, decide whether
+-- to consume a decision or skip (override).
+interleave ::
+  forall v.
+  (Var v) =>
+  Ann ->
+  Term v Ann ->
+  Type v Ann ->
+  [Term v Ann] ->
+  M v (Term v Ann)
+interleave outerAnn f0 ty0 args0 =
+  go f0 (Type.unforall ty0) args0
+  where
+    headLoc = ABT.annotation f0
+    go f ty args = case ty of
+      -- Implicit: try to fill it.
+      Type.ImplicitArrow' _ conc -> do
+        case args of
+          [] -> pure (rebuildApps outerAnn f args)
+          (a : rest) ->
+            if isOverrideArg a
+              then -- User supplied this implicit explicitly; consume the arg
+              -- and keep going.
+                go (Term.app (ABT.annotation f <> ABT.annotation a) f a) conc rest
+              else do
+                mDec <- popDecision
+                case mDec of
+                  Nothing ->
+                    -- Queue empty: leave the rest alone.
+                    pure (rebuildApps outerAnn f args)
+                  Just tree -> do
+                    -- Chunk F1: record the synthesized insertion so
+                    -- the LSP can detect implicit args at the head's
+                    -- source position.
+                    recordImplicit headLoc tree
+                    let dictTm = buildDictionary outerAnn tree
+                        f' = Term.app (ABT.annotation f <> ABT.annotation dictTm) f dictTm
+                    go f' conc args
+      -- Explicit: consume one arg.
+      Type.Arrow' _ conc ->
+        case args of
+          [] -> pure f
+          (a : rest) ->
+            go (Term.app (ABT.annotation f <> ABT.annotation a) f a) (Type.unforall conc) rest
+      -- Type wraps in effects or other forms — re-emit remaining args
+      -- as plain Apps and stop.
+      _ -> pure (rebuildApps outerAnn f args)
+
+-- | Reconstruct an Apps' from head and explicit arg list.
+rebuildApps :: (Var v) => Ann -> Term v Ann -> [Term v Ann] -> Term v Ann
+rebuildApps a f args = case args of
+  [] -> f
+  _ -> Term.apps f (map (\x -> (a, x)) args)
+
+------------------------------------------------------------------------------
+-- Dictionary construction
+------------------------------------------------------------------------------
+
+-- | Convert a 'GR.ResolutionTree' into a 'Term.Term' representing
+-- the dictionary lookup, recursively.
+--
+-- Example: @Show (List Nat)@ resolved as
+--
+-- @
+--   ResolutionTree
+--     { rtGiven = Show.list, rtChildren = [ResolutionTree { rtGiven = Show.nat }] }
+-- @
+--
+-- becomes the term @Show.list Show.nat@: a 'Term.app' applying the
+-- chosen given to its premise dictionaries.
+buildDictionary :: (Var v) => Ann -> GR.ResolutionTree v Ann -> Term v Ann
+buildDictionary a tree =
+  let head_ = Term.ref a (GR.givenName (GR.rtGiven tree))
+      premises = map (buildDictionary a) (GR.rtChildren tree)
+   in case premises of
+        [] -> head_
+        _ -> Term.apps head_ (map (\p -> (a, p)) premises)
+
+------------------------------------------------------------------------------
+-- Override detection
+------------------------------------------------------------------------------
+
+-- | True iff the argument's annotation has been widened by A3's
+-- @\@@-positional override syntax (per
+-- @parser-typechecker/src/Unison/Syntax/TermParser.hs:~967@):
+--
+-- @
+--   overrideArg = do
+--     atTok <- reserved "@"
+--     d <- termLeaf
+--     let widened = ann atTok <> ann d
+--     pure d {ABT.annotation = widened}
+-- @
+--
+-- The widening shifts the outer annotation's start strictly to the
+-- left of the inner term's natural start. We detect this by
+-- comparing the outer annotation's start position to the start of
+-- the leftmost annotation among the term's sub-children. If the
+-- outer is strictly earlier, the term was widened.
+--
+-- For terms with no inner sub-children (a single 'Var', 'Ref',
+-- 'Builtin', or literal), we cannot reliably tell from annotations
+-- alone — see the module-level comment for the limitation. We
+-- return 'False' in that case (treat as non-override).
+isOverrideArg :: Term v Ann -> Bool
+isOverrideArg t =
+  case ABT.annotation t of
+    Ann outerStart _ ->
+      case innerLeftmostStart t of
+        Just innerStart -> outerStart < innerStart
+        Nothing -> False
+    _ -> False
+
+-- | Find the leftmost source-position start among the term's direct
+-- structural children, if any. Returns 'Nothing' for a leaf.
+innerLeftmostStart :: Term v Ann -> Maybe L.Pos
+innerLeftmostStart t = case ABT.out t of
+  ABT.Var _ -> Nothing
+  ABT.Cycle body -> annStart (ABT.annotation body)
+  ABT.Abs _ body -> annStart (ABT.annotation body)
+  ABT.Tm body ->
+    let kids = foldMap (\c -> [ABT.annotation c]) body
+        starts = [s | a <- kids, Just s <- [annStart a]]
+     in case starts of
+          [] -> Nothing
+          xs -> Just (minimum xs)
+
+annStart :: Ann -> Maybe L.Pos
+annStart = \case
+  Ann s _ -> Just s
+  GeneratedFrom a -> annStart a
+  _ -> Nothing

--- a/parser-typechecker/src/Unison/Typechecker/GivenApply.hs
+++ b/parser-typechecker/src/Unison/Typechecker/GivenApply.hs
@@ -118,7 +118,6 @@ import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.Text qualified as Text
 import Unison.ABT qualified as ABT
-import Unison.Lexer.Pos qualified as L
 import Unison.Parser.Ann (Ann (..))
 import Unison.Parser.Ann qualified as Ann
 import Unison.Reference (Reference)
@@ -391,7 +390,30 @@ rewriteApply env outer f args = case ABT.out f of
         -- No type info; leave the apply chain alone (no implicits to insert).
         pure (rebuildApps (ABT.annotation outer) f' args')
       Just ft ->
-        interleave (ABT.annotation outer) f' ft args'
+        -- ADR-007: if f was wrapped with @give@, demote /every/
+        -- leading @=>@ in its type to @->@ so 'interleave' consumes
+        -- the next args as regular positional arguments instead of
+        -- popping decisions from the queue. The typechecker has
+        -- already suppressed the matching 'ConstraintGoal' emissions
+        -- for those slots, so popping here would mis-align the queue.
+        -- 'lowerAll' must descend through any leading 'Forall'
+        -- quantifiers before reaching the @=>@ chain, otherwise a
+        -- type like @forall a. C a => a -> a@ falls into the
+        -- catch-all branch unchanged and 'interleave' below sees
+        -- the un-lowered 'ImplicitArrow' and pops a sibling
+        -- binding's resolved dictionary off the queue — leaking
+        -- that dictionary's locally-bound variables into this
+        -- scope (the @_implicit_<name>_<i>@ free-var hashing
+        -- crash).
+        let lowerAll ty = case ty of
+              Type.ForallNamed' v body -> Type.forAll (ABT.annotation ty) v (lowerAll body)
+              Type.ImplicitArrow' i o -> Type.arrow (ABT.annotation ty) i (lowerAll o)
+              _ -> ty
+            ft' =
+              if Ann.isLowered (ABT.annotation f')
+                then lowerAll ft
+                else ft
+         in interleave (ABT.annotation outer) f' ft' args'
 
 -- | Try to infer the type of the apply-chain's head from syntactic
 -- information alone.
@@ -418,29 +440,25 @@ interleave outerAnn f0 ty0 args0 =
   where
     headLoc = ABT.annotation f0
     go f ty args = case ty of
-      -- Implicit: try to fill it.
+      -- Implicit: pop a resolved-dictionary decision from the queue
+      -- and apply it. (ADR-007: when @give f@ is in effect at this
+      -- call site, the caller of 'interleave' has already demoted
+      -- the leading @=>@ to @->@ in @ty@, so we never enter this
+      -- branch for that slot — the explicit dictionary the user
+      -- supplied falls through to the 'Arrow'' case below.)
       Type.ImplicitArrow' _ conc -> do
-        case args of
-          [] -> pure (rebuildApps outerAnn f args)
-          (a : rest) ->
-            if isOverrideArg a
-              then -- User supplied this implicit explicitly; consume the arg
-              -- and keep going.
-                go (Term.app (ABT.annotation f <> ABT.annotation a) f a) conc rest
-              else do
-                mDec <- popDecision
-                case mDec of
-                  Nothing ->
-                    -- Queue empty: leave the rest alone.
-                    pure (rebuildApps outerAnn f args)
-                  Just tree -> do
-                    -- Chunk F1: record the synthesized insertion so
-                    -- the LSP can detect implicit args at the head's
-                    -- source position.
-                    recordImplicit headLoc tree
-                    let dictTm = buildDictionary outerAnn tree
-                        f' = Term.app (ABT.annotation f <> ABT.annotation dictTm) f dictTm
-                    go f' conc args
+        mDec <- popDecision
+        case mDec of
+          Nothing ->
+            -- Queue empty: leave the rest alone.
+            pure (rebuildApps outerAnn f args)
+          Just tree -> do
+            -- Chunk F1: record the synthesized insertion so the LSP
+            -- can detect implicit args at the head's source position.
+            recordImplicit headLoc tree
+            let dictTm = buildDictionary outerAnn tree
+                f' = Term.app (ABT.annotation f <> ABT.annotation dictTm) f dictTm
+            go f' conc args
       -- Explicit: consume one arg.
       Type.Arrow' _ conc ->
         case args of
@@ -583,10 +601,18 @@ stripLeadingImplicitLambdas ty0 tm0 =
 stripImplicitArgsByType ::
   forall v.
   (Var v) =>
+  -- | Predicate: is this term reference tagged as a @given@ in the
+  -- current namespace? Used to decide whether a positional argument
+  -- filling a leading @=>@ slot is the resolver's default pick (a
+  -- given-tagged reference, safe to elide) or a user-supplied
+  -- dictionary that the user wrote via the @give@ keyword (must be
+  -- preserved, and the head is re-annotated with 'Ann.Lowered' so the
+  -- printer renders the @give @ prefix).
+  (Reference -> Bool) ->
   (Term v Ann -> Maybe (Type v Ann)) ->
   Term v Ann ->
   Term v Ann
-stripImplicitArgsByType lookupTermType = go
+stripImplicitArgsByType isGivenRef lookupTermType = go
   where
     go :: Term v Ann -> Term v Ann
     go t = case ABT.out t of
@@ -597,18 +623,61 @@ stripImplicitArgsByType lookupTermType = go
       ABT.Tm other -> ABT.tm' (ABT.annotation t) (fmap go other)
 
     -- \| Collect the apps spine, find the head, look up its declared
-    -- type, and skip args for each leading @=>@ in that type.
+    -- type, and decide what to do with the leading @=>@-filling args.
+    -- If every such arg looks like an auto-resolved dictionary
+    -- (namespace-tagged @given@ reference), strip them — this is the
+    -- ADR-015 elide-mode default. Otherwise the user wrote @give@ at
+    -- this call site; keep the args and tag the head with
+    -- 'Ann.Lowered' so the printer emits the @give @ prefix.
+    --
+    -- The head's own annotation can itself carry 'Ann.Lowered'
+    -- (the parser puts it there when it sees the @give@ keyword,
+    -- and 'applyGivenDecisionsAll' preserves it). When it does,
+    -- the user explicitly asked for explicit dictionary passing,
+    -- so we must not elide the implicit args even if they happen
+    -- to look like auto-resolutions.
     stripApps :: Term v Ann -> Term v Ann
     stripApps tm =
       let (head_, args) = collect tm []
           recurseArgs xs = map (\(a, x) -> (a, go x)) xs
+          headIsLowered = Ann.isLowered (ABT.annotation head_)
        in case lookupTermType head_ of
             Just ty ->
               let nImplicits = countLeadingImplicits ty
-                  args' = drop nImplicits args
-               in rebuild (ABT.annotation tm) (go head_) (recurseArgs args')
+                  (implicitArgs, rest) = splitAt nImplicits args
+               in if not headIsLowered
+                    && length implicitArgs == nImplicits
+                    && all (argLooksAutoResolved . snd) implicitArgs
+                    then rebuild (ABT.annotation tm) (go head_) (recurseArgs rest)
+                    else
+                      let head' = markLowered (go head_)
+                       in rebuild (ABT.annotation tm) head' (recurseArgs args)
             Nothing ->
               rebuild (ABT.annotation tm) (go head_) (recurseArgs args)
+
+    -- | An arg "looks auto-resolved" iff it could plausibly be what
+    -- the resolver picked: either a namespace-given top-level
+    -- reference (ambient pool), or a local 'Var' (lexical given
+    -- bound by @=>I@ or a @let given@). Anything else (a non-given
+    -- top-level reference, a literal, a complex expression) is
+    -- treated as a user-supplied dictionary that @give@ should
+    -- preserve.
+    argLooksAutoResolved :: Term v Ann -> Bool
+    argLooksAutoResolved a = case ABT.out a of
+      ABT.Tm (Term.Ref r) -> isGivenRef r
+      ABT.Var _ -> True
+      _ -> False
+
+    -- | Wrap the apply-chain head with a sentinel 'Term.Ann' whose
+    -- type is 'Type.giveMarkerRef'. The surface 'TermPrinter'
+    -- recognises this sentinel on an @Apps'@ head and renders the
+    -- chain with a leading @give @ keyword. The sentinel is a
+    -- print-time-only construct — it never reaches hashing because
+    -- 'stripImplicitArgsByType' runs as a view-side post-pass.
+    markLowered :: Term v Ann -> Term v Ann
+    markLowered h =
+      let a = ABT.annotation h
+       in Term.ann a h (Type.ref a Type.giveMarkerRef)
 
     collect :: Term v Ann -> [(Ann, Term v Ann)] -> (Term v Ann, [(Ann, Term v Ann)])
     collect t acc = case ABT.out t of
@@ -681,60 +750,11 @@ localGivenPrefix = "Local.given."
 -- @overrideArg@: only single-leaf terms (Var, Ref, Builtin, literal,
 -- TermLink, TypeLink, Blank) can be @\@@-widened. Composite terms
 -- with sub-children are never overrides.
+-- | ADR-007: was a heuristic for detecting @\@@-override args via
+-- annotation widening. Now that the override path goes through the
+-- @give@-prefix syntax (which tags the /function/ with
+-- 'Ann.Lowered' so 'rewriteApply' demotes the type before
+-- 'interleave' sees it), there's no need to inspect the arg. Kept
+-- as a stub so external callers compile; always returns 'False'.
 isOverrideArg :: Term v Ann -> Bool
-isOverrideArg t
-  | isLeafForOverride t,
-    Ann outerStart _ <- ABT.annotation t,
-    Just innerStart <- innerLeftmostStart t,
-    outerStart < innerStart =
-      True
-  | otherwise = False
-
--- | Restricted predicate matching the same surface forms 'termLeaf'
--- accepts for an @\@@-override (see
--- @parser-typechecker/src/Unison/Syntax/TermParser.hs:overrideArg@).
--- Returns 'True' only for atomic surface terms whose AST has no
--- structural children; this is what lets us trust an outer-vs-inner
--- annotation gap as a real override marker.
---
--- NOTE: As of this writing, single-leaf overrides (e.g. @f @ d@ where
--- @d@ is a bare identifier) cannot be detected via annotation
--- widening — the inner annotation is unavailable, so
--- 'innerLeftmostStart' returns 'Nothing' for these and
--- 'isOverrideArg' falls back to 'False'. Composite-leaf overrides
--- like @f @ (g x)@ also do not match this predicate because the
--- inner term has structural children, which would falsely conflict
--- with structural composites like list literals @[1,2,3]@. Until the
--- override path is rewired with an explicit AST marker, override
--- detection is effectively disabled: every implicit slot is filled
--- by the resolver. Users who want to override resolution must use
--- the @let given@ shadowing form (ADR-010).
-isLeafForOverride :: Term v Ann -> Bool
-isLeafForOverride t = case ABT.out t of
-  ABT.Var _ -> True
-  ABT.Tm body -> case body of
-    Term.Ref _ -> True
-    Term.Constructor _ -> True
-    Term.Request _ -> True
-    _ -> False
-  _ -> False
-
--- | Find the leftmost source-position start among the term's direct
--- structural children, if any. Returns 'Nothing' for a leaf.
-innerLeftmostStart :: Term v Ann -> Maybe L.Pos
-innerLeftmostStart t = case ABT.out t of
-  ABT.Var _ -> Nothing
-  ABT.Cycle body -> annStart (ABT.annotation body)
-  ABT.Abs _ body -> annStart (ABT.annotation body)
-  ABT.Tm body ->
-    let kids = foldMap (\c -> [ABT.annotation c]) body
-        starts = [s | a <- kids, Just s <- [annStart a]]
-     in case starts of
-          [] -> Nothing
-          xs -> Just (minimum xs)
-
-annStart :: Ann -> Maybe L.Pos
-annStart = \case
-  Ann s _ -> Just s
-  GeneratedFrom a -> annStart a
-  _ -> Nothing
+isOverrideArg _ = False

--- a/parser-typechecker/src/Unison/Typechecker/GivenApply.hs
+++ b/parser-typechecker/src/Unison/Typechecker/GivenApply.hs
@@ -655,7 +655,7 @@ stripImplicitArgsByType isGivenRef lookupTermType = go
             Nothing ->
               rebuild (ABT.annotation tm) (go head_) (recurseArgs args)
 
-    -- | An arg "looks auto-resolved" iff it could plausibly be what
+    -- \| An arg "looks auto-resolved" iff it could plausibly be what
     -- the resolver picked: either a namespace-given top-level
     -- reference (ambient pool), or a local 'Var' (lexical given
     -- bound by @=>I@ or a @let given@). Anything else (a non-given
@@ -668,7 +668,7 @@ stripImplicitArgsByType isGivenRef lookupTermType = go
       ABT.Var _ -> True
       _ -> False
 
-    -- | Wrap the apply-chain head with a sentinel 'Term.Ann' whose
+    -- \| Wrap the apply-chain head with a sentinel 'Term.Ann' whose
     -- type is 'Type.giveMarkerRef'. The surface 'TermPrinter'
     -- recognises this sentinel on an @Apps'@ head and renders the
     -- chain with a leading @give @ keyword. The sentinel is a

--- a/parser-typechecker/src/Unison/Typechecker/GivenElaborator.hs
+++ b/parser-typechecker/src/Unison/Typechecker/GivenElaborator.hs
@@ -1,0 +1,313 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | Phase-2 chunk D2: drive the standalone resolver
+-- ('Unison.Typechecker.GivenResolver') from real typechecker output.
+--
+-- D1 ported the resolver into the codebase as a pure function on
+-- @Type.Type v loc@. C2.1 added a lexical given environment to
+-- 'Unison.Typechecker.Context'. C2.2 emits 'Context.ConstraintGoal'
+-- info notes at every @ImplicitArrow@ apply-site, each carrying the
+-- goal type, the apply-site location, and a snapshot of the lexical
+-- given environment.
+--
+-- This module is the bridge: given a sequence of typechecker info
+-- notes plus a list of /ambient/ givens (top-level givens harvested
+-- from the namespace per @Unison.Codebase.Givens.namesMarkedGiven@,
+-- chunk B1), it constructs a per-goal 'GR.Pool' and calls 'GR.resolve'
+-- once per goal. The verdict is recorded as a 'Context.SolvedImplicit'
+-- info note so that the D3 post-pass can walk the term and substitute
+-- the resolved dictionary terms back into the AST — exactly how
+-- 'applyTdnrDecisions' walks 'Context.Decision' notes today (see
+-- @parser-typechecker/src/Unison/FileParsers.hs:329@).
+--
+-- ## Pool construction
+--
+-- Each goal has its own pool because the lexical-given snapshot is
+-- per-goal (the goal at a deep let-binding sees more local givens than
+-- the goal at top level). The ambient pool is shared across all goals
+-- in the file.
+--
+-- For each goal:
+--
+-- 1. Take the 'goalScope' map (lexical givens captured by C2.1) and
+--    decompose each entry's type with 'decomposeGivenType'. The
+--    resulting 'GR.Given' records are tagged with @Lexical 0@ — D2
+--    does not yet preserve binder-depth, so all lexical givens are
+--    treated as equally inner. ADR-008's most-inner-wins rule still
+--    chooses lexical over ambient correctly because @Lexical 0 < Ambient@.
+--
+-- 2. Append the supplied ambient pool, tagged @Ambient@.
+--
+-- 3. Run 'GR.resolve' on the goal type.
+--
+-- ## Decomposition (top-level givens)
+--
+-- The user-facing API for top-level givens is a name in the namespace
+-- whose 'MdValues' contains 'Unison.Codebase.Givens.givenSentinel' (B1).
+-- The caller (FileParsers / the file-elaboration entry point) is
+-- responsible for resolving each such name to its 'Reference' and
+-- 'Type.Type' and passing the result here as a list of 'AmbientGiven'
+-- records.
+--
+-- The decomposition itself is straightforward: strip leading @forall@s
+-- to extract 'givenTyVars'; walk the @ImplicitArrow@ chain in the body
+-- to extract premises; what remains is the conclusion. (Outer 'Arrow's
+-- — i.e. value-level parameters — are part of the conclusion. A
+-- @Show a => List a -> Text@ given concludes @List a -> Text@, with
+-- premise @Show a@.)
+--
+-- ## Lexical-depth convention
+--
+-- Per ADR-008 the resolver picks lexical-inner candidates over
+-- lexical-outer ones at the same subsumption level. The 'goalScope'
+-- snapshot we receive from C2.1 is a flat 'Map' that does /not/ carry
+-- depth — it is simply "every given visible at the apply-site". For
+-- D2 we tag every lexical given with @GR.Lexical 0@: the resolver's
+-- ordering rule then uses 'Ambient' only when no lexical hit exists,
+-- and ties between two equally-lexical givens are broken by
+-- specificity (also fine).
+--
+-- A future chunk may extend C2.1 to track binder depth so the resolver
+-- can distinguish two lexical givens of different scopes.
+--
+-- ## Shared-metavar awareness (ADR-023)
+--
+-- D2 runs the resolver as a /post-pass/ over the typechecker's info
+-- notes, after all inference has reached its fixed point. By that
+-- point 'substituteSolved' (in 'Context') has already been applied to
+-- every 'ConstraintGoal' (its wildcard arm propagates the final
+-- context substitution into 'goalType' and 'goalScope'). The types we
+-- pass to the resolver therefore contain only those existentials that
+-- remained unsolved at the end of inference — and the resolver's
+-- standalone unifier treats them as flexible variables when the
+-- candidate's freshened skolems suggest, and otherwise rigid.
+--
+-- Because we are post-typechecker and not interleaved with it, the
+-- 'metavar-invalidation' rule from ADR-023 (Option A) is satisfied
+-- trivially: there is no later substitution that can invalidate a
+-- memoized resolution. Memoization is per-call to 'GR.resolve' and is
+-- discarded between goals; that is sound because each goal carries an
+-- independent type, and even when the type variables happen to share
+-- names across goals the per-goal memo table is fresh.
+--
+-- A future refactor that interleaves resolution with the @M v loc@
+-- monad — folding the resolver back into the typechecker proper —
+-- would need to revisit this and either invalidate memo entries on
+-- substitution (per ADR-023) or restrict memoization to fully-applied
+-- goal types. We defer that decision; D2 stays standalone.
+module Unison.Typechecker.GivenElaborator
+  ( -- * Top-level givens
+    AmbientGiven (..),
+    ambientPool,
+    decomposeGivenType,
+
+    -- * Goal-driven elaboration
+    elaborateGoals,
+    elaborateInfoNotes,
+
+    -- * Diagnostics
+    extractConstraintGoals,
+    implicitDecisions,
+  )
+where
+
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Unison.Reference (Reference)
+import Unison.Type (Type)
+import Unison.Type qualified as Type
+import Unison.Typechecker.Context qualified as Context
+import Unison.Typechecker.GivenResolver qualified as GR
+import Unison.Typechecker.TypeVar qualified as TypeVar
+import Unison.Var (Var)
+
+------------------------------------------------------------------------------
+-- Ambient givens (top-level / namespace)
+------------------------------------------------------------------------------
+
+-- | A top-level given fetched from the namespace. The caller is
+-- responsible for filtering to /just/ those names the user marked
+-- with 'Unison.Codebase.Givens.givenSentinel' and looking up each
+-- one's 'Reference' and full type signature in the codebase.
+--
+-- Decomposition into @forall@-bound type variables, premises, and
+-- conclusion is performed by 'decomposeGivenType'.
+data AmbientGiven v loc = AmbientGiven
+  { ambientName :: !Reference,
+    ambientType :: !(Type v loc)
+  }
+  deriving stock (Show)
+
+-- | Build a 'GR.Pool' of @Ambient@-scoped givens from a list of
+-- top-level givens.
+ambientPool :: (Var v) => [AmbientGiven v loc] -> GR.Pool v loc
+ambientPool xs = GR.poolFromList (map toGiven xs)
+  where
+    toGiven (AmbientGiven r ty) =
+      let (vs, prems, concl) = decomposeGivenType ty
+       in GR.Given
+            { GR.givenName = r,
+              GR.givenTyVars = vs,
+              GR.givenPremises = prems,
+              GR.givenConclusion = concl,
+              GR.givenScope = GR.Ambient
+            }
+
+-- | Decompose a given's declared type into
+-- @(forall-bound vars, premises, conclusion)@.
+--
+-- Strips leading 'Type.ForallNamed'' to extract type variables, then
+-- walks the @ImplicitArrow@ chain to peel premises. What remains is
+-- the conclusion. Regular @Arrow@s are /not/ peeled — a value-level
+-- parameter is part of the conclusion.
+--
+-- Examples:
+--
+-- @
+--   forall a. Show a => List a -> Text
+--     ↳ ([a], [Show a], List a -> Text)
+--
+--   forall a b. (Eq a, Ord b) => Map a b
+--     ↳ ([a, b], [Eq a, Ord b], Map a b)
+--
+--   List a   (no foralls, no premises)
+--     ↳ ([], [], List a)
+-- @
+decomposeGivenType ::
+  (Var v) =>
+  Type v loc ->
+  ([v], [Type v loc], Type v loc)
+decomposeGivenType ty =
+  let (vs, body) = Type.unforall' ty
+      (prems, concl) = peelImplicits body
+   in (vs, prems, concl)
+  where
+    peelImplicits t = case t of
+      Type.ImplicitArrow' i o ->
+        let (rest, c) = peelImplicits o
+         in (i : rest, c)
+      _ -> ([], t)
+
+------------------------------------------------------------------------------
+-- Goal-driven elaboration
+------------------------------------------------------------------------------
+
+-- | A pending 'Context.ConstraintGoal' projected into surface form.
+-- The typechecker emits 'Context.ConstraintGoal' notes whose types
+-- carry 'TypeVar' wrappers; we lower them once here so the rest of
+-- the elaborator (and the resolver) sees plain 'Type.Type v loc'.
+data PendingGoal v loc = PendingGoal
+  { pgLoc :: !loc,
+    pgType :: !(Type v loc),
+    pgScope :: !(Map Reference (Type v loc))
+  }
+  deriving stock (Show)
+
+-- | Project the 'Context.ConstraintGoal' notes out of a heterogeneous
+-- info-note list, lowering each goal's types from
+-- 'Context.Type v loc' to surface 'Type.Type v loc'.
+extractConstraintGoals ::
+  (Var v) =>
+  [Context.InfoNote v loc] ->
+  [PendingGoal v loc]
+extractConstraintGoals = foldr step []
+  where
+    step (Context.ConstraintGoal loc ty scope) acc =
+      PendingGoal
+        { pgLoc = loc,
+          pgType = TypeVar.lowerType ty,
+          pgScope = TypeVar.lowerType <$> scope
+        }
+        : acc
+    step _ acc = acc
+
+-- | Run the resolver on each pending goal, returning one
+-- 'Context.SolvedImplicit' info note per goal.
+--
+-- Each goal's pool is built fresh: it is the union of (the supplied
+-- ambient pool) and (the goal's own lexical-givens snapshot, tagged
+-- @Lexical 0@). This per-goal construction is what makes lexical
+-- shadowing work — a goal that sees a deep @given x@ binding has
+-- @x@ in its scope; goals at outer scope do not.
+elaborateGoals ::
+  (Var v, Ord loc) =>
+  -- | Ambient (top-level / namespace) givens, shared by every goal.
+  GR.Pool v loc ->
+  -- | The goals emitted by the typechecker, projected with
+  -- 'extractConstraintGoals'.
+  [PendingGoal v loc] ->
+  [Context.InfoNote v loc]
+elaborateGoals ambient = map (resolveOne ambient)
+
+-- | Convenience: run the entire elaboration pass over a list of info
+-- notes. The result is the original list with one 'SolvedImplicit'
+-- note appended per 'ConstraintGoal' (the original 'ConstraintGoal'
+-- notes are preserved so D4's error rendering still has access to
+-- them).
+elaborateInfoNotes ::
+  (Var v, Ord loc) =>
+  GR.Pool v loc ->
+  [Context.InfoNote v loc] ->
+  [Context.InfoNote v loc]
+elaborateInfoNotes ambient infos =
+  infos <> elaborateGoals ambient (extractConstraintGoals infos)
+
+-- | Project the 'Context.SolvedImplicit' notes out of a heterogeneous
+-- info-note list. Useful for the D3 post-pass and for tests.
+implicitDecisions ::
+  [Context.InfoNote v loc] ->
+  [(loc, Type v loc, Either (GR.ResolveError v loc) (GR.ResolutionTree v loc))]
+implicitDecisions = foldr step []
+  where
+    step (Context.SolvedImplicit loc ty d) acc = (loc, ty, d) : acc
+    step _ acc = acc
+
+------------------------------------------------------------------------------
+-- The per-goal pool + resolve
+------------------------------------------------------------------------------
+
+resolveOne ::
+  forall v loc.
+  (Var v, Ord loc) =>
+  GR.Pool v loc ->
+  PendingGoal v loc ->
+  Context.InfoNote v loc
+resolveOne ambient PendingGoal {pgLoc, pgType, pgScope} =
+  let lexical = lexicalPool pgScope
+      pool = mergePool lexical ambient
+      decision = GR.resolve pool pgType
+   in Context.SolvedImplicit
+        { Context.implicitGoalLoc = pgLoc,
+          Context.implicitGoalType = pgType,
+          Context.implicitDecision = decision
+        }
+
+-- | Build a 'GR.Pool' of @Lexical 0@-scoped givens from a per-goal
+-- 'goalScope' snapshot.
+--
+-- Each entry @(reference, type)@ is decomposed into @forall@-vars +
+-- premises + conclusion exactly like an ambient given; the only
+-- difference is the 'GR.givenScope' tag.
+--
+-- D2 does not yet track binder depth, so every lexical given gets
+-- @Lexical 0@. ADR-008's most-inner-wins rule between two lexical
+-- givens at the same depth therefore degenerates into the
+-- specificity ordering — fine for D2's tests, and revisable in a
+-- later chunk by extending C2.1's snapshot to carry depth.
+lexicalPool :: (Var v) => Map Reference (Type v loc) -> GR.Pool v loc
+lexicalPool m = GR.poolFromList (map mk (Map.toList m))
+  where
+    mk (r, ty) =
+      let (vs, prems, concl) = decomposeGivenType ty
+       in GR.Given
+            { GR.givenName = r,
+              GR.givenTyVars = vs,
+              GR.givenPremises = prems,
+              GR.givenConclusion = concl,
+              GR.givenScope = GR.Lexical 0
+            }
+
+mergePool :: GR.Pool v loc -> GR.Pool v loc -> GR.Pool v loc
+mergePool a b = GR.poolFromList (GR.poolGivens a <> GR.poolGivens b)

--- a/parser-typechecker/src/Unison/Typechecker/GivenElaborator.hs
+++ b/parser-typechecker/src/Unison/Typechecker/GivenElaborator.hs
@@ -101,6 +101,7 @@ module Unison.Typechecker.GivenElaborator
   ( -- * Top-level givens
     AmbientGiven (..),
     ambientPool,
+    mergePool,
     decomposeGivenType,
 
     -- * Goal-driven elaboration
@@ -181,8 +182,16 @@ decomposeGivenType ::
   ([v], [Type v loc], Type v loc)
 decomposeGivenType ty =
   let (vs, body) = Type.unforall' ty
-      (prems, concl) = peelImplicits body
-   in (vs, prems, concl)
+      (prems, concl0) = peelImplicits body
+      -- After 'addAbilities' / 'existentializeArrows' the generalized
+      -- signature wraps its conclusion in an 'Effect [] _'. The
+      -- resolver unifies head-only against a 'ConstraintGoal' whose
+      -- type was lowered without that wrapper, so we strip the
+      -- (always empty for a constraint) effect row here. Without
+      -- this, @forall a. Show a => Show [a]@ stored from
+      -- 'topLevelComponents' fails to unify with the goal @Show [Nat]@.
+      concl = snd (Type.unEffect0 concl0)
+   in (vs, map (snd . Type.unEffect0) prems, concl)
   where
     peelImplicits t = case t of
       Type.ImplicitArrow' i o ->

--- a/parser-typechecker/src/Unison/Typechecker/GivenResolver.hs
+++ b/parser-typechecker/src/Unison/Typechecker/GivenResolver.hs
@@ -296,35 +296,40 @@ resolveCounted ::
   Pool v loc ->
   Type v loc ->
   (Either (ResolveError v loc) (ResolutionTree v loc), Int)
-resolveCounted opts pool goal
-  -- D4: detect inference-only metavariables in the goal and short-
-  -- circuit. The resolver cannot meaningfully match such goals: any
-  -- candidate would head-unify with the metavar, leading to
-  -- spurious 'NoGiven' or 'Ambiguous' diagnostics that mislead
-  -- the user.
-  | goalHasInferenceVar goal =
-      (Left (UnresolvedMetavarInGoal goal), 0)
-  | otherwise =
-      let (result, finalSt) =
-            runState
-              (resolveImpl goal [] 0)
-              (initialState opts pool goal)
-       in (result, sWork finalSt)
+resolveCounted opts pool goal =
+  -- D4 previously short-circuited when the goal contained an
+  -- 'Var.Inference'-typed variable, on the theory that any candidate
+  -- would head-unify with the metavar and produce a spurious
+  -- diagnostic. In practice the resolver's unifier treats free
+  -- variables symmetrically and the constraint goal often carries
+  -- an unresolved metavar that surrounding inference has already
+  -- pinned — we just haven't substituted it into the note. We now
+  -- run the resolver unconditionally; if it succeeds the unifier
+  -- pins the metavar to the candidate, and if no candidate matches
+  -- the 'NoGiven' surface diagnostic accurately reports that there
+  -- is no instance — adding a type annotation is a special case of
+  -- that.
+  let (result, finalSt) =
+        runState
+          (resolveImpl goal [] 0)
+          (initialState opts pool goal)
+   in (result, sWork finalSt)
 
--- | Does the goal contain any free variable that was created by type
--- inference (a 'Var.Inference' kind)? Such variables are existentials
--- the surrounding inference has not yet pinned. The resolver treats
--- them as flexible during head-unification, which is fine for resolved
--- types but produces misleading errors when the user genuinely just
--- needs a type annotation.
-goalHasInferenceVar :: forall v loc. (Var v) => Type v loc -> Bool
-goalHasInferenceVar goal =
-  any isInferenceVar (Set.toList (ABT.freeVars goal))
-  where
-    isInferenceVar :: v -> Bool
-    isInferenceVar v = case Var.typeOf v of
-      Var.Inference _ -> True
-      _ -> False
+-- (Kept for reference: previously used to short-circuit resolution
+-- when the goal carried an unresolved metavariable. The check turned
+-- out to be too aggressive — a freshly-created existential whose
+-- substitution is in flight is indistinguishable from a permanently
+-- unconstrained one, but the unifier handles both correctly. The
+-- check is no longer consulted; if no candidate matches, 'NoGiven'
+-- is the right surface diagnostic.)
+
+-- | Whether a 'Var.Type' indicates a variable created by the
+-- typechecker's inference machinery. Used by 'matchHead' to decide
+-- which goal-side variables to treat as flexible.
+isInferenceVar :: Var.Type -> Bool
+isInferenceVar = \case
+  Var.Inference _ -> True
+  _ -> False
 
 ------------------------------------------------------------------------------
 -- The algorithm
@@ -469,7 +474,20 @@ matchHead goal g = do
   -- them at the call site). Implementation: pass the fresh set as
   -- the unifier's flexible-variable whitelist; everything else is
   -- treated rigid.
-  case unify mempty (Set.fromList fresh) concl' goal of
+  --
+  -- Exception: unresolved inference variables that surrounding type
+  -- inference hasn't yet pinned are also treated as flexible. When
+  -- the elaborator emits a 'ConstraintGoal' for a polymorphic
+  -- function used in a context that fully determines its type
+  -- elsewhere, the goal's existential may not have been substituted
+  -- into the note by the time the resolver runs. Treating those
+  -- existentials as flexible lets the unifier bind them to whatever
+  -- the candidate exposes — which is exactly what surrounding
+  -- inference will end up doing.
+  let inferenceVarsInGoal =
+        Set.filter (isInferenceVar . Var.typeOf) (ABT.freeVars goal)
+      flex = Set.fromList fresh `Set.union` inferenceVarsInGoal
+  case unify mempty flex concl' goal of
     Nothing -> pure Nothing
     Just s ->
       pure $

--- a/parser-typechecker/src/Unison/Typechecker/GivenResolver.hs
+++ b/parser-typechecker/src/Unison/Typechecker/GivenResolver.hs
@@ -1,0 +1,748 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | Phase-2 chunk D1 port of the implicit-resolution spike
+-- (@spike\/implicits\/src\/Implicits\/Resolve.hs@) adapted to use the
+-- real 'Unison.Type.Type' AST.
+--
+-- This module is exercised by unit tests only; D2 wires it into the
+-- typechecker. The algorithm (per @docs\/implicits-plan.md@ §1.3) is:
+--
+-- @
+--   resolve(T, stack, depth) =
+--     if depth > maxDepth: error DepthExceeded(stack)
+--     if any(unifies(T, S)) for S in stack: fail this branch (cycle)
+--     candidates = { g | conclusion(g) unifies with T under sigma }
+--     ... try each, picking most-specific or reporting ambiguity
+-- @
+--
+-- Refinements applied since the spike:
+--
+-- * Specificity uses *one-way* matching of *declared* conclusions
+--   ('oneWayMatch'), per the post-spike refinement in ADR-008. The
+--   candidate-under-comparison's quantified variables are flexible;
+--   the other candidate's are rigid.
+--
+-- * Memoization is per-top-level-resolve, keyed on the goal type, and
+--   caches both successes and failures (per ADR-023 Option A). The
+--   metavar-binding invalidation rule from ADR-023 is a no-op here in
+--   D1 because the resolver does not yet share metavariables with the
+--   outer typechecker; D2 will add invalidation when the outer
+--   substitution is plumbed in.
+--
+-- ## Unification choice
+--
+-- The typechecker's 'Unison.Typechecker.Context' provides 'subtype'
+-- and 'equate' but they are tightly bound to the @M v loc@ monad
+-- (existential markers, scope tracking, 'Blank' annotations,
+-- 'TypeVar.Existential' / 'TypeVar.Universal' wrapping). They cannot
+-- be reused without dragging in the entire context state.
+--
+-- The spike's standalone Robinson unifier is a far better fit: the
+-- resolver freshens each candidate's quantified variables to its own
+-- pool and unifies with the goal under a pure substitution. We port
+-- it verbatim, retargeted at 'Type.F'. D2 will revisit this when the
+-- resolver runs inside the typechecker monad.
+module Unison.Typechecker.GivenResolver
+  ( -- * Givens and pool
+    Given (..),
+    Scope (..),
+    Pool (..),
+    poolFromList,
+
+    -- * Result tree
+    ResolutionTree (..),
+    Substitution,
+
+    -- * Errors
+    ResolveError (..),
+    NearMiss (..),
+
+    -- * Entry points
+    resolve,
+    resolveWith,
+    resolveCounted,
+
+    -- * Options
+    ResolveOptions (..),
+    defaultOptions,
+  )
+where
+
+import Control.Monad.State.Strict (State, get, modify', runState)
+import Data.List (foldl1')
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Unison.ABT qualified as ABT
+import Unison.Reference (Reference)
+import Unison.Type (Type)
+import Unison.Type qualified as Type
+import Unison.Var (Var)
+import Unison.Var qualified as Var
+
+------------------------------------------------------------------------------
+-- Public types
+------------------------------------------------------------------------------
+
+-- | Substitution from variable to type. The resolver's substitutions
+-- are kept idempotent (applying twice is the same as applying once).
+type Substitution v loc = Map v (Type v loc)
+
+-- | Lexical depth or ambient scope. Smaller 'Lexical' values are
+-- *more* inner (e.g. @Lexical 0@ is the innermost binder); 'Ambient'
+-- is the outermost. Per ADR-008, lexical-inner candidates win over
+-- ambient ones at the same subsumption level.
+data Scope = Lexical !Int | Ambient
+  deriving stock (Eq, Ord, Show)
+
+-- | A single available given. Universally quantified over
+-- 'givenTyVars'.
+--
+-- Example: @given Show.list : Show a => Show (List a)@ is
+--
+-- @
+--   Given { givenName       = Reference.Builtin "Show.list"
+--         , givenTyVars     = [a]
+--         , givenPremises   = [App Show (Var a)]
+--         , givenConclusion = App Show (App List (Var a))
+--         , givenScope      = Ambient
+--         }
+-- @
+data Given v loc = Given
+  { givenName :: !Reference,
+    givenTyVars :: ![v],
+    givenPremises :: ![Type v loc],
+    givenConclusion :: !(Type v loc),
+    givenScope :: !Scope
+  }
+  deriving stock (Show)
+
+-- | Two givens are considered equal by their reference: the rest of
+-- the record is metadata recoverable from the term whose hash is the
+-- 'Reference'. Equality on 'Reference' is what callers want when they
+-- need set-membership of givens.
+instance Eq (Given v loc) where
+  a == b = givenName a == givenName b
+
+-- | The candidate pool. Order is irrelevant; we keep it as a list
+-- because we always traverse linearly.
+newtype Pool v loc = Pool {poolGivens :: [Given v loc]}
+  deriving stock (Show)
+
+poolFromList :: [Given v loc] -> Pool v loc
+poolFromList = Pool
+
+-- | A successful resolution.
+data ResolutionTree v loc = ResolutionTree
+  { -- | The chosen given.
+    rtGiven :: !(Given v loc),
+    -- | The substitution that specialised the given's conclusion to
+    -- the goal (and was propagated into the premises).
+    rtSubst :: !(Substitution v loc),
+    -- | Resolution proofs for each premise, in order.
+    rtChildren :: ![ResolutionTree v loc]
+  }
+  deriving stock (Show)
+
+-- | Resolution errors. Keep these structured so the rendering pass
+-- (chunk D4) can format them.
+data ResolveError v loc
+  = -- | No matching given for the goal; near-misses are candidates
+    -- whose conclusions head-unified with the goal but whose premises
+    -- failed to resolve.
+    NoGiven (Type v loc) [NearMiss v loc]
+  | -- | Multiple givens of incomparable specificity match.
+    Ambiguous (Type v loc) [Given v loc]
+  | -- | Resolution chain exceeded the depth limit; the chain
+    -- (outermost first) is included for diagnosis.
+    DepthExceeded [Type v loc]
+  | -- | Hard cycle: the goal recurred along its own chain. Currently
+    -- emitted only when the resolver detects a self-referential goal
+    -- with no escape hatch. The list is the chain at the point of
+    -- detection (outermost first). Per ADR-009, ordinary cycles
+    -- short-circuit per-branch and surface as 'NoGiven'; this
+    -- variant is the explicit hard-cycle diagnosis exposed for D4
+    -- rendering.
+    Cycle [Type v loc]
+  | -- | The goal contained an unresolved metavariable (an inference
+    -- variable that was not pinned by surrounding inference). The
+    -- resolver cannot meaningfully proceed: head-unification would
+    -- accept any candidate. D4 surfaces this as a distinct
+    -- diagnostic so the user is told to add a type annotation rather
+    -- than chasing a missing given.
+    --
+    -- The 'Type' is the goal as the resolver saw it (with the
+    -- metavar still present).
+    UnresolvedMetavarInGoal (Type v loc)
+  deriving stock (Show)
+
+-- | A candidate that head-unified with the goal but failed somewhere
+-- in its premises. Carries the sub-error so the user can see *why*
+-- it didn't work.
+data NearMiss v loc = NearMiss
+  { nmGiven :: !(Given v loc),
+    nmReason :: !(ResolveError v loc)
+  }
+  deriving stock (Show)
+
+------------------------------------------------------------------------------
+-- Options
+------------------------------------------------------------------------------
+
+data ResolveOptions = ResolveOptions
+  { -- | Maximum chain depth before bailing with 'DepthExceeded'.
+    -- Default 50, per ADR-009.
+    optMaxDepth :: !Int
+  }
+  deriving stock (Eq, Show)
+
+defaultOptions :: ResolveOptions
+defaultOptions = ResolveOptions {optMaxDepth = 50}
+
+------------------------------------------------------------------------------
+-- Resolution monad
+------------------------------------------------------------------------------
+
+-- | Map keyed by the structural shape of the goal type. We discard
+-- the goal's annotation when comparing for memoization — annotations
+-- carry source locations, but two goals at different source locations
+-- with the same shape are still the same resolution problem.
+newtype MemoKey v = MemoKey (Type v ())
+  deriving stock (Eq, Ord)
+
+mkMemoKey :: (Ord v) => Type v loc -> MemoKey v
+mkMemoKey = MemoKey . void'
+  where
+    void' :: (Ord v) => Type v loc -> Type v ()
+    void' = ABT.amap (const ())
+
+data RState v loc = RState
+  { -- | Running supply of fresh variables. Each @freshen@ pulls from
+    -- here and the resolver guarantees no collision with the
+    -- candidate's own variables or any goal variable already in
+    -- play.
+    sUsed :: !(Set v),
+    -- | Memoization table: 'MemoKey' to either error or success.
+    -- Cleared between top-level 'resolve' calls. Caches both hits and
+    -- misses (per ADR-023).
+    sMemo :: !(Map (MemoKey v) (Either (ResolveError v loc) (ResolutionTree v loc))),
+    -- | Number of memo *misses* — distinct sub-goals attempted.
+    -- Exposed via 'resolveCounted' so tests can verify the diamond
+    -- bound from §4.2#6 of the plan.
+    sWork :: !Int,
+    -- | Resolution options.
+    sOpts :: !ResolveOptions,
+    -- | Pool of available givens.
+    sPool :: !(Pool v loc)
+  }
+
+type R v loc = State (RState v loc)
+
+initialState :: forall v loc. (Var v) => ResolveOptions -> Pool v loc -> Type v loc -> RState v loc
+initialState opts pool goal =
+  RState
+    { sUsed = seedUsed,
+      sMemo = Map.empty,
+      sWork = 0,
+      sOpts = opts,
+      sPool = pool
+    }
+  where
+    -- Seed the fresh-variable supply with every variable that occurs
+    -- in the goal or in any candidate so freshening can never collide.
+    seedUsed =
+      Set.unions
+        ( ABT.freeVars goal
+            : map givenAllVars (poolGivens pool)
+        )
+    givenAllVars g =
+      Set.unions
+        ( Set.fromList (givenTyVars g)
+            : ABT.freeVars (givenConclusion g)
+            : map ABT.freeVars (givenPremises g)
+        )
+
+------------------------------------------------------------------------------
+-- Top-level entry points
+------------------------------------------------------------------------------
+
+-- | Resolve a goal in the given pool with default options.
+resolve ::
+  (Var v, Ord loc) =>
+  Pool v loc ->
+  Type v loc ->
+  Either (ResolveError v loc) (ResolutionTree v loc)
+resolve = resolveWith defaultOptions
+
+-- | Resolve with explicit options.
+resolveWith ::
+  (Var v, Ord loc) =>
+  ResolveOptions ->
+  Pool v loc ->
+  Type v loc ->
+  Either (ResolveError v loc) (ResolutionTree v loc)
+resolveWith opts pool goal = fst (resolveCounted opts pool goal)
+
+-- | Like 'resolveWith' but also returns the number of distinct
+-- sub-goals actually attempted (memo misses). Used by the diamond
+-- tests to verify the memoization bound.
+resolveCounted ::
+  (Var v, Ord loc) =>
+  ResolveOptions ->
+  Pool v loc ->
+  Type v loc ->
+  (Either (ResolveError v loc) (ResolutionTree v loc), Int)
+resolveCounted opts pool goal
+  -- D4: detect inference-only metavariables in the goal and short-
+  -- circuit. The resolver cannot meaningfully match such goals: any
+  -- candidate would head-unify with the metavar, leading to
+  -- spurious 'NoGiven' or 'Ambiguous' diagnostics that mislead
+  -- the user.
+  | goalHasInferenceVar goal =
+      (Left (UnresolvedMetavarInGoal goal), 0)
+  | otherwise =
+      let (result, finalSt) =
+            runState
+              (resolveImpl goal [] 0)
+              (initialState opts pool goal)
+       in (result, sWork finalSt)
+
+-- | Does the goal contain any free variable that was created by type
+-- inference (a 'Var.Inference' kind)? Such variables are existentials
+-- the surrounding inference has not yet pinned. The resolver treats
+-- them as flexible during head-unification, which is fine for resolved
+-- types but produces misleading errors when the user genuinely just
+-- needs a type annotation.
+goalHasInferenceVar :: forall v loc. (Var v) => Type v loc -> Bool
+goalHasInferenceVar goal =
+  any isInferenceVar (Set.toList (ABT.freeVars goal))
+  where
+    isInferenceVar :: v -> Bool
+    isInferenceVar v = case Var.typeOf v of
+      Var.Inference _ -> True
+      _ -> False
+
+------------------------------------------------------------------------------
+-- The algorithm
+------------------------------------------------------------------------------
+
+-- | Recursive resolution worker.
+resolveImpl ::
+  (Var v, Ord loc) =>
+  Type v loc ->
+  [Type v loc] ->
+  Int ->
+  R v loc (Either (ResolveError v loc) (ResolutionTree v loc))
+resolveImpl goal stack depth = do
+  opts <- gets' sOpts
+  if depth > optMaxDepth opts
+    then pure (Left (DepthExceeded (reverse (goal : stack))))
+    else
+      -- Per-branch cycle detection: if any in-flight goal unifies
+      -- with the new goal, *this branch* fails. Other candidates may
+      -- still succeed; the overall query may still succeed via a
+      -- non-cyclic alternative. Per ADR-009.
+      if any (cycleHit goal) stack
+        then pure (Left (NoGiven goal []))
+        else do
+          memo <- gets' sMemo
+          let key = mkMemoKey goal
+          case Map.lookup key memo of
+            Just hit -> pure hit
+            Nothing -> do
+              bumpWork
+              result <- attemptCandidates goal stack depth
+              modify' (\st -> st {sMemo = Map.insert key result (sMemo st)})
+              pure result
+
+bumpWork :: R v loc ()
+bumpWork = modify' (\st -> st {sWork = sWork st + 1})
+
+gets' :: (RState v loc -> a) -> R v loc a
+gets' f = fmap f get
+
+-- | Two types are "the same in-flight goal" iff they /unify/ under
+-- the empty substitution, treating every free variable on either side
+-- as flexible. This catches alpha-renamed cycles such as
+-- @Foo a@ vs. @Foo b@ where the renamed copy was produced by
+-- 'freshenGiven' on a recursive given.
+--
+-- D1 carry-over: the original implementation passed @Set.empty@ for
+-- the flex set, which makes 'unify' equivalent to structural equality
+-- modulo annotations. With closed monotype goals (D1's tests) the
+-- distinction was unobservable, but in D2 the goal can carry
+-- metavariables that outer inference has not yet pinned, so we widen
+-- the flex set to /all/ free variables in either side.
+--
+-- Note: this is intentionally a /heuristic/ for cycle pruning; it is
+-- safe to over-approximate (a false-positive cycle just causes /this
+-- branch/ to fail, while other candidates may still resolve the goal,
+-- per ADR-009's per-branch cycle policy).
+cycleHit :: (Var v, Ord loc) => Type v loc -> Type v loc -> Bool
+cycleHit a b =
+  let flex = ABT.freeVars a `Set.union` ABT.freeVars b
+   in case unify mempty flex a b of
+        Just _ -> True
+        Nothing -> False
+
+-- | Try every given that head-unifies with the goal, then pick the
+-- unique winner.
+attemptCandidates ::
+  forall v loc.
+  (Var v, Ord loc) =>
+  Type v loc ->
+  [Type v loc] ->
+  Int ->
+  R v loc (Either (ResolveError v loc) (ResolutionTree v loc))
+attemptCandidates goal stack depth = do
+  pool <- gets' sPool
+  -- Step 1: head-unify each candidate with the goal.
+  candidates0 <- mapMaybeM (matchHead goal) (poolGivens pool)
+  -- Step 2: recursively resolve each candidate's premises. A
+  -- candidate whose premises don't all resolve becomes a near-miss.
+  attempts <- mapM (tryCandidate goal stack depth) candidates0
+  let (nearMisses, successes) = partitionAttempts attempts
+  case successes of
+    [] -> pure (Left (NoGiven goal nearMisses))
+    [single] -> pure (Right (rebuildTree single))
+    multiple -> pure (decideMostSpecific goal multiple)
+
+-- | A candidate that has passed head-unification but not yet had its
+-- premises resolved.
+data Candidate v loc = Candidate
+  { candGiven :: !(Given v loc),
+    -- | Premises after freshening + head-unification substitution
+    -- applied.
+    candPremises :: ![Type v loc],
+    -- | Substitution produced by head-unification. Stored on the
+    -- 'ResolutionTree' so post-passes (D3) can apply it to terms.
+    candSubst :: !(Substitution v loc),
+    -- | Conclusion *after* freshening but *before* head-unification.
+    -- Used for specificity comparison: post-unification, both
+    -- candidates' specialised conclusions equal the goal and carry no
+    -- information.
+    candFreshConclusion :: !(Type v loc),
+    -- | The fresh-renamed quantified variables. These are treated as
+    -- *flexible* (unifiable) when this candidate's conclusion is the
+    -- pattern in 'oneWayMatch', and as *rigid* when this candidate's
+    -- conclusion is the target of someone else's pattern.
+    candFreshTyVars :: ![v]
+  }
+
+data Attempt v loc
+  = Miss !(NearMiss v loc)
+  | Hit !(Candidate v loc) ![ResolutionTree v loc]
+
+partitionAttempts ::
+  [Attempt v loc] ->
+  ([NearMiss v loc], [(Candidate v loc, [ResolutionTree v loc])])
+partitionAttempts = foldr step ([], [])
+  where
+    step (Miss m) (ms, hs) = (m : ms, hs)
+    step (Hit c rs) (ms, hs) = (ms, (c, rs) : hs)
+
+rebuildTree :: (Candidate v loc, [ResolutionTree v loc]) -> ResolutionTree v loc
+rebuildTree (c, prems) =
+  ResolutionTree
+    { rtGiven = candGiven c,
+      rtSubst = candSubst c,
+      rtChildren = prems
+    }
+
+-- | Head-unify a single given's conclusion with the goal. Returns a
+-- 'Candidate' iff they unify. The candidate's quantified variables
+-- are first renamed to a fresh, collision-free pool.
+matchHead ::
+  (Var v, Ord loc) =>
+  Type v loc ->
+  Given v loc ->
+  R v loc (Maybe (Candidate v loc))
+matchHead goal g = do
+  let Given {givenTyVars, givenPremises, givenConclusion} = g
+  (fresh, prems', concl') <- freshenGiven givenTyVars givenPremises givenConclusion
+  -- The candidate's freshened variables are *flexible* (unifiable);
+  -- variables in the goal are *rigid* (we have already committed to
+  -- them at the call site). Implementation: pass the fresh set as
+  -- the unifier's flexible-variable whitelist; everything else is
+  -- treated rigid.
+  case unify mempty (Set.fromList fresh) concl' goal of
+    Nothing -> pure Nothing
+    Just s ->
+      pure $
+        Just
+          Candidate
+            { candGiven = g,
+              candPremises = map (applySubst s) prems',
+              candSubst = s,
+              candFreshConclusion = concl',
+              candFreshTyVars = fresh
+            }
+
+-- | Resolve every premise of a candidate. If they all succeed, return
+-- a 'Hit'; the first failing premise turns the whole candidate into a
+-- 'Miss'.
+tryCandidate ::
+  (Var v, Ord loc) =>
+  Type v loc ->
+  [Type v loc] ->
+  Int ->
+  Candidate v loc ->
+  R v loc (Attempt v loc)
+tryCandidate goal stack depth cand =
+  let stack' = goal : stack
+   in go [] (candPremises cand) stack' depth
+  where
+    go acc [] _ _ = pure (Hit cand (reverse acc))
+    go acc (p : ps) stk d = do
+      sub <- resolveImpl p stk (d + 1)
+      case sub of
+        Right tree -> go (tree : acc) ps stk d
+        Left err -> pure (Miss (NearMiss (candGiven cand) err))
+
+------------------------------------------------------------------------------
+-- Specificity ordering (ADR-008 refined: one-way match of declared
+-- conclusions; the pattern's quantified variables are flexible, the
+-- target's are rigid).
+------------------------------------------------------------------------------
+
+decideMostSpecific ::
+  (Var v, Ord loc) =>
+  Type v loc ->
+  [(Candidate v loc, [ResolutionTree v loc])] ->
+  Either (ResolveError v loc) (ResolutionTree v loc)
+decideMostSpecific goal hits =
+  -- Step 1: keep only the most-inner-scoped survivors.
+  let best = filterMostInner hits
+   in case best of
+        [single] -> Right (rebuildTree single)
+        multiple ->
+          -- Step 2: drop any that are strictly subsumed by another.
+          case filter (notStrictlySubsumedIn multiple) multiple of
+            [single] -> Right (rebuildTree single)
+            ambiguous ->
+              Left (Ambiguous goal (map (candGiven . fst) ambiguous))
+
+filterMostInner ::
+  [(Candidate v loc, [ResolutionTree v loc])] ->
+  [(Candidate v loc, [ResolutionTree v loc])]
+filterMostInner [] = []
+filterMostInner xs =
+  let scopeKey = givenScope . candGiven . fst
+      best = foldl1' min (map scopeKey xs)
+   in filter ((== best) . scopeKey) xs
+
+-- | True iff no *other* candidate is strictly more specific than this
+-- one.
+notStrictlySubsumedIn ::
+  (Var v, Ord loc) =>
+  [(Candidate v loc, [ResolutionTree v loc])] ->
+  (Candidate v loc, [ResolutionTree v loc]) ->
+  Bool
+notStrictlySubsumedIn others me =
+  not (any (`strictlyMoreSpecific` me) others)
+
+-- | @a `strictlyMoreSpecific` b@ iff @a@'s conclusion is a strict
+-- instance of @b@'s conclusion: i.e., @b@ pattern-matches @a@
+-- one-way (so @b@ is more general) and @a@ does not pattern-match
+-- @b@.
+strictlyMoreSpecific ::
+  forall v loc.
+  (Var v, Ord loc) =>
+  (Candidate v loc, [ResolutionTree v loc]) ->
+  (Candidate v loc, [ResolutionTree v loc]) ->
+  Bool
+strictlyMoreSpecific (a, _) (b, _)
+  | candGiven a == candGiven b = False
+  | otherwise =
+      let ca = candFreshConclusion a
+          cb = candFreshConclusion b
+          -- "b matches a" : try to instantiate b's pattern (b's
+          -- fresh vars are flexible) so that b == a (a's vars are
+          -- rigid).
+          bMatchesA = matched (Set.fromList (candFreshTyVars b)) cb ca
+          aMatchesB = matched (Set.fromList (candFreshTyVars a)) ca cb
+       in bMatchesA && not aMatchesB
+  where
+    matched flex pat target = case oneWayMatch flex pat target of
+      Just _ -> True
+      Nothing -> False
+
+------------------------------------------------------------------------------
+-- Robinson unification on 'Type v loc'
+--
+-- Standalone, not the 'Context'-monad unifier. See module-level
+-- comment for rationale.
+------------------------------------------------------------------------------
+
+-- | Apply a substitution to a type. The substitution must be
+-- idempotent (which 'unify' maintains), so a single pass suffices.
+applySubst :: (Var v) => Substitution v loc -> Type v loc -> Type v loc
+applySubst s
+  | Map.null s = id
+  | otherwise = ABT.substsInheritAnnotation (Map.toList s)
+
+-- | Unify two types, treating only variables in @flex@ as
+-- unifiable. Variables outside @flex@ are rigid (constants).
+--
+-- Two free occurrences of a rigid variable @v@ unify with each other
+-- (since @TVar v == TVar v@ structurally) but not with anything else.
+unify ::
+  (Var v, Ord loc) =>
+  Substitution v loc ->
+  Set v ->
+  Type v loc ->
+  Type v loc ->
+  Maybe (Substitution v loc)
+unify s0 flex t u = go s0 (applySubst s0 t) (applySubst s0 u)
+  where
+    go s a b = case (ABT.out a, ABT.out b) of
+      _ | structuralEq a b -> Just s
+      (ABT.Var va, _) | va `Set.member` flex -> bind s va b
+      (_, ABT.Var vb) | vb `Set.member` flex -> bind s vb a
+      -- Two rigid vars that didn't structurally match: not unifiable.
+      (ABT.Var _, _) -> Nothing
+      (_, ABT.Var _) -> Nothing
+      (ABT.Tm fa, ABT.Tm fb) -> goF s fa fb
+      _ -> Nothing
+
+    goF s fa fb = case (fa, fb) of
+      (Type.Ref r1, Type.Ref r2)
+        | r1 == r2 -> Just s
+        | otherwise -> Nothing
+      (Type.App f1 x1, Type.App f2 x2) -> do
+        s1 <- go s f1 f2
+        go s1 (applySubst s1 x1) (applySubst s1 x2)
+      (Type.Arrow i1 o1, Type.Arrow i2 o2) -> do
+        s1 <- go s i1 i2
+        go s1 (applySubst s1 o1) (applySubst s1 o2)
+      (Type.ImplicitArrow i1 o1, Type.ImplicitArrow i2 o2) -> do
+        s1 <- go s i1 i2
+        go s1 (applySubst s1 o1) (applySubst s1 o2)
+      (Type.Effect e1 t1, Type.Effect e2 t2) -> do
+        s1 <- go s e1 e2
+        go s1 (applySubst s1 t1) (applySubst s1 t2)
+      (Type.Effects es1, Type.Effects es2)
+        | length es1 == length es2 -> goList s es1 es2
+        | otherwise -> Nothing
+      _ -> Nothing
+
+    goList s [] [] = Just s
+    goList s (x : xs) (y : ys) = do
+      s1 <- go s (applySubst s x) (applySubst s y)
+      goList s1 xs ys
+    goList _ _ _ = Nothing
+
+    bind s v t1
+      | ABT.Var v' <- ABT.out t1, v == v' = Just s
+      | v `Set.member` ABT.freeVars (applySubst s t1) = Nothing -- occurs check
+      | otherwise =
+          -- extend s with [v := t1] and propagate into existing image
+          let single = Map.singleton v t1
+              s' = Map.insert v t1 (Map.map (applySubst single) s)
+           in Just s'
+
+-- | Structural equality up to annotations.
+structuralEq :: (Var v, Ord loc) => Type v loc -> Type v loc -> Bool
+structuralEq = (==)
+
+-- | One-way structural match: is there a substitution σ with
+-- σ(@pat@) = @target@, treating *only* variables in @flex@ as
+-- unifiable? Variables in @target@ are rigid by construction.
+--
+-- Used for specificity comparisons (ADR-008): a candidate whose
+-- pattern *one-way matches* another's conclusion is more general
+-- than that other.
+oneWayMatch ::
+  forall v loc.
+  (Var v, Ord loc) =>
+  Set v ->
+  Type v loc ->
+  Type v loc ->
+  Maybe (Substitution v loc)
+oneWayMatch flex pat target = go Map.empty pat target
+  where
+    go :: Substitution v loc -> Type v loc -> Type v loc -> Maybe (Substitution v loc)
+    go s a b = case (ABT.out a, ABT.out b) of
+      (ABT.Var va, _) | va `Set.member` flex ->
+        case Map.lookup va s of
+          Just t' -> if structuralEq t' b then Just s else Nothing
+          Nothing -> Just (Map.insert va b s)
+      (ABT.Var va, ABT.Var vb)
+        | va == vb -> Just s
+        | otherwise -> Nothing
+      (ABT.Tm fa, ABT.Tm fb) -> goF s fa fb
+      _ -> Nothing
+
+    goF :: Substitution v loc -> Type.F (Type v loc) -> Type.F (Type v loc) -> Maybe (Substitution v loc)
+    goF s fa fb = case (fa, fb) of
+      (Type.Ref r1, Type.Ref r2)
+        | r1 == r2 -> Just s
+        | otherwise -> Nothing
+      (Type.App f1 x1, Type.App f2 x2) -> do
+        s1 <- go s f1 f2
+        go s1 x1 x2
+      (Type.Arrow i1 o1, Type.Arrow i2 o2) -> do
+        s1 <- go s i1 i2
+        go s1 o1 o2
+      (Type.ImplicitArrow i1 o1, Type.ImplicitArrow i2 o2) -> do
+        s1 <- go s i1 i2
+        go s1 o1 o2
+      (Type.Effect e1 t1, Type.Effect e2 t2) -> do
+        s1 <- go s e1 e2
+        go s1 t1 t2
+      (Type.Effects es1, Type.Effects es2)
+        | length es1 == length es2 -> goList s es1 es2
+        | otherwise -> Nothing
+      _ -> Nothing
+
+    goList s [] [] = Just s
+    goList s (x : xs) (y : ys) = do
+      s1 <- go s x y
+      goList s1 xs ys
+    goList _ _ _ = Nothing
+
+------------------------------------------------------------------------------
+-- Freshening
+------------------------------------------------------------------------------
+
+-- | Replace every variable in @vs@ with a fresh, collision-free
+-- equivalent throughout @prems@ and @concl@. Returns the fresh
+-- variables (in the same order as @vs@), the renamed premises, and
+-- the renamed conclusion.
+freshenGiven ::
+  (Var v) =>
+  [v] ->
+  [Type v loc] ->
+  Type v loc ->
+  R v loc ([v], [Type v loc], Type v loc)
+freshenGiven vs prems concl = do
+  used <- gets' sUsed
+  let (used', fresh) = freshenAll used vs
+  modify' (\st -> st {sUsed = used'})
+  let pairs = zip vs (map ABT.var fresh)
+      ren = ABT.substsInheritAnnotation pairs
+  pure (fresh, map ren prems, ren concl)
+  where
+    freshenAll usedSet [] = (usedSet, [])
+    freshenAll usedSet (v : rest) =
+      let v' = Var.freshIn usedSet v
+          (usedSet'', rest') = freshenAll (Set.insert v' usedSet) rest
+       in (usedSet'', v' : rest')
+
+------------------------------------------------------------------------------
+-- Misc helpers
+------------------------------------------------------------------------------
+
+mapMaybeM :: (Monad m) => (a -> m (Maybe b)) -> [a] -> m [b]
+mapMaybeM f = go []
+  where
+    go acc [] = pure (reverse acc)
+    go acc (x : xs) = do
+      mb <- f x
+      case mb of
+        Just b -> go (b : acc) xs
+        Nothing -> go acc xs

--- a/parser-typechecker/src/Unison/Typechecker/TypeError.hs
+++ b/parser-typechecker/src/Unison/Typechecker/TypeError.hs
@@ -346,6 +346,9 @@ generalMismatch = do
       | otherwise =
           case found of
             Type.Arrow' i o -> (i :) <$> findUnderApplication o expected
+            -- ADR-019: 'ImplicitArrow' is treated like 'Arrow' here
+            -- (chunks D2/D3 may revisit).
+            Type.ImplicitArrow' i o -> (i :) <$> findUnderApplication o expected
             Type.ForallNamed' _ body -> findUnderApplication body expected
             Type.Effect' _ inner -> findUnderApplication inner expected
             _ -> Nothing

--- a/parser-typechecker/src/Unison/Typechecker/Variance.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Variance.hs
@@ -64,6 +64,10 @@ collectVariance prev group = descend Positive
     descend pol = \case
       Arrow' i o ->
         Map.unionWith (++) (descend (inv pol) i) (descend pol o)
+      -- ADR-019: implicit arrows have the same variance as ordinary
+      -- arrows (contravariant in input, covariant in output).
+      ImplicitArrow' i o ->
+        Map.unionWith (++) (descend (inv pol) i) (descend pol o)
       Effect1' e r ->
         Map.unionWith (++) (descend pol e) (descend pol r)
       Apps' f xs

--- a/parser-typechecker/src/Unison/UnisonFile.hs
+++ b/parser-typechecker/src/Unison/UnisonFile.hs
@@ -271,9 +271,13 @@ typecheckedUnisonFile ::
   Map v (Reference.Id, EffectDeclaration v a) ->
   [[(v, a, Term v a, Type v a)]] ->
   [(WatchKind, [(v, a, Term v a, Type v a)])] ->
+  -- | Names recorded as @given@ by the parser. Forwarded into the
+  -- 'TypecheckedUnisonFile' so downstream commands (e.g. @add@) can
+  -- auto-mark them as namespace givens.
+  Set v ->
   TypecheckedUnisonFile v a
-typecheckedUnisonFile datas effects tlcs watches =
-  TypecheckedUnisonFileId Nothing datas effects tlcs watches hashImpl
+typecheckedUnisonFile datas effects tlcs watches gbs =
+  TypecheckedUnisonFileId Nothing datas effects tlcs watches hashImpl gbs
   where
     hashImpl :: (Map v (a, Reference.Id, Maybe WatchKind, Term v a, Type v a))
     hashImpl =
@@ -387,16 +391,10 @@ dependencies file =
     ]
 
 discardTypes :: (Ord v) => TypecheckedUnisonFile v a -> UnisonFile v a
-discardTypes (TypecheckedUnisonFileId fn datas effects terms watches _) =
+discardTypes (TypecheckedUnisonFileId fn datas effects terms watches _ gbs) =
   let watches' = g . mconcat <$> List.multimap watches
       g tup3s = [(v, a, e) | (v, a, e, _t) <- tup3s]
-   in -- 'givenBindings' is not preserved through typechecking — by the
-      -- time a 'TypecheckedUnisonFile' exists the typechecker has
-      -- already consumed the side channel. Producing 'discardTypes'
-      -- (mostly used for downstream tooling like the LSP) re-issues an
-      -- empty set; if a future caller needs it they can extend
-      -- 'TypecheckedUnisonFile' similarly.
-      UnisonFileId fn (coerce datas) (coerce effects) (Map.fromList [(v, (a, trm)) | (v, a, trm, _typ) <- join terms]) watches' Set.empty
+   in UnisonFileId fn (coerce datas) (coerce effects) (Map.fromList [(v, (a, trm)) | (v, a, trm, _typ) <- join terms]) watches' gbs
 
 declsToTypeLookup :: (Var v) => UnisonFile v a -> TL.TypeLookup v a
 declsToTypeLookup uf =

--- a/parser-typechecker/src/Unison/UnisonFile.hs
+++ b/parser-typechecker/src/Unison/UnisonFile.hs
@@ -87,7 +87,8 @@ emptyUnisonFile =
       dataDeclarationsId = Map.empty,
       effectDeclarationsId = Map.empty,
       terms = Map.empty,
-      watches = Map.empty
+      watches = Map.empty,
+      givenBindings = Set.empty
     }
 
 leftBiasedMerge :: forall v a. (Ord v) => UnisonFile v a -> UnisonFile v a -> UnisonFile v a
@@ -101,7 +102,13 @@ leftBiasedMerge lhs rhs =
           dataDeclarationsId = mergedDataDecls,
           effectDeclarationsId = mergedEffectDecls,
           terms = mergedTerms,
-          watches = mergedWatches
+          watches = mergedWatches,
+          -- Combine the given-binding sets from both files. Variables
+          -- not present in either side's terms have their entries
+          -- silently kept; downstream consumers only consult this set
+          -- when looking up a binding's variable, so unused entries
+          -- are harmless.
+          givenBindings = givenBindings lhs <> givenBindings rhs
         }
   where
     lhsTermNames =
@@ -174,8 +181,8 @@ hashTerms :: TypecheckedUnisonFile v a -> Map v (a, TermReference, Maybe WatchKi
 hashTerms = fmap (over _2 Reference.DerivedId) . hashTermsId
 
 mapTerms :: (Term v a -> Term v a) -> UnisonFile v a -> UnisonFile v a
-mapTerms f (UnisonFileId fn datas effects terms watches) =
-  UnisonFileId fn datas effects terms' watches'
+mapTerms f (UnisonFileId fn datas effects terms watches gbs) =
+  UnisonFileId fn datas effects terms' watches' gbs
   where
     terms' = over (mapped . _2) f terms
     watches' = over (mapped . mapped . _3) f watches
@@ -207,7 +214,7 @@ mapTerms f (UnisonFileId fn datas effects terms watches) =
 -- then converting back to a "regular" UnisonFile with free variables in the
 -- terms.
 prepareRewrite :: (Monoid a, Var v) => UnisonFile v a -> ([v] -> Term v a -> Term v a, UnisonFile v a, UnisonFile v a -> UnisonFile v a)
-prepareRewrite uf@(UnisonFileId _fn _datas _effects _terms watches) =
+prepareRewrite uf@(UnisonFileId _fn _datas _effects _terms watches _gbs) =
   (freshen, mapTerms substs uf, mapTerms refToVar)
   where
     -- fn to replace free vars with unique refs
@@ -244,8 +251,8 @@ prepareRewrite uf@(UnisonFileId _fn _datas _effects _terms watches) =
 -- This function returns what symbols were modified.
 -- The `Set v` is symbols that should be left alone.
 rewrite :: (Var v, Eq a) => Set v -> (Term v a -> Maybe (Term v a)) -> UnisonFile v a -> ([v], UnisonFile v a)
-rewrite leaveAlone rewriteFn uf@(UnisonFileId fn datas effects _terms watches) =
-  (rewritten, UnisonFileId fn datas effects (Map.fromList $ unEitherTerms terms') (unEither <$> watches'))
+rewrite leaveAlone rewriteFn uf@(UnisonFileId fn datas effects _terms watches gbs) =
+  (rewritten, UnisonFileId fn datas effects (Map.fromList $ unEitherTerms terms') (unEither <$> watches') gbs)
   where
     terms' = go (termBindings uf)
     watches' = go <$> watches
@@ -383,7 +390,13 @@ discardTypes :: (Ord v) => TypecheckedUnisonFile v a -> UnisonFile v a
 discardTypes (TypecheckedUnisonFileId fn datas effects terms watches _) =
   let watches' = g . mconcat <$> List.multimap watches
       g tup3s = [(v, a, e) | (v, a, e, _t) <- tup3s]
-   in UnisonFileId fn (coerce datas) (coerce effects) (Map.fromList [(v, (a, trm)) | (v, a, trm, _typ) <- join terms]) watches'
+   in -- 'givenBindings' is not preserved through typechecking — by the
+      -- time a 'TypecheckedUnisonFile' exists the typechecker has
+      -- already consumed the side channel. Producing 'discardTypes'
+      -- (mostly used for downstream tooling like the LSP) re-issues an
+      -- empty set; if a future caller needs it they can extend
+      -- 'TypecheckedUnisonFile' similarly.
+      UnisonFileId fn (coerce datas) (coerce effects) (Map.fromList [(v, (a, trm)) | (v, a, trm, _typ) <- join terms]) watches' Set.empty
 
 declsToTypeLookup :: (Var v) => UnisonFile v a -> TL.TypeLookup v a
 declsToTypeLookup uf =

--- a/parser-typechecker/src/Unison/UnisonFile.hs
+++ b/parser-typechecker/src/Unison/UnisonFile.hs
@@ -88,7 +88,8 @@ emptyUnisonFile =
       effectDeclarationsId = Map.empty,
       terms = Map.empty,
       watches = Map.empty,
-      givenBindings = Set.empty
+      givenBindings = Set.empty,
+      classBindings = Set.empty
     }
 
 leftBiasedMerge :: forall v a. (Ord v) => UnisonFile v a -> UnisonFile v a -> UnisonFile v a
@@ -108,7 +109,8 @@ leftBiasedMerge lhs rhs =
           -- silently kept; downstream consumers only consult this set
           -- when looking up a binding's variable, so unused entries
           -- are harmless.
-          givenBindings = givenBindings lhs <> givenBindings rhs
+          givenBindings = givenBindings lhs <> givenBindings rhs,
+          classBindings = classBindings lhs <> classBindings rhs
         }
   where
     lhsTermNames =
@@ -181,8 +183,8 @@ hashTerms :: TypecheckedUnisonFile v a -> Map v (a, TermReference, Maybe WatchKi
 hashTerms = fmap (over _2 Reference.DerivedId) . hashTermsId
 
 mapTerms :: (Term v a -> Term v a) -> UnisonFile v a -> UnisonFile v a
-mapTerms f (UnisonFileId fn datas effects terms watches gbs) =
-  UnisonFileId fn datas effects terms' watches' gbs
+mapTerms f (UnisonFileId fn datas effects terms watches gbs cbs) =
+  UnisonFileId fn datas effects terms' watches' gbs cbs
   where
     terms' = over (mapped . _2) f terms
     watches' = over (mapped . mapped . _3) f watches
@@ -214,7 +216,7 @@ mapTerms f (UnisonFileId fn datas effects terms watches gbs) =
 -- then converting back to a "regular" UnisonFile with free variables in the
 -- terms.
 prepareRewrite :: (Monoid a, Var v) => UnisonFile v a -> ([v] -> Term v a -> Term v a, UnisonFile v a, UnisonFile v a -> UnisonFile v a)
-prepareRewrite uf@(UnisonFileId _fn _datas _effects _terms watches _gbs) =
+prepareRewrite uf@(UnisonFileId _fn _datas _effects _terms watches _gbs _cbs) =
   (freshen, mapTerms substs uf, mapTerms refToVar)
   where
     -- fn to replace free vars with unique refs
@@ -251,8 +253,8 @@ prepareRewrite uf@(UnisonFileId _fn _datas _effects _terms watches _gbs) =
 -- This function returns what symbols were modified.
 -- The `Set v` is symbols that should be left alone.
 rewrite :: (Var v, Eq a) => Set v -> (Term v a -> Maybe (Term v a)) -> UnisonFile v a -> ([v], UnisonFile v a)
-rewrite leaveAlone rewriteFn uf@(UnisonFileId fn datas effects _terms watches gbs) =
-  (rewritten, UnisonFileId fn datas effects (Map.fromList $ unEitherTerms terms') (unEither <$> watches') gbs)
+rewrite leaveAlone rewriteFn uf@(UnisonFileId fn datas effects _terms watches gbs cbs) =
+  (rewritten, UnisonFileId fn datas effects (Map.fromList $ unEitherTerms terms') (unEither <$> watches') gbs cbs)
   where
     terms' = go (termBindings uf)
     watches' = go <$> watches
@@ -275,9 +277,13 @@ typecheckedUnisonFile ::
   -- 'TypecheckedUnisonFile' so downstream commands (e.g. @add@) can
   -- auto-mark them as namespace givens.
   Set v ->
+  -- | Type names recorded as @class@ declarations by the parser.
+  -- Forwarded so @add@ / @update@ can mark them in namespace metadata
+  -- via 'Unison.Codebase.Classes.markClassAt'.
+  Set v ->
   TypecheckedUnisonFile v a
-typecheckedUnisonFile datas effects tlcs watches gbs =
-  TypecheckedUnisonFileId Nothing datas effects tlcs watches hashImpl gbs
+typecheckedUnisonFile datas effects tlcs watches gbs cbs =
+  TypecheckedUnisonFileId Nothing datas effects tlcs watches hashImpl gbs cbs
   where
     hashImpl :: (Map v (a, Reference.Id, Maybe WatchKind, Term v a, Type v a))
     hashImpl =
@@ -391,10 +397,10 @@ dependencies file =
     ]
 
 discardTypes :: (Ord v) => TypecheckedUnisonFile v a -> UnisonFile v a
-discardTypes (TypecheckedUnisonFileId fn datas effects terms watches _ gbs) =
+discardTypes (TypecheckedUnisonFileId fn datas effects terms watches _ gbs cbs) =
   let watches' = g . mconcat <$> List.multimap watches
       g tup3s = [(v, a, e) | (v, a, e, _t) <- tup3s]
-   in UnisonFileId fn (coerce datas) (coerce effects) (Map.fromList [(v, (a, trm)) | (v, a, trm, _typ) <- join terms]) watches' gbs
+   in UnisonFileId fn (coerce datas) (coerce effects) (Map.fromList [(v, (a, trm)) | (v, a, trm, _typ) <- join terms]) watches' gbs cbs
 
 declsToTypeLookup :: (Var v) => UnisonFile v a -> TL.TypeLookup v a
 declsToTypeLookup uf =

--- a/parser-typechecker/src/Unison/UnisonFile/Type.hs
+++ b/parser-typechecker/src/Unison/UnisonFile/Type.hs
@@ -60,7 +60,14 @@ data TypecheckedUnisonFile v a = TypecheckedUnisonFileId
     effectDeclarationsId' :: Map v (TypeReferenceId, EffectDeclaration v a),
     topLevelComponents' :: [[(v, a {- ann for whole binding -}, Term v a, Type v a)]],
     watchComponents :: [(WatchKind, [(v, a {- ann for whole watch -}, Term v a, Type v a)])],
-    hashTermsId :: Map v (a {- ann for whole binding -}, TermReferenceId, Maybe WatchKind, Term v a, Type v a)
+    hashTermsId :: Map v (a {- ann for whole binding -}, TermReferenceId, Maybe WatchKind, Term v a, Type v a),
+    -- | Names that the parser recorded as @given@ declarations.
+    -- Threaded through from 'UnisonFile.givenBindings' so the
+    -- @update@ / @add@ flow can mark each one as a given in the
+    -- namespace's metadata automatically (rather than requiring an
+    -- explicit follow-up @mark.given@). Empty for files with no
+    -- @given@ declarations.
+    givenBindings' :: Set v
   }
   deriving stock (Generic, Show)
 
@@ -89,10 +96,11 @@ pattern TypecheckedUnisonFile fn ds es tlcs wcs hts <-
     tlcs
     wcs
     (fmap (over _2 Reference.DerivedId) -> hts)
+    _
 
 instance (Ord v) => Functor (TypecheckedUnisonFile v) where
-  fmap f (TypecheckedUnisonFileId fn ds es tlcs wcs hashTerms) =
-    TypecheckedUnisonFileId fn' ds' es' tlcs' wcs' hashTerms'
+  fmap f (TypecheckedUnisonFileId fn ds es tlcs wcs hashTerms gbs) =
+    TypecheckedUnisonFileId fn' ds' es' tlcs' wcs' hashTerms' gbs
     where
       fn' = (fmap . first) f fn
       ds' = ds <&> \(refId, decl) -> (refId, fmap f decl)

--- a/parser-typechecker/src/Unison/UnisonFile/Type.hs
+++ b/parser-typechecker/src/Unison/UnisonFile/Type.hs
@@ -24,12 +24,17 @@ data UnisonFile v a = UnisonFileId
     watches :: Map WatchKind [(v, a {- ann for whole watch -}, Term v a)],
     -- | ADR-010 / chunk L2 fixup: variable names that originated from
     -- the @given@ keyword. Populated by the parser via the side channel
-    -- in 'Unison.Syntax.Parser' (@StateT (Set v)@) and read by the
-    -- typechecker to identify @given@ origins without inspecting type
-    -- shape. Includes both file-level @given@ declarations and
-    -- @let given@ bindings inside term bodies. Empty for files with no
-    -- @given@ declarations.
-    givenBindings :: Set v
+    -- in 'Unison.Syntax.Parser' and read by the typechecker to identify
+    -- @given@ origins without inspecting type shape. Includes both
+    -- file-level @given@ declarations and @let given@ bindings inside
+    -- term bodies.
+    givenBindings :: Set v,
+    -- | ADR-007: type names declared with the @class@ keyword. The
+    -- @add@ / @update@ command uses this to mark each entry in the
+    -- namespace via 'Unison.Codebase.Classes.markClassAt' so @view@
+    -- can later recover the @class@ keyword (and record-field syntax)
+    -- on round-trip.
+    classBindings :: Set v
   }
   deriving stock (Generic, Show)
 
@@ -40,8 +45,9 @@ pattern UnisonFile ::
   Map v (a, Term v a) ->
   Map WatchKind [(v, a, Term v a)] ->
   Set v ->
+  Set v ->
   UnisonFile v a
-pattern UnisonFile fn ds es tms ws gbs <-
+pattern UnisonFile fn ds es tms ws gbs cbs <-
   UnisonFileId
     fn
     (fmap (first Reference.DerivedId) -> ds)
@@ -49,6 +55,7 @@ pattern UnisonFile fn ds es tms ws gbs <-
     tms
     ws
     gbs
+    cbs
 
 {-# COMPLETE UnisonFile #-}
 
@@ -64,10 +71,13 @@ data TypecheckedUnisonFile v a = TypecheckedUnisonFileId
     -- | Names that the parser recorded as @given@ declarations.
     -- Threaded through from 'UnisonFile.givenBindings' so the
     -- @update@ / @add@ flow can mark each one as a given in the
-    -- namespace's metadata automatically (rather than requiring an
-    -- explicit follow-up @mark.given@). Empty for files with no
-    -- @given@ declarations.
-    givenBindings' :: Set v
+    -- namespace's metadata automatically.
+    givenBindings' :: Set v,
+    -- | ADR-007: type names that the parser recorded as @class@
+    -- declarations. Threaded through from 'UnisonFile.classBindings'
+    -- so @add@ / @update@ can mark each one via
+    -- 'Unison.Codebase.Classes.markClassAt'.
+    classBindings' :: Set v
   }
   deriving stock (Generic, Show)
 
@@ -97,10 +107,11 @@ pattern TypecheckedUnisonFile fn ds es tlcs wcs hts <-
     wcs
     (fmap (over _2 Reference.DerivedId) -> hts)
     _
+    _
 
 instance (Ord v) => Functor (TypecheckedUnisonFile v) where
-  fmap f (TypecheckedUnisonFileId fn ds es tlcs wcs hashTerms gbs) =
-    TypecheckedUnisonFileId fn' ds' es' tlcs' wcs' hashTerms' gbs
+  fmap f (TypecheckedUnisonFileId fn ds es tlcs wcs hashTerms gbs cbs) =
+    TypecheckedUnisonFileId fn' ds' es' tlcs' wcs' hashTerms' gbs cbs
     where
       fn' = (fmap . first) f fn
       ds' = ds <&> \(refId, decl) -> (refId, fmap f decl)

--- a/parser-typechecker/src/Unison/UnisonFile/Type.hs
+++ b/parser-typechecker/src/Unison/UnisonFile/Type.hs
@@ -21,7 +21,15 @@ data UnisonFile v a = UnisonFileId
     dataDeclarationsId :: Map v (TypeReferenceId, DataDeclaration v a),
     effectDeclarationsId :: Map v (TypeReferenceId, EffectDeclaration v a),
     terms :: Map v (a {- ann for name of the binding -}, Term v a),
-    watches :: Map WatchKind [(v, a {- ann for whole watch -}, Term v a)]
+    watches :: Map WatchKind [(v, a {- ann for whole watch -}, Term v a)],
+    -- | ADR-010 / chunk L2 fixup: variable names that originated from
+    -- the @given@ keyword. Populated by the parser via the side channel
+    -- in 'Unison.Syntax.Parser' (@StateT (Set v)@) and read by the
+    -- typechecker to identify @given@ origins without inspecting type
+    -- shape. Includes both file-level @given@ declarations and
+    -- @let given@ bindings inside term bodies. Empty for files with no
+    -- @given@ declarations.
+    givenBindings :: Set v
   }
   deriving stock (Generic, Show)
 
@@ -31,14 +39,16 @@ pattern UnisonFile ::
   Map v (TypeReference, EffectDeclaration v a) ->
   Map v (a, Term v a) ->
   Map WatchKind [(v, a, Term v a)] ->
+  Set v ->
   UnisonFile v a
-pattern UnisonFile fn ds es tms ws <-
+pattern UnisonFile fn ds es tms ws gbs <-
   UnisonFileId
     fn
     (fmap (first Reference.DerivedId) -> ds)
     (fmap (first Reference.DerivedId) -> es)
     tms
     ws
+    gbs
 
 {-# COMPLETE UnisonFile #-}
 

--- a/parser-typechecker/tests/Suite.hs
+++ b/parser-typechecker/tests/Suite.hs
@@ -11,17 +11,27 @@ import Unison.Core.Test.Name qualified as Name
 import Unison.Test.ABT qualified as ABT
 import Unison.Test.Codebase.Branch qualified as Branch
 import Unison.Test.Codebase.Causal qualified as Causal
+import Unison.Test.Codebase.Givens qualified as Givens
 import Unison.Test.Codebase.Path qualified as Path
 import Unison.Test.CodebaseInit qualified as CodebaseInit
 import Unison.Test.DataDeclaration qualified as DataDeclaration
 import Unison.Test.Referent qualified as Referent
 import Unison.Test.Syntax.FileParser qualified as FileParser
+import Unison.Test.Syntax.ImplicitParser qualified as ImplicitParser
+import Unison.Test.Syntax.ImplicitPrinter qualified as ImplicitPrinter
 import Unison.Test.Syntax.TermParser qualified as TermParser
+import Unison.Test.Syntax.TypeParser qualified as TypeParser
 import Unison.Test.Syntax.TypePrinter qualified as TypePrinter
 import Unison.Test.Term qualified as Term
 import Unison.Test.Type qualified as Type
 import Unison.Test.Typechecker qualified as Typechecker
 import Unison.Test.Typechecker.Context qualified as Context
+import Unison.Test.Typechecker.GivenApply qualified as GivenApply
+import Unison.Test.Typechecker.GivenDecl qualified as GivenDecl
+import Unison.Test.Typechecker.GivenElaborator qualified as GivenElaborator
+import Unison.Test.Typechecker.GivenResolver qualified as GivenResolver
+import Unison.Test.Typechecker.GivenResolverProperties qualified as GivenResolverProperties
+import Unison.Test.Typechecker.ImplicitErrorRendering qualified as ImplicitErrorRendering
 import Unison.Test.Typechecker.TypeError qualified as TypeError
 import Unison.Test.Util.Relation qualified as Relation
 import Unison.Test.Util.Text qualified as Text
@@ -32,6 +42,9 @@ test =
   tests
     [ Term.test,
       TermParser.test,
+      TypeParser.test,
+      ImplicitParser.test,
+      ImplicitPrinter.test,
       Type.test,
       TypeError.test,
       TypePrinter.test,
@@ -46,9 +59,16 @@ test =
       Var.test,
       Typechecker.test,
       Context.test,
+      GivenApply.test,
+      GivenDecl.test,
+      GivenElaborator.test,
+      GivenResolver.test,
+      GivenResolverProperties.test,
+      ImplicitErrorRendering.test,
       Name.test,
       CodebaseInit.test,
-      Branch.test
+      Branch.test,
+      Givens.test
     ]
 
 main :: IO ()

--- a/parser-typechecker/tests/Unison/Test/Codebase/Givens.hs
+++ b/parser-typechecker/tests/Unison/Test/Codebase/Givens.hs
@@ -1,0 +1,184 @@
+-- | Unit tests for "Unison.Codebase.Givens".
+module Unison.Test.Codebase.Givens
+  ( test,
+  )
+where
+
+import Data.Function ((&))
+import Data.Functor.Identity (Identity)
+import Data.Map qualified as Map
+import Data.Set qualified as Set
+import EasyTest
+import Unison.Codebase.Branch (Branch0)
+import Unison.Codebase.Branch qualified as Branch
+import Unison.Codebase.Givens qualified as Givens
+import Unison.Codebase.Metadata qualified as Metadata
+import Unison.Hashing.V2.Convert qualified as Convert
+import Unison.NameSegment.Internal (NameSegment (NameSegment))
+import Unison.Parser.Ann (Ann (External))
+import Unison.Prelude (view)
+import Unison.Reference (TermReference)
+import Unison.Reference qualified as Reference
+import Unison.Referent (Referent)
+import Unison.Referent qualified as Referent
+import Unison.Symbol (Symbol)
+import Unison.Term (Term)
+import Unison.Term qualified as Term
+import Unison.Util.Star2 qualified as Star2
+
+dummyTermRef :: TermReference
+dummyTermRef = Reference.Builtin "Test.dummyTerm"
+
+dummyReferent :: Referent
+dummyReferent = Referent.Ref dummyTermRef
+
+barName :: NameSegment
+barName = NameSegment "bar"
+
+otherTag :: TermReference
+otherTag = Reference.Builtin "Test.someOtherTag"
+
+emptyBranch :: Branch0 Identity
+emptyBranch = Branch.empty0
+
+-- A branch containing a single (referent, name) pair with no metadata.
+branchWithDummy :: Branch0 Identity
+branchWithDummy =
+  Branch.branch0
+    (mempty & Star2.insertD1 (dummyReferent, barName))
+    mempty
+    Map.empty
+    Map.empty
+
+-- A branch where `dummyReferent` carries an unrelated metadata value
+-- but not the given sentinel.
+branchWithUnrelatedMetadata :: Branch0 Identity
+branchWithUnrelatedMetadata =
+  Branch.branch0
+    ( mempty
+        & Star2.insertD1 (dummyReferent, barName)
+        & Metadata.insert (dummyReferent, otherTag)
+    )
+    mempty
+    Map.empty
+    Map.empty
+
+test :: Test ()
+test =
+  scope "codebase.givens" . tests $
+    [ scope "isGiven returns False on a fresh branch" do
+        expect (not (Givens.isGiven dummyReferent emptyBranch))
+        expect (not (Givens.isGiven dummyReferent branchWithDummy)),
+      scope "isGiven returns False when only unrelated metadata is present" do
+        expect (not (Givens.isGiven dummyReferent branchWithUnrelatedMetadata))
+        expect (not (Givens.isGivenAt dummyReferent barName branchWithUnrelatedMetadata)),
+      scope "markGivenAt makes isGiven return True" do
+        let marked = Givens.markGivenAt dummyReferent barName branchWithDummy
+        expect (Givens.isGiven dummyReferent marked)
+        expect (Givens.isGivenAt dummyReferent barName marked),
+      scope "markGivenAt is a no-op for absent referents" do
+        let marked = Givens.markGivenAt dummyReferent barName emptyBranch
+        expect (not (Givens.isGiven dummyReferent marked)),
+      scope "unmarkGivenAt removes only the sentinel and preserves other metadata" do
+        let starting =
+              Givens.markGivenAt dummyReferent barName branchWithUnrelatedMetadata
+            unmarked = Givens.unmarkGivenAt dummyReferent barName starting
+        expect (not (Givens.isGiven dummyReferent unmarked))
+        -- The unrelated metadata value must still be associated with
+        -- the referent after unmarking.
+        expect (Set.member otherTag (Givens.metadataValuesFor dummyReferent unmarked)),
+      scope "namesMarkedGiven returns the segments where the sentinel applies" do
+        let marked = Givens.markGivenAt dummyReferent barName branchWithDummy
+        expect (Givens.namesMarkedGiven dummyReferent branchWithDummy == Set.empty)
+        expect (Givens.namesMarkedGiven dummyReferent marked == Set.singleton barName),
+      scope "namespace-hash round-trip: mark then unmark restores the original hash" do
+        let marked = Givens.markGivenAt dummyReferent barName branchWithDummy
+            unmarked = Givens.unmarkGivenAt dummyReferent barName marked
+            h0 = Convert.hashBranch0 branchWithDummy
+            h1 = Convert.hashBranch0 marked
+            h2 = Convert.hashBranch0 unmarked
+        -- Marking changes the namespace (Branch0) hash, demonstrating
+        -- that MdValues participates in the namespace hash and so the
+        -- sentinel is preserved through the hashing layer.
+        expect (h0 /= h1)
+        -- Unmarking returns to the original namespace hash: the
+        -- sentinel is the only difference and so it round-trips
+        -- through hashing without ambiguity.
+        expect (h0 == h2),
+      scope "marking only adds the sentinel to the metadata set" do
+        -- Structural sanity: 'markGivenAt' is purely additive on the
+        -- metadata-value set keyed on the referent. This is the
+        -- prerequisite for the hash invariance below: marking
+        -- changes only 'MdValues', it does not rewrite the
+        -- referent under which the term is published.
+        let marked = Givens.markGivenAt dummyReferent barName branchWithDummy
+            mdBefore = Givens.metadataValuesFor dummyReferent branchWithDummy
+            mdAfter = Givens.metadataValuesFor dummyReferent marked
+        -- The pre-existing metadata is preserved.
+        expect (mdBefore `Set.isSubsetOf` mdAfter)
+        -- The only new entry is the sentinel.
+        expect (Set.delete Givens.givenSentinel mdAfter == mdBefore),
+      scope "marking does not change the term hash (ADR-014)" do
+        -- ADR-014 promises that marking a definition as a given does
+        -- not perturb its term hash: only the enclosing namespace
+        -- hash changes, because the sentinel lives in 'MdValues' and
+        -- not in the term itself. We exercise the marking pipeline
+        -- on a sample term:
+        --
+        --   1. Build a 'Reference' from a term via 'hashClosedTerm'
+        --      and place a referent for it under a name in a branch.
+        --   2. Apply 'markGivenAt' to mark that name as a given.
+        --   3. Recover the referent stored in the post-marking
+        --      branch's d1 relation (i.e., the term's referent as
+        --      it now lives in the codebase metadata schema after
+        --      passing through the marking pipeline).
+        --   4. Recompute the term's hash from the original 'Term'.
+        --
+        -- The pre-marking reference, the recovered post-marking
+        -- referent's reference, and the recomputed hash must all be
+        -- byte-identical. A regression in which marking somehow
+        -- rewrote the referent (e.g. by folding the metadata into
+        -- the term hash) would be caught here.
+        let sampleTerm :: Term Symbol Ann
+            sampleTerm = Term.nat External 42
+            hashBefore = Convert.hashClosedTerm sampleTerm
+            sampleTermRef = Reference.fromId hashBefore
+            sampleReferent' = Referent.Ref sampleTermRef
+            seg = NameSegment "myGiven"
+            branchBefore :: Branch0 Identity
+            branchBefore =
+              Branch.branch0
+                (mempty & Star2.insertD1 (sampleReferent', seg))
+                mempty
+                Map.empty
+                Map.empty
+            branchAfter = Givens.markGivenAt sampleReferent' seg branchBefore
+            -- Recover the referent as it lives in the post-marking
+            -- branch. If marking had rewritten the (referent, name)
+            -- mapping under a different reference, this lookup
+            -- would either come up empty or yield a different
+            -- referent.
+            referentsAfter :: Set.Set Referent
+            referentsAfter =
+              Star2.lookupD1 seg (view Branch.terms_ branchAfter)
+            -- And rehash the term, post-marking, to confirm the
+            -- term value is unaffected by anything done in the
+            -- marking pipeline.
+            hashAfter = Convert.hashClosedTerm sampleTerm
+        -- Pre-marking referent is recoverable from the post-marking
+        -- branch under the same name segment, with the same term
+        -- reference.
+        expect (Set.member sampleReferent' referentsAfter)
+        expect (referentsAfter == Set.singleton sampleReferent')
+        -- The recomputed hash matches both the pre-marking hash
+        -- and the term reference embedded in the post-marking
+        -- referent. Byte-for-byte identical per ADR-014.
+        expect (hashBefore == hashAfter)
+        let referentRefs =
+              Set.map (\case Referent.Ref r -> Just r; _ -> Nothing) referentsAfter
+        expect (referentRefs == Set.singleton (Just sampleTermRef))
+        -- And the marking actually took effect: 'isGiven' returns
+        -- True only for the post-marking branch.
+        expect (Givens.isGiven sampleReferent' branchAfter)
+        expect (not (Givens.isGiven sampleReferent' branchBefore))
+    ]

--- a/parser-typechecker/tests/Unison/Test/Common.hs
+++ b/parser-typechecker/tests/Unison/Test/Common.hs
@@ -3,6 +3,7 @@ module Unison.Test.Common
     t,
     tm,
     parseAndSynthesizeAsFile,
+    parseAndSynthesizeAsFileWithGivens,
     parsingEnv,
   )
 where
@@ -26,6 +27,7 @@ import Unison.Syntax.TermParser qualified as TermParser
 import Unison.Syntax.TypeParser qualified as TypeParser
 import Unison.Term qualified as Term
 import Unison.Type qualified as Type
+import Unison.Typechecker.GivenElaborator qualified as GivenElaborator
 import Unison.UnisonFile (TypecheckedUnisonFile, UnisonFile)
 import Unison.Util.Pretty qualified as Pr
 import Unison.Var (Var)
@@ -70,7 +72,26 @@ parseAndSynthesizeAsFile ::
   Result
     (Seq (Note Symbol Ann))
     (Either (UnisonFile Symbol Ann) (TypecheckedUnisonFile Symbol Ann))
-parseAndSynthesizeAsFile ambient filename s = do
+parseAndSynthesizeAsFile ambient filename s =
+  parseAndSynthesizeAsFileWithGivens ambient [] filename s
+
+-- | Like 'parseAndSynthesizeAsFile' but also threads an explicit list
+-- of ambient givens through 'computeTypecheckingEnvironment', and —
+-- crucially — surfaces the typechecker's info notes on the /success/
+-- path too. The original 'parseAndSynthesizeAsFile' silently dropped
+-- notes when typechecking succeeded, which makes it useless for
+-- asserting on 'TypeInfo' notes (e.g. 'SolvedImplicit') emitted by the
+-- chunk L1 elaborator. Used by the source-level e2e test in
+-- "Unison.Test.Typechecker.GivenApply".
+parseAndSynthesizeAsFileWithGivens ::
+  [Type Symbol] ->
+  [GivenElaborator.AmbientGiven Symbol Ann] ->
+  FilePath ->
+  String ->
+  Result
+    (Seq (Note Symbol Ann))
+    (Either (UnisonFile Symbol Ann) (TypecheckedUnisonFile Symbol Ann))
+parseAndSynthesizeAsFileWithGivens ambient givens filename s = do
   file <- Result.fromParsing (runIdentity (Parsers.parseFile filename s parsingEnv))
   let typecheckingEnv =
         runIdentity $
@@ -78,10 +99,11 @@ parseAndSynthesizeAsFile ambient filename s = do
             (FP.ShouldUseTndr'Yes parsingEnv)
             ambient
             (\_deps -> pure B.typeLookup)
+            givens
             file
   case FP.synthesizeFile typecheckingEnv file of
     Result.Result notes Nothing -> tell notes >> pure (Left file)
-    Result.Result _ (Just typecheckedFile) -> pure (Right typecheckedFile)
+    Result.Result notes (Just typecheckedFile) -> tell notes >> pure (Right typecheckedFile)
 
 parsingEnv :: Parser.ParsingEnv Identity
 parsingEnv =

--- a/parser-typechecker/tests/Unison/Test/Syntax/ImplicitParser.hs
+++ b/parser-typechecker/tests/Unison/Test/Syntax/ImplicitParser.hs
@@ -31,8 +31,8 @@ import Data.Text qualified as Text
 import EasyTest
 import Text.RawString.QQ
 import Unison.ABT qualified as ABT
-import Unison.Lexer.Pos qualified as Pos
 import Unison.Parser.Ann (Ann (..))
+import Unison.Parser.Ann qualified as Ann
 import Unison.Parsers qualified as Ps
 import Unison.PrintError (renderParseErrorAsANSI)
 import Unison.Symbol (Symbol)
@@ -62,21 +62,29 @@ test =
       scope "override.structural" overrideArgWidensAnnotation
     ]
 
--- | @summon T@ in expression position. ADR-006 specifies the keyword.
+-- | @summon@ in expression position. ADR-006 specifies the builtin.
 --
--- These exercise the parser only; we use builtin types so the
--- name-resolution pass that follows the parser doesn't reject
--- references to Phase-2 standard-library types we haven't loaded.
+-- @summon@ is no longer a keyword: it is a regular term reference
+-- whose declared type @forall a. a => a@ drives implicit resolution
+-- via the normal machinery. The user pins the type either with an
+-- explicit annotation — @(summon : T)@ — or implicitly via the
+-- surrounding context (e.g. a function argument whose parameter
+-- type fixes it).
+--
+-- These exercise the parser only; the typechecker later wires the
+-- @=>@ on @summon@'s declared type to a 'ConstraintGoal'.
 summonExprs :: [String]
 summonExprs =
-  [ -- atomic type argument
-    "summon Nat",
+  [ -- bare reference (no annotation; typechecker will need context)
+    "summon",
+    -- explicit annotation
+    "(summon : Nat)",
     -- parenthesized list type
-    "summon [Nat]",
+    "(summon : [Nat])",
     -- nested: summon used as a function argument
-    "id (summon Nat)",
-    -- summon followed by a parenthesized arrow type
-    "summon (Nat -> Nat)"
+    "id (summon : Nat)",
+    -- annotation that is a parenthesized arrow type
+    "(summon : (Nat -> Nat))"
   ]
 
 -- | @let given name : T = body@ inside a let block. The block syntax
@@ -148,10 +156,10 @@ constraintInGivenSig =
       ]
   ]
 
--- | @\@@-positional explicit override at call sites (chunk A3,
--- ADR-007). The parser produces ordinary positional application;
--- the source range of each override argument is widened to include
--- the leading @\@@ so downstream chunks can recognise it.
+-- | @give@-prefix explicit dictionary at call sites (chunk A3,
+-- ADR-007). @give f@ syntactically demotes one leading @=>@ in
+-- @f@'s declared type to @->@, so the next argument fills the
+-- implicit slot positionally.
 --
 -- We use bare identifiers (not in the builtins-only parsing env) on
 -- purpose: at parse time these become free variables, which is
@@ -160,41 +168,40 @@ constraintInGivenSig =
 overrideApps :: [String]
 overrideApps =
   [ -- the canonical example from the design doc
-    "sort @ ordDescending xs",
+    "give sort ordDescending xs",
     -- override at the last position
-    "f @ d",
-    -- chained overrides: fills the first two implicit slots
-    "g @ d1 @ d2 x",
-    -- override sandwiched between regular args (mixed positions)
-    "h x @ d y",
+    "give f d",
+    -- chained overrides: fills two implicit slots (nest @give@)
+    "give (give g) d1 d2 x",
+    -- override sandwiched between regular args (parenthesized so it
+    -- binds tightly to its function head)
+    "h x (give id d) y",
     -- parenthesized dictionary expression as override argument
-    "f @ (mkOrd compare) xs",
+    "give f (mkOrd compare) xs",
     -- override-only call of a single-implicit function
-    "showD @ mockShow"
+    "give showD mockShow"
   ]
 
 -- | Realistic combinations that mix A1 ⊕ A2 ⊕ A3 features.
 combinations :: [String]
 combinations =
-  [ -- A2 ⊕ A3: the resolved override argument is itself a `summon`
-    -- expression that uses the A1 `=>` arrow inside the type.
-    "sort @ (summon (Ord a => Ord [a])) xs",
-    -- A2: `summon` inside the body of a `let given`.
+  [ -- A2 ⊕ A3: the @give@-supplied dictionary is itself a @summon@
+    -- expression with an A1 @=>@ arrow inside its annotation.
+    "give sort (summon : Ord a => Ord [a]) xs",
+    -- A2: @summon@ inside the body of a @let given@.
     unlines
       [ "let",
-        "  given d : Nat = summon Nat",
+        "  given d : Nat = (summon : Nat)",
         "  d"
       ],
-    -- A3: `@`-override applied to a function whose result is itself
-    -- supplied to a second `@`-override, chained.
-    "build @ d (resolve @ d2 x)",
-    -- Operator precedence around `summon`: the `+` binds tighter
-    -- than `summon`'s greedy type-argument parse only because the
-    -- type sits in parens.
-    "(summon Nat) + 1",
-    -- `summon` whose argument uses a constraint arrow followed by
+    -- A3: nested @give@ — supply an explicit dict to a function
+    -- whose result is itself given an explicit dict.
+    "give build d (give resolve d2 x)",
+    -- @(summon : Nat) + 1@: arithmetic against a summoned value.
+    "(summon : Nat) + 1",
+    -- @summon@ whose annotation uses a constraint arrow followed by
     -- an effect arrow (A1 plus existing effect grammar).
-    "summon (Monad m => (a ->{e} m b) -> m a -> m b)"
+    "(summon : Monad m => (a ->{e} m b) -> m a -> m b)"
   ]
 
 -- | Combinations that have to live at file scope because they
@@ -203,13 +210,13 @@ combinationFiles :: [String]
 combinationFiles =
   [ -- Top-level given whose body is a `summon` call.
     unlines
-      [ "given fortyTwo : Nat = summon Nat",
+      [ "given fortyTwo : Nat = (summon : Nat)",
         "main = fortyTwo"
       ],
-    -- Top-level given referenced through an `@`-override in `main`.
+    -- Top-level given referenced through a @give@-prefix in @main@.
     unlines
       [ "given d : Nat = 42",
-        "main = sort @ d xs"
+        "main = give sort d xs"
       ]
   ]
 
@@ -254,11 +261,17 @@ docRewrites =
 
 -- | Negative cases for @summon@ (chunk A2 carry-over). Each pair is
 -- @(source, why)@; @why@ shows up in the test scope name.
+--
+-- ADR-006 made @summon@ a regular term reference rather than a
+-- keyword, so the previous "summon with no argument" parse-failure
+-- case is gone: bare @summon@ is now a syntactically valid term.
+-- (The typechecker still rejects it without surrounding type
+-- context — but that is a /typecheck/ failure, not a parse one.)
 summonNegatives :: [(String, String)]
 summonNegatives =
-  [ -- A2 carry-over (b): `summon` with no argument.
-    ("summon", "summon with no argument"),
-    -- `summon` followed only by a closing token.
+  [ -- `summon` followed by a stray closing token in expression
+    -- position: still a parse failure because @)@ cannot follow an
+    -- identifier here.
     ("summon )", "summon followed by stray closing paren")
   ]
 
@@ -311,53 +324,33 @@ letGivenNegatives =
     )
   ]
 
--- | Negative cases for @\@@-override (A3 carry-over): malformed
--- override syntax must be rejected, not silently accepted.
+-- | Negative cases for @give@-prefix (A3 carry-over): malformed
+-- @give@ syntax must be rejected, not silently accepted.
 overrideNegatives :: [(String, String)]
 overrideNegatives =
-  [ -- A3 carry-over (a): `f @` with no following argument.
-    ("f @", "override @ with no following arg"),
-    -- A3 carry-over (b): `@d` at the head of a term (no preceding
-    -- function). The `@`-override is an *argument-position* construct.
-    ("@d", "leading @ at term head"),
-    -- A3 carry-over (c): double `@` token.
-    ("f @ @ x", "double @")
+  [ -- @give@ with no following term.
+    ("give", "give with no following term")
   ]
 
--- | Structural test (A3 carry-over): parsing @f \@ d@ must produce an
--- application whose second argument has its annotation widened to
--- include the leading @\@@ token. The cheap observable: the start
--- column of the override-arg's annotation is strictly less than the
--- start column of the bare leaf @d@ would have been. Since the
--- leading @\@@ is at column 3 and @d@ is at column 5 in the source
--- @"f @ d"@, the widened annotation must start at column 3.
---
--- This pins the contract that downstream chunks (D2/D3) rely on.
+-- | Structural test (A3 carry-over): parsing @give f d@ must produce
+-- an application whose /function/ head has its annotation wrapped
+-- with 'Ann.Lowered'. That's the discriminator downstream chunks
+-- (typechecker, GivenApply) rely on to skip the implicit-resolution
+-- machinery at @f@'s use-site.
 overrideArgWidensAnnotation :: Test ()
-overrideArgWidensAnnotation = scope "ann widened by leading @" $
-  case runIdentity (Ps.parse @_ @Symbol TP.term "f @ d" Common.parsingEnv) of
+overrideArgWidensAnnotation = scope "give wraps head annotation with Lowered" $
+  case runIdentity (Ps.parse @_ @Symbol TP.term "give f d" Common.parsingEnv) of
     Left e ->
-      crash . Text.unpack $ renderParseErrorAsANSI 60 "f @ d" e
+      crash . Text.unpack $ renderParseErrorAsANSI 60 "give f d" e
     Right t -> case Term.unApps t of
-      Just (_f, [arg]) ->
-        case ABT.annotation arg of
-          Ann startPos _ ->
-            -- `f` is at column 1, ` ` at column 2, `@` at column 3,
-            -- ` ` at column 4, `d` at column 5. The widened arg
-            -- annotation must start at the `@` (column 3), not at
-            -- the bare `d` (column 5).
-            let col = Pos.column startPos
-             in if col < 5 && col >= 3
-                  then ok
-                  else do
-                    note $ "expected widened ann start column in [3,5); got " ++ show col
-                    note $ "full annotation: " ++ show (ABT.annotation arg)
-                    crash "override-arg annotation was not widened"
-          _ -> do
-            note $ "expected an Ann annotation, got: " ++ show (ABT.annotation arg)
-            crash "non-Ann annotation on parsed override-arg"
+      Just (f, [_arg]) ->
+        case ABT.annotation f of
+          Ann.Lowered _ -> ok
+          a -> do
+            note $ "expected Lowered annotation on function head; got: " ++ show a
+            crash "give-prefix did not wrap head with Ann.Lowered"
       _ -> do
-        note $ "expected `f @ d` to parse as one application with one arg; got: " ++ show t
+        note $ "expected `give f d` to parse as one application with one arg; got: " ++ show t
         crash "structural mismatch"
 
 parsesTerm :: String -> Test ()

--- a/parser-typechecker/tests/Unison/Test/Syntax/ImplicitParser.hs
+++ b/parser-typechecker/tests/Unison/Test/Syntax/ImplicitParser.hs
@@ -1,0 +1,441 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+-- | Snapshot tests for the implicit-parameters surface syntax,
+-- consolidating chunks A1, A2, and A3 (parser-only).
+--
+--   * A1 ('=>' constraint arrow): see also @TypeParser.hs@; this
+--     module exercises the constraint arrow in *term* contexts
+--     (inside @summon@ and inside @given@ signatures).
+--   * A2: top-level @given@ declarations, @summon T@ expressions, and
+--     @let given@ block statements. See ADR-006 (@summon@ syntax),
+--     ADR-010 (@given@ as the declaration keyword), and ADR-022 (the
+--     keyword-migration policy).
+--   * A3: @\@@-positional explicit override at call sites — @f \@ d x@
+--     fills @f@'s next implicit slot with @d@, then applies to @x@.
+--     See ADR-007. The same @\@@ token is also used in pattern
+--     position (as-patterns, e.g. @Foo\@Bar@) and in doc-block
+--     position (@\@rewrite@); all three uses are confirmed below to
+--     coexist.
+--
+-- These are parser-only tests: A2 desugars @summon T@ to a typed
+-- hole and a @given@ declaration to a regular type-annotated
+-- binding; A3 desugars @f \@ d@ to ordinary positional application
+-- (with the argument's source range widened to include the leading
+-- @\@@). Semantics land in chunks C and D.
+module Unison.Test.Syntax.ImplicitParser where
+
+import Data.Functor.Identity (Identity (..))
+import Data.List (intercalate)
+import Data.Text qualified as Text
+import EasyTest
+import Text.RawString.QQ
+import Unison.ABT qualified as ABT
+import Unison.Lexer.Pos qualified as Pos
+import Unison.Parser.Ann (Ann (..))
+import Unison.Parsers qualified as Ps
+import Unison.PrintError (renderParseErrorAsANSI)
+import Unison.Symbol (Symbol)
+import Unison.Syntax.FileParser (file)
+import Unison.Syntax.Parser qualified as P
+import Unison.Syntax.TermParser qualified as TP
+import Unison.Term qualified as Term
+import Unison.Test.Common qualified as Common
+import Unison.UnisonFile (UnisonFile)
+
+test :: Test ()
+test =
+  scope "implicit-parser" . tests $
+    [ scope "summon-expr" $ tests (parsesTerm <$> summonExprs),
+      scope "let-given" $ tests (parsesTerm <$> letGivens),
+      scope "top-level-given" $ tests (parsesFile <$> topLevelGivens),
+      scope "override-app" $ tests (parsesTerm <$> overrideApps),
+      scope "as-pattern-still-works" $ tests (parsesTerm <$> asPatterns),
+      scope "doc-rewrite-still-works" $ tests (parsesTerm <$> docRewrites),
+      scope "constraint-in-given-signature" $ tests (parsesTerm <$> constraintInGivenSig),
+      scope "combination" $ tests (parsesTerm <$> combinations),
+      scope "combination-file" $ tests (parsesFile <$> combinationFiles),
+      scope "summon.malformed" $ tests (failsToParseTerm <$> summonNegatives),
+      scope "given.malformed" $ tests (failsToParseFile <$> givenFileNegatives),
+      scope "let-given.malformed" $ tests (failsToParseTerm <$> letGivenNegatives),
+      scope "override.malformed" $ tests (failsToParseTerm <$> overrideNegatives),
+      scope "override.structural" overrideArgWidensAnnotation
+    ]
+
+-- | @summon T@ in expression position. ADR-006 specifies the keyword.
+--
+-- These exercise the parser only; we use builtin types so the
+-- name-resolution pass that follows the parser doesn't reject
+-- references to Phase-2 standard-library types we haven't loaded.
+summonExprs :: [String]
+summonExprs =
+  [ -- atomic type argument
+    "summon Nat",
+    -- parenthesized list type
+    "summon [Nat]",
+    -- nested: summon used as a function argument
+    "id (summon Nat)",
+    -- summon followed by a parenthesized arrow type
+    "summon (Nat -> Nat)"
+  ]
+
+-- | @let given name : T = body@ inside a let block. The block syntax
+-- relies on @binding@ accepting the @given@ prefix; see the call
+-- site in @Unison.Syntax.TermParser.statement@.
+--
+-- These run through @TP.term@ with the builtins-only parsing env,
+-- so we stick to types that resolve there.
+letGivens :: [String]
+letGivens =
+  [ unlines
+      [ "let",
+        "  given x : Nat = 42",
+        "  x"
+      ],
+    unlines
+      [ "let",
+        "  given xs : [Nat] = [1,2,3]",
+        "  xs"
+      ]
+  ]
+
+-- | Top-level @given@ definitions in a file. The file parser reaches
+-- @binding@ from its top-level statement parser, so this exercises
+-- the same keyword path as the let-block tests but at file scope.
+--
+-- We restrict to types that resolve in the builtins-only parsing
+-- environment (@Common.parsingEnv@); the Phase-2 standard library
+-- types like @Show@/@Ord@ are not in scope here, so we use @Nat@
+-- and @[Nat]@ as stand-ins. The point is to exercise the
+-- @given@-keyword grammar, not to typecheck.
+topLevelGivens :: [String]
+topLevelGivens =
+  [ unlines
+      [ "given fortyTwo : Nat = 42",
+        "main = fortyTwo"
+      ],
+    [r|given ones : [Nat] = [1,1,1]
+main = ones
+|]
+  ]
+
+-- | A1 ⊕ A2 carry-over: a @given@ whose declared type uses the A1
+-- constraint arrow @=>@. Exercises the wiring between
+-- @givenBindingBody@'s type-annotation slot and
+-- 'TypeParser.valueType'.
+--
+-- We exercise this through @let given@ (term position) rather than
+-- file scope so we don't depend on type-name resolution: the file
+-- parser would reject unknown type names like @Foo@/@Bar@ that the
+-- Phase-2 stdlib supplies; @TP.term@ doesn't run that pass.
+constraintInGivenSig :: [String]
+constraintInGivenSig =
+  [ unlines
+      [ "let",
+        "  given showList : Show a => Show (List a) = listShow",
+        "  showList"
+      ],
+    unlines
+      [ "let",
+        "  given fooBar : Foo a => Bar a = bar",
+        "  fooBar"
+      ],
+    -- multi-constraint variant of the same form
+    unlines
+      [ "let",
+        "  given d : (Eq a, Show a) => ShowEq a = mkShowEq",
+        "  d"
+      ]
+  ]
+
+-- | @\@@-positional explicit override at call sites (chunk A3,
+-- ADR-007). The parser produces ordinary positional application;
+-- the source range of each override argument is widened to include
+-- the leading @\@@ so downstream chunks can recognise it.
+--
+-- We use bare identifiers (not in the builtins-only parsing env) on
+-- purpose: at parse time these become free variables, which is
+-- enough to exercise the application grammar without depending on
+-- the standard library being loaded.
+overrideApps :: [String]
+overrideApps =
+  [ -- the canonical example from the design doc
+    "sort @ ordDescending xs",
+    -- override at the last position
+    "f @ d",
+    -- chained overrides: fills the first two implicit slots
+    "g @ d1 @ d2 x",
+    -- override sandwiched between regular args (mixed positions)
+    "h x @ d y",
+    -- parenthesized dictionary expression as override argument
+    "f @ (mkOrd compare) xs",
+    -- override-only call of a single-implicit function
+    "showD @ mockShow"
+  ]
+
+-- | Realistic combinations that mix A1 ⊕ A2 ⊕ A3 features.
+combinations :: [String]
+combinations =
+  [ -- A2 ⊕ A3: the resolved override argument is itself a `summon`
+    -- expression that uses the A1 `=>` arrow inside the type.
+    "sort @ (summon (Ord a => Ord [a])) xs",
+    -- A2: `summon` inside the body of a `let given`.
+    unlines
+      [ "let",
+        "  given d : Nat = summon Nat",
+        "  d"
+      ],
+    -- A3: `@`-override applied to a function whose result is itself
+    -- supplied to a second `@`-override, chained.
+    "build @ d (resolve @ d2 x)",
+    -- Operator precedence around `summon`: the `+` binds tighter
+    -- than `summon`'s greedy type-argument parse only because the
+    -- type sits in parens.
+    "(summon Nat) + 1",
+    -- `summon` whose argument uses a constraint arrow followed by
+    -- an effect arrow (A1 plus existing effect grammar).
+    "summon (Monad m => (a ->{e} m b) -> m a -> m b)"
+  ]
+
+-- | Combinations that have to live at file scope because they
+-- contain top-level @given@ declarations.
+combinationFiles :: [String]
+combinationFiles =
+  [ -- Top-level given whose body is a `summon` call.
+    unlines
+      [ "given fortyTwo : Nat = summon Nat",
+        "main = fortyTwo"
+      ],
+    -- Top-level given referenced through an `@`-override in `main`.
+    unlines
+      [ "given d : Nat = 42",
+        "main = sort @ d xs"
+      ]
+  ]
+
+-- | The same @\@@ token still parses as an as-pattern in pattern
+-- position. Pattern-context @\@@ is handled by 'pHqNamey' in
+-- 'TermParser.hs' (~line 410), a different parser entry-point from
+-- the term-application path that A3 modified, so the two grammars
+-- are syntactically disjoint.
+asPatterns :: [String]
+asPatterns =
+  [ unlines
+      [ "match xs with",
+        "  whole@(_ +: _) -> whole",
+        "  _ -> []"
+      ],
+    -- nested as-pattern with constructor sub-pattern
+    unlines
+      [ "match opt with",
+        "  pair@(Some _) -> pair",
+        "  None -> None"
+      ]
+  ]
+
+-- | The @\@rewrite@ syntax — the third use of the @\@@ token —
+-- is parsed in 'rewriteBlock' (line ~104) using
+-- 'openBlockWith \"\@rewrite\"'. It lives entirely outside
+-- 'term4'\'s application path, so A3's changes do not affect it.
+-- The form is @\@rewrite term LHS ==> RHS@ and friends.
+docRewrites :: [String]
+docRewrites =
+  [ unlines
+      [ "@rewrite",
+        "  term x ==> x"
+      ],
+    -- two rules in one block
+    unlines
+      [ "@rewrite",
+        "  term x ==> x",
+        "  term y ==> y"
+      ]
+  ]
+
+-- | Negative cases for @summon@ (chunk A2 carry-over). Each pair is
+-- @(source, why)@; @why@ shows up in the test scope name.
+summonNegatives :: [(String, String)]
+summonNegatives =
+  [ -- A2 carry-over (b): `summon` with no argument.
+    ("summon", "summon with no argument"),
+    -- `summon` followed only by a closing token.
+    ("summon )", "summon followed by stray closing paren")
+  ]
+
+-- | Negative cases for @given@ at top level / in files (A2 carry-over).
+givenFileNegatives :: [(String, String)]
+givenFileNegatives =
+  [ -- A2 carry-over (a): `given` declaration with no body.
+    ( unlines
+        [ "given x : Nat",
+          "main = x"
+        ],
+      "given with no body"
+    ),
+    -- A2 carry-over (c): top-level `given x = …` with no `:` annotation.
+    -- ADR-010 requires the type annotation; the annotation drives
+    -- C2.3's signature-checking and C2.2's constraint-goal emission.
+    ( unlines
+        [ "given x = 42",
+          "main = x"
+        ],
+      "top-level given missing : annotation"
+    ),
+    -- `given` with no name at all.
+    ( unlines
+        [ "given : Nat = 42",
+          "main = 1"
+        ],
+      "given with no name"
+    )
+  ]
+
+-- | Negative cases for @let given@ inside a let-block (A2 carry-over).
+letGivenNegatives :: [(String, String)]
+letGivenNegatives =
+  [ -- A2 carry-over (d): `let given x = …` with no annotation.
+    ( unlines
+        [ "let",
+          "  given x = 42",
+          "  x"
+        ],
+      "let-given missing : annotation"
+    ),
+    -- `let given` with neither annotation nor body.
+    ( unlines
+        [ "let",
+          "  given x",
+          "  x"
+        ],
+      "let-given with no body or annotation"
+    )
+  ]
+
+-- | Negative cases for @\@@-override (A3 carry-over): malformed
+-- override syntax must be rejected, not silently accepted.
+overrideNegatives :: [(String, String)]
+overrideNegatives =
+  [ -- A3 carry-over (a): `f @` with no following argument.
+    ("f @", "override @ with no following arg"),
+    -- A3 carry-over (b): `@d` at the head of a term (no preceding
+    -- function). The `@`-override is an *argument-position* construct.
+    ("@d", "leading @ at term head"),
+    -- A3 carry-over (c): double `@` token.
+    ("f @ @ x", "double @")
+  ]
+
+-- | Structural test (A3 carry-over): parsing @f \@ d@ must produce an
+-- application whose second argument has its annotation widened to
+-- include the leading @\@@ token. The cheap observable: the start
+-- column of the override-arg's annotation is strictly less than the
+-- start column of the bare leaf @d@ would have been. Since the
+-- leading @\@@ is at column 3 and @d@ is at column 5 in the source
+-- @"f @ d"@, the widened annotation must start at column 3.
+--
+-- This pins the contract that downstream chunks (D2/D3) rely on.
+overrideArgWidensAnnotation :: Test ()
+overrideArgWidensAnnotation = scope "ann widened by leading @" $
+  case runIdentity (Ps.parse @_ @Symbol TP.term "f @ d" Common.parsingEnv) of
+    Left e ->
+      crash . Text.unpack $ renderParseErrorAsANSI 60 "f @ d" e
+    Right t -> case Term.unApps t of
+      Just (_f, [arg]) ->
+        case ABT.annotation arg of
+          Ann startPos _ ->
+            -- `f` is at column 1, ` ` at column 2, `@` at column 3,
+            -- ` ` at column 4, `d` at column 5. The widened arg
+            -- annotation must start at the `@` (column 3), not at
+            -- the bare `d` (column 5).
+            let col = Pos.column startPos
+             in if col < 5 && col >= 3
+                  then ok
+                  else do
+                    note $ "expected widened ann start column in [3,5); got " ++ show col
+                    note $ "full annotation: " ++ show (ABT.annotation arg)
+                    crash "override-arg annotation was not widened"
+          _ -> do
+            note $ "expected an Ann annotation, got: " ++ show (ABT.annotation arg)
+            crash "non-Ann annotation on parsed override-arg"
+      _ -> do
+        note $ "expected `f @ d` to parse as one application with one arg; got: " ++ show t
+        crash "structural mismatch"
+
+parsesTerm :: String -> Test ()
+parsesTerm s = scope (label s) $
+  case runIdentity (Ps.parse @_ @Symbol TP.term s Common.parsingEnv) of
+    Left e -> do
+      note . Text.unpack $ renderParseErrorAsANSI 60 s e
+      crash . Text.unpack $ renderParseErrorAsANSI 60 s e
+    Right _ -> ok
+
+parsesFile :: String -> Test ()
+parsesFile s = scope (label s) $
+  case runIdentity (P.run (P.rootFile file) s Common.parsingEnv) ::
+         Either (P.Err Symbol) (UnisonFile Symbol Ann) of
+    Left e -> do
+      note . Text.unpack $ renderParseErrorAsANSI 60 s e
+      crash . Text.unpack $ renderParseErrorAsANSI 60 s e
+    Right _ -> ok
+
+-- | Negative-test helper for term-parser inputs. The parser is
+-- expected to fail; on failure we record the error message so a
+-- reviewer can confirm it is helpful (Part 4 of the A4 acceptance
+-- criteria).
+failsToParseTerm :: (String, String) -> Test ()
+failsToParseTerm (s, why) = scope (label (s ++ "  -- " ++ why)) $
+  case runIdentity (Ps.parse @_ @Symbol TP.term s Common.parsingEnv) of
+    Left e -> do
+      -- Record the error message so the snapshot suite makes the
+      -- diagnostic visible to the next reviewer; if the message is
+      -- confusing for a given case, that is a signal to the parser
+      -- author to add a more targeted failure.
+      note . Text.unpack $ renderParseErrorAsANSI 60 s e
+      ok
+    Right t -> do
+      note $ "expected parse failure (" ++ why ++ "); got: " ++ show t
+      crash "parser unexpectedly succeeded"
+
+-- | Negative-test helper for file-parser inputs.
+failsToParseFile :: (String, String) -> Test ()
+failsToParseFile (s, why) = scope (label (s ++ "  -- " ++ why)) $
+  case runIdentity (P.run (P.rootFile file) s Common.parsingEnv) ::
+         Either (P.Err Symbol) (UnisonFile Symbol Ann) of
+    Left e -> do
+      note . Text.unpack $ renderParseErrorAsANSI 60 s e
+      ok
+    Right _ -> do
+      note $ "expected parse failure (" ++ why ++ ")"
+      crash "parser unexpectedly succeeded"
+
+-- | Build a distinct test-scope name from a fixture.
+--
+-- A naïve "first line" picker collides for multi-line fixtures that
+-- begin with a layout opener (e.g., two @let@-given fixtures both
+-- displaying as @let-given.let@; two @\@rewrite@ fixtures sharing
+-- the same first rule). The rules below restore distinctness:
+--
+--   * Drop a leading layout opener (@let@, @do@, @where@, @with@) —
+--     the next non-empty line is the part the reader cares about.
+--   * For @\@rewrite@ fixtures, join *all* non-empty content lines
+--     with @\" / \"@ so two rule lists differ in their label.
+--   * For all other multi-line fixtures, use the first non-empty
+--     content line.
+--
+-- This addresses the @label@-collision carry-overs flagged in both
+-- the A2 review (let-given fixtures) and the A3 review (doc-rewrite
+-- fixtures).
+label :: String -> String
+label s = case filter (not . null) . map trim $ lines s of
+  [] -> ""
+  [single] -> single
+  contentLines@(first : second : _)
+    -- Layout openers (@let@, @do@, etc.) carry no distinguishing
+    -- info on their own; use the next non-empty content line.
+    | first `elem` layoutOpeners -> second
+    -- @\@rewrite@: join all content lines so two rewrite fixtures
+    -- differ in their labels even when they share a first rule.
+    | first == "@rewrite" -> intercalate " / " contentLines
+    | otherwise -> first
+  where
+    trim = dropWhile (== ' ')
+    layoutOpeners = ["let", "do", "where", "with"]

--- a/parser-typechecker/tests/Unison/Test/Syntax/ImplicitPrinter.hs
+++ b/parser-typechecker/tests/Unison/Test/Syntax/ImplicitPrinter.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Round-trip property tests for the @=>@ constraint-arrow syntax
+-- (chunk P1). For each fixture we:
+--
+--   1. parse the source as a value type;
+--   2. pretty-print the parsed type via 'Unison.Syntax.TypePrinter';
+--   3. re-parse the printed text;
+--   4. assert the two ABTs are structurally equal (modulo annotations).
+--
+-- This pins the contract that @view@\/@edit@\/@update@ of declarations
+-- containing @=>@ preserve the constraint-arrow syntax: without the
+-- printer arm added in chunk P1, step 2 would emit @->@ for implicit
+-- positions and the second parse would yield a different AST.
+--
+-- We use 'Unison.Test.Common.t', which calls 'TypeParser.valueType'
+-- under the builtins-only parsing env and applies
+-- 'Type.generalizeLowercase' so lowercase free names become @forall@-bound.
+-- The round-trip therefore exercises the @forall ... =>@ interaction in
+-- addition to the @=>@ rendering itself.
+module Unison.Test.Syntax.ImplicitPrinter where
+
+import Data.Map qualified as Map
+import Data.Text qualified as Text
+import EasyTest
+import Unison.ABT qualified as ABT
+import Unison.Builtin qualified
+import Unison.PrettyPrintEnv.Names qualified as PPE
+import Unison.Syntax.TypePrinter qualified as TypePrinter
+import Unison.Test.Common qualified as Common
+import Unison.Util.ColorText (toPlain)
+import Unison.Util.Pretty qualified as PP
+
+-- | Round-trip a single source fixture: parse -> print -> parse,
+-- assert structural equality (modulo annotations).
+roundTrip :: String -> Test ()
+roundTrip s = scope (label s) $ do
+  let original = Common.t s
+      ppe =
+        PPE.makePPE
+          (PPE.hqNamer Common.hqLength Unison.Builtin.names)
+          PPE.dontSuffixify
+      printed =
+        Text.unpack
+          . toPlain
+          . PP.render 80
+          . PP.syntaxToColor
+          . TypePrinter.runPretty ppe
+          $ TypePrinter.prettyRaw Map.empty (-1) original
+      reparsed = Common.t printed
+  -- ABT structural equality drops annotations, so this is a faithful
+  -- round-trip property: any cosmetic difference (whitespace, paren
+  -- redundancy) is allowed; structural difference is not.
+  if ABT.amap (const ()) original == ABT.amap (const ()) reparsed
+    then ok
+    else do
+      note $ "input    : " <> s
+      note $ "printed  : " <> printed
+      note $ "original : " <> show original
+      note $ "reparsed : " <> show reparsed
+      crash "round-trip mismatch"
+
+-- | Fixtures cover the corpus the printer must reproduce, drawn from
+-- @docs/implicits-plan.md@ §1.2 and the A4 parser snapshot suite:
+--
+--   * single-constraint signatures (@Show a => a -> Text@);
+--   * tuple-of-constraints signatures (@(Show a, Eq a) => [a] -> [a]@);
+--   * higher-kinded constraints (@Functor f => ...@);
+--   * constraints with effect arrows in the conclusion;
+--   * the given-conclusion form (@Show a => Show (List a)@).
+fixtures :: [String]
+fixtures =
+  [ "Show a => a -> Text",
+    "(Show a, Eq a) => [a] -> [a]",
+    "Functor f => (a -> b) -> f a -> f b",
+    "(Monad m, Traversable t) => (a ->{e} m b) -> t a ->{e} m (t b)",
+    "Show a => Show (List a)"
+  ]
+
+test :: Test ()
+test =
+  scope "implicit-printer" . tests $
+    [ scope "round-trip" $ tests (roundTrip <$> fixtures)
+    ]
+
+-- | Pick the first non-empty line for the test scope name.
+label :: String -> String
+label s = case filter (not . null) (lines s) of
+  [] -> ""
+  (l : _) -> l

--- a/parser-typechecker/tests/Unison/Test/Syntax/TypeParser.hs
+++ b/parser-typechecker/tests/Unison/Test/Syntax/TypeParser.hs
@@ -1,0 +1,112 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Snapshot tests for the type-signature parser, exercising the
+-- implicit-parameter constraint-arrow @=>@ syntax introduced by
+-- chunk A1 of the implicits feature (see
+-- @docs/implicits-phase-2-chunks.md@ and ADR-001).
+--
+-- Round-trip pretty-printing is a Phase 4 deliverable; for now these
+-- tests ensure that:
+--
+--   * positive examples from @docs/implicits-plan.md@ §1.2 parse;
+--   * malformed @=>@ usages produce parse errors (no spurious
+--     successes that downstream phases would have to clean up).
+module Unison.Test.Syntax.TypeParser where
+
+import Control.Monad (join)
+import Data.Functor.Identity (Identity (..))
+import Data.Text qualified as Text
+import EasyTest
+import Unison.Parsers qualified as Ps
+import Unison.PrintError (renderParseErrorAsANSI)
+import Unison.Symbol (Symbol)
+import Unison.Syntax.TypeParser qualified as TP
+import Unison.Test.Common qualified as Common
+
+test :: Test ()
+test =
+  scope "typeparser" . tests $
+    [ scope "constraint-arrow" $ tests (parses <$> positives),
+      scope "constraint-arrow.malformed" $ tests (failsToParse <$> negatives),
+      scope "lexer-distinguishes-arrows" $ tests (parses <$> arrowDistinctions)
+    ]
+
+-- | Examples taken from @docs/implicits-plan.md@ §1.2 (consuming givens).
+positives :: [String]
+positives =
+  [ -- single constraint
+    "Show a => a -> Text",
+    "Ord a => [a] -> [a]",
+    -- HKT
+    "Functor f => (a -> b) -> f a -> f b",
+    "Monad m => (a -> m b) -> m a -> m b",
+    -- multiple constraints in a tuple
+    "(Monad m, Traversable t) => (a -> m b) -> t a -> m (t b)",
+    "(Eq a, Show a) => a -> a -> Text",
+    -- constraint followed by a forall'd body
+    -- (note: forall on the LHS would be unusual; on the RHS is the typical form)
+    "Show a => forall b . b -> a -> Text",
+    -- nested parens in body
+    "Show a => (a -> Text) -> Text",
+    -- multiple constraints, single-paren grouping
+    "(Show a) => a -> Text",
+    -- constraint on a higher-arity type
+    "Functor f => f a -> f a",
+    -- A1 carry-over: given-conclusion form, plan §1.2.
+    -- A constraint followed directly by a constraint-shaped conclusion
+    -- (no arrow, just `Show (List a)`) must parse: this is the
+    -- "given Show (List a) requires Show a" reading of `=>`.
+    "Show a => Show (List a)",
+    -- A1 carry-over: constraint combined with an effect-arrow body.
+    -- Plan §1.2 explicitly lists the `(Monad m) => (a ->{e} m b) -> ...`
+    -- form; the body uses the existing `->{eff}` arrow syntax.
+    "(Monad m) => (a ->{e} m b) -> m a -> m b"
+  ]
+
+-- | The lexer must continue to distinguish @=>@ from @==>@ and @=@.
+-- These don't use @=>@ themselves but live in the same neighborhood
+-- and would regress if the lexer were edited carelessly.
+arrowDistinctions :: [String]
+arrowDistinctions =
+  [ "Nat -> Nat",
+    "a -> b -> c",
+    "{State s} a -> b"
+  ]
+
+-- | Negative cases: malformed constraint arrows. Each of these should
+-- fail to parse as a value type.
+--
+-- We don't assert a specific error class because the cheapest A1
+-- behaviour is "generic parse failure"; A4's snapshot suite will
+-- pin precise diagnostics.
+negatives :: [(String, String)]
+negatives =
+  [ ("=> Foo", "missing LHS"),
+    ("Foo =>", "missing RHS"),
+    ("Show a =>", "missing RHS after multi-token LHS"),
+    ("=> => Foo", "double constraint arrow"),
+    ("Show => => Foo", "constraint arrow with no body between two LHSes"),
+    -- A1 carry-over: ADR-001 forbids nested `=>` chains. The user
+    -- must group constraints with parens: `(Show a, Eq a) => T`.
+    ("Show a => Eq a => T", "nested =>: ADR-001 requires (..., ...) => grouping")
+  ]
+
+parses :: String -> Test ()
+parses s = scope (label s) $
+  case runIdentity (Ps.parse @_ @Symbol TP.valueType s Common.parsingEnv) of
+    Left e -> do
+      note . Text.unpack $ renderParseErrorAsANSI 60 s e
+      crash . Text.unpack $ renderParseErrorAsANSI 60 s e
+    Right _ -> ok
+
+failsToParse :: (String, String) -> Test ()
+failsToParse (s, why) = scope (label (s ++ "  -- " ++ why)) $
+  case runIdentity (Ps.parse @_ @Symbol TP.valueType s Common.parsingEnv) of
+    Left _ -> ok
+    Right t -> do
+      note $ "expected parse failure (" ++ why ++ "); got: " ++ show t
+      crash "parser unexpectedly succeeded"
+
+-- | Pick the first non-empty line for the test scope name.
+label :: String -> String
+label = join . take 1 . lines

--- a/parser-typechecker/tests/Unison/Test/Type.hs
+++ b/parser-typechecker/tests/Unison/Test/Type.hs
@@ -3,6 +3,7 @@
 module Unison.Test.Type where
 
 import EasyTest
+import Unison.Hashing.V2.Convert qualified as HashingConvert
 import Unison.Symbol (Symbol)
 import Unison.Type
 import Unison.Typechecker qualified as Typechecker
@@ -30,5 +31,28 @@ test =
               vt2 = var () v2
               x = forAll () v (nat () --> effect () [vt, builtin () "eff"] (nat ())) :: Type Symbol ()
               y = forAll () v2 (nat () --> effect () [vt2] (nat ())) :: Type Symbol ()
-          expect . not $ Typechecker.isSubtype x y
+          expect . not $ Typechecker.isSubtype x y,
+        -- ADR-019 / chunk C1.1: 'ImplicitArrow' is a distinct AST node
+        -- from 'Arrow' and must hash distinctly (per ADR-014). The
+        -- v2-hashing entry point used here is the same one the codebase
+        -- uses to compute type hashes for storage.
+        scope "ImplicitArrow hashes distinctly from Arrow" $ do
+          let v = Var.named "x" :: Symbol
+              vt = var () v :: Type Symbol ()
+              b = builtin () "b"
+              tArrow = forAll () v (arrow () vt b)
+              tImplicit = forAll () v (implicitArrow () vt b)
+              refA = HashingConvert.typeToReference tArrow
+              refI = HashingConvert.typeToReference tImplicit
+          expect (refA /= refI),
+        -- ADR-019: a type containing 'ImplicitArrow' produces a stable
+        -- hash, demonstrating the v2-hashing tokenizer handles the new
+        -- constructor. Two structurally identical types must hash equal.
+        scope "ImplicitArrow hashing is stable" $ do
+          let v = Var.named "x" :: Symbol
+              vt = var () v :: Type Symbol ()
+              b = builtin () "b"
+              t1 = forAll () v (implicitArrow () vt (arrow () vt b))
+              t2 = forAll () v (implicitArrow () vt (arrow () vt b))
+          expect (HashingConvert.typeToReference t1 == HashingConvert.typeToReference t2)
       ]

--- a/parser-typechecker/tests/Unison/Test/Typechecker/Context.hs
+++ b/parser-typechecker/tests/Unison/Test/Typechecker/Context.hs
@@ -2,13 +2,18 @@
 
 module Unison.Test.Typechecker.Context (test) where
 
-import Data.Foldable (for_)
+import Data.Foldable (for_, toList)
+import Data.Map qualified as Map
+import Data.Set qualified as Set
 import EasyTest
 import Unison.PrettyPrintEnv qualified as PPE
+import Unison.Reference qualified as Reference
 import Unison.Symbol (Symbol)
 import Unison.Term qualified as Term
 import Unison.Type qualified as Type
 import Unison.Typechecker.Context qualified as Context
+import Unison.Typechecker.TypeLookup qualified as TL
+import Unison.Typechecker.TypeVar qualified as TypeVar
 import Unison.Typechecker.Variance
 import Unison.Var qualified as Var
 
@@ -16,7 +21,9 @@ test :: Test ()
 test =
   scope "context" $
     tests
-      [ scope "verifyClosedTerm" verifyClosedTermTest
+      [ scope "verifyClosedTerm" verifyClosedTermTest,
+        scope "lexicalGivensThreading" lexicalGivensThreadingTest,
+        scope "constraintGoalEmission" constraintGoalEmissionTest
       ]
 
 type TV = Context.TypeVar Symbol ()
@@ -35,7 +42,7 @@ verifyClosedTermTest =
                 ()
                 (Term.ann () (Term.var () a) (Type.var () a'))
                 (Term.ann () (Term.var () b) (Type.var () b'))
-            res = Context.synthesizeClosed PPE.empty Context.PatternMatchCoverageCheckAndKindInferenceSwitch'Enabled defaultVariances [] mempty t
+            res = Context.synthesizeClosed PPE.empty Context.PatternMatchCoverageCheckAndKindInferenceSwitch'Enabled defaultVariances [] Map.empty Set.empty mempty t
             errors = Context.typeErrors res
             expectUnknownSymbol (Context.ErrorNote cause _) = case cause of
               Context.UnknownSymbol _ _ -> ok
@@ -44,3 +51,218 @@ verifyClosedTermTest =
               expectEqual 4 (length errors) -- there are 4 unknown symbols: a, a', b, b'
               for_ errors expectUnknownSymbol
     ]
+
+-- | ADR-010 / chunk C2.1: confirms the lexical given environment is
+-- threaded through nested binding forms ('Lam', 'Let1') without
+-- disturbing the typechecker's result. Two expectations:
+--
+--   1. Typechecking a nested term (a let-binding whose RHS is a
+--      lambda, then applied to a literal) succeeds — exercises the
+--      'withLexicalGivens' wrappers in the 'Term.Let1Top'' and
+--      'Term.Lam'' arms of 'synthesizeWanted' without semantic
+--      effect.
+--
+--   2. Passing a non-empty initial givens map produces the same
+--      outcome as passing 'Map.empty', confirming the seed is not yet
+--      consulted by inference (chunks D1+ will change this).
+--
+-- The match-arm and letrec wrappers are exercised indirectly by the
+-- existing typechecker test suite — every transcript with a 'match'
+-- or mutual recursion crosses 'withLexicalGivens'.
+lexicalGivensThreadingTest :: Test ()
+lexicalGivensThreadingTest =
+  tests
+    [ scope "typechecks-with-empty-givens" $
+        case run Map.empty of
+          Right _ -> ok
+          Left err -> crash err,
+      scope "typechecks-with-nonempty-givens" $
+        -- A non-empty givens map should be accepted and ignored by
+        -- inference (until chunks D1+ wire up resolution). The map
+        -- value is meaningless to the typechecker today; what we
+        -- verify is that 'synthesizeClosed' with a populated initial
+        -- env produces the same outcome as with an empty one.
+        let nonEmpty =
+              Map.singleton
+                -- Any builtin reference works as a placeholder key;
+                -- we only care that the field is observed and saved
+                -- across binders.
+                Type.intRef
+                (Type.int ())
+         in case run nonEmpty of
+              Right _ -> ok
+              Left err -> crash err
+    ]
+  where
+    -- Term: @let f = (n -> n) in f 42@.
+    --
+    -- The let-binding body forces 'Term.Let1Top'' synthesis (which
+    -- now wraps its body in 'withLexicalGivens'); the lambda forces
+    -- the 'Term.Lam'' arm (also wrapped).
+    --
+    -- We deliberately use a 'Nat' literal rather than a richer
+    -- construction so the test does not depend on builtin
+    -- lookups — 'mempty' below is a 'TypeLookup' with no decls. The
+    -- kind-inference pass requires data decls, so we disable it via
+    -- the 'Disabled' switch.
+    run givens =
+      let n = Var.named @Symbol "n"
+          f = Var.named @Symbol "f"
+          fortyTwo = Term.nat () 42
+          inner = Term.lamWithoutBindingAnns () [n] (Term.var () n)
+          term =
+            Term.let1'
+              False
+              [(f, inner)]
+              (Term.app () (Term.var () f) fortyTwo)
+          res =
+            Context.synthesizeClosed
+              PPE.empty
+              Context.PatternMatchCoverageCheckAndKindInferenceSwitch'Disabled
+              defaultVariances
+              []
+              givens
+              Set.empty
+              mempty
+              term
+       in case Context.typeErrors res of
+            errs
+              | null errs -> Right ()
+              | otherwise ->
+                  Left ("unexpected type errors: " <> show (length errs))
+
+-- | ADR-019 / chunk C2.2: confirms inference emits a 'ConstraintGoal'
+-- info note for each 'ImplicitArrow' parameter at an apply-site, with
+-- the right type and the lexical given environment captured into the
+-- goal's scope snapshot.
+--
+-- Strategy: register a builtin term reference @f@ in the 'TypeLookup'
+-- whose declared type is @C => Nat -> Nat@ (a single implicit
+-- parameter, then a regular arrow). Synthesize the closed term @f 42@.
+-- Inspect the emitted 'InfoNote's:
+--
+--   1. exactly one 'ConstraintGoal' note appears (one implicit slot);
+--   2. its 'goalType' equals the constraint type @C@;
+--   3. with a non-empty initial @lexicalGivens@ map, the goal's
+--      'goalScope' captures it faithfully (proves C2.1's env reaches
+--      C2.2's emission point).
+--
+-- Multi-constraint signatures @(C1, C2) =>@ desugar to nested
+-- 'ImplicitArrow' per ADR-019; the same emission code recurses, so a
+-- two-implicit case is exercised by the existing fixed-point on the
+-- conclusion. We test the single-implicit case here for clarity.
+constraintGoalEmissionTest :: Test ()
+constraintGoalEmissionTest =
+  tests
+    [ scope "single-implicit-emits-one-goal" $
+        let notes = runWith Map.empty
+            goals = constraintGoals notes
+         in do
+              expectEqual 1 (length goals)
+              for_ goals $ \(_, ty, _) ->
+                -- Lower the captured 'Context.Type' back to a surface
+                -- 'Type.Type Symbol ()' so we can compare with the
+                -- declared constraint type.
+                expectEqual constraintTy (TypeVar.lowerType ty),
+      scope "captures-lexical-givens-snapshot" $
+        -- Seed givens at the surface 'Type.Type' level for clarity,
+        -- then lift to 'Context.Type' for 'runWith' (the typechecker
+        -- internally uses 'TypeVar' annotations).
+        let surfaceGivens =
+              Map.singleton (Reference.Builtin "Snapshot.K") snapshotTy
+            givens = TypeVar.liftType <$> surfaceGivens
+            notes = runWith givens
+            goals = constraintGoals notes
+         in do
+              expectEqual 1 (length goals)
+              for_ goals $ \(_, _, scopeSnap) ->
+                -- Lower each captured type to surface form for the
+                -- structural comparison; the keys are unaffected.
+                expectEqual surfaceGivens (TypeVar.lowerType <$> scopeSnap),
+      scope "no-implicit-no-goals" $
+        -- Sanity check: a function with a plain 'Arrow' type produces
+        -- zero 'ConstraintGoal' notes.
+        let notes = runPlain
+            goals = constraintGoals notes
+         in expectEqual 0 (length goals)
+    ]
+  where
+    -- Builtin "C" stands in for a class type at the test level; we
+    -- never need a real declaration since the typechecker only
+    -- reasons about the type structurally for goal emission.
+    constraintRef = Reference.Builtin "TestC"
+    constraintTy = Type.ref () constraintRef
+    snapshotTy = Type.int ()
+    -- f : C => Nat -> Nat
+    fRef = Reference.Builtin "TestImplicitFn"
+    fType =
+      Type.implicitArrow
+        ()
+        constraintTy
+        (Type.arrow () (Type.nat ()) (Type.nat ()))
+    -- g : Nat -> Nat (no implicit)
+    gRef = Reference.Builtin "TestPlainFn"
+    gType = Type.arrow () (Type.nat ()) (Type.nat ())
+
+    typeLookup :: TL.TypeLookup Symbol ()
+    typeLookup =
+      mempty
+        { TL.typeOfTerms =
+            Map.fromList
+              [ (fRef, fType),
+                (gRef, gType)
+              ]
+        }
+
+    -- 'synthesizeClosed' takes the givens map at the typechecker's
+    -- internal 'Context.Type' shape (which is
+    -- @Type.Type (TypeVar v loc) loc@). Surface-form types must be
+    -- lifted via 'TypeVar.liftType' before passing. We let inference
+    -- pick the var when 'givens' is 'Map.empty'.
+    runWith ::
+      Map.Map Reference.TermReference (Context.Type Symbol ()) ->
+      [Context.InfoNote Symbol ()]
+    runWith givens =
+      let term = Term.app () (Term.ref () fRef) (Term.nat () 42)
+          res =
+            Context.synthesizeClosed
+              PPE.empty
+              Context.PatternMatchCoverageCheckAndKindInferenceSwitch'Disabled
+              defaultVariances
+              []
+              givens
+              Set.empty
+              typeLookup
+              term
+       in toList (Context.infoNotes res)
+
+    runPlain :: [Context.InfoNote Symbol ()]
+    runPlain =
+      let term = Term.app () (Term.ref () gRef) (Term.nat () 42)
+          res =
+            Context.synthesizeClosed
+              PPE.empty
+              Context.PatternMatchCoverageCheckAndKindInferenceSwitch'Disabled
+              defaultVariances
+              []
+              (Map.empty :: Map.Map Reference.TermReference (Context.Type Symbol ()))
+              Set.empty
+              typeLookup
+              term
+       in toList (Context.infoNotes res)
+
+    -- Project the ConstraintGoal notes into a tuple form for
+    -- inspection. Other note variants are dropped.
+    --
+    -- Note: 'ConstraintGoal' carries 'Context.Type' (which is
+    -- 'Type.Type (TypeVar v loc) loc') rather than the surface
+    -- 'Type.Type v loc'. We keep the internal form here since the
+    -- typechecker has not yet generalized.
+    constraintGoals ::
+      [Context.InfoNote Symbol ()] ->
+      [((), Context.Type Symbol (), Map.Map Reference.TermReference (Context.Type Symbol ()))]
+    constraintGoals = mapMaybe' $ \case
+      Context.ConstraintGoal l ty sc -> Just (l, ty, sc)
+      _ -> Nothing
+      where
+        mapMaybe' f = foldr (\x acc -> maybe acc (: acc) (f x)) []

--- a/parser-typechecker/tests/Unison/Test/Typechecker/GivenApply.hs
+++ b/parser-typechecker/tests/Unison/Test/Typechecker/GivenApply.hs
@@ -130,15 +130,18 @@ testIsOverrideArg =
             inner = Term.var (naturalAnn 7 1) (Var.named "x" :: Symbol)
             outer = Term.app (naturalAnn 5 3) (Term.var (naturalAnn 5 1) (Var.named "f" :: Symbol)) inner
          in expect (not (GA.isOverrideArg outer)),
-      scope "widened-compound-is-override" $
+      scope "widened-compound-is-not-override" $
         let -- A widened compound expression: outer App ann starts
-            -- before the leftmost child's annotation.
+            -- before the leftmost child's annotation. The previous
+            -- 'isOverrideArg' design treated this as an override, but
+            -- it conflicts with surface forms like list literals
+            -- (where the outer brackets naturally widen the
+            -- annotation past the first child); after the fix
+            -- 'isOverrideArg' is restricted to leaf surface terms.
             inner = Term.var (naturalAnn 7 1) (Var.named "x" :: Symbol)
-            -- Outer is widened: starts at col 3 (the `@`), but its
-            -- subterms start at col 5 (the bare `f x`).
             outerWidened =
               Term.app (Ann (L.Pos 1 3) (L.Pos 1 8)) (Term.var (naturalAnn 5 1) (Var.named "f" :: Symbol)) inner
-         in expect (GA.isOverrideArg outerWidened)
+         in expect (not (GA.isOverrideArg outerWidened))
     ]
 
 ------------------------------------------------------------------------------
@@ -669,25 +672,21 @@ testSourceLevelLetGivenShadowsAmbient =
               -- pins parser → resolver → apply chain end-to-end without
               -- depending on hash-based references.
               expect (any isLocalGiven chosenNames),
-            scope "local-and-ambient-coexist-at-different-scopes" $
-              -- The file emits 'ConstraintGoal' notes from multiple
-              -- contexts: the @useImplicit@ binding's own @=>@ premise
-              -- check (outside the let scope), and the apply-site
-              -- inside main's let-body (inside the let scope). We
-              -- confirm /both/ ambient and local appear, evidence that
-              -- the lexical-given env was correctly pushed and popped
-              -- across the binder boundary.
-              tests
-                [ scope "local-appears" $
-                    expect $
-                      any isLocalGiven chosenNames,
-                  scope "ambient-also-appears-elsewhere" $
-                    -- Plurality: outside the let scope, only ambient
-                    -- exists, so it must appear too. If neither shows
-                    -- up the test environment isn't exercising both.
-                    expect $
-                      ambientNatRef `elem` chosenNames
-                ]
+            scope "local-overrides-but-ambient-still-reachable" $
+              -- The previous shape of this test asserted that the
+              -- ambient given /also/ appears in the chosen-decisions
+              -- list, because the typechecker emitted a spurious
+              -- second goal for @useImplicit@'s own @=>@ binding
+              -- check. That goal was always misplaced — the binding
+              -- site is the introduction of an implicit parameter,
+              -- not a call site that wants one filled — and is no
+              -- longer emitted now that the @=>I@ rule consumes the
+              -- injected leading lambda. The lexical-scoping check
+              -- below remains: with the local given present, every
+              -- emitted goal at the apply-site must pick the local.
+              expect $
+                all isLocalGiven chosenNames
+                  && ambientNatRef `notElem` chosenNames
           ]
 
 ------------------------------------------------------------------------------

--- a/parser-typechecker/tests/Unison/Test/Typechecker/GivenApply.hs
+++ b/parser-typechecker/tests/Unison/Test/Typechecker/GivenApply.hs
@@ -1,0 +1,924 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Tests for "Unison.Typechecker.GivenApply" (chunk D3): the
+-- post-typecheck pass that walks a term and substitutes resolved
+-- implicit arguments into 'App' nodes.
+--
+-- These tests build small terms programmatically (the file-level
+-- parser support for @given@ declarations from chunk A2 is on this
+-- branch but not yet wired into the file's lexical-given collection;
+-- that wiring is for a later C-stream chunk). We exercise the
+-- elaborate-then-apply pipeline directly:
+--
+--  1. Build a term that mentions a function with an @ImplicitArrow@
+--     in its type.
+--  2. Run 'Context.synthesizeClosed' to emit 'ConstraintGoal' notes.
+--  3. Run 'Elab.elaborateInfoNotes' with an ambient pool to convert
+--     the goals into 'SolvedImplicit' decisions.
+--  4. Run 'GivenApply.applyGivenDecisions' on the original term and
+--     verify the resulting 'App' structure.
+module Unison.Test.Typechecker.GivenApply (test) where
+
+import Data.Foldable (for_, toList)
+import Data.Map qualified as Map
+import Data.Set qualified as Set
+import Data.Text qualified as Text
+import EasyTest
+import Unison.ABT qualified as ABT
+import Unison.Lexer.Pos qualified as L
+import Unison.Parser.Ann (Ann (..))
+import Unison.PrettyPrintEnv qualified as PPE
+import Unison.Reference qualified as Reference
+import Unison.Result qualified as Result
+import Unison.Symbol (Symbol)
+import Unison.Term (Term)
+import Unison.Term qualified as Term
+import Unison.Test.Common qualified as Common
+import Unison.Type qualified as Type
+import Unison.Typechecker.Context qualified as Context
+import Unison.Typechecker.GivenApply qualified as GA
+import Unison.Typechecker.GivenElaborator qualified as Elab
+import Unison.Typechecker.GivenResolver qualified as GR
+import Unison.Typechecker.TypeLookup qualified as TL
+import Unison.Typechecker.TypeVar qualified as TypeVar
+import Unison.Typechecker.Variance (defaultVariances)
+import Unison.Var qualified as Var
+
+test :: Test ()
+test =
+  scope "GivenApply"
+    . tests
+    $ [ scope "buildDictionary" testBuildDictionary,
+        scope "isOverrideArg" testIsOverrideArg,
+        scope "end-to-end-single-implicit" testEndToEndSingle,
+        scope "end-to-end-chained-dictionaries" testEndToEndChained,
+        scope "source-level-end-to-end" testSourceLevelEndToEnd,
+        scope "source-level-let-given-shadows-ambient" testSourceLevelLetGivenShadowsAmbient,
+        scope "source-level-file-internal-given" testSourceLevelFileInternalGiven,
+        -- L2 fixup: premise-free givens at file scope (the canonical
+        -- ADR-010 example) and inside a @let@ block.
+        scope "source-level-file-given-premise-free" testSourceLevelFileGivenPremiseFree,
+        scope "source-level-let-given-premise-free" testSourceLevelLetGivenPremiseFree,
+        scope "override-skips-decision" testOverrideSkipsDecision,
+        scope "no-implicit-no-rewrite" testNoImplicitNoRewrite,
+        scope "missing-decision-leaves-term-alone" testMissingDecision,
+        scope "override-marker-preserved" testOverrideMarkerPreserved
+      ]
+
+------------------------------------------------------------------------------
+-- 1. Pure unit tests for 'buildDictionary'
+------------------------------------------------------------------------------
+
+testBuildDictionary :: Test ()
+testBuildDictionary =
+  tests
+    [ scope "leaf-given-becomes-ref" $
+        let g = mkGiven (Reference.Builtin "Show.nat") []
+            tree = GR.ResolutionTree g Map.empty []
+            t = GA.buildDictionary External tree :: Term.Term Symbol Ann
+         in case ABT.out t of
+              ABT.Tm (Term.Ref r) ->
+                expectEqual (Reference.Builtin "Show.nat") r
+              other -> crash ("expected Ref, got: " <> show other),
+      scope "nested-given-becomes-app" $
+        let inner = GR.ResolutionTree (mkGiven (Reference.Builtin "Show.nat") []) Map.empty []
+            outerG = mkGiven (Reference.Builtin "Show.list") []
+            outer = GR.ResolutionTree outerG Map.empty [inner]
+            t = GA.buildDictionary External outer :: Term.Term Symbol Ann
+         in case ABT.out t of
+              ABT.Tm (Term.App f a) -> do
+                case ABT.out f of
+                  ABT.Tm (Term.Ref r) -> expectEqual (Reference.Builtin "Show.list") r
+                  o -> crash ("function head: " <> show o)
+                case ABT.out a of
+                  ABT.Tm (Term.Ref r) -> expectEqual (Reference.Builtin "Show.nat") r
+                  o -> crash ("argument: " <> show o)
+              other -> crash ("expected App, got: " <> show other)
+    ]
+
+------------------------------------------------------------------------------
+-- 2. Override detection
+------------------------------------------------------------------------------
+
+-- A natural (non-widened) Ann from a fresh single-line range.
+naturalAnn :: Int -> Int -> Ann
+naturalAnn col len = Ann (L.Pos 1 col) (L.Pos 1 (col + len))
+
+-- A widened Ann simulating A3's `ann atTok <> ann d`: shift start
+-- by 2 (one for `@`, one for the space) but keep the end the same.
+widenedAnn :: Int -> Int -> Ann
+widenedAnn col len = Ann (L.Pos 1 (col - 2)) (L.Pos 1 (col + len))
+
+testIsOverrideArg :: Test ()
+testIsOverrideArg =
+  tests
+    [ scope "regular-leaf-is-not-override" $
+        let -- A bare leaf var. Without internal sub-children, override
+            -- detection is a soft Nothing → returns False (the
+            -- limitation documented in GivenApply.hs).
+            t = Term.var (naturalAnn 5 4) (Var.named "v" :: Symbol) :: Term.Term Symbol Ann
+         in expect (not (GA.isOverrideArg t)),
+      scope "widened-leaf-still-undetectable-by-design" $
+        let -- A widened leaf is also returned as False — this is the
+            -- documented limitation. Users wrap leaf overrides in
+            -- parens to make them detectable.
+            t = Term.var (widenedAnn 5 4) (Var.named "v" :: Symbol) :: Term.Term Symbol Ann
+         in expect (not (GA.isOverrideArg t)),
+      scope "regular-compound-is-not-override" $
+        let -- A non-widened compound expression: `f x` where the
+            -- outer App's annotation matches the children's extents.
+            inner = Term.var (naturalAnn 7 1) (Var.named "x" :: Symbol)
+            outer = Term.app (naturalAnn 5 3) (Term.var (naturalAnn 5 1) (Var.named "f" :: Symbol)) inner
+         in expect (not (GA.isOverrideArg outer)),
+      scope "widened-compound-is-override" $
+        let -- A widened compound expression: outer App ann starts
+            -- before the leftmost child's annotation.
+            inner = Term.var (naturalAnn 7 1) (Var.named "x" :: Symbol)
+            -- Outer is widened: starts at col 3 (the `@`), but its
+            -- subterms start at col 5 (the bare `f x`).
+            outerWidened =
+              Term.app (Ann (L.Pos 1 3) (L.Pos 1 8)) (Term.var (naturalAnn 5 1) (Var.named "f" :: Symbol)) inner
+         in expect (GA.isOverrideArg outerWidened)
+    ]
+
+------------------------------------------------------------------------------
+-- 3. End-to-end single-implicit substitution
+------------------------------------------------------------------------------
+
+-- A constraint-class-like type "TestC".
+constraintRef :: Reference.Reference
+constraintRef = Reference.Builtin "TestC"
+
+constraintTy :: Type.Type Symbol Ann
+constraintTy = Type.ref External constraintRef
+
+-- A function `fImplicit : TestC => Nat -> Nat`.
+fImplicitRef :: Reference.Reference
+fImplicitRef = Reference.Builtin "TestImplicitFn"
+
+fImplicitType :: Type.Type Symbol Ann
+fImplicitType =
+  Type.implicitArrow
+    External
+    constraintTy
+    (Type.arrow External (Type.nat External) (Type.nat External))
+
+-- A plain function `fPlain : Nat -> Nat`.
+fPlainRef :: Reference.Reference
+fPlainRef = Reference.Builtin "TestPlainFn"
+
+fPlainType :: Type.Type Symbol Ann
+fPlainType = Type.arrow External (Type.nat External) (Type.nat External)
+
+-- An ambient given that resolves to a `TestC` dictionary.
+ambientGivenRef :: Reference.Reference
+ambientGivenRef = Reference.Builtin "AmbientTestC"
+
+ambientGiven :: Elab.AmbientGiven Symbol Ann
+ambientGiven =
+  Elab.AmbientGiven {Elab.ambientName = ambientGivenRef, Elab.ambientType = constraintTy}
+
+typeLookup :: TL.TypeLookup Symbol Ann
+typeLookup =
+  mempty
+    { TL.typeOfTerms =
+        Map.fromList
+          [ (fImplicitRef, fImplicitType),
+            (fPlainRef, fPlainType)
+          ]
+    }
+
+-- Run the end-to-end pipeline on a term and return the rewritten
+-- term plus the info-notes (with implicit decisions added).
+--
+-- The term is built at the user-facing 'Term.Term Symbol Ann' shape;
+-- we lift it to 'Context.Term' with 'TypeVar.liftTerm' before
+-- synthesis (which lives in the 'TypeVar'-wrapped world), then run
+-- D3 on the original surface term.
+elaborateAndApply ::
+  Term Symbol Ann ->
+  GR.Pool Symbol Ann ->
+  Term Symbol Ann
+elaborateAndApply term ambient =
+  let lifted = TypeVar.liftTerm term
+      res =
+        Context.synthesizeClosed
+          PPE.empty
+          Context.PatternMatchCoverageCheckAndKindInferenceSwitch'Disabled
+          defaultVariances
+          []
+          Map.empty
+          Set.empty
+          typeLookup
+          lifted
+      infos = toList (Context.infoNotes res)
+      enriched = Elab.elaborateInfoNotes ambient infos
+   in fst (GA.applyGivenDecisions enriched typeLookup term)
+
+testEndToEndSingle :: Test ()
+testEndToEndSingle =
+  scope "f 42 with ambient TestC ⇒ App (App f dict) 42" $
+    let term = Term.app External (Term.ref External fImplicitRef) (Term.nat External 42)
+        ambient = Elab.ambientPool [ambientGiven]
+        rewritten = elaborateAndApply term ambient
+     in -- Expected shape: App (App fImplicit ambientGiven) 42
+        case ABT.out rewritten of
+          ABT.Tm (Term.App outerF arg42) -> do
+            -- outerF should be App fImplicitRef ambientGivenRef
+            case ABT.out outerF of
+              ABT.Tm (Term.App f dict) -> do
+                case ABT.out f of
+                  ABT.Tm (Term.Ref r) -> expectEqual fImplicitRef r
+                  o -> crash ("expected fImplicitRef, got: " <> show o)
+                case ABT.out dict of
+                  ABT.Tm (Term.Ref r) -> expectEqual ambientGivenRef r
+                  o -> crash ("expected ambientGivenRef, got: " <> show o)
+              o -> crash ("expected App at outer-f, got: " <> show o)
+            -- The user's argument should still be 42.
+            case ABT.out arg42 of
+              ABT.Tm (Term.Nat 42) -> ok
+              o -> crash ("expected Nat 42, got: " <> show o)
+          o -> crash ("expected App, got: " <> show o)
+
+------------------------------------------------------------------------------
+-- 4. Chained dictionaries: Show (List Nat) via Show.list (Show.nat)
+------------------------------------------------------------------------------
+
+-- Build a polymorphic given Show.list : forall a. Show a => Show
+-- (List a), plus an ambient Show.nat : Show Nat. The constraint is
+-- just `Reference.Builtin "Show"` applied to a type argument; we
+-- model it directly in Type.Type.
+
+showRef :: Reference.Reference
+showRef = Reference.Builtin "Show"
+
+listRef :: Reference.Reference
+listRef = Reference.Builtin "List"
+
+showOf :: Type.Type Symbol Ann -> Type.Type Symbol Ann
+showOf t = Type.app External (Type.ref External showRef) t
+
+-- A function `fShow : Show (List Nat) => Nat -> Nat`.
+fShowRef :: Reference.Reference
+fShowRef = Reference.Builtin "TestShowFn"
+
+fShowType :: Type.Type Symbol Ann
+fShowType =
+  Type.implicitArrow
+    External
+    (showOf (Type.app External (Type.ref External listRef) (Type.nat External)))
+    (Type.arrow External (Type.nat External) (Type.nat External))
+
+showNatRef :: Reference.Reference
+showNatRef = Reference.Builtin "Show.nat"
+
+showListRef :: Reference.Reference
+showListRef = Reference.Builtin "Show.list"
+
+showNatGiven :: Elab.AmbientGiven Symbol Ann
+showNatGiven =
+  Elab.AmbientGiven
+    { Elab.ambientName = showNatRef,
+      Elab.ambientType = showOf (Type.nat External)
+    }
+
+-- forall a. Show a => Show (List a)
+showListGiven :: Elab.AmbientGiven Symbol Ann
+showListGiven =
+  let a = Type.var External (Var.named "a" :: Symbol)
+      sig =
+        Type.forAll
+          External
+          (Var.named "a" :: Symbol)
+          (Type.implicitArrow External (showOf a) (showOf (Type.app External (Type.ref External listRef) a)))
+   in Elab.AmbientGiven
+        { Elab.ambientName = showListRef,
+          Elab.ambientType = sig
+        }
+
+testEndToEndChained :: Test ()
+testEndToEndChained =
+  scope "Show (List Nat) resolves via Show.list (Show.nat)" $
+    let typeLookup' =
+          mempty
+            { TL.typeOfTerms = Map.fromList [(fShowRef, fShowType)]
+            }
+        term :: Term Symbol Ann
+        term = Term.app External (Term.ref External fShowRef) (Term.nat External 7)
+        ambient = Elab.ambientPool [showListGiven, showNatGiven]
+        res =
+          Context.synthesizeClosed
+            PPE.empty
+            Context.PatternMatchCoverageCheckAndKindInferenceSwitch'Disabled
+            defaultVariances
+            []
+            Map.empty
+            Set.empty
+            typeLookup'
+            (TypeVar.liftTerm term)
+        infos = toList (Context.infoNotes res)
+        enriched = Elab.elaborateInfoNotes ambient infos
+        rewritten = fst (GA.applyGivenDecisions enriched typeLookup' term)
+     in -- Expected: App (App fShow (App showListRef showNatRef)) 7
+        case ABT.out rewritten of
+          ABT.Tm (Term.App outerF _arg7) -> case ABT.out outerF of
+            ABT.Tm (Term.App f dict) -> do
+              -- f is fShow
+              case ABT.out f of
+                ABT.Tm (Term.Ref r) -> expectEqual fShowRef r
+                o -> crash ("expected fShow, got: " <> show o)
+              -- dict is App showList showNat
+              case ABT.out dict of
+                ABT.Tm (Term.App showListT showNatT) -> do
+                  case ABT.out showListT of
+                    ABT.Tm (Term.Ref r) -> expectEqual showListRef r
+                    o -> crash ("expected showList, got: " <> show o)
+                  case ABT.out showNatT of
+                    ABT.Tm (Term.Ref r) -> expectEqual showNatRef r
+                    o -> crash ("expected showNat, got: " <> show o)
+                o -> crash ("expected App for chained dict, got: " <> show o)
+            o -> crash ("expected outer App, got: " <> show o)
+          o -> crash ("expected outermost App, got: " <> show o)
+
+------------------------------------------------------------------------------
+-- 5. Override skips decision
+------------------------------------------------------------------------------
+
+-- This test simulates A3's `f @ d x` syntax. We construct a term
+-- that already has a *widened*-annotation argument at the implicit
+-- slot, then verify D3 leaves the slot alone (no dictionary
+-- inserted) even though the typechecker emitted a constraint goal.
+testOverrideSkipsDecision :: Test ()
+testOverrideSkipsDecision =
+  scope "f @userOverride 42 keeps user's override and skips elaborator" $
+    -- The override here is a compound expression so 'isOverrideArg'
+    -- can detect the widening (recall the leaf-limitation).
+    let userOverrideRef = Reference.Builtin "UserOverride"
+        userOverride =
+          -- `(id userOverride)` style: a compound whose outer ann
+          -- is widened to start before its first child.
+          Term.app
+            -- outer ann starts at col 3 (the `@`), the inner refs
+            -- start at col 5.
+            (Ann (L.Pos 1 3) (L.Pos 1 20))
+            (Term.var (Ann (L.Pos 1 5) (L.Pos 1 7)) (Var.named "id" :: Symbol))
+            (Term.ref (Ann (L.Pos 1 8) (L.Pos 1 20)) userOverrideRef)
+        term :: Term Symbol Ann
+        term =
+          Term.app
+            External
+            ( Term.app
+                External
+                (Term.ref External fImplicitRef)
+                userOverride
+            )
+            (Term.nat External 42)
+        -- Even though we provide an ambient given, D3 should NOT
+        -- consume it because the override-arg is widened.
+        ambient = Elab.ambientPool [ambientGiven]
+        res =
+          Context.synthesizeClosed
+            PPE.empty
+            Context.PatternMatchCoverageCheckAndKindInferenceSwitch'Disabled
+            defaultVariances
+            []
+            Map.empty
+            Set.empty
+            typeLookup
+            (TypeVar.liftTerm term)
+        infos = toList (Context.infoNotes res)
+        enriched = Elab.elaborateInfoNotes ambient infos
+        rewritten = fst (GA.applyGivenDecisions enriched typeLookup term)
+     in -- The rewritten term should preserve userOverride at the
+        -- implicit slot rather than substituting ambientGiven.
+        case ABT.out rewritten of
+          ABT.Tm (Term.App outerF _arg42) -> case ABT.out outerF of
+            ABT.Tm (Term.App _f arg) ->
+              -- arg should be the compound override expression, not a Ref to ambientGiven.
+              case ABT.out arg of
+                ABT.Tm (Term.App _ inner) -> case ABT.out inner of
+                  ABT.Tm (Term.Ref r) -> expectEqual userOverrideRef r
+                  o -> crash ("expected userOverride at slot, got: " <> show o)
+                o -> crash ("expected compound override, got: " <> show o)
+            o -> crash ("expected outer App, got: " <> show o)
+          o -> crash ("expected outermost App, got: " <> show o)
+
+------------------------------------------------------------------------------
+-- 6. No implicits ⇒ term unchanged
+------------------------------------------------------------------------------
+
+testNoImplicitNoRewrite :: Test ()
+testNoImplicitNoRewrite =
+  scope "fPlain 42 emits no goals and is unchanged" $
+    let term = Term.app External (Term.ref External fPlainRef) (Term.nat External 42)
+        rewritten = elaborateAndApply term (GR.poolFromList [])
+     in -- Same shape as input: App (Ref fPlainRef) (Nat 42).
+        case ABT.out rewritten of
+          ABT.Tm (Term.App f arg) -> do
+            case ABT.out f of
+              ABT.Tm (Term.Ref r) -> expectEqual fPlainRef r
+              o -> crash ("expected fPlainRef, got: " <> show o)
+            case ABT.out arg of
+              ABT.Tm (Term.Nat 42) -> ok
+              o -> crash ("expected Nat 42, got: " <> show o)
+          o -> crash ("expected single App, got: " <> show o)
+
+------------------------------------------------------------------------------
+-- 7. Missing decision (typecheck error) leaves the term alone
+------------------------------------------------------------------------------
+
+testMissingDecision :: Test ()
+testMissingDecision =
+  scope "no ambient, no lexical given ⇒ term unchanged, error preserved on info notes" $
+    let term = Term.app External (Term.ref External fImplicitRef) (Term.nat External 42)
+        rewritten = elaborateAndApply term (GR.poolFromList [])
+     in -- D3 leaves the unsuccessful slot alone; the term keeps its
+        -- original arity. (D4 will surface the error.)
+        case ABT.out rewritten of
+          ABT.Tm (Term.App f arg) -> do
+            case ABT.out f of
+              ABT.Tm (Term.Ref r) -> expectEqual fImplicitRef r
+              o -> crash ("expected fImplicitRef, got: " <> show o)
+            case ABT.out arg of
+              ABT.Tm (Term.Nat 42) -> ok
+              o -> crash ("expected Nat 42, got: " <> show o)
+          o -> crash ("expected App, got: " <> show o)
+
+------------------------------------------------------------------------------
+-- 8. Property: D3 does not strip the widened annotation on override
+-- arguments. (The spec calls for `parse(print(elaborate(t)))`
+-- preserving override markers, but the printer for '=>' is Phase 4;
+-- we test the necessary precondition: D3 is non-destructive on
+-- override-arg annotations.)
+------------------------------------------------------------------------------
+
+testOverrideMarkerPreserved :: Test ()
+testOverrideMarkerPreserved =
+  scope "D3 preserves widened annotations on override-arg slots" $
+    let userOverrideRef = Reference.Builtin "UserOverride"
+        widenedOuter = Ann (L.Pos 1 3) (L.Pos 1 20)
+        userOverride =
+          Term.app
+            widenedOuter
+            (Term.var (Ann (L.Pos 1 5) (L.Pos 1 7)) (Var.named "id" :: Symbol))
+            (Term.ref (Ann (L.Pos 1 8) (L.Pos 1 20)) userOverrideRef)
+        term :: Term Symbol Ann
+        term =
+          Term.app
+            External
+            ( Term.app
+                External
+                (Term.ref External fImplicitRef)
+                userOverride
+            )
+            (Term.nat External 42)
+        ambient = Elab.ambientPool [ambientGiven]
+        rewritten = elaborateAndApply term ambient
+     in case ABT.out rewritten of
+          ABT.Tm (Term.App outerF _arg42) ->
+            case ABT.out outerF of
+              ABT.Tm (Term.App _f arg) ->
+                -- The widened annotation must survive the rewrite.
+                expectEqual widenedOuter (ABT.annotation arg)
+              o -> crash ("expected outer App, got: " <> show o)
+          o -> crash ("expected App, got: " <> show o)
+
+------------------------------------------------------------------------------
+-- 9. Source-level end-to-end pin: parser ⇒ typechecker ⇒ resolver
+--
+-- The other end-to-end tests above ('testEndToEndSingle' /
+-- 'testEndToEndChained') build their input terms programmatically with
+-- 'Type.implicitArrow ()'. That bypasses the parser entirely, so a
+-- regression in 'Unison.Syntax.TypeParser' (where '=>' is desugared to
+-- 'Type.implicitArrow' on top of '~>'-and-friends) would go unnoticed
+-- by them.
+--
+-- This test pins the wire from source down through the elaborator: it
+-- feeds a small Unison source string through
+-- 'parseAndSynthesizeAsFileWithGivens' and asserts that the
+-- typechecker's info-note stream contains:
+--
+--   1. A 'ConstraintGoal' (proving the parser produced an
+--      'ImplicitArrow' that C2.2 then saw at the apply-site).
+--   2. A 'SolvedImplicit' whose decision is @Right ResolutionTree@
+--      (proving the chunk L1 wiring threaded the ambient pool through
+--      to the resolver, and that resolution succeeded against the
+--      supplied ambient given).
+--   3. The chosen given's reference matches what we supplied.
+--
+-- Before chunk L1, 'synthesizeFile' passed @Map.empty@ as the ambient
+-- pool, so namespace givens never participated in resolution and only
+-- the failure path was observable from a file-level program. With L1
+-- in place, an ambient pool plumbed through 'computeTypecheckingEnvironment'
+-- reaches the resolver and the success path is now observable here.
+------------------------------------------------------------------------------
+
+testSourceLevelEndToEnd :: Test ()
+testSourceLevelEndToEnd =
+  scope "parse=>synthesize=>resolve picks ambient given on the success path" $
+    let src =
+          unlines
+            [ "useImplicit : Nat => Nat -> Nat",
+              "useImplicit n = n",
+              "",
+              "main : Nat",
+              "main = useImplicit 42"
+            ]
+        -- An ambient given whose conclusion type matches the
+        -- 'Nat'-shaped constraint that the parsed function emits.
+        natGivenRef = Reference.Builtin "Test.natWitness"
+        natGiven =
+          Elab.AmbientGiven
+            { Elab.ambientName = natGivenRef,
+              Elab.ambientType = Type.nat External
+            }
+        Result.Result notes _ =
+          Common.parseAndSynthesizeAsFileWithGivens
+            []
+            [natGiven]
+            "source-level-implicit.u"
+            src
+        notes' = toList notes
+        constraintGoals =
+          [ ty
+          | Result.TypeInfo (Context.ConstraintGoal _ ty _) <- notes'
+          ]
+        solvedImplicitTrees =
+          [ (ty, tree)
+          | Result.TypeInfo (Context.SolvedImplicit _ ty (Right tree)) <- notes'
+          ]
+        unresolved =
+          [ (loc, ty)
+          | Result.UnresolvedImplicit loc ty _ <- notes'
+          ]
+     in tests
+          [ scope "constraint-goal-emitted-from-parsed-=>" $
+              -- The parser+typechecker together must produce at least
+              -- one 'ConstraintGoal'. Zero would mean either the parser
+              -- desugared '=>' to '->' (regression) or the typechecker
+              -- failed to recurse into the implicit slot at the apply
+              -- site. We accept any non-zero count: minimization /
+              -- generalization may duplicate the goal across components.
+              expect (not (null constraintGoals)),
+            scope "solved-implicit-emitted-on-success-path" $
+              -- L1 wiring: the ambient pool reached the resolver, so
+              -- at least one goal must have been solved with a
+              -- 'ResolutionTree' decision.
+              expect (not (null solvedImplicitTrees)),
+            scope "no-unresolved-implicits-when-given-is-supplied" $
+              -- With a satisfying ambient given supplied, no
+              -- 'UnresolvedImplicit' note should be surfaced — the
+              -- whole point of L1 is that namespace givens now feed
+              -- the resolver.
+              expect (null unresolved),
+            scope "chosen-given-is-the-supplied-one" $
+              -- The resolver picked /our/ ambient given, not some
+              -- spurious other reference. Asserting on every solved
+              -- decision (rather than just one) keeps this honest if
+              -- letrec-component layout duplicates the goal: every
+              -- copy must pick the same given.
+              for_ solvedImplicitTrees $ \(_, tree) ->
+                expectEqual natGivenRef (GR.givenName (GR.rtGiven tree))
+          ]
+
+------------------------------------------------------------------------------
+-- Source-level: chunk L2 — `let given` shadows ambient
+--
+-- The same parse=>synthesize=>resolve pipeline as 'testSourceLevelEndToEnd',
+-- but exercising a @let given@ binding inside a function body. Both
+-- an ambient given (passed via 'parseAndSynthesizeAsFileWithGivens')
+-- and a local @let given@ binding match the apply-site goal; per
+-- ADR-008 the local should win.
+--
+-- The synthetic reference for a local @let given@ is built by chunk L2
+-- as @Reference.Builtin "Local.given.<varname>"@; see
+-- 'extendLexicalGivenFromBinding' in 'Unison.Typechecker.Context'.
+-- Asserting on the *prefix* of the chosen ref's name lets the test
+-- pin the parser → resolver → apply chain end-to-end without
+-- depending on hash-based references for the local binding.
+------------------------------------------------------------------------------
+
+testSourceLevelLetGivenShadowsAmbient :: Test ()
+testSourceLevelLetGivenShadowsAmbient =
+  scope "let given local with => shadows the ambient given at the same goal" $
+    -- For chunk L2 to register a binding as a lexical given, the
+    -- binding's declared type must begin with at least one
+    -- 'ImplicitArrow' (the same signal C2.3 uses to emit 'GivenDecl'
+    -- notes). To avoid the trivial @Nat => Nat@ cycle (where the
+    -- local's premise is the same as the goal, so the resolver
+    -- short-circuits the lexical branch and falls back to ambient), we
+    -- make the local's premise a /different/ type — @Boolean@ — and
+    -- supply an ambient Boolean given to satisfy that premise. The
+    -- apply-site goal is still @Nat@; both an ambient @Nat@ and the
+    -- lexical @Boolean => Nat@ produce a successful tree, and per
+    -- ADR-008's lexical-inner-wins rule the local must be chosen.
+    let src =
+          unlines
+            [ "useImplicit : Nat => Nat -> Nat",
+              "useImplicit n = n",
+              "",
+              "main : Nat",
+              "main =",
+              "  let given altNat : Boolean => Nat = 7",
+              "      useImplicit 42"
+            ]
+        ambientNatRef :: Reference.Reference
+        ambientNatRef = Reference.Builtin "Test.ambientNat"
+        ambientNat =
+          Elab.AmbientGiven
+            { Elab.ambientName = ambientNatRef,
+              Elab.ambientType = Type.nat External
+            }
+        ambientBoolRef :: Reference.Reference
+        ambientBoolRef = Reference.Builtin "Test.ambientBool"
+        ambientBool =
+          Elab.AmbientGiven
+            { Elab.ambientName = ambientBoolRef,
+              Elab.ambientType = Type.boolean External
+            }
+        Result.Result notes _ =
+          Common.parseAndSynthesizeAsFileWithGivens
+            []
+            [ambientNat, ambientBool]
+            "let-given-shadows.u"
+            src
+        notes' = toList notes
+        solvedTrees =
+          [ tree
+          | Result.TypeInfo (Context.SolvedImplicit _ _ (Right tree)) <- notes'
+          ]
+        unresolved =
+          [ ()
+          | Result.UnresolvedImplicit _ _ _ <- notes'
+          ]
+        chosenNames = map (GR.givenName . GR.rtGiven) solvedTrees
+        isLocalGiven r = case r of
+          Reference.Builtin t -> "Local.given." `Text.isPrefixOf` t
+          _ -> False
+     in tests
+          [ scope "decision-emitted" $
+              expect (not (null solvedTrees)),
+            scope "no-unresolved-implicits" $
+              expect (null unresolved),
+            scope "local-let-given-was-chosen-over-ambient" $
+              -- The TestC apply-site goal must be solved by the lexical
+              -- local given. The synthetic ref (synthetic
+              -- @Reference.Builtin "Local.given.<varname>"@) is the
+              -- resolver's witness that L2's wiring threaded the
+              -- binding into the lexical scope. Asserting on the prefix
+              -- pins parser → resolver → apply chain end-to-end without
+              -- depending on hash-based references.
+              expect (any isLocalGiven chosenNames),
+            scope "local-and-ambient-coexist-at-different-scopes" $
+              -- The file emits 'ConstraintGoal' notes from multiple
+              -- contexts: the @useImplicit@ binding's own @=>@ premise
+              -- check (outside the let scope), and the apply-site
+              -- inside main's let-body (inside the let scope). We
+              -- confirm /both/ ambient and local appear, evidence that
+              -- the lexical-given env was correctly pushed and popped
+              -- across the binder boundary.
+              tests
+                [ scope "local-appears" $
+                    expect $
+                      any isLocalGiven chosenNames,
+                  scope "ambient-also-appears-elsewhere" $
+                    -- Plurality: outside the let scope, only ambient
+                    -- exists, so it must appear too. If neither shows
+                    -- up the test environment isn't exercising both.
+                    expect $
+                      ambientNatRef `elem` chosenNames
+                ]
+          ]
+
+------------------------------------------------------------------------------
+-- Source-level: file-internal given (review carry-over from L1).
+--
+-- L1 only harvests givens from the *namespace* (codebase-committed
+-- definitions). A given declared in the same .u file as the consumer
+-- never reaches L1's ambient pool because it isn't part of the
+-- codebase yet. L2's in-typechecker lexical-given env handles this:
+-- 'annotateLetRecBindings'' registers every given-shaped top-level
+-- binding into 'lexicalGivens', so consumers in the same file see it.
+--
+-- This test exercises a self-contained .u file with no ambient pool
+-- and no library deps. The file declares its own given and a function
+-- that consumes it; resolution must succeed against the in-file
+-- given alone.
+------------------------------------------------------------------------------
+
+testSourceLevelFileInternalGiven :: Test ()
+testSourceLevelFileInternalGiven =
+  scope "file-internal given resolves the consumer's implicit slot" $
+    -- Uses the @given@ keyword (per ADR-010 / chunk L2 fixup the
+    -- @=>@-in-the-type heuristic no longer suffices — only bindings
+    -- explicitly declared via @given@ become candidates).
+    let src =
+          unlines
+            [ "given fileGiven : Boolean => Nat = 99",
+              "",
+              "useImplicit : Nat => Nat -> Nat",
+              "useImplicit n = n",
+              "",
+              "main : Nat",
+              "main = useImplicit 42"
+            ]
+        -- The /only/ ambient is Boolean (used as the file-internal
+        -- given's premise). No ambient Nat is supplied — if the
+        -- file-internal given isn't picked up by L2, resolution fails
+        -- with NoGiven and the test catches it via UnresolvedImplicit.
+        ambientBoolRef :: Reference.Reference
+        ambientBoolRef = Reference.Builtin "Test.ambientBoolFI"
+        ambientBool =
+          Elab.AmbientGiven
+            { Elab.ambientName = ambientBoolRef,
+              Elab.ambientType = Type.boolean External
+            }
+        Result.Result notes _ =
+          Common.parseAndSynthesizeAsFileWithGivens
+            []
+            [ambientBool]
+            "file-internal-given.u"
+            src
+        notes' = toList notes
+        solvedTrees =
+          [ tree
+          | Result.TypeInfo (Context.SolvedImplicit _ _ (Right tree)) <- notes'
+          ]
+        unresolved =
+          [ ()
+          | Result.UnresolvedImplicit _ _ _ <- notes'
+          ]
+        chosenNames = map (GR.givenName . GR.rtGiven) solvedTrees
+        isLocalGiven r = case r of
+          Reference.Builtin t -> "Local.given." `Text.isPrefixOf` t
+          _ -> False
+     in tests
+          [ scope "no-unresolved-implicits" $
+              -- Confirms the resolver succeeded for every goal, which
+              -- requires the file-internal @fileGiven@ to be in pool.
+              expect (null unresolved),
+            scope "decision-emitted" $
+              expect (not (null solvedTrees)),
+            scope "file-internal-given-was-chosen" $
+              -- The Nat goal at @useImplicit 42@'s apply-site must
+              -- resolve via @fileGiven@ — visible only because L2's
+              -- 'annotateLetRecBindings'' wiring registered it as a
+              -- lexical-scope given, not because it's in the
+              -- ambient (codebase-derived) pool.
+              expect (any isLocalGiven chosenNames)
+          ]
+
+------------------------------------------------------------------------------
+-- Source-level: chunk L2 fixup — premise-free file-level @given@
+--
+-- The canonical ADR-010 example. The given's type has no @=>@
+-- premises (just the conclusion), so the previous shape-based
+-- predicate ('null . fst . unImplicitArrows') silently dropped it.
+-- After the fix, the parser tags the @given@-bound variable name
+-- and the typechecker registers the binding by name.
+--
+-- Source: a self-contained file declaring @given showNat : Show Nat = …@
+-- and a consumer @print : Show a => a -> Text@. Resolution must
+-- succeed against the in-file given alone (no ambients supplied).
+------------------------------------------------------------------------------
+
+testSourceLevelFileGivenPremiseFree :: Test ()
+testSourceLevelFileGivenPremiseFree =
+  scope "premise-free file-level given (no `=>`) resolves the consumer's slot" $
+    -- Use a Nat-shaped goal to keep the test self-contained: we
+    -- declare @given fileGiven : Nat = 99@ and a consumer
+    -- @useImplicit : Nat => Nat -> Nat@, then call @useImplicit 42@.
+    -- With no ambients, resolution must come from the file-internal
+    -- premise-free given.
+    let src =
+          unlines
+            [ "given fileGiven : Nat = 99",
+              "",
+              "useImplicit : Nat => Nat -> Nat",
+              "useImplicit n = n",
+              "",
+              "main : Nat",
+              "main = useImplicit 42"
+            ]
+        Result.Result notes _ =
+          -- No ambient pool at all. Resolution must succeed via the
+          -- file-internal premise-free given.
+          Common.parseAndSynthesizeAsFileWithGivens
+            []
+            []
+            "file-given-premise-free.u"
+            src
+        notes' = toList notes
+        solvedTrees =
+          [ tree
+          | Result.TypeInfo (Context.SolvedImplicit _ _ (Right tree)) <- notes'
+          ]
+        unresolved =
+          [ ()
+          | Result.UnresolvedImplicit _ _ _ <- notes'
+          ]
+        chosenNames = map (GR.givenName . GR.rtGiven) solvedTrees
+        isLocalGiven r = case r of
+          Reference.Builtin t -> "Local.given." `Text.isPrefixOf` t
+          _ -> False
+     in tests
+          [ scope "no-unresolved-implicits" $
+              expect (null unresolved),
+            scope "decision-emitted" $
+              expect (not (null solvedTrees)),
+            scope "file-internal-premise-free-given-was-chosen" $
+              expect (any isLocalGiven chosenNames)
+          ]
+
+------------------------------------------------------------------------------
+-- Source-level: chunk L2 fixup — premise-free @let given@
+--
+-- Like 'testSourceLevelFileGivenPremiseFree' but the given is bound
+-- inside a @let@ block in the body of @main@. The variable @local@
+-- has type @Nat@ — no @=>@ at all — so this is exactly the
+-- "@given local : Ord a = …@" canonical example, just at @Nat@ for
+-- self-containment.
+------------------------------------------------------------------------------
+
+testSourceLevelLetGivenPremiseFree :: Test ()
+testSourceLevelLetGivenPremiseFree =
+  scope "premise-free `let given` (no `=>`) resolves the consumer's slot" $
+    -- The local @given fileGiven : Nat = 7@ has no premises (the
+    -- canonical ADR-010 example). The consumer's premise is @Boolean@
+    -- (intentionally different from the local's conclusion), satisfied
+    -- by an ambient. The apply-site goal is @Boolean@ — wait, that
+    -- would not exercise the local. Redesign: the consumer's premise
+    -- is @Nat@ (matches the local's conclusion). Pre-fix this test
+    -- would be silently dropped by the shape predicate; post-fix the
+    -- parser-tagged side channel registers @local@ and the apply-site
+    -- @Nat@ goal resolves through it. The ambient @Nat@ is supplied
+    -- so the consumer's /own/ @Nat =>@ definition-site check (which
+    -- happens outside the let scope) is also satisfied; the test then
+    -- asserts that the apply-site /inside/ the let chooses the local
+    -- (per ADR-008's lexical-inner-wins rule).
+    let src =
+          unlines
+            [ "useImplicit : Nat => Nat -> Nat",
+              "useImplicit n = n",
+              "",
+              "main : Nat",
+              "main =",
+              "  let given local : Nat = 7",
+              "      useImplicit 42"
+            ]
+        ambientNatRef :: Reference.Reference
+        ambientNatRef = Reference.Builtin "Test.ambientNat.PF"
+        ambientNat =
+          Elab.AmbientGiven
+            { Elab.ambientName = ambientNatRef,
+              Elab.ambientType = Type.nat External
+            }
+        Result.Result notes _ =
+          Common.parseAndSynthesizeAsFileWithGivens
+            []
+            [ambientNat]
+            "let-given-premise-free.u"
+            src
+        notes' = toList notes
+        solvedTrees =
+          [ tree
+          | Result.TypeInfo (Context.SolvedImplicit _ _ (Right tree)) <- notes'
+          ]
+        unresolved =
+          [ ()
+          | Result.UnresolvedImplicit _ _ _ <- notes'
+          ]
+        chosenNames = map (GR.givenName . GR.rtGiven) solvedTrees
+        isLocalGiven r = case r of
+          Reference.Builtin t -> "Local.given." `Text.isPrefixOf` t
+          _ -> False
+     in tests
+          [ scope "no-unresolved-implicits" $
+              expect (null unresolved),
+            scope "decision-emitted" $
+              expect (not (null solvedTrees)),
+            scope "premise-free-let-given-was-chosen" $
+              -- The Nat goal at the apply-site inside the let body
+              -- must resolve to the lexical local (per ADR-008's
+              -- lexical-inner-wins). Pre-fix the local was silently
+              -- dropped by the shape predicate; post-fix the
+              -- parser-tagged side channel registers it.
+              expect (any isLocalGiven chosenNames)
+          ]
+
+------------------------------------------------------------------------------
+-- Helpers
+------------------------------------------------------------------------------
+
+mkGiven ::
+  Reference.Reference ->
+  [Type.Type Symbol Ann] ->
+  GR.Given Symbol Ann
+mkGiven r premises =
+  GR.Given
+    { GR.givenName = r,
+      GR.givenTyVars = [],
+      GR.givenPremises = premises,
+      GR.givenConclusion = Type.ref External (Reference.Builtin "Dummy"),
+      GR.givenScope = GR.Ambient
+    }

--- a/parser-typechecker/tests/Unison/Test/Typechecker/GivenDecl.hs
+++ b/parser-typechecker/tests/Unison/Test/Typechecker/GivenDecl.hs
@@ -1,0 +1,229 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | ADR-019 / chunk C2.3: tests for @given@-declaration validation.
+--
+-- A top-level binding like
+--
+-- > given Show.list : forall a. Show a => Show (List a) = body
+--
+-- typechecks under the C2.2 'ImplicitArrow' machinery: the body is
+-- checked against the conclusion @Show (List a)@ after the implicit
+-- @Show a@ parameter is stripped via 'checkWanted''s 'ImplicitArrow'
+-- clause. C2.3 sits on top of that: when validation succeeds, a
+-- 'Context.GivenDecl' info note is emitted carrying the binding's
+-- variable, declared type, and stripped conclusion. 'synthesizeFile'
+-- (and the UCM command surface in B2) consume these notes to mark
+-- namespace metadata via 'Unison.Codebase.Givens.markGivenAt'.
+--
+-- Cases covered:
+--
+--   1. monomorphic given (no @forall@, no constraints):
+--      @given f : Nat = 0@ — should /not/ emit a 'GivenDecl' note
+--      (no implicit arrows in the signature).
+--   2. constraint-bearing given (single @=>@):
+--      @given f : C => Nat = 42@ — emits exactly one 'GivenDecl'
+--      note with conclusion @Nat@.
+--   3. polymorphic constraint-bearing given (the spec's running
+--      example shape): @given f : forall a. C a => Nat = 42@ —
+--      emits a 'GivenDecl' note whose conclusion has the @forall a.@
+--      stripped (since 'Type.unImplicitArrows' looks through outer
+--      'Type.Forall').
+--   4. body whose type does not match the conclusion: produces a
+--      type error and no 'GivenDecl' note.
+module Unison.Test.Typechecker.GivenDecl (test) where
+
+import Data.Foldable (for_, toList)
+import Data.Map qualified as Map
+import Data.Set qualified as Set
+import EasyTest
+import Unison.PrettyPrintEnv qualified as PPE
+import Unison.Reference qualified as Reference
+import Unison.Symbol (Symbol)
+import Unison.Term qualified as Term
+import Unison.Type qualified as Type
+import Unison.Typechecker.Context qualified as Context
+import Unison.Typechecker.TypeVar qualified as TypeVar
+import Unison.Typechecker.Variance (defaultVariances)
+import Unison.Var qualified as Var
+
+test :: Test ()
+test =
+  scope "givenDecl" $
+    tests
+      [ scope "monomorphic-no-implicit-no-note" monomorphicNoNoteTest,
+        scope "single-constraint-emits-note" singleConstraintEmitsNoteTest,
+        scope "polymorphic-with-constraint-emits-note" polymorphicEmitsNoteTest,
+        scope "body-mismatch-conclusion-fails" bodyMismatchTest
+      ]
+
+-- | A plain @given f : Nat = 42@ binding has no implicit arrows in
+-- its declared type. C2.3 should /not/ emit a 'GivenDecl' note for
+-- it — the note is gated on the presence of at least one
+-- 'ImplicitArrow' in the signature.
+monomorphicNoNoteTest :: Test ()
+monomorphicNoNoteTest =
+  let f = Var.named @Symbol "f"
+      -- We desugar a top-level binding into a singleton letrec so
+      -- the typechecker hits 'annotateLetRecBindings'' (where the
+      -- C2.3 emission lives).
+      binding = Term.ann () (Term.nat () 42) (Type.nat ())
+      term =
+        Term.letRec'
+          True
+          [(f, (), binding)]
+          (constUnit ())
+      notes = runClosed term
+   in expectEqual 0 (length (givenDecls notes))
+
+-- | A constraint-bearing given like @given f : C => Nat = 42@ should
+-- emit exactly one 'GivenDecl' note. The conclusion type is @Nat@.
+singleConstraintEmitsNoteTest :: Test ()
+singleConstraintEmitsNoteTest =
+  let f = Var.named @Symbol "f"
+      cRef = Reference.Builtin "TestC"
+      cTy = Type.ref () cRef
+      -- declared: C => Nat
+      declared = Type.implicitArrow () cTy (Type.nat ())
+      -- body: 42 — matches the conclusion 'Nat' directly. Per
+      -- ADR-019 / C2.2, checking against an 'ImplicitArrow' recurses
+      -- on the conclusion.
+      body = Term.nat () 42
+      binding = Term.ann () body declared
+      term =
+        Term.letRec'
+          True
+          [(f, (), binding)]
+          (constUnit ())
+      -- ADR-010 / chunk L2 fixup: the parser tags @given@-bound vars,
+      -- so this programmatic test stands in for the parser by handing
+      -- the typechecker the same set directly.
+      notes = runClosedWithGivens (Set.singleton f) term
+      decls = givenDecls notes
+   in tests
+        [ scope "exactly-one-note" $ expectEqual 1 (length decls),
+          scope "note-records-the-variable" $
+            for_ decls $
+              \(v, _d, _c) -> expectEqual f (Var.reset v),
+          scope "conclusion-is-nat" $
+            for_ decls $ \(_v, _d, c) ->
+              expectEqual (Type.nat ()) (TypeVar.lowerType c)
+        ]
+
+-- | A polymorphic given @given f : forall a. C a => Nat = 42@ emits
+-- a note whose conclusion strips both the outer 'Forall' and the
+-- leading 'ImplicitArrow'.
+polymorphicEmitsNoteTest :: Test ()
+polymorphicEmitsNoteTest =
+  let f = Var.named @Symbol "f"
+      a = Var.named @Symbol "a"
+      cRef = Reference.Builtin "TestC1"
+      -- C a (a is the bound forall var)
+      ca = Type.app () (Type.ref () cRef) (Type.var () a)
+      conclusionTy = Type.nat ()
+      -- declared: forall a. C a => Nat
+      declared =
+        Type.forAll () a (Type.implicitArrow () ca conclusionTy)
+      body = Term.nat () 42
+      binding = Term.ann () body declared
+      term =
+        Term.letRec'
+          True
+          [(f, (), binding)]
+          (constUnit ())
+      notes = runClosedWithGivens (Set.singleton f) term
+      decls = givenDecls notes
+   in tests
+        [ scope "exactly-one-note" $ expectEqual 1 (length decls),
+          scope "conclusion-strips-forall-and-implicit-arrow" $
+            for_ decls $ \(_v, _d, c) ->
+              expectEqual conclusionTy (TypeVar.lowerType c)
+        ]
+
+-- | A given whose body's type does /not/ match the declared
+-- conclusion produces a type error. The existing 'Mismatch'
+-- machinery (driven by C2.2's @=>App@ recursion into the conclusion)
+-- is the error path; C2.3 inherits it without modification.
+bodyMismatchTest :: Test ()
+bodyMismatchTest =
+  let f = Var.named @Symbol "f"
+      cRef = Reference.Builtin "TestC2"
+      cTy = Type.ref () cRef
+      -- declared: C => Nat
+      declared = Type.implicitArrow () cTy (Type.nat ())
+      -- body: a Text literal — doesn't match 'Nat' conclusion.
+      body = Term.text () "not a nat"
+      binding = Term.ann () body declared
+      term =
+        Term.letRec'
+          True
+          [(f, (), binding)]
+          (constUnit ())
+      res =
+        Context.synthesizeClosed
+          PPE.empty
+          Context.PatternMatchCoverageCheckAndKindInferenceSwitch'Disabled
+          defaultVariances
+          []
+          (Map.empty :: Map.Map Reference.TermReference (Context.Type Symbol ()))
+          Set.empty
+          mempty
+          (TypeVar.liftTerm term)
+      notes = toList (Context.infoNotes res)
+      errs = Context.typeErrors res
+   in tests
+        [ scope "at-least-one-type-error" $
+            expect (not (null errs)),
+          scope "no-givendecl-note-on-failure" $
+            expectEqual 0 (length (givenDecls notes))
+        ]
+
+-- Helpers ---------------------------------------------------------------
+
+-- A unit-typed body to use as the 'in' of a top-level letrec. We
+-- avoid pulling in 'Unison.Builtin.Decls' here so the test stays
+-- self-contained; the typechecker accepts a literal 'Nat' as the
+-- letrec body for our purposes.
+constUnit :: a -> Term.Term Symbol a
+constUnit a = Term.nat a 0
+
+runClosed :: Term.Term Symbol () -> [Context.InfoNote Symbol ()]
+runClosed = runClosedWithGivens Set.empty
+
+-- | Like 'runClosed' but pre-populates the typechecker's
+-- 'givenBindings' set with the supplied variable names — used by tests
+-- that programmatically construct a binding the parser would have
+-- tagged via the @given@ keyword. (After the L2 fixup, the predicate
+-- is name-based; without this set the typechecker correctly refuses
+-- to emit 'GivenDecl' / 'extendLexicalGivenFromBinding' for an
+-- arbitrary type-annotated binding.)
+runClosedWithGivens ::
+  Set.Set Symbol ->
+  Term.Term Symbol () ->
+  [Context.InfoNote Symbol ()]
+runClosedWithGivens gbs term =
+  -- 'synthesizeClosed' wants a 'Context.Term' (TypeVar-tagged).
+  -- Constructed terms here use the surface 'Term.Term' so we lift
+  -- via 'TypeVar.liftTerm', the same step that 'Typechecker.synthesize'
+  -- performs at the public API boundary.
+  let res =
+        Context.synthesizeClosed
+          PPE.empty
+          Context.PatternMatchCoverageCheckAndKindInferenceSwitch'Disabled
+          defaultVariances
+          []
+          (Map.empty :: Map.Map Reference.TermReference (Context.Type Symbol ()))
+          gbs
+          mempty
+          (TypeVar.liftTerm term)
+   in toList (Context.infoNotes res)
+
+-- Project 'GivenDecl' notes into (var, declared, conclusion) tuples.
+-- Other note variants are dropped.
+givenDecls ::
+  [Context.InfoNote Symbol ()] ->
+  [(Symbol, Context.Type Symbol (), Context.Type Symbol ())]
+givenDecls = mapMaybe' $ \case
+  Context.GivenDecl _ v d c -> Just (v, d, c)
+  _ -> Nothing
+  where
+    mapMaybe' f = foldr (\x acc -> maybe acc (: acc) (f x)) []

--- a/parser-typechecker/tests/Unison/Test/Typechecker/GivenElaborator.hs
+++ b/parser-typechecker/tests/Unison/Test/Typechecker/GivenElaborator.hs
@@ -721,10 +721,15 @@ testCycleWithMetavar =
 
 testUnresolvedMetavarInGoal :: Test ()
 testUnresolvedMetavarInGoal =
-  scope "free-inference-var-in-goal-yields-UnresolvedMetavarInGoal" $
+  scope "free-inference-var-in-goal-resolves-against-unique-candidate" $
+    -- After the resolver was relaxed to accept goal-side inference
+    -- variables as flexible, a goal like @Show ?a@ resolves to a
+    -- unique candidate by binding @?a@ to whatever the candidate
+    -- exposes. Surrounding type inference is expected to be the
+    -- ultimate authority on @?a@; the resolver no longer raises
+    -- 'UnresolvedMetavarInGoal' before trying.
     let inferVar :: Symbol
         inferVar = Var.inferOther
-        -- Goal: Show ?a where ?a is an inference variable.
         goal = Type.app () (Type.ref () (Reference.Builtin "Show")) (Type.var () inferVar)
         showNat =
           GR.Given
@@ -737,8 +742,9 @@ testUnresolvedMetavarInGoal =
             }
         pool = GR.poolFromList [showNat]
      in case GR.resolve pool goal of
-          Left (GR.UnresolvedMetavarInGoal _) -> ok
+          Right tree
+            | GR.givenName (GR.rtGiven tree) == Reference.Builtin "Show.nat" -> ok
+            | otherwise ->
+                crash ("expected Show.nat, got: " <> show tree)
           Left other ->
-            crash ("expected UnresolvedMetavarInGoal, got: " <> show other)
-          Right tree ->
-            crash ("expected failure, got: " <> show tree)
+            crash ("expected successful resolution, got: " <> show other)

--- a/parser-typechecker/tests/Unison/Test/Typechecker/GivenElaborator.hs
+++ b/parser-typechecker/tests/Unison/Test/Typechecker/GivenElaborator.hs
@@ -1,0 +1,744 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Integration tests for "Unison.Typechecker.GivenElaborator" (chunk
+-- D2). We run the typechecker over small terms whose signatures
+-- contain @ImplicitArrow@ parameters, confirm that 'ConstraintGoal'
+-- info notes are emitted, then drive the elaborator and check the
+-- resulting 'SolvedImplicit' decisions.
+--
+-- Three flavours of given source are exercised:
+--
+--   * a /lexical/ given (built programmatically through
+--     'Context.synthesizeClosed''s initial-givens parameter — A2's
+--     parser support is not on this branch);
+--   * a /namespace/ (top-level / ambient) given supplied via the
+--     elaborator's 'AmbientGiven' API;
+--   * the /failure/ path: a goal with no matching given in either
+--     pool produces a 'ResolveError' inside the 'SolvedImplicit'
+--     note.
+module Unison.Test.Typechecker.GivenElaborator (test) where
+
+import Data.Foldable (for_, toList)
+import Data.Map qualified as Map
+import Data.Set qualified as Set
+import EasyTest
+import Unison.PrettyPrintEnv qualified as PPE
+import Unison.Reference qualified as Reference
+import Unison.Symbol (Symbol)
+import Unison.Term qualified as Term
+import Unison.Type qualified as Type
+import Unison.Typechecker.Context qualified as Context
+import Unison.Typechecker.GivenElaborator qualified as Elab
+import Unison.Typechecker.GivenResolver qualified as GR
+import Unison.Typechecker.TypeLookup qualified as TL
+import Unison.Typechecker.TypeVar qualified as TypeVar
+import Unison.Typechecker.Variance (defaultVariances)
+import Unison.Var qualified as Var
+
+test :: Test ()
+test =
+  scope "GivenElaborator"
+    . tests
+    $ [ scope "decomposeGivenType" testDecomposeGivenType,
+        scope "ambient-resolution" testAmbientResolution,
+        scope "lexical-resolution" testLexicalResolution,
+        scope "missing-given-yields-error" testMissingGiven,
+        scope "no-implicit-no-decisions" testNoImplicit,
+        scope "lexical-shadows-ambient" testLexicalShadowsAmbient,
+        -- L2: @let given@ at the AST level extends lexicalGivens.
+        scope "let-given-extends-lexical-givens" testLetGivenExtendsLexical,
+        scope "let-given-shadows-ambient" testLetGivenShadowsAmbient,
+        -- L2 fixup: premise-free @given local : C = …@ (no @=>@ in
+        -- the type) — the canonical ADR-010 example. Before the fix
+        -- the type-shape predicate silently dropped this binding;
+        -- the parser-tagged side channel makes it work.
+        scope "let-given-premise-free-extends-lexical-givens" testLetGivenPremiseFree,
+        -- D4 carry-overs from D2 review.
+        scope "ambiguous-given-yields-error" testAmbiguousGiven,
+        scope "depth-exceeded-yields-error" testDepthExceeded,
+        scope "cycle-with-metavar-regression" testCycleWithMetavar,
+        scope "unresolved-metavar-in-goal" testUnresolvedMetavarInGoal
+      ]
+
+------------------------------------------------------------------------------
+-- Test fixtures
+------------------------------------------------------------------------------
+
+-- A constraint-class-like type "TestC".
+constraintRef :: Reference.Reference
+constraintRef = Reference.Builtin "TestC"
+
+constraintTy :: Type.Type Symbol ()
+constraintTy = Type.ref () constraintRef
+
+-- A second constraint type, used for the lexical-shadows-ambient test.
+otherConstraintRef :: Reference.Reference
+otherConstraintRef = Reference.Builtin "OtherC"
+
+otherConstraintTy :: Type.Type Symbol ()
+otherConstraintTy = Type.ref () otherConstraintRef
+
+-- A function "f : TestC => Nat -> Nat" stored in the typechecker's
+-- TypeLookup so synthesis can find its declared type by reference.
+fRef :: Reference.Reference
+fRef = Reference.Builtin "TestImplicitFn"
+
+fType :: Type.Type Symbol ()
+fType =
+  Type.implicitArrow
+    ()
+    constraintTy
+    (Type.arrow () (Type.nat ()) (Type.nat ()))
+
+-- A function "g : Nat -> Nat" — no implicit parameter.
+gRef :: Reference.Reference
+gRef = Reference.Builtin "TestPlainFn"
+
+gType :: Type.Type Symbol ()
+gType = Type.arrow () (Type.nat ()) (Type.nat ())
+
+-- A function "h : OtherC => TestC => Nat -> Nat" — two implicits to
+-- exercise multi-constraint signatures (each emits its own goal).
+hRef :: Reference.Reference
+hRef = Reference.Builtin "TestImplicitFn2"
+
+hType :: Type.Type Symbol ()
+hType =
+  Type.implicitArrow
+    ()
+    otherConstraintTy
+    (Type.implicitArrow () constraintTy (Type.arrow () (Type.nat ()) (Type.nat ())))
+
+-- Witness term used by the L2 'let given' tests: a builtin whose
+-- declared type is the *conclusion* (TestC). The binding annotation is
+-- @OtherC => TestC@; checking the body against that annotation peels
+-- the leading 'ImplicitArrow' (emitting an OtherC goal) and recurses on
+-- the conclusion 'TestC' — at which point the body's declared type
+-- matches without further inference fuss.
+witnessLetGivenRef :: Reference.Reference
+witnessLetGivenRef = Reference.Builtin "WitnessLetGiven"
+
+witnessLetGivenType :: Type.Type Symbol ()
+witnessLetGivenType = constraintTy
+
+typeLookup :: TL.TypeLookup Symbol ()
+typeLookup =
+  mempty
+    { TL.typeOfTerms =
+        Map.fromList
+          [ (fRef, fType),
+            (gRef, gType),
+            (hRef, hType),
+            (witnessLetGivenRef, witnessLetGivenType)
+          ]
+    }
+
+-- Run synthesis on @f 42@.
+runFCall :: Map.Map Reference.Reference (Context.Type Symbol ()) -> [Context.InfoNote Symbol ()]
+runFCall givens = runApply fRef givens
+
+-- Run synthesis on @h 42@ (two implicits).
+runHCall :: Map.Map Reference.Reference (Context.Type Symbol ()) -> [Context.InfoNote Symbol ()]
+runHCall givens = runApply hRef givens
+
+-- Run synthesis on @g 42@ (no implicits).
+runGCall :: [Context.InfoNote Symbol ()]
+runGCall = runApply gRef Map.empty
+
+runApply ::
+  Reference.Reference ->
+  Map.Map Reference.Reference (Context.Type Symbol ()) ->
+  [Context.InfoNote Symbol ()]
+runApply ref givens =
+  let term = Term.app () (Term.ref () ref) (Term.nat () 42)
+      res =
+        Context.synthesizeClosed
+          PPE.empty
+          Context.PatternMatchCoverageCheckAndKindInferenceSwitch'Disabled
+          defaultVariances
+          []
+          givens
+          Set.empty
+          typeLookup
+          term
+   in toList (Context.infoNotes res)
+
+-- A namespace-level given that produces a 'TestC' dictionary directly.
+-- Type: @TestC@ (no foralls, no premises).
+ambientShowNatRef :: Reference.Reference
+ambientShowNatRef = Reference.Builtin "AmbientShowNat"
+
+ambientShowNat :: Elab.AmbientGiven Symbol ()
+ambientShowNat =
+  Elab.AmbientGiven
+    { Elab.ambientName = ambientShowNatRef,
+      Elab.ambientType = constraintTy
+    }
+
+-- An ambient given for OtherC. Used in 'testLexicalShadowsAmbient'.
+ambientOtherCRef :: Reference.Reference
+ambientOtherCRef = Reference.Builtin "AmbientOtherC"
+
+ambientOtherC :: Elab.AmbientGiven Symbol ()
+ambientOtherC =
+  Elab.AmbientGiven
+    { Elab.ambientName = ambientOtherCRef,
+      Elab.ambientType = otherConstraintTy
+    }
+
+------------------------------------------------------------------------------
+-- 1. Decomposition unit tests
+------------------------------------------------------------------------------
+
+testDecomposeGivenType :: Test ()
+testDecomposeGivenType =
+  tests
+    [ scope "no-foralls-no-premises" $
+        let (vs, prems, concl) = Elab.decomposeGivenType constraintTy
+         in do
+              expectEqual ([] :: [Symbol]) vs
+              expectEqual [] prems
+              expectEqual constraintTy concl,
+      scope "implicit-arrow-becomes-premise" $
+        let ty = Type.implicitArrow () constraintTy otherConstraintTy
+            (vs, prems, concl) = Elab.decomposeGivenType ty
+         in do
+              expectEqual ([] :: [Symbol]) vs
+              expectEqual [constraintTy] prems
+              expectEqual otherConstraintTy concl,
+      scope "regular-arrow-stays-in-conclusion" $
+        let -- TestC -> Nat -> Nat: regular arrows are *not* premises.
+            ty = Type.arrow () constraintTy (Type.arrow () (Type.nat ()) (Type.nat ()))
+            (vs, prems, concl) = Elab.decomposeGivenType ty
+         in do
+              expectEqual ([] :: [Symbol]) vs
+              expectEqual [] prems
+              expectEqual ty concl
+    ]
+
+------------------------------------------------------------------------------
+-- 2. End-to-end with an ambient (top-level / namespace) given
+------------------------------------------------------------------------------
+
+testAmbientResolution :: Test ()
+testAmbientResolution =
+  scope "single-ambient-given-resolves-single-implicit" $
+    let infos = runFCall Map.empty
+        ambient = Elab.ambientPool [ambientShowNat]
+        elaborated = Elab.elaborateInfoNotes ambient infos
+        decisions = Elab.implicitDecisions elaborated
+     in do
+          -- Exactly one constraint goal was emitted (single implicit).
+          let goalCount = length (Elab.extractConstraintGoals infos)
+          expectEqual 1 goalCount
+          -- Exactly one decision was produced.
+          expectEqual 1 (length decisions)
+          case decisions of
+            [(_, _, Right tree)] ->
+              expectEqual ambientShowNatRef (GR.givenName (GR.rtGiven tree))
+            other -> crash ("unexpected decisions: " <> show (length other))
+
+------------------------------------------------------------------------------
+-- 3. End-to-end with a lexical given (programmatic threading)
+------------------------------------------------------------------------------
+
+testLexicalResolution :: Test ()
+testLexicalResolution =
+  scope "single-lexical-given-resolves-single-implicit" $
+    -- Build the lexical-given snapshot at the surface level, lift to
+    -- Context.Type, and pass it as the typechecker's initial givens
+    -- map. A2's parser sugar (@let given x = ...@) is not on this
+    -- branch, so we exercise the same code path programmatically.
+    let lexicalRef = Reference.Builtin "LexicalShowNat"
+        surfaceGivens = Map.singleton lexicalRef constraintTy
+        givens = TypeVar.liftType <$> surfaceGivens
+        infos = runFCall givens
+        -- No ambient pool here: the only given is lexical.
+        empty = GR.poolFromList []
+        elaborated = Elab.elaborateInfoNotes empty infos
+        decisions = Elab.implicitDecisions elaborated
+     in case decisions of
+          [(_, _, Right tree)] ->
+            expectEqual lexicalRef (GR.givenName (GR.rtGiven tree))
+          other ->
+            crash ("expected one Right decision, got: " <> show (length other))
+
+------------------------------------------------------------------------------
+-- 4. Failure path: no matching given in either pool
+------------------------------------------------------------------------------
+
+testMissingGiven :: Test ()
+testMissingGiven =
+  scope "no-given-produces-resolve-error" $
+    let infos = runFCall Map.empty
+        empty = GR.poolFromList []
+        elaborated = Elab.elaborateInfoNotes empty infos
+        decisions = Elab.implicitDecisions elaborated
+     in case decisions of
+          [(_, _, Left (GR.NoGiven _ _))] -> ok
+          [(_, _, Left other)] ->
+            crash ("expected NoGiven, got: " <> show other)
+          [(_, _, Right _)] ->
+            crash "expected resolution failure, got success"
+          xs ->
+            crash ("expected exactly one decision, got " <> show (length xs))
+
+------------------------------------------------------------------------------
+-- 5. No-implicit term produces no decisions
+------------------------------------------------------------------------------
+
+testNoImplicit :: Test ()
+testNoImplicit =
+  scope "plain-arrow-emits-no-decisions" $
+    let infos = runGCall
+        elaborated = Elab.elaborateInfoNotes (GR.poolFromList []) infos
+        decisions = Elab.implicitDecisions elaborated
+     in expectEqual 0 (length decisions)
+
+------------------------------------------------------------------------------
+-- 6. Lexical given wins over ambient at the same goal type (ADR-008)
+------------------------------------------------------------------------------
+
+-- The two-implicit signature lets us test both layers in the same
+-- call: 'h : OtherC => TestC => Nat -> Nat' applied to '42' emits two
+-- goals, one for OtherC and one for TestC. We provide:
+--
+--   * A lexical given for OtherC at a different reference than the
+--     ambient one, and
+--   * Ambient givens for both OtherC and TestC.
+--
+-- The resolver should pick the lexical 'OtherC' (per
+-- 'GR.Lexical 0 < GR.Ambient') and the ambient 'TestC' (the only
+-- candidate of any sort).
+testLexicalShadowsAmbient :: Test ()
+testLexicalShadowsAmbient =
+  scope "lexical-given-wins-over-ambient" $
+    let lexicalOtherCRef = Reference.Builtin "LexicalOtherC"
+        surfaceGivens = Map.singleton lexicalOtherCRef otherConstraintTy
+        givens = TypeVar.liftType <$> surfaceGivens
+        infos = runHCall givens
+        ambient = Elab.ambientPool [ambientOtherC, ambientShowNat]
+        elaborated = Elab.elaborateInfoNotes ambient infos
+        decisions = Elab.implicitDecisions elaborated
+        names = [GR.givenName (GR.rtGiven t) | (_, _, Right t) <- decisions]
+     in do
+          expectEqual 2 (length decisions)
+          -- The lexical OtherC should win over the ambient one.
+          expect (lexicalOtherCRef `elem` names)
+          expect (notElem ambientOtherCRef names)
+          -- The TestC goal has no lexical candidate; the ambient one
+          -- must be the chosen resolution.
+          expect (ambientShowNatRef `elem` names)
+
+------------------------------------------------------------------------------
+-- L2: @let given@ at the AST level. A binding whose declared type
+-- begins with an 'ImplicitArrow' should be picked up by the
+-- typechecker's lexical-given environment so a 'ConstraintGoal' inside
+-- the let-body resolves against it.
+--
+-- We construct the AST that A2's parser would produce for
+--
+-- @
+--   let given local : TestC = body
+--    in f 42
+-- @
+--
+-- by hand: a non-top 'singleLet' whose binding is a 'Term.Ann' with
+-- declared type @TestC@... but @TestC@ alone has no @=>@ so it isn't
+-- a given. The minimal shape that triggers chunk L2's wiring is a
+-- declared type that contains at least one 'ImplicitArrow'; i.e. the
+-- given's type itself takes a premise. The simplest two-layer test:
+-- give the local a /derived/ given of shape @TestC => TestC@ — its
+-- conclusion matches the goal and its premise is satisfied by the
+-- ambient @TestC@ given. The resolver must then choose the lexical
+-- candidate (per 'GR.Lexical 0 < GR.Ambient').
+--
+-- Note: the resolver records 'givenName' as a synthetic
+-- @Reference.Builtin "Local.given.<varname>"@ for local lexical
+-- givens; chunk L2 doesn't yet plumb a fully-applied dictionary back
+-- through the rewriter, but the 'SolvedImplicit' info note carries
+-- the chosen ref, which is what these tests assert on.
+------------------------------------------------------------------------------
+
+testLetGivenExtendsLexical :: Test ()
+testLetGivenExtendsLexical =
+  scope "let-given binding registers a lexical given" $
+    -- @
+    --   let local : OtherC => TestC = 42
+    --    in f 42        -- f : TestC => Nat -> Nat
+    -- @
+    --
+    -- The binding's declared type begins with '=>', so chunk L2's
+    -- 'extendLexicalGivenFromBinding' wires a synthetic
+    -- @Local.given.local : OtherC => TestC@ into the lexical-given env
+    -- before checking the body. The apply-site goal is @TestC@; the
+    -- local's conclusion matches and its premise @OtherC@ is satisfied
+    -- by an ambient given for OtherC. No ambient TestC is supplied —
+    -- so any TestC decision must come from the local.
+    let localVar = Var.named @Symbol "local"
+        expectedRef = Reference.Builtin "Local.given.local"
+        -- Body: a witness Ref whose declared type is exactly the
+        -- conclusion (TestC). The binding's annotation is
+        -- 'OtherC => TestC', so 'checkWanted''s 'ImplicitArrow' clause
+        -- emits the OtherC goal and recurses on the conclusion.
+        givenBody = Term.ref () witnessLetGivenRef
+        -- 'OtherC => TestC' requires premise OtherC, concludes TestC.
+        givenTy =
+          Type.implicitArrow () otherConstraintTy constraintTy
+        givenBinding = Term.ann () givenBody givenTy
+        -- Body of the let: 'f 42'. f : TestC => Nat -> Nat, so the
+        -- typechecker emits a 'TestC' goal at this apply-site.
+        letBody = Term.app () (Term.ref () fRef) (Term.nat () 42)
+        term =
+          Term.singleLet
+            False
+            ()
+            ()
+            (localVar, givenBinding)
+            letBody
+        res =
+          Context.synthesizeClosed
+            PPE.empty
+            Context.PatternMatchCoverageCheckAndKindInferenceSwitch'Disabled
+            defaultVariances
+            []
+            Map.empty
+            -- ADR-010 / chunk L2 fixup: the parser tags @given@-bound
+            -- vars; programmatic tests stand in for that here by
+            -- handing the typechecker the same set directly.
+            (Set.singleton localVar)
+            typeLookup
+            (TypeVar.liftTerm term)
+        infos = toList (Context.infoNotes res)
+        -- Provide ambient OtherC (used only to satisfy the local's
+        -- premise, never the top-level TestC goal).
+        ambient = Elab.ambientPool [ambientOtherC]
+        elaborated = Elab.elaborateInfoNotes ambient infos
+        decisions = Elab.implicitDecisions elaborated
+        solvedNames =
+          [ GR.givenName (GR.rtGiven tree)
+          | (_, _, Right tree) <- decisions
+          ]
+     in tests
+          [ scope "at-least-one-decision-emitted" $
+              expect (not (null decisions)),
+            scope "lexical-local-was-chosen" $
+              -- The TestC goal at the let-body's apply-site must be
+              -- solved by the local lexical given. The synthetic ref
+              -- 'Local.given.local' is the resolver's witness that L2's
+              -- wiring threaded the binding into the lexical scope.
+              expect (expectedRef `elem` solvedNames)
+          ]
+
+testLetGivenShadowsAmbient :: Test ()
+testLetGivenShadowsAmbient =
+  scope "let-given shadows ambient at the same goal type" $
+    -- @
+    --   let shadow : OtherC => TestC = 42
+    --    in f 42        -- f : TestC => Nat -> Nat
+    -- @
+    --
+    -- This time we *also* supply an ambient TestC. The resolver must
+    -- still pick the local 'shadow' (per 'GR.Lexical 0 < GR.Ambient'
+    -- in 'filterMostInner'), demonstrating that the L2 wiring threads
+    -- the local with 'Lexical 0' rather than mistakenly tagging it
+    -- 'Ambient'.
+    let localVar = Var.named @Symbol "shadow"
+        expectedRef = Reference.Builtin "Local.given.shadow"
+        givenTy =
+          Type.implicitArrow () otherConstraintTy constraintTy
+        givenBody = Term.ref () witnessLetGivenRef
+        givenBinding = Term.ann () givenBody givenTy
+        letBody = Term.app () (Term.ref () fRef) (Term.nat () 1)
+        term =
+          Term.singleLet
+            False
+            ()
+            ()
+            (localVar, givenBinding)
+            letBody
+        res =
+          Context.synthesizeClosed
+            PPE.empty
+            Context.PatternMatchCoverageCheckAndKindInferenceSwitch'Disabled
+            defaultVariances
+            []
+            Map.empty
+            (Set.singleton localVar)
+            typeLookup
+            (TypeVar.liftTerm term)
+        infos = toList (Context.infoNotes res)
+        -- Both ambient TestC AND lexical TestC are available.
+        ambient = Elab.ambientPool [ambientOtherC, ambientShowNat]
+        elaborated = Elab.elaborateInfoNotes ambient infos
+        decisions = Elab.implicitDecisions elaborated
+        topNames =
+          [ GR.givenName (GR.rtGiven tree)
+          | (_, _, Right tree) <- decisions
+          ]
+     in tests
+          [ scope "decision-emitted" $ expect (not (null decisions)),
+            scope "lexical-beats-ambient" $
+              expect (expectedRef `elem` topNames),
+            scope "ambient-was-not-the-top-choice" $
+              -- For every decision whose goal is TestC the chosen
+              -- given must be the lexical one — never the ambient
+              -- TestC. (Ambient OtherC may legitimately appear as a
+              -- premise sub-resolution of the local given.)
+              for_ decisions $ \(_, _, dec) ->
+                case dec of
+                  Right tree ->
+                    let gn = GR.givenName (GR.rtGiven tree)
+                     in expect (gn /= ambientShowNatRef)
+                  Left _ -> ok
+          ]
+
+------------------------------------------------------------------------------
+-- L2 fixup: premise-free @let given local : TestC = …@. This is the
+-- canonical ADR-010 example: the binding's declared type has no @=>@
+-- premises. Before the fix the predicate
+-- @null . fst . unImplicitArrows@ silently dropped this binding, so
+-- the lexical given environment was never extended and the apply-site
+-- goal failed to resolve. After the parser-tagged side channel the
+-- typechecker recognises the binding by name and registers it.
+--
+-- Test setup: the local has type @TestC@ (no premises). The body of
+-- the let mentions @f 42@, where @f : TestC => Nat -> Nat@. With no
+-- ambient TestC supplied, the only way the apply-site resolves is via
+-- the local — which requires L2's letrec hook to register it. We
+-- simulate the parser's tagging by populating 'givenBindings' with
+-- the local's variable name directly.
+------------------------------------------------------------------------------
+
+testLetGivenPremiseFree :: Test ()
+testLetGivenPremiseFree =
+  scope "premise-free local given (no `=>`) registers as a lexical given" $
+    let localVar = Var.named @Symbol "local"
+        expectedRef = Reference.Builtin "Local.given.local"
+        -- Premise-free: the binding's type is just @TestC@. The body
+        -- is a witness reference whose declared type matches.
+        givenBody = Term.ref () witnessLetGivenRef
+        -- Note the absence of @Type.implicitArrow@ here: the type is
+        -- a plain conclusion. Pre-fix this would not register.
+        givenBinding = Term.ann () givenBody constraintTy
+        letBody = Term.app () (Term.ref () fRef) (Term.nat () 42)
+        term =
+          Term.singleLet
+            False
+            ()
+            ()
+            (localVar, givenBinding)
+            letBody
+        res =
+          Context.synthesizeClosed
+            PPE.empty
+            Context.PatternMatchCoverageCheckAndKindInferenceSwitch'Disabled
+            defaultVariances
+            []
+            Map.empty
+            -- Stand-in for the parser's tag.
+            (Set.singleton localVar)
+            typeLookup
+            (TypeVar.liftTerm term)
+        infos = toList (Context.infoNotes res)
+        -- No ambient TestC: resolution must come from the local.
+        ambient = Elab.ambientPool []
+        elaborated = Elab.elaborateInfoNotes ambient infos
+        decisions = Elab.implicitDecisions elaborated
+        solvedNames =
+          [ GR.givenName (GR.rtGiven tree)
+          | (_, _, Right tree) <- decisions
+          ]
+     in tests
+          [ scope "at-least-one-decision-emitted" $
+              expect (not (null decisions)),
+            scope "premise-free-local-was-chosen" $
+              expect (expectedRef `elem` solvedNames)
+          ]
+
+------------------------------------------------------------------------------
+-- D4 carry-over: Ambiguous reaches the elaborator end-to-end (D2 only
+-- exercised NoGiven). Two ambient givens of identical conclusion both
+-- match the goal; the resolver must yield 'Ambiguous'.
+------------------------------------------------------------------------------
+
+ambientShowNatA :: Elab.AmbientGiven Symbol ()
+ambientShowNatA =
+  Elab.AmbientGiven
+    { Elab.ambientName = Reference.Builtin "AmbientShowNat.A",
+      Elab.ambientType = constraintTy
+    }
+
+ambientShowNatB :: Elab.AmbientGiven Symbol ()
+ambientShowNatB =
+  Elab.AmbientGiven
+    { Elab.ambientName = Reference.Builtin "AmbientShowNat.B",
+      Elab.ambientType = constraintTy
+    }
+
+testAmbiguousGiven :: Test ()
+testAmbiguousGiven =
+  scope "two-equally-applicable-givens-yield-Ambiguous" $
+    let infos = runFCall Map.empty
+        ambient = Elab.ambientPool [ambientShowNatA, ambientShowNatB]
+        elaborated = Elab.elaborateInfoNotes ambient infos
+        decisions = Elab.implicitDecisions elaborated
+     in case decisions of
+          [(_, _, Left (GR.Ambiguous _ candidates))] -> do
+            -- Both candidates show up in the diagnostic.
+            let names = map GR.givenName candidates
+            expect (Reference.Builtin "AmbientShowNat.A" `elem` names)
+            expect (Reference.Builtin "AmbientShowNat.B" `elem` names)
+          [(_, _, other)] ->
+            crash ("expected Ambiguous, got: " <> show other)
+          xs ->
+            crash ("expected one decision, got " <> show (length xs))
+
+------------------------------------------------------------------------------
+-- D4 carry-over: DepthExceeded surfaces through the elaborator. We
+-- build a self-referential given (Self requires Self) with no base
+-- case; the resolver must bail with DepthExceeded (or NoGiven via the
+-- per-branch cycle short-circuit, depending on memoization order).
+------------------------------------------------------------------------------
+
+-- A self-recursive given: SelfC requires SelfC, no base case.
+selfRef :: Reference.Reference
+selfRef = Reference.Builtin "SelfFromSelf"
+
+selfConstraintRef :: Reference.Reference
+selfConstraintRef = Reference.Builtin "SelfC"
+
+selfConstraintTy :: Type.Type Symbol ()
+selfConstraintTy = Type.ref () selfConstraintRef
+
+selfFromSelf :: Elab.AmbientGiven Symbol ()
+selfFromSelf =
+  Elab.AmbientGiven
+    { Elab.ambientName = selfRef,
+      Elab.ambientType =
+        Type.implicitArrow () selfConstraintTy selfConstraintTy
+    }
+
+-- A function whose only implicit is SelfC.
+selfFnRef :: Reference.Reference
+selfFnRef = Reference.Builtin "SelfFn"
+
+selfFnType :: Type.Type Symbol ()
+selfFnType =
+  Type.implicitArrow
+    ()
+    selfConstraintTy
+    (Type.arrow () (Type.nat ()) (Type.nat ()))
+
+testDepthExceeded :: Test ()
+testDepthExceeded =
+  scope "self-referential-given-depth-bails" $
+    let ourTypeLookup =
+          mempty {TL.typeOfTerms = Map.fromList [(selfFnRef, selfFnType)]}
+        term = Term.app () (Term.ref () selfFnRef) (Term.nat () 42)
+        res =
+          Context.synthesizeClosed
+            PPE.empty
+            Context.PatternMatchCoverageCheckAndKindInferenceSwitch'Disabled
+            defaultVariances
+            []
+            Map.empty
+            Set.empty
+            ourTypeLookup
+            term
+        infos = toList (Context.infoNotes res)
+        ambient = Elab.ambientPool [selfFromSelf]
+        elaborated = Elab.elaborateInfoNotes ambient infos
+        decisions = Elab.implicitDecisions elaborated
+     in case decisions of
+          [(_, _, Left (GR.DepthExceeded _))] -> ok
+          [(_, _, Left (GR.NoGiven _ _))] ->
+            -- Either is acceptable — the per-branch cycle short-
+            -- circuit can produce NoGiven before depth is reached.
+            ok
+          [(_, _, other)] ->
+            crash ("expected DepthExceeded or NoGiven, got: " <> show other)
+          xs ->
+            crash ("expected one decision, got " <> show (length xs))
+
+------------------------------------------------------------------------------
+-- D4 carry-over: cycle/metavar regression. A mutually-recursive given
+-- pair (FooFromBar / BarFromFoo) where the goal type carries an
+-- inference variable in a non-conclusion position. This exercises the
+-- now-fixed `cycleHit` widened-flex behavior: the per-branch cycle
+-- check must compare alpha-renamed fresh copies as equivalent goals.
+--
+-- We construct the goal directly (without going through synthesis) so
+-- we can place a fresh free variable in the goal that cycleHit must
+-- treat as flexible. Per the resolver's contract this should fail
+-- with NoGiven (cycle short-circuit), not hang.
+------------------------------------------------------------------------------
+
+testCycleWithMetavar :: Test ()
+testCycleWithMetavar =
+  scope "mutual-recursion-with-flexible-goal-var-fails-cleanly" $
+    let -- Two builtins for the recursive pair.
+        fooC :: Type.Type Symbol ()
+        fooC = Type.ref () (Reference.Builtin "Foo")
+        barC :: Type.Type Symbol ()
+        barC = Type.ref () (Reference.Builtin "Bar")
+        fooFromBar :: GR.Given Symbol ()
+        fooFromBar =
+          GR.Given
+            { GR.givenName = Reference.Builtin "fooFromBar",
+              GR.givenTyVars = [],
+              GR.givenPremises = [barC],
+              GR.givenConclusion = fooC,
+              GR.givenScope = GR.Ambient
+            }
+        barFromFoo :: GR.Given Symbol ()
+        barFromFoo =
+          GR.Given
+            { GR.givenName = Reference.Builtin "barFromFoo",
+              GR.givenTyVars = [],
+              GR.givenPremises = [fooC],
+              GR.givenConclusion = barC,
+              GR.givenScope = GR.Ambient
+            }
+        pool = GR.poolFromList [fooFromBar, barFromFoo]
+        -- Goal: 'Foo'. The cycle would hang without per-branch cycle
+        -- detection; we assert it terminates with NoGiven (the
+        -- candidate's premise resolution failed via the cycle path).
+        result = GR.resolve pool fooC
+     in case result of
+          Left (GR.NoGiven _ _) -> ok
+          Left other ->
+            crash ("expected NoGiven via cycle short-circuit, got: " <> show other)
+          Right t ->
+            crash ("expected failure, got: " <> show t)
+
+------------------------------------------------------------------------------
+-- D4: unresolved metavar in the goal yields its own dedicated error
+-- variant. We construct a goal with a free variable whose 'Var.typeOf'
+-- is 'Inference' (not user-named) and check the resolver short-
+-- circuits to 'UnresolvedMetavarInGoal'.
+------------------------------------------------------------------------------
+
+testUnresolvedMetavarInGoal :: Test ()
+testUnresolvedMetavarInGoal =
+  scope "free-inference-var-in-goal-yields-UnresolvedMetavarInGoal" $
+    let inferVar :: Symbol
+        inferVar = Var.inferOther
+        -- Goal: Show ?a where ?a is an inference variable.
+        goal = Type.app () (Type.ref () (Reference.Builtin "Show")) (Type.var () inferVar)
+        showNat =
+          GR.Given
+            { GR.givenName = Reference.Builtin "Show.nat",
+              GR.givenTyVars = [],
+              GR.givenPremises = [],
+              GR.givenConclusion =
+                Type.app () (Type.ref () (Reference.Builtin "Show")) (Type.ref () (Reference.Builtin "Nat")),
+              GR.givenScope = GR.Ambient
+            }
+        pool = GR.poolFromList [showNat]
+     in case GR.resolve pool goal of
+          Left (GR.UnresolvedMetavarInGoal _) -> ok
+          Left other ->
+            crash ("expected UnresolvedMetavarInGoal, got: " <> show other)
+          Right tree ->
+            crash ("expected failure, got: " <> show tree)

--- a/parser-typechecker/tests/Unison/Test/Typechecker/GivenResolver.hs
+++ b/parser-typechecker/tests/Unison/Test/Typechecker/GivenResolver.hs
@@ -1,0 +1,427 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Phase-2 chunk D1 tests for the implicit-resolution port. Mirrors
+-- the spike's 15-test matrix (see
+-- @spike\/implicits\/test\/Main.hs@), retargeted at real
+-- 'Unison.Type.Type' values.
+--
+-- Tests are organised into the six success-criteria groups from
+-- @docs\/implicits-plan.md@ §4.2 plus a small "sanity" group.
+module Unison.Test.Typechecker.GivenResolver (test) where
+
+import Data.List (sort)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Time.Clock (diffUTCTime, getCurrentTime)
+import EasyTest
+import Unison.Reference (Reference)
+import Unison.Reference qualified as Reference
+import Unison.Symbol (Symbol)
+import Unison.Type (Type)
+import Unison.Type qualified as Type
+import Unison.Typechecker.GivenResolver
+  ( Given (..),
+    ResolutionTree (..),
+    ResolveError (..),
+    ResolveOptions (..),
+    Scope (..),
+    defaultOptions,
+    poolFromList,
+    resolve,
+    resolveCounted,
+    resolveWith,
+  )
+import Unison.Var qualified as Var
+
+------------------------------------------------------------------------------
+-- Test entry point
+------------------------------------------------------------------------------
+
+test :: Test ()
+test =
+  scope "Typechecker.GivenResolver" $
+    tests
+      [ scope "1.cycles" testCycles,
+        scope "2.specificity" testSpecificity,
+        scope "3.hkt" testHkt,
+        scope "4.ambiguity" testAmbiguity,
+        scope "5.performance" testPerformance,
+        scope "6.diamond" testDiamond,
+        scope "sanity" testSanity
+      ]
+
+------------------------------------------------------------------------------
+-- Type aliases for readable test data
+------------------------------------------------------------------------------
+
+type Ty = Type Symbol ()
+
+ref :: Text -> Ty
+ref name = Type.builtin () name
+
+-- Type constructor builtins.
+showC, ordC, functorC, mapC, listC, optionalC, natC, fooC, barC, selfC :: Ty
+showC = ref "Show"
+ordC = ref "Ord"
+functorC = ref "Functor"
+mapC = ref "Map"
+listC = ref "List"
+optionalC = ref "Optional"
+natC = ref "Nat"
+fooC = ref "Foo"
+barC = ref "Bar"
+selfC = ref "Self"
+
+-- Type variables.
+tvA, tvF, tvK, tvV :: Symbol
+tvA = Var.named "a"
+tvF = Var.named "f"
+tvK = Var.named "k"
+tvV = Var.named "v"
+
+tv :: Symbol -> Ty
+tv = Type.var ()
+
+-- | Givens are keyed by 'Reference'; we use 'Builtin' so equality
+-- comparisons match the spike's by-name semantics.
+gname :: Text -> Reference
+gname = Reference.Builtin
+
+-- Convenience builders.
+appOne :: Ty -> Ty -> Ty
+appOne = Type.app ()
+
+appTwo :: Ty -> Ty -> Ty -> Ty
+appTwo c x y = Type.app () (Type.app () c x) y
+
+mkGiven ::
+  Text ->
+  [Symbol] ->
+  [Ty] ->
+  Ty ->
+  Scope ->
+  Given Symbol ()
+mkGiven name vars premises concl s =
+  Given
+    { givenName = gname name,
+      givenTyVars = vars,
+      givenPremises = premises,
+      givenConclusion = concl,
+      givenScope = s
+    }
+
+-- | The chosen given's builtin name (for assertion).
+chosenName :: ResolutionTree Symbol () -> Text
+chosenName = refName . givenName . rtGiven
+
+refName :: Reference -> Text
+refName (Reference.Builtin n) = n
+refName r = error ("unexpected non-builtin reference: " <> show r)
+
+tshow :: (Show a) => a -> Text
+tshow = Text.pack . show
+
+------------------------------------------------------------------------------
+-- 1. Cycles terminate.
+------------------------------------------------------------------------------
+
+testCycles :: Test ()
+testCycles =
+  tests
+    [ scope "Foo<->Bar mutual recursion fails cleanly" $
+        let pool =
+              poolFromList
+                [ mkGiven "fooFromBar" [] [barC] fooC Ambient,
+                  mkGiven "barFromFoo" [] [fooC] barC Ambient
+                ]
+         in case resolve pool fooC of
+              Left (NoGiven _ _) -> ok
+              Left e -> crash ("expected NoGiven, got: " <> show e)
+              Right t -> crash ("expected failure, got: " <> show t),
+      scope "Cycle with escape hatch resolves via the escape" $
+        -- Two ways to resolve Foo: a base instance, and a cyclic
+        -- detour via Bar->Foo. The cyclic candidate fails per-branch,
+        -- but the base instance succeeds. Result is success or
+        -- ambiguity — *not* a hang.
+        let pool =
+              poolFromList
+                [ mkGiven "baseFoo" [] [] fooC Ambient,
+                  mkGiven "fooFromBar" [] [barC] fooC Ambient,
+                  mkGiven "barFromFoo" [] [fooC] barC Ambient
+                ]
+         in case resolve pool fooC of
+              Right _ -> ok
+              Left (Ambiguous _ _) -> ok
+              Left e -> crash ("unexpected error: " <> show e)
+    ]
+
+------------------------------------------------------------------------------
+-- 2. Specificity ordering.
+------------------------------------------------------------------------------
+
+testSpecificity :: Test ()
+testSpecificity =
+  tests
+    [ scope "Show (List Nat) is preferred over Show (List a)" $
+        let showListA =
+              mkGiven
+                "Show.list"
+                [tvA]
+                [appOne showC (tv tvA)]
+                (appOne showC (appOne listC (tv tvA)))
+                Ambient
+            showListNat =
+              mkGiven
+                "Show.listNat"
+                []
+                []
+                (appOne showC (appOne listC natC))
+                Ambient
+            showNat =
+              mkGiven "Show.nat" [] [] (appOne showC natC) Ambient
+            pool = poolFromList [showListA, showListNat, showNat]
+            goal = appOne showC (appOne listC natC)
+         in case resolve pool goal of
+              Right rt -> expectEqual ("Show.listNat" :: Text) (chosenName rt)
+              Left e -> crash ("expected success, got: " <> show e),
+      scope "Show (List a) wins when no Nat-specific given is available" $
+        let showListA =
+              mkGiven
+                "Show.list"
+                [tvA]
+                [appOne showC (tv tvA)]
+                (appOne showC (appOne listC (tv tvA)))
+                Ambient
+            showNat =
+              mkGiven "Show.nat" [] [] (appOne showC natC) Ambient
+            pool = poolFromList [showListA, showNat]
+            goal = appOne showC (appOne listC natC)
+         in case resolve pool goal of
+              Right rt -> expectEqual ("Show.list" :: Text) (chosenName rt)
+              Left e -> crash ("expected success, got: " <> show e)
+    ]
+
+------------------------------------------------------------------------------
+-- 3. HKT support.
+------------------------------------------------------------------------------
+
+testHkt :: Test ()
+testHkt =
+  tests
+    [ scope "Functor List resolves" $
+        let pool =
+              poolFromList
+                [ mkGiven "Functor.list" [] [] (appOne functorC listC) Ambient,
+                  mkGiven "Functor.optional" [] [] (appOne functorC optionalC) Ambient
+                ]
+            goal = appOne functorC listC
+         in case resolve pool goal of
+              Right rt -> expectEqual ("Functor.list" :: Text) (chosenName rt)
+              Left e -> crash ("expected success, got: " <> show e),
+      scope "Functor Optional resolves" $
+        let pool =
+              poolFromList
+                [ mkGiven "Functor.list" [] [] (appOne functorC listC) Ambient,
+                  mkGiven "Functor.optional" [] [] (appOne functorC optionalC) Ambient
+                ]
+            goal = appOne functorC optionalC
+         in case resolve pool goal of
+              Right rt -> expectEqual ("Functor.optional" :: Text) (chosenName rt)
+              Left e -> crash ("expected success, got: " <> show e),
+      scope "Polymorphic Functor f matches a fresh constructor" $
+        -- Functor.id : forall f. Functor f
+        -- Functor.list : Functor List
+        -- Goal: Functor List should pick the more-specific one.
+        let pool =
+              poolFromList
+                [ mkGiven "Functor.id" [tvF] [] (appOne functorC (tv tvF)) Ambient,
+                  mkGiven "Functor.list" [] [] (appOne functorC listC) Ambient
+                ]
+         in case resolve pool (appOne functorC listC) of
+              Right rt -> expectEqual ("Functor.list" :: Text) (chosenName rt)
+              Left e -> crash ("expected success, got: " <> show e)
+    ]
+
+------------------------------------------------------------------------------
+-- 4. Ambiguity.
+------------------------------------------------------------------------------
+
+testAmbiguity :: Test ()
+testAmbiguity =
+  scope "Two givens of identical type produce Ambiguous" $
+    let g1 = mkGiven "Show.nat.A" [] [] (appOne showC natC) Ambient
+        g2 = mkGiven "Show.nat.B" [] [] (appOne showC natC) Ambient
+        pool = poolFromList [g1, g2]
+     in case resolve pool (appOne showC natC) of
+          Left (Ambiguous _ candidates) ->
+            let names = sort (map (refName . givenName) candidates)
+             in expectEqual (["Show.nat.A", "Show.nat.B"] :: [Text]) names
+          other -> crash ("expected Ambiguous, got: " <> show other)
+
+------------------------------------------------------------------------------
+-- 5. Performance: ~1000 givens, depth-20 chain in <2s.
+------------------------------------------------------------------------------
+
+testPerformance :: Test ()
+testPerformance =
+  scope "1000 givens, depth-20 chain in <2s" $ do
+    let chainCons :: Int -> Ty
+        chainCons k = ref ("Cn" <> tshow k)
+        chainGivens =
+          [ mkGiven
+              ("chain" <> tshow k)
+              []
+              [chainCons (k + 1)]
+              (chainCons k)
+              Ambient
+          | k <- [0 .. 19 :: Int]
+          ]
+        baseGiven = mkGiven "chainBase" [] [] (chainCons 20) Ambient
+        noise =
+          [ mkGiven
+              ("noise" <> tshow k)
+              []
+              []
+              (ref ("Noise" <> tshow k))
+              Ambient
+          | k <- [0 .. 979 :: Int]
+          ]
+        pool = poolFromList (chainGivens ++ [baseGiven] ++ noise)
+        goal = chainCons 0
+    (res, elapsed) <- io $ do
+      t0 <- getCurrentTime
+      let !r = resolve pool goal
+      t1 <- getCurrentTime
+      pure (r, realToFrac (diffUTCTime t1 t0) :: Double)
+    case res of
+      Right _ -> pure ()
+      Left e -> crash ("expected success, got: " <> show e)
+    if elapsed < 2.0
+      then ok
+      else crash ("chain resolved too slowly: " <> show elapsed <> "s")
+
+------------------------------------------------------------------------------
+-- 6. Diamond dependencies don't blow up.
+------------------------------------------------------------------------------
+
+testDiamond :: Test ()
+testDiamond =
+  tests
+    [ scope "Show (Map (List Nat) Nat) memoizes Show Nat exactly once" $
+        -- Givens:
+        --   Show.nat       : Show Nat
+        --   Show.list <a>  : Show a => Show (List a)
+        --   Show.map  <k v>: Show k => Show v => Show (Map k v)
+        --
+        -- Goal: Show (Map (List Nat) Nat). Three distinct sub-goals
+        -- in the dependency tree:
+        --   Show (Map (List Nat) Nat), Show (List Nat), Show Nat
+        let pool =
+              poolFromList
+                [ mkGiven "Show.nat" [] [] (appOne showC natC) Ambient,
+                  mkGiven
+                    "Show.list"
+                    [tvA]
+                    [appOne showC (tv tvA)]
+                    (appOne showC (appOne listC (tv tvA)))
+                    Ambient,
+                  mkGiven
+                    "Show.map"
+                    [tvK, tvV]
+                    [ appOne showC (tv tvK),
+                      appOne showC (tv tvV)
+                    ]
+                    (appOne showC (appTwo mapC (tv tvK) (tv tvV)))
+                    Ambient
+                ]
+            goal =
+              appOne showC (appTwo mapC (appOne listC natC) natC)
+            (res, work) = resolveCounted defaultOptions pool goal
+         in case res of
+              Right rt -> do
+                expectEqual ("Show.map" :: Text) (chosenName rt)
+                expectEqual 3 work
+              Left e -> crash ("expected success, got: " <> show e),
+      scope "Wider diamond: Show (Map (List Nat) (List Nat)) memoizes Show (List Nat) once" $
+        let pool =
+              poolFromList
+                [ mkGiven "Show.nat" [] [] (appOne showC natC) Ambient,
+                  mkGiven
+                    "Show.list"
+                    [tvA]
+                    [appOne showC (tv tvA)]
+                    (appOne showC (appOne listC (tv tvA)))
+                    Ambient,
+                  mkGiven
+                    "Show.map"
+                    [tvK, tvV]
+                    [ appOne showC (tv tvK),
+                      appOne showC (tv tvV)
+                    ]
+                    (appOne showC (appTwo mapC (tv tvK) (tv tvV)))
+                    Ambient
+                ]
+            goal =
+              appOne
+                showC
+                (appTwo mapC (appOne listC natC) (appOne listC natC))
+            (res, work) = resolveCounted defaultOptions pool goal
+         in case res of
+              Right _ ->
+                -- Distinct sub-goals: top-level, Show (List Nat), Show Nat.
+                expectEqual 3 work
+              Left e -> crash ("expected success, got: " <> show e)
+    ]
+
+------------------------------------------------------------------------------
+-- Sanity tests.
+------------------------------------------------------------------------------
+
+testSanity :: Test ()
+testSanity =
+  tests
+    [ scope "Trivial: Show Nat" $
+        let pool = poolFromList [mkGiven "Show.nat" [] [] (appOne showC natC) Ambient]
+         in case resolve pool (appOne showC natC) of
+              Right rt -> expectEqual ("Show.nat" :: Text) (chosenName rt)
+              Left e -> crash ("expected success, got: " <> show e),
+      scope "Chained: Show (List Nat) via Show.list & Show.nat" $
+        let pool =
+              poolFromList
+                [ mkGiven "Show.nat" [] [] (appOne showC natC) Ambient,
+                  mkGiven
+                    "Show.list"
+                    [tvA]
+                    [appOne showC (tv tvA)]
+                    (appOne showC (appOne listC (tv tvA)))
+                    Ambient
+                ]
+            goal = appOne showC (appOne listC natC)
+         in case resolve pool goal of
+              Right rt -> do
+                expectEqual ("Show.list" :: Text) (chosenName rt)
+                case rtChildren rt of
+                  [inner] ->
+                    expectEqual ("Show.nat" :: Text) (chosenName inner)
+                  ps ->
+                    crash ("expected exactly one premise, got: " <> show (length ps))
+              Left e -> crash ("expected success, got: " <> show e),
+      scope "Depth limit triggers a failure" $
+        -- Self requires Self with no base case: with a small depth
+        -- limit, this must fail (either DepthExceeded or NoGiven via
+        -- the per-branch cycle path — both are acceptable).
+        let pool = poolFromList [mkGiven "selfFromSelf" [] [selfC] selfC Ambient]
+            opts = ResolveOptions {optMaxDepth = 5}
+         in case resolveWith opts pool selfC of
+              Left _ -> ok
+              Right t -> crash ("expected failure, got: " <> show t),
+      scope "lexical-inner local given beats ambient" $
+        let local =
+              mkGiven "Ord.flip.local" [] [] (appOne ordC natC) (Lexical 0)
+            ambient =
+              mkGiven "Ord.nat" [] [] (appOne ordC natC) Ambient
+            pool = poolFromList [ambient, local]
+         in case resolve pool (appOne ordC natC) of
+              Right rt -> expectEqual ("Ord.flip.local" :: Text) (chosenName rt)
+              Left e -> crash ("expected success, got: " <> show e)
+    ]

--- a/parser-typechecker/tests/Unison/Test/Typechecker/GivenResolverProperties.hs
+++ b/parser-typechecker/tests/Unison/Test/Typechecker/GivenResolverProperties.hs
@@ -1,0 +1,272 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | Phase-2 chunk D4 property tests for the implicit-resolution
+-- algorithm. Per the chunk spec we exercise:
+--
+--   * /Cycle\/metavar interaction/. The spike's cycle tests are all
+--     ground; this stresses the per-branch cycle short-circuit when
+--     the goal carries an inference variable. The invariant is
+--     /termination plus a structured failure/ — a hang, a runtime
+--     exception, or a 'Right' decision (we built the pool to be
+--     unsolvable) all count as bugs.
+--
+--   * /Diamond + shared metavar/. ADR-023's metavar-invalidation rule
+--     says: when a metavar that appears in a memoized goal becomes
+--     bound, the memo entry is no longer trustworthy. The spike's
+--     diamond test verified the work-count bound on ground goals; we
+--     extend it to the case where the same metavar appears in two
+--     paths through the diamond, and one path resolves it. The
+--     correctness invariant is that both paths agree on the metavar
+--     binding at the end (they reach the same dictionary), or the
+--     resolver reports a structured error — but never a /silently/
+--     wrong choice.
+--
+-- Tests are randomised over a small space of pool shapes; each scope
+-- runs ~25 iterations.
+module Unison.Test.Typechecker.GivenResolverProperties (test) where
+
+import Control.Monad (replicateM)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import EasyTest
+import Unison.Reference (Reference)
+import Unison.Reference qualified as Reference
+import Unison.Symbol (Symbol)
+import Unison.Type (Type)
+import Unison.Type qualified as Type
+import Unison.Typechecker.GivenResolver
+  ( Given (..),
+    ResolutionTree (..),
+    ResolveError (..),
+    Scope (..),
+    defaultOptions,
+    poolFromList,
+    resolve,
+    resolveCounted,
+  )
+import Unison.Var qualified as Var
+
+------------------------------------------------------------------------------
+-- Test entry point
+------------------------------------------------------------------------------
+
+test :: Test ()
+test =
+  scope "GivenResolverProperties" $
+    tests
+      [ scope "cycle-metavar-terminates" propCycleMetavar,
+        scope "diamond-shared-metavar-correctness" propDiamondSharedMetavar
+      ]
+
+------------------------------------------------------------------------------
+-- Helpers
+------------------------------------------------------------------------------
+
+type Ty = Type Symbol ()
+
+ref :: Text -> Ty
+ref = Type.builtin ()
+
+appOne :: Ty -> Ty -> Ty
+appOne = Type.app ()
+
+tv :: Symbol -> Ty
+tv = Type.var ()
+
+mkGiven :: Text -> [Symbol] -> [Ty] -> Ty -> Scope -> Given Symbol ()
+mkGiven name vars premises concl s =
+  Given
+    { givenName = Reference.Builtin name,
+      givenTyVars = vars,
+      givenPremises = premises,
+      givenConclusion = concl,
+      givenScope = s
+    }
+
+-- A user-named (rigid) variable.
+userVar :: Symbol
+userVar = Var.named "a"
+
+------------------------------------------------------------------------------
+-- Property 1: cycle/metavar termination.
+--
+-- Build a randomised pool of givens that contain a mutual cycle. The
+-- goal type is an instantiation of the cycle's outer type with a free
+
+-- * user* variable in some position. (We use a user var rather than an
+
+-- inference var so the resolver attempts proper resolution; otherwise
+-- it short-circuits with UnresolvedMetavarInGoal.)
+--
+-- Invariant: regardless of the cycle shape, the resolver returns in
+-- bounded time with a structured error — it does not hang.
+------------------------------------------------------------------------------
+
+propCycleMetavar :: Test ()
+propCycleMetavar = do
+  -- 25 randomised iterations.
+  _ <- replicateM 25 oneRound
+  pure ()
+  where
+    oneRound :: Test ()
+    oneRound = do
+      -- Pick a cycle length 2..5.
+      n <- int' 2 5
+      -- Build n distinct type constructors C0..Cn-1 plus mutual
+      -- givens. Each Ci-from-Ci+1 (mod n).
+      let ctors = [ref ("C" <> Text.pack (show k)) | k <- [0 .. n - 1]]
+          mutualGivens =
+            [ mkGiven
+                ("from_C" <> Text.pack (show ((k + 1) `mod` n)) <> "_to_C" <> Text.pack (show k))
+                []
+                [ctors !! ((k + 1) `mod` n)]
+                (ctors !! k)
+                Ambient
+            | k <- [0 .. n - 1]
+            ]
+      -- Optionally add a base case that breaks the cycle for one
+      -- ctor — making this a property test of "with-or-without
+      -- escape, the resolver always terminates with a Result".
+      hasEscape <- bool
+      escapeIdx <- int' 0 (n - 1)
+      let baseGiven =
+            [ mkGiven ("base_C" <> Text.pack (show escapeIdx)) [] [] (ctors !! escapeIdx) Ambient
+            | hasEscape
+            ]
+      -- The goal is C0 applied to either nothing or a free user var
+      -- (to exercise the head-unification flex-set logic).
+      paramShape <- int' 0 1
+      let goal = case paramShape of
+            0 -> ctors !! 0
+            _ -> appOne (ctors !! 0) (tv userVar)
+          -- Polymorphic givens that head-match the parametric goal.
+          polyGivens =
+            if paramShape == 1
+              then
+                [ mkGiven
+                    ("poly_from_C" <> Text.pack (show ((k + 1) `mod` n)) <> "_to_C" <> Text.pack (show k))
+                    [userVar]
+                    [appOne (ctors !! ((k + 1) `mod` n)) (tv userVar)]
+                    (appOne (ctors !! k) (tv userVar))
+                    Ambient
+                | k <- [0 .. n - 1]
+                ]
+              else []
+          pool = poolFromList (mutualGivens ++ baseGiven ++ polyGivens)
+      -- Run resolution. Either Right or Left; never hangs (EasyTest
+      -- has no built-in timeout, but unbounded recursion would have
+      -- triggered DepthExceeded by the resolver's optMaxDepth).
+      case resolve pool goal of
+        Right _ ->
+          -- A successful resolve is OK iff there's an escape hatch
+          -- \*or* a polymorphic given chain that head-matches without
+          -- recursing. Both are valid pool shapes.
+          ok
+        Left (NoGiven _ _) -> ok
+        Left (DepthExceeded _) -> ok
+        Left (Cycle _) -> ok
+        Left (Ambiguous _ _) -> ok
+        Left (UnresolvedMetavarInGoal _) ->
+          -- This shouldn't happen since 'a' is a user-typed variable
+          -- (Var.named), not an inference variable.
+          crash "user var should not trigger UnresolvedMetavarInGoal"
+
+------------------------------------------------------------------------------
+-- Property 2: diamond + shared metavar correctness.
+--
+-- A goal whose chain reaches the same sub-goal along multiple paths,
+-- where the sub-goal contains an existential. We assert:
+--
+--   1. The resolver succeeds.
+--   2. The number of distinct memo misses is bounded by the number
+--      of distinct sub-goals in the dependency tree (not the number
+--      of paths). This is the "diamond" property from §4.2#6.
+--   3. The chosen given for the shared sub-goal is the *same* one
+--      regardless of which path reached it (memo consistency).
+--
+-- Test setup: Show (Map (List a) (List a)) for varying ground 'a'.
+-- The dependency tree visits Show (List a) along two paths (key and
+-- value of the Map); the shared sub-goal appears once.
+------------------------------------------------------------------------------
+
+propDiamondSharedMetavar :: Test ()
+propDiamondSharedMetavar = do
+  -- 25 randomised iterations across a few choices of ground 'a'.
+  _ <- replicateM 25 oneRound
+  pure ()
+  where
+    oneRound :: Test ()
+    oneRound = do
+      -- Pick a ground type for the inner element.
+      groundIdx <- int' 0 2
+      let groundTy = case groundIdx of
+            0 -> ref "Nat"
+            1 -> ref "Text"
+            _ -> ref "Boolean"
+          showC = ref "Show"
+          listC = ref "List"
+          mapC = ref "Map"
+          tvA = Var.named "a"
+          tvK = Var.named "k"
+          tvV = Var.named "v"
+          showNat = mkGiven "Show.nat" [] [] (appOne showC (ref "Nat")) Ambient
+          showText = mkGiven "Show.text" [] [] (appOne showC (ref "Text")) Ambient
+          showBoolean = mkGiven "Show.boolean" [] [] (appOne showC (ref "Boolean")) Ambient
+          showList =
+            mkGiven
+              "Show.list"
+              [tvA]
+              [appOne showC (tv tvA)]
+              (appOne showC (appOne listC (tv tvA)))
+              Ambient
+          showMap =
+            mkGiven
+              "Show.map"
+              [tvK, tvV]
+              [appOne showC (tv tvK), appOne showC (tv tvV)]
+              (appOne showC (Type.app () (Type.app () mapC (tv tvK)) (tv tvV)))
+              Ambient
+          pool =
+            poolFromList
+              [showNat, showText, showBoolean, showList, showMap]
+          -- Show (Map (List a) (List a)) where 'a' is the chosen ground.
+          goal =
+            appOne
+              showC
+              ( Type.app
+                  ()
+                  ( Type.app
+                      ()
+                      mapC
+                      (appOne listC groundTy)
+                  )
+                  (appOne listC groundTy)
+              )
+      let (res, work) = resolveCounted defaultOpts pool goal
+      case res of
+        Right tree -> do
+          -- Distinct sub-goals visited: top-level Show (Map ...),
+          -- Show (List <ground>), Show <ground>. So 3 memo misses.
+          expectEqual 3 work
+          -- Both children of Show.map must be the same Show.list
+          -- chosen the same way. The shared metavar (a := <ground>)
+          -- got bound at the first child; ADR-023 says the second
+          -- visit reuses the memoized success.
+          case rtChildren tree of
+            [child1, child2] -> do
+              expectEqual (givenName (rtGiven child1)) (givenName (rtGiven child2))
+              -- And the two trees must have the same (single) child:
+              -- Show <ground>, with the chosen ground-given.
+              expectEqual
+                (childChosen child1)
+                (childChosen child2)
+            other -> crash ("expected 2 children, got: " <> show (length other))
+        Left e -> crash ("expected success, got: " <> show e)
+
+    childChosen :: ResolutionTree Symbol () -> Maybe Reference
+    childChosen rt = case rtChildren rt of
+      [c] -> Just (givenName (rtGiven c))
+      _ -> Nothing
+
+    defaultOpts = defaultOptions

--- a/parser-typechecker/tests/Unison/Test/Typechecker/ImplicitErrorRendering.hs
+++ b/parser-typechecker/tests/Unison/Test/Typechecker/ImplicitErrorRendering.hs
@@ -1,0 +1,216 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | Phase-2 chunk D4 message-rendering tests for the four (plus one)
+-- implicit-resolution error categories. These tests exercise
+-- 'Unison.PrintError.printNoteWithSource' on hand-built
+-- 'Result.UnresolvedImplicit' notes, and assert the rendered output
+-- contains category-specific phrases plus the relevant supporting
+-- detail (near-miss listing, candidate listing, chain rendering, etc.).
+--
+-- This is the assert-message variant of "≥4 distinct golden-file
+-- tests" called for in the chunk spec. Asserting on substrings rather
+-- than full byte-for-byte goldens keeps the tests robust to
+-- color-text and word-wrap perturbations while still verifying the
+-- user-visible categorical distinctions are present.
+module Unison.Test.Typechecker.ImplicitErrorRendering (test) where
+
+import Data.List (isInfixOf)
+import Data.Text qualified as Text
+import EasyTest
+import Unison.Parser.Ann (Ann (..))
+import Unison.PrettyPrintEnv qualified as PPE
+import Unison.PrintError qualified as PrintError
+import Unison.Reference qualified as Reference
+import Unison.Result qualified as Result
+import Unison.Symbol (Symbol)
+import Unison.Type qualified as Type
+import Unison.Typechecker.GivenResolver
+  ( Given (..),
+    NearMiss (..),
+    ResolveError (..),
+    Scope (..),
+  )
+import Unison.Util.ColorText qualified as Color
+import Unison.Util.Pretty qualified as Pr
+import Unison.Var qualified as Var
+
+------------------------------------------------------------------------------
+-- Test entry point
+------------------------------------------------------------------------------
+
+test :: Test ()
+test =
+  scope "ImplicitErrorRendering" $
+    tests
+      [ scope "NoGiven-with-near-miss" testNoGivenNearMiss,
+        scope "Ambiguous-lists-candidates" testAmbiguous,
+        scope "DepthExceeded-shows-chain" testDepthExceeded,
+        scope "Cycle-shows-cycle" testCycle,
+        scope "UnresolvedMetavarInGoal-suggests-annotation" testUnresolvedMetavar
+      ]
+
+------------------------------------------------------------------------------
+-- Helpers
+------------------------------------------------------------------------------
+
+renderPlain :: Result.Note Symbol Ann -> String
+renderPlain note =
+  Text.unpack
+    . Color.toPlain
+    . Pr.render PrintError.defaultWidth
+    $ PrintError.printNoteWithSource PPE.empty source note
+  where
+    -- A small bit of source so the location-hint code has something
+    -- to point at. We don't assert on the source highlighting itself —
+    -- only on the structured text the renderer emits — so any source
+    -- string suffices.
+    source = "x = 0\n"
+
+-- | Check that each needle appears in the rendered output.
+-- Whitespace in the haystack is normalised (newlines become spaces,
+-- consecutive spaces collapse) so that word-wrap doesn't perturb
+-- match expectations. Needles must therefore be written without
+-- newlines.
+containsAll :: String -> [String] -> Test ()
+containsAll rendered needles = do
+  let normalised = unwords (words rendered)
+      missing = filter (not . (`isInfixOf` normalised)) needles
+  if null missing
+    then ok
+    else
+      crash $
+        "rendered output missing expected substrings: "
+          <> show missing
+          <> "\nfull output:\n"
+          <> rendered
+
+------------------------------------------------------------------------------
+-- Scenario builders
+------------------------------------------------------------------------------
+
+showC, listC, natC :: Type.Type Symbol Ann
+showC = Type.builtin External "Show"
+listC = Type.builtin External "List"
+natC = Type.builtin External "Nat"
+
+showListT :: Type.Type Symbol Ann
+showListT = Type.app External showC listC
+
+goalShowListNat :: Type.Type Symbol Ann
+goalShowListNat = Type.app External showC (Type.app External listC natC)
+
+mkGivenA :: Text.Text -> [Type.Type Symbol Ann] -> Type.Type Symbol Ann -> Given Symbol Ann
+mkGivenA name premises concl =
+  Given
+    { givenName = Reference.Builtin name,
+      givenTyVars = [],
+      givenPremises = premises,
+      givenConclusion = concl,
+      givenScope = Ambient
+    }
+
+------------------------------------------------------------------------------
+-- 1. NoGiven with one near-miss whose nested reason is also NoGiven.
+------------------------------------------------------------------------------
+
+testNoGivenNearMiss :: Test ()
+testNoGivenNearMiss =
+  let inner =
+        NearMiss
+          (mkGivenA "Show.list" [Type.app External showC natC] showListT)
+          (NoGiven (Type.app External showC natC) [])
+      err = NoGiven goalShowListNat [inner]
+      note = Result.UnresolvedImplicit External goalShowListNat err
+      rendered = renderPlain note
+   in containsAll
+        rendered
+        [ "couldn't find a",
+          "given",
+          "Show.list",
+          "failed because",
+          "no given for"
+        ]
+
+------------------------------------------------------------------------------
+-- 2. Ambiguous: two named candidates that both head-match.
+------------------------------------------------------------------------------
+
+testAmbiguous :: Test ()
+testAmbiguous =
+  let g1 = mkGivenA "Show.nat.A" [] (Type.app External showC natC)
+      g2 = mkGivenA "Show.nat.B" [] (Type.app External showC natC)
+      err = Ambiguous (Type.app External showC natC) [g1, g2]
+      note = Result.UnresolvedImplicit External (Type.app External showC natC) err
+      rendered = renderPlain note
+   in containsAll
+        rendered
+        [ "multiple",
+          "ambiguous",
+          "Show.nat.A",
+          "Show.nat.B"
+        ]
+
+------------------------------------------------------------------------------
+-- 3. DepthExceeded: a long chain (truncated by the renderer if needed).
+------------------------------------------------------------------------------
+
+testDepthExceeded :: Test ()
+testDepthExceeded =
+  let chain =
+        [ Type.builtin External (Text.pack ("Step" <> show k))
+        | k <- [0 .. 14 :: Int]
+        ]
+      err :: ResolveError Symbol Ann
+      err = DepthExceeded chain
+      note = Result.UnresolvedImplicit External (head chain) err
+      rendered = renderPlain note
+   in containsAll
+        rendered
+        [ "exceeded the maximum depth",
+          "Step0",
+          -- The renderer shows head and tail; Step14 (last) should
+          -- appear regardless of truncation.
+          "Step14"
+        ]
+
+------------------------------------------------------------------------------
+-- 4. Cycle: explicit hard-cycle diagnosis with the cycle path.
+------------------------------------------------------------------------------
+
+testCycle :: Test ()
+testCycle =
+  let cycleChain =
+        [ Type.builtin External "Foo",
+          Type.builtin External "Bar",
+          Type.builtin External "Foo"
+        ]
+      err :: ResolveError Symbol Ann
+      err = Cycle cycleChain
+      note = Result.UnresolvedImplicit External (head cycleChain) err
+      rendered = renderPlain note
+   in containsAll
+        rendered
+        [ "cycle",
+          "Foo",
+          "Bar"
+        ]
+
+------------------------------------------------------------------------------
+-- 5. UnresolvedMetavarInGoal: distinct user-visible message.
+------------------------------------------------------------------------------
+
+testUnresolvedMetavar :: Test ()
+testUnresolvedMetavar =
+  let inferVar :: Symbol
+      inferVar = Var.inferOther
+      goal = Type.app External showC (Type.var External inferVar)
+      err :: ResolveError Symbol Ann
+      err = UnresolvedMetavarInGoal goal
+      note = Result.UnresolvedImplicit External goal err
+      rendered = renderPlain note
+   in containsAll
+        rendered
+        [ "unsolved type variable",
+          "Add a type annotation"
+        ]

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.38.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -41,6 +41,7 @@ library
       Unison.Codebase.Editor.DisplayObject
       Unison.Codebase.Editor.RemoteRepo
       Unison.Codebase.FileCodebase
+      Unison.Codebase.Givens
       Unison.Codebase.Init
       Unison.Codebase.Init.CreateCodebaseError
       Unison.Codebase.Init.OpenCodebaseError
@@ -137,6 +138,9 @@ library
       Unison.Typechecker.Context
       Unison.Typechecker.Context.Structure
       Unison.Typechecker.Extractor
+      Unison.Typechecker.GivenApply
+      Unison.Typechecker.GivenElaborator
+      Unison.Typechecker.GivenResolver
       Unison.Typechecker.TypeError
       Unison.Typechecker.TypeLookup
       Unison.Typechecker.TypeVar
@@ -263,19 +267,29 @@ test-suite parser-typechecker-tests
       Unison.Test.ABT
       Unison.Test.Codebase.Branch
       Unison.Test.Codebase.Causal
+      Unison.Test.Codebase.Givens
       Unison.Test.Codebase.Path
       Unison.Test.CodebaseInit
       Unison.Test.Common
       Unison.Test.DataDeclaration
       Unison.Test.Referent
       Unison.Test.Syntax.FileParser
+      Unison.Test.Syntax.ImplicitParser
+      Unison.Test.Syntax.ImplicitPrinter
       Unison.Test.Syntax.TermParser
+      Unison.Test.Syntax.TypeParser
       Unison.Test.Syntax.TypePrinter
       Unison.Test.Term
       Unison.Test.Type
       Unison.Test.Typechecker
       Unison.Test.Typechecker.Components
       Unison.Test.Typechecker.Context
+      Unison.Test.Typechecker.GivenApply
+      Unison.Test.Typechecker.GivenDecl
+      Unison.Test.Typechecker.GivenElaborator
+      Unison.Test.Typechecker.GivenResolver
+      Unison.Test.Typechecker.GivenResolverProperties
+      Unison.Test.Typechecker.ImplicitErrorRendering
       Unison.Test.Typechecker.TypeError
       Unison.Test.Util.Pretty
       Unison.Test.Util.Relation
@@ -325,6 +339,7 @@ test-suite parser-typechecker-tests
     , raw-strings-qq
     , temporary
     , text
+    , time
     , unison-core
     , unison-core1
     , unison-hash

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -41,6 +41,7 @@ library
       Unison.Codebase.Editor.DisplayObject
       Unison.Codebase.Editor.RemoteRepo
       Unison.Codebase.FileCodebase
+      Unison.Codebase.Classes
       Unison.Codebase.Givens
       Unison.Codebase.Init
       Unison.Codebase.Init.CreateCodebaseError

--- a/spike/implicits/FINDINGS.md
+++ b/spike/implicits/FINDINGS.md
@@ -1,0 +1,112 @@
+# Phase 1 spike — findings
+
+This is the Phase 1 gate writeup required by `docs/implicits-plan.md` §4.4.
+
+## Status
+
+All six spike success criteria from `docs/implicits-plan.md` §4.2 are
+demonstrated. 15 test cases under `tasty` + `tasty-hunit`, all passing on
+GHC 9.10.3.
+
+```
+implicit-resolution spike
+  1. cycles terminate                                  2/2 OK
+  2. specificity ordering                              2/2 OK
+  3. HKT support                                       3/3 OK
+  4. ambiguity                                         1/1 OK
+  5. performance (1000 givens, depth-20 chain) <2s     1/1 OK
+  6. diamond dependencies                              2/2 OK
+  sanity                                               4/4 OK
+```
+
+Performance: 1000-given pool with depth-20 chain resolves in
+sub-millisecond. Dominant cost is the O(n) head-unification scan over
+candidates; a conclusion-keyed index would fix it if it ever matters in
+production.
+
+## What worked
+
+- The `docs/implicits-plan.md` §1.3 algorithm translated almost
+  line-by-line into ~280 lines of Haskell. One `State` monad threads the
+  fresh-supply, memo, and work counter.
+- HKT works for free with curried `TApp`; no kind machinery needed in
+  the resolver. Matches ADR 011's claim.
+- Per-branch cycle detection via in-flight goal stack handles
+  `Foo<->Bar` mutual recursion without hanging; sibling alternatives
+  still succeed.
+- Memoization keyed on the substitution-applied goal, scoped to one
+  top-level `resolve`, decisively handles diamond dependencies.
+  Instrumented `resolveCounted` confirms `Show (Map (List Nat) Nat)`
+  solves exactly 3 distinct sub-goals (top, `Show (List Nat)`, `Show
+  Nat`).
+
+## Surprises
+
+- **Specificity must compare *un-specialised* (alpha-renamed but not yet
+  unified) conclusions.** First pass compared the post-unification
+  conclusions, but those equal the goal by construction — they
+  head-unified with it. Fix was to retain `candFreshConclusion` on each
+  candidate. *Plan implication: ADR 008 wording is ambiguous on this
+  point — see refinement below.*
+- Cycle hits use `unify`, not `==`, to catch alpha-renamed cycles.
+  Correct, but it can spuriously fire when an outer goal has unresolved
+  metavars. Warrants a property test in Phase 2.D.
+- Candidate freshening must happen on *every* match attempt, before
+  head-unification, to avoid one candidate inheriting variable bindings
+  from another.
+- `tasty` was zero-friction. `easytest` would have been fine but
+  `tasty`'s grouped streaming output suited criterion-by-criterion
+  validation.
+
+## What the plan should refine
+
+1. **Tighten ADR 008 (specificity).** "σ(B) = A and σ ≠ identity" is
+   ambiguous about (a) whether to compare declared or specialised
+   conclusions and (b) which side's variables σ may touch. The right
+   rule is: compare alpha-renamed *declared* conclusions, with σ only
+   allowed to substitute B's quantified variables (A's are treated as
+   rigid). The spike's `oneWayMatch` does this; full `unify` would be
+   too permissive and reverse the asymmetry.
+
+2. **Add ADR 023 — memoization scope and cache-key shape.** §4.2#6
+   mentions memoization as a property but doesn't specify what gets
+   memoized (failures? successes? both?), nor how cache keys handle
+   metavariables. Recommendation: per top-level resolve, key = zonked
+   goal type, cache successes and failures alike. Sub-goals containing
+   free metavars (which they will, before TDNR pins types down) need an
+   explicit story.
+
+3. **`NearMiss` should carry the unifying substitution**, not just the
+   given. "Near-miss: `Show.list` with `a := Nat`" is more useful than
+   just `Show.list`.
+
+4. **Extend `ResolveError` with `Cycle [Ty]`.** The §1.3 pseudo-code
+   says "fail this branch" but doesn't specify the error variant. The
+   spike used `NoGiven goal []`, which technically works but conflates
+   "no instance" with "instance exists but cyclic". Phase 2.D should
+   distinguish these for diagnostic clarity.
+
+## Phase 2 readiness
+
+No ADR-level showstoppers. Data model translates cleanly:
+
+| Spike type           | Phase 2 home                                                  |
+|----------------------|---------------------------------------------------------------|
+| `Ty`                 | `Unison.Type.Type v loc`                                      |
+| `Given`              | record keyed on dictionary `Reference`                        |
+| `Pool`               | snapshot from the threaded lexical-given-environment (2.C.2)  |
+| `ResolutionTree`     | fed into an `applyTdnrDecisions`-shaped post-pass (2.D)       |
+| `ResolveError`       | structured error notes consumed by the existing renderer (4)  |
+
+Recommend opening **ADR 023** and tightening **ADR 008** before Phase 2
+kickoff. Both are clarifications, not direction changes.
+
+## Reproducing
+
+```sh
+cd spike/implicits
+cabal test
+```
+
+Requires GHC 9.10.3 (matches the rest of the repo per `stack.yaml`'s
+LTS-24.21).

--- a/spike/implicits/README.md
+++ b/spike/implicits/README.md
@@ -1,0 +1,72 @@
+# `unison-implicits-spike`
+
+Phase 1 spike for Unison's implicit-parameters feature. **This is throwaway
+code**: a standalone Haskell package whose only purpose is to validate the
+resolution algorithm described in
+[`docs/implicits-plan.md`](../../docs/implicits-plan.md), sections 1.3 and 4,
+before any production code is touched.
+
+It is intentionally isolated from the main build:
+
+- Not listed in the top-level `stack.yaml`.
+- Has its own `cabal.project` (pinned to GHC 9.10.3 to match `lts-24.21`,
+  but compiles on 9.6+).
+- Depends only on `base`, `containers`, `tasty`, `tasty-hunit`, `time`. It does
+  *not* depend on any other Unison package.
+
+## Building and testing
+
+```sh
+cd spike/implicits
+cabal test
+```
+
+If your system has a different GHC, edit `cabal.project` (`with-compiler:`)
+or remove that line entirely.
+
+## What it validates
+
+All six success criteria from §4.2 of the plan:
+
+1. **Cycles terminate.** Per-branch cycle detection via a stack of in-flight
+   goals.
+2. **Specificity ordering.** Subsumption (more-specific wins) plus
+   lexical-inner-wins for local givens.
+3. **HKT.** Higher-kinded givens resolve when the type representation is
+   curried application (`TApp`).
+4. **Ambiguity.** Two unrelated givens of the same type produce an
+   `Ambiguous` error listing both.
+5. **Performance.** A pool of ~1000 givens with chains ~20 deep resolves in
+   well under a second on commodity hardware.
+6. **Diamond dependencies.** Sub-results are memoized within a single
+   top-level resolution; the same goal type is solved exactly once even
+   when reached along multiple chain paths. Verified via an instrumented
+   counter exposed by `resolveCounted`.
+
+## Layout
+
+```
+spike/implicits/
+  unison-implicits-spike.cabal
+  cabal.project
+  README.md
+  src/
+    Implicits/Types.hs   -- Ty, Given, Pool, ResolutionTree, errors
+    Implicits/Unify.hs   -- Robinson's algorithm over Ty
+    Implicits/Resolve.hs -- the resolution algorithm proper
+  test/
+    Main.hs              -- tasty + tasty-hunit, six success criteria
+```
+
+The Phase 1 gate writeup ("what worked / surprises / plan refinements")
+is delivered separately alongside this spike rather than committed as
+a file here. See the parent task's response.
+
+## Non-goals
+
+- Not tied to Unison's real `Type.F`. The mock `Ty` is plain enough for
+  unification + HKT without smuggling in ABT, kinds, abilities, etc.
+- No parser. Pools are hand-built in tests.
+- No namespace concept. The `Scope` field on a given is `Lexical Int |
+  Ambient`; nothing else.
+- No TDNR integration. None of the production code is touched.

--- a/spike/implicits/cabal.project
+++ b/spike/implicits/cabal.project
@@ -1,0 +1,8 @@
+-- Standalone cabal project for the implicits resolution spike.
+-- Not connected to the main Unison build (no stack.yaml entry).
+--
+-- Pinned to GHC 9.10.3 to mirror lts-24.21 used by the main build,
+-- but the code is plain enough to compile on any 9.6+ GHC.
+with-compiler: ghc-9.10.3
+
+packages: .

--- a/spike/implicits/src/Implicits/Resolve.hs
+++ b/spike/implicits/src/Implicits/Resolve.hs
@@ -1,0 +1,359 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+-- | The implicit-resolution algorithm itself.
+--
+-- Implements the pseudocode of @docs/implicits-plan.md@ §1.3:
+--
+-- @
+--   resolve(T, stack, depth) =
+--     if depth > maxDepth: error DepthExceeded(stack)
+--     if any(unifies(T, S)) for S in stack: fail this branch (cycle)
+--     candidates = { g | conclusion(g) unifies with T under sigma }
+--     ... try each, picking most-specific or reporting ambiguity
+-- @
+--
+-- Plus the spike-specific success criteria from §4.2: per-resolution
+-- memoization for diamond dependencies, a parameterised depth limit, and
+-- an instrumented variant ('resolveCounted') that returns how many
+-- distinct sub-goals were actually solved (so tests can assert the
+-- diamond memoization bound).
+module Implicits.Resolve
+  ( -- * Entry points
+    resolve,
+    resolveWith,
+    resolveCounted,
+
+    -- * Parameters
+    ResolveOptions (..),
+    defaultOptions,
+  )
+where
+
+import Control.Monad.State.Strict
+import qualified Data.IntMap.Strict as IntMap
+import Data.List (foldl1')
+import qualified Data.Map.Strict as Map
+import Implicits.Types
+import Implicits.Unify
+
+------------------------------------------------------------------------------
+-- Options
+------------------------------------------------------------------------------
+
+data ResolveOptions = ResolveOptions
+  { -- | Maximum chain depth before bailing with 'DepthExceeded'. Default
+    -- 50 per ADR 009.
+    optMaxDepth :: !Int
+  }
+  deriving stock (Eq, Show)
+
+defaultOptions :: ResolveOptions
+defaultOptions = ResolveOptions {optMaxDepth = 50}
+
+------------------------------------------------------------------------------
+-- Resolution monad
+------------------------------------------------------------------------------
+
+-- | All the bookkeeping a single top-level 'resolve' call carries.
+data RState = RState
+  { -- | Fresh-variable supply. Starts well above any user-supplied
+    -- 'TyVar' integer; we also re-freshen on every candidate match so
+    -- collisions are impossible in practice.
+    sNext :: !Int,
+    -- | Memoization table: mapping fully-substituted goal type to its
+    -- resolution. Cleared between top-level 'resolve' calls. Keying on
+    -- the goal-as-given is the diamond-dependency property of success
+    -- criterion #6 — a sub-goal like @Show Nat@ reached along multiple
+    -- chain paths is solved exactly once.
+    sMemo :: !(Map.Map Ty (Either ResolveError ResolutionTree)),
+    -- | Number of memo *misses* (i.e. distinct sub-goals actually
+    -- attempted). Exposed via 'resolveCounted' so tests can verify the
+    -- diamond bound.
+    sWork :: !Int,
+    -- | Resolution options.
+    sOpts :: !ResolveOptions,
+    -- | Pool of available givens, threaded through the state so we can
+    -- recurse without an extra Reader.
+    sPool :: !Pool
+  }
+
+type R = State RState
+
+initialState :: ResolveOptions -> Pool -> RState
+initialState opts pool =
+  RState
+    { sNext = 1000000000, -- well above anything a user constructs
+      sMemo = Map.empty,
+      sWork = 0,
+      sOpts = opts,
+      sPool = pool
+    }
+
+bumpWork :: R ()
+bumpWork = modify' $ \st -> st {sWork = sWork st + 1}
+
+-- | Lift a 'Supply' computation into 'R', threading the fresh-variable
+-- counter through the resolver state.
+withSupply :: Supply a -> R a
+withSupply m = do
+  st <- get
+  let (a, n') = runState m (sNext st)
+  put st {sNext = n'}
+  pure a
+
+------------------------------------------------------------------------------
+-- Top-level entry points
+------------------------------------------------------------------------------
+
+-- | Resolve a goal in the given pool with default options.
+resolve :: Pool -> Ty -> Either ResolveError ResolutionTree
+resolve = resolveWith defaultOptions
+
+-- | Resolve with explicit options.
+resolveWith :: ResolveOptions -> Pool -> Ty -> Either ResolveError ResolutionTree
+resolveWith opts pool goal = fst (resolveCounted opts pool goal)
+
+-- | Resolve and also return the number of distinct sub-resolution
+-- *attempts* (memo misses). Used by tests to verify the diamond bound:
+-- for a goal whose chain reaches @n@ unique sub-types, the work count
+-- equals @n@ even when those types occur along multiple paths.
+resolveCounted ::
+  ResolveOptions ->
+  Pool ->
+  Ty ->
+  (Either ResolveError ResolutionTree, Int)
+resolveCounted opts pool goal =
+  let (result, finalSt) = runState (resolveImpl goal [] 0) (initialState opts pool)
+   in (result, sWork finalSt)
+
+------------------------------------------------------------------------------
+-- The algorithm
+------------------------------------------------------------------------------
+
+-- | Recursive resolution worker. Parameters:
+--
+-- * @goal@ — the type to resolve.
+-- * @stack@ — outer goals currently in flight on this branch (for
+--   per-branch cycle detection, §1.3).
+-- * @depth@ — current depth (for the global limit).
+resolveImpl :: Ty -> [Ty] -> Int -> R (Either ResolveError ResolutionTree)
+resolveImpl goal stack depth = do
+  opts <- gets sOpts
+  if depth > optMaxDepth opts
+    then pure (Left (DepthExceeded (reverse (goal : stack))))
+    else do
+      -- Per-branch cycle detection: if any in-flight goal unifies with
+      -- the new goal, *this branch* fails. Other candidates may still
+      -- succeed; the overall query may still succeed via a non-cyclic
+      -- alternative.
+      if any (cycleHit goal) stack
+        then pure (Left (NoGiven goal []))
+        else do
+          memo <- gets sMemo
+          case Map.lookup goal memo of
+            Just hit -> pure hit
+            Nothing -> do
+              bumpWork
+              result <- attemptCandidates goal stack depth
+              modify' $ \st -> st {sMemo = Map.insert goal result (sMemo st)}
+              pure result
+
+-- | Two types are "the same in-flight goal" iff they unify under the
+-- empty substitution. Stricter than '==' (catches alpha-renamed cycles)
+-- but cheap enough to do once per stack entry.
+cycleHit :: Ty -> Ty -> Bool
+cycleHit a b = case unify emptySubst a b of
+  Just _ -> True
+  Nothing -> False
+
+-- | Try every given in the pool that head-unifies with the goal, then
+-- pick the unique winner.
+attemptCandidates ::
+  Ty ->
+  [Ty] ->
+  Int ->
+  R (Either ResolveError ResolutionTree)
+attemptCandidates goal stack depth = do
+  pool <- gets sPool
+  -- Step 1: head-unify each candidate with the goal.
+  candidates0 <- mapMaybeM (matchHead goal) (poolGivens pool)
+  -- Step 2: recursively resolve each candidate's premises. A candidate
+  -- whose premises don't all resolve becomes a near-miss.
+  attempts <- mapM (tryCandidate goal stack depth) candidates0
+  let (nearMisses, successes) = partitionAttempts attempts
+  case successes of
+    [] -> pure (Left (NoGiven goal nearMisses))
+    [single] -> pure (Right (rebuildTree single))
+    multiple -> pure (decideMostSpecific goal multiple)
+
+-- | A candidate that has passed head-unification but not yet had its
+-- premises resolved.
+data Candidate = Candidate
+  { candGiven :: !Given,
+    -- | Premises after freshening + head-unification substitution.
+    candPremises :: ![Ty],
+    -- | Specialised conclusion (matches the goal under unification).
+    candConclusion :: !Ty,
+    -- | Conclusion *before* head-unification, but *after* freshening.
+    -- Used for specificity comparison: two candidates' specialised
+    -- conclusions are equal at the goal, so we compare the shape they
+    -- had before specialisation.
+    candFreshConclusion :: !Ty
+  }
+
+data Attempt
+  = Miss !NearMiss
+  | Hit !Candidate ![ResolutionTree]
+
+partitionAttempts :: [Attempt] -> ([NearMiss], [(Candidate, [ResolutionTree])])
+partitionAttempts = foldr step ([], [])
+  where
+    step (Miss m) (ms, hs) = (m : ms, hs)
+    step (Hit c rs) (ms, hs) = (ms, (c, rs) : hs)
+
+rebuildTree :: (Candidate, [ResolutionTree]) -> ResolutionTree
+rebuildTree (c, prems) =
+  ResolutionTree
+    { rtChosen = candGiven c,
+      rtSpecialisedConclusion = candConclusion c,
+      rtPremises = prems
+    }
+
+-- | Head-unify a single given's conclusion with the goal. If they
+-- unify, return a 'Candidate' with freshened quantified variables and
+-- the head-unification substitution applied.
+matchHead :: Ty -> Given -> R (Maybe Candidate)
+matchHead goal g = do
+  let Given {givenTyVars, givenPremises, givenConclusion} = g
+  (premises', concl') <- withSupply (freshen givenTyVars givenPremises givenConclusion)
+  case unify emptySubst concl' goal of
+    Nothing -> pure Nothing
+    Just s ->
+      pure $
+        Just
+          Candidate
+            { candGiven = g,
+              candPremises = map (applySubst s) premises',
+              candConclusion = applySubst s concl',
+              candFreshConclusion = concl'
+            }
+
+-- | Resolve every premise of a candidate. If they all succeed, return a
+-- 'Hit'; the first failing premise turns the whole candidate into a
+-- 'Miss'.
+tryCandidate :: Ty -> [Ty] -> Int -> Candidate -> R Attempt
+tryCandidate goal stack depth cand =
+  let stack' = goal : stack
+   in go [] (candPremises cand) stack' depth
+  where
+    go acc [] _ _ = pure (Hit cand (reverse acc))
+    go acc (p : ps) stk d = do
+      sub <- resolveImpl p stk (d + 1)
+      case sub of
+        Right tree -> go (tree : acc) ps stk d
+        Left err -> pure (Miss (NearMiss (candGiven cand) err))
+
+------------------------------------------------------------------------------
+-- Specificity ordering
+------------------------------------------------------------------------------
+
+-- | Decide the unique winner among candidates whose premises all
+-- resolved. Ordering rules from §1.3:
+--
+--   * Lexical proximity: smaller 'Lexical' beats larger; both beat
+--     'Ambient'. (The 'Ord Scope' instance already encodes this.)
+--   * Subsumption: if one candidate's conclusion is a strict instance
+--     of another's, the more-specific one wins.
+--   * If neither rule produces a unique maximum, return 'Ambiguous'.
+decideMostSpecific ::
+  Ty ->
+  [(Candidate, [ResolutionTree])] ->
+  Either ResolveError ResolutionTree
+decideMostSpecific goal hits =
+  let -- Step 1: keep only the most-inner-scoped survivors.
+      best = filterMostInner hits
+   in case best of
+        [single] -> Right (rebuildTree single)
+        multiple ->
+          -- Step 2: among them, drop any that are strictly subsumed
+          -- by another candidate (i.e., another candidate is more
+          -- specific). What remains should be a single most-specific
+          -- candidate; if not, it's ambiguous.
+          case filter (notStrictlySubsumedIn multiple) multiple of
+            [single] -> Right (rebuildTree single)
+            ambiguous ->
+              Left
+                ( Ambiguous
+                    goal
+                    (map (candGiven . fst) ambiguous)
+                )
+
+filterMostInner ::
+  [(Candidate, [ResolutionTree])] ->
+  [(Candidate, [ResolutionTree])]
+filterMostInner [] = []
+filterMostInner xs =
+  let scopeKey = givenScope . candGiven . fst
+      best = foldl1' min (map scopeKey xs)
+   in filter ((== best) . scopeKey) xs
+
+-- | True iff no *other* candidate is strictly more specific than this
+-- one.
+notStrictlySubsumedIn ::
+  [(Candidate, [ResolutionTree])] ->
+  (Candidate, [ResolutionTree]) ->
+  Bool
+notStrictlySubsumedIn others me =
+  not (any (`strictlyMoreSpecific` me) others)
+
+-- | @a `strictlyMoreSpecific` b@ iff @a@'s conclusion is a strict
+-- instance of @b@'s conclusion: i.e., @b@ pattern-matches @a@ (so @b@
+-- is more general) and @a@ does not pattern-match @b@.
+strictlyMoreSpecific ::
+  (Candidate, [ResolutionTree]) ->
+  (Candidate, [ResolutionTree]) ->
+  Bool
+strictlyMoreSpecific (a, _) (b, _)
+  | candGiven a == candGiven b = False
+  | otherwise =
+      -- Compare on the *fresh, un-specialised* conclusions: post-
+      -- unification, both candidates' specialised conclusions equal
+      -- the goal and carry no information.
+      let ca = candFreshConclusion a
+          cb = candFreshConclusion b
+          bMatchesA = case oneWayMatch cb ca of Just _ -> True; Nothing -> False
+          aMatchesB = case oneWayMatch ca cb of Just _ -> True; Nothing -> False
+       in bMatchesA && not aMatchesB
+
+-- | One-way structural match: is there a substitution σ with σ(pat) =
+-- target, treating only pat's free variables as unifiable? (Variables
+-- in @target@ are treated as rigid constants.)
+oneWayMatch :: Ty -> Ty -> Maybe Subst
+oneWayMatch pat target = go IntMap.empty pat target
+  where
+    go s a b = case (a, b) of
+      (TVar (TyVar i), _) ->
+        case IntMap.lookup i s of
+          Just t' -> if t' == b then Just s else Nothing
+          Nothing -> Just (IntMap.insert i b s)
+      (TCon c1, TCon c2)
+        | c1 == c2 -> Just s
+        | otherwise -> Nothing
+      (TApp f1 x1, TApp f2 x2) -> do
+        s1 <- go s f1 f2
+        go s1 x1 x2
+      _ -> Nothing
+
+------------------------------------------------------------------------------
+-- Helpers
+------------------------------------------------------------------------------
+
+mapMaybeM :: (Monad m) => (a -> m (Maybe b)) -> [a] -> m [b]
+mapMaybeM f = go []
+  where
+    go acc [] = pure (reverse acc)
+    go acc (x : xs) = do
+      mb <- f x
+      case mb of
+        Just b -> go (b : acc) xs
+        Nothing -> go acc xs

--- a/spike/implicits/src/Implicits/Types.hs
+++ b/spike/implicits/src/Implicits/Types.hs
@@ -1,0 +1,194 @@
+-- | Mock AST and supporting types for the implicit-resolution spike.
+--
+-- See @docs/implicits-plan.md@ §1.3 and §4. None of this is intended to
+-- match Unison's real 'Unison.Type.F' — it is just rich enough to exercise
+-- unification with higher-kinded constructors.
+module Implicits.Types
+  ( -- * Mock type AST
+    Ty (..),
+    TyVar (..),
+    ConName (..),
+
+    -- * Givens
+    Given (..),
+    Scope (..),
+    Pool (..),
+    poolFromList,
+
+    -- * Resolution result
+    ResolutionTree (..),
+    ResolveError (..),
+    NearMiss (..),
+
+    -- * Substitutions (used by Unify and Resolve)
+    Subst,
+    emptySubst,
+
+    -- * Helpers
+    freeTyVars,
+    applySubst,
+    showTy,
+  )
+where
+
+import Data.IntMap.Strict (IntMap)
+import qualified Data.IntMap.Strict as IntMap
+import Data.Set (Set)
+import qualified Data.Set as Set
+
+------------------------------------------------------------------------------
+-- Mock type AST
+------------------------------------------------------------------------------
+
+-- | A Hindley-Milner-ish type AST, curried so HKTs fall out naturally.
+--
+-- Examples:
+--
+-- @
+--   Show (List Nat)    = TApp (TCon \"Show\")
+--                             (TApp (TCon \"List\") (TCon \"Nat\"))
+--   Functor f          = TApp (TCon \"Functor\") (TVar f)
+--   Map (List a) Nat   = TApp (TApp (TCon \"Map\") (TApp (TCon \"List\") (TVar a)))
+--                             (TCon \"Nat\")
+-- @
+data Ty
+  = TVar !TyVar
+  | TCon !ConName
+  | TApp !Ty !Ty
+  deriving stock (Eq, Ord, Show)
+
+-- | Type variable. Both unification metavariables and rigid quantified
+-- variables share this representation; the resolver distinguishes them by
+-- whether they live in the candidate's own 'givenTyVars' (rigid until
+-- freshened) or the unifier's metavariable supply.
+newtype TyVar = TyVar Int
+  deriving stock (Show)
+  deriving newtype (Eq, Ord)
+
+newtype ConName = ConName String
+  deriving stock (Show)
+  deriving newtype (Eq, Ord)
+
+------------------------------------------------------------------------------
+-- Givens
+------------------------------------------------------------------------------
+
+-- | A single available given. Universally quantified over 'givenTyVars'.
+--
+-- A given like @Show a => Show (List a)@ becomes
+--
+-- @
+--   Given { givenName       = \"Show.list\"
+--         , givenTyVars     = [a]
+--         , givenPremises   = [TApp Show (TVar a)]
+--         , givenConclusion = TApp Show (TApp List (TVar a))
+--         , givenScope      = Ambient
+--         }
+-- @
+data Given = Given
+  { givenName :: !String,
+    givenTyVars :: ![TyVar],
+    givenPremises :: ![Ty],
+    givenConclusion :: !Ty,
+    givenScope :: !Scope
+  }
+  deriving stock (Eq, Show)
+
+-- | Lexical depth or ambient scope. Smaller 'Lexical' values are *more*
+-- inner (e.g. @Lexical 0@ is the innermost binder); 'Ambient' is the
+-- outermost.
+data Scope
+  = Lexical !Int
+  | Ambient
+  deriving stock (Eq, Ord, Show)
+
+-- | The candidate pool. Order is irrelevant; we keep it as a list because
+-- we always traverse it linearly.
+newtype Pool = Pool {poolGivens :: [Given]}
+  deriving stock (Eq, Show)
+
+poolFromList :: [Given] -> Pool
+poolFromList = Pool
+
+------------------------------------------------------------------------------
+-- Resolution result
+------------------------------------------------------------------------------
+
+-- | A successful resolution: which given was chosen, what its conclusion
+-- was specialised to, and how each premise was satisfied.
+data ResolutionTree = ResolutionTree
+  { rtChosen :: !Given,
+    rtSpecialisedConclusion :: !Ty,
+    rtPremises :: ![ResolutionTree]
+  }
+  deriving stock (Eq, Show)
+
+-- | Resolution errors, with enough information for the eventual diagnostic
+-- formatter.
+data ResolveError
+  = -- | No matching given for the goal; near-misses are candidates whose
+    -- conclusions unified with the goal but whose premises failed.
+    NoGiven !Ty ![NearMiss]
+  | -- | Multiple givens of incomparable specificity match.
+    Ambiguous !Ty ![Given]
+  | -- | Resolution chain exceeded the depth limit; the chain (outermost
+    -- first) is included for diagnosis.
+    DepthExceeded ![Ty]
+  deriving stock (Eq, Show)
+
+-- | A candidate that unified at the head but failed somewhere in its
+-- premises. Carries the sub-error so we can show the user *why* it didn't
+-- pan out.
+data NearMiss = NearMiss
+  { nmGiven :: !Given,
+    nmReason :: !ResolveError
+  }
+  deriving stock (Eq, Show)
+
+------------------------------------------------------------------------------
+-- Substitutions
+------------------------------------------------------------------------------
+
+-- | Substitution from 'TyVar' identifiers (the inner 'Int') to types.
+type Subst = IntMap Ty
+
+emptySubst :: Subst
+emptySubst = IntMap.empty
+
+-- | Free variables of a type.
+freeTyVars :: Ty -> Set TyVar
+freeTyVars = go Set.empty
+  where
+    go !acc = \case
+      TVar v -> Set.insert v acc
+      TCon _ -> acc
+      TApp a b -> go (go acc a) b
+
+-- | Apply a substitution to a type. Substitutions must be idempotent
+-- (which the unifier maintains), so a single pass is sufficient.
+applySubst :: Subst -> Ty -> Ty
+applySubst s = go
+  where
+    go t = case t of
+      TVar (TyVar i) -> case IntMap.lookup i s of
+        Just t' -> t'
+        Nothing -> t
+      TCon _ -> t
+      TApp a b -> TApp (go a) (go b)
+
+------------------------------------------------------------------------------
+-- Pretty-printing helpers
+------------------------------------------------------------------------------
+
+-- | Render a 'Ty' as a Unison-ish surface string. Used in error messages
+-- and tests.
+showTy :: Ty -> String
+showTy = top
+  where
+    top = \case
+      TApp f a -> top f ++ " " ++ atom a
+      t -> atom t
+    atom = \case
+      TVar (TyVar i) -> "v" ++ show i
+      TCon (ConName n) -> n
+      t@TApp {} -> "(" ++ top t ++ ")"

--- a/spike/implicits/src/Implicits/Unify.hs
+++ b/spike/implicits/src/Implicits/Unify.hs
@@ -1,0 +1,87 @@
+-- | Robinson's unification over the spike 'Ty' AST.
+--
+-- Substitutions are 'IntMap's keyed on the inner 'Int' of a 'TyVar' and
+-- maintained idempotent (the result of 'unify' satisfies @apply s (apply s
+-- t) == apply s t@).
+module Implicits.Unify
+  ( unify,
+
+    -- * Renaming utilities used by the resolver
+    freshen,
+    Supply,
+    runSupply,
+    fresh,
+  )
+where
+
+import Control.Monad.State.Strict (State, evalState, get, put)
+import qualified Data.IntMap.Strict as IntMap
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import Implicits.Types
+
+-- | Attempt to unify two types. Returns the (idempotent) most general
+-- unifier extending the supplied substitution, or 'Nothing' on conflict.
+unify :: Subst -> Ty -> Ty -> Maybe Subst
+unify s t u = go s (applySubst s t) (applySubst s u)
+  where
+    go s0 a b = case (a, b) of
+      _ | a == b -> Just s0
+      (TVar v, _) -> bind s0 v b
+      (_, TVar v) -> bind s0 v a
+      (TCon c1, TCon c2)
+        | c1 == c2 -> Just s0
+        | otherwise -> Nothing
+      (TApp f1 x1, TApp f2 x2) -> do
+        s1 <- go s0 f1 f2
+        go s1 (applySubst s1 x1) (applySubst s1 x2)
+      _ -> Nothing
+
+    bind s0 (TyVar i) t1
+      | TVar (TyVar j) <- t1, i == j = Just s0
+      | occurs i t1 = Nothing
+      | otherwise =
+          -- extend s0 with [i := t1] and propagate into existing image
+          let s1 = IntMap.insert i t1 (fmap (applySubst (IntMap.singleton i t1)) s0)
+           in Just s1
+
+    occurs i t1 = TyVar i `Set.member` freeTyVars (applySubst s t1)
+
+------------------------------------------------------------------------------
+-- Fresh-variable supply
+------------------------------------------------------------------------------
+
+-- | A monotonic supply of fresh 'TyVar' integers.
+type Supply = State Int
+
+runSupply :: Int -> Supply a -> a
+runSupply !start = flip evalState start
+
+fresh :: Supply TyVar
+fresh = do
+  n <- get
+  put (n + 1)
+  pure (TyVar n)
+
+-- | Rename every 'TyVar' in 'givenTyVars' of a candidate to a fresh
+-- metavariable, returning the renamed premises and conclusion. Variables
+-- *not* listed in 'givenTyVars' are left alone (they would only appear if
+-- callers reused inner names; we still tolerate it).
+freshen :: [TyVar] -> [Ty] -> Ty -> Supply ([Ty], Ty)
+freshen vs prems concl = do
+  -- Build an alpha-renaming substitution.
+  pairs <- mapM (\v -> (v,) <$> fresh) vs
+  let ren :: Map.Map TyVar TyVar
+      ren = Map.fromList pairs
+      rename = renameTy ren
+  pure (map rename prems, rename concl)
+
+-- | Rename only those variables found in the supplied map; leave others
+-- untouched.
+renameTy :: Map.Map TyVar TyVar -> Ty -> Ty
+renameTy ren = go
+  where
+    go = \case
+      TVar v -> TVar (Map.findWithDefault v v ren)
+      TCon c -> TCon c
+      TApp a b -> TApp (go a) (go b)

--- a/spike/implicits/test/Main.hs
+++ b/spike/implicits/test/Main.hs
@@ -1,0 +1,467 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Test harness for the implicit-resolution spike. Covers the six
+-- success criteria from @docs/implicits-plan.md@ §4.2.
+--
+-- Library choice: @tasty@ + @tasty-hunit@. The rest of the Unison repo
+-- uses @easytest@, but @tasty@ keeps this spike's dependency graph
+-- entirely outside the main @stack.yaml@ and is closer to what the
+-- production typechecker tests already use elsewhere in the wider
+-- ecosystem. Either choice is acceptable per the brief.
+module Main (main) where
+
+import Data.List (find, sort)
+import Data.Time.Clock (diffUTCTime, getCurrentTime)
+import Implicits.Resolve
+import Implicits.Types
+import Test.Tasty
+import Test.Tasty.HUnit
+
+main :: IO ()
+main = defaultMain tests
+
+tests :: TestTree
+tests =
+  testGroup
+    "implicit-resolution spike"
+    [ testCriterion1_cycles,
+      testCriterion2_specificity,
+      testCriterion3_hkt,
+      testCriterion4_ambiguity,
+      testCriterion5_performance,
+      testCriterion6_diamond,
+      -- Extra sanity tests beyond the six criteria.
+      testGroup
+        "sanity"
+        [ testTrivialResolve,
+          testChainedResolve,
+          testDepthLimit,
+          testLexicalInnerWins
+        ]
+    ]
+
+------------------------------------------------------------------------------
+-- Type aliases for readable test data
+------------------------------------------------------------------------------
+
+-- Common type constructors.
+showC, ordC, eqC, functorC, monadC, mapC, listC, optionalC, natC, textC, fooC, barC :: Ty
+showC = TCon (ConName "Show")
+ordC = TCon (ConName "Ord")
+eqC = TCon (ConName "Eq")
+functorC = TCon (ConName "Functor")
+monadC = TCon (ConName "Monad")
+mapC = TCon (ConName "Map")
+listC = TCon (ConName "List")
+optionalC = TCon (ConName "Optional")
+natC = TCon (ConName "Nat")
+textC = TCon (ConName "Text")
+fooC = TCon (ConName "Foo")
+barC = TCon (ConName "Bar")
+
+-- Type variables.
+tvA, tvB, tvF, tvK, tvV :: TyVar
+tvA = TyVar 1
+tvB = TyVar 2
+tvF = TyVar 3
+tvK = TyVar 4
+tvV = TyVar 5
+
+-- Convenience: build "Show t" etc.
+appOne :: Ty -> Ty -> Ty
+appOne = TApp
+
+appTwo :: Ty -> Ty -> Ty -> Ty
+appTwo c x y = TApp (TApp c x) y
+
+------------------------------------------------------------------------------
+-- 1. Cycles terminate.
+------------------------------------------------------------------------------
+
+testCriterion1_cycles :: TestTree
+testCriterion1_cycles =
+  testGroup
+    "1. cycles terminate"
+    [ testCase "Foo<->Bar mutual recursion fails cleanly, no hang" $ do
+        -- Pool: given a : Foo => Bar, given b : Bar => Foo.
+        -- Goal: Foo. There is no non-cyclic path; this must error
+        -- (NoGiven), not hang.
+        let pool =
+              poolFromList
+                [ Given
+                    { givenName = "fooFromBar",
+                      givenTyVars = [],
+                      givenPremises = [barC],
+                      givenConclusion = fooC,
+                      givenScope = Ambient
+                    },
+                  Given
+                    { givenName = "barFromFoo",
+                      givenTyVars = [],
+                      givenPremises = [fooC],
+                      givenConclusion = barC,
+                      givenScope = Ambient
+                    }
+                ]
+        case resolve pool fooC of
+          Left (NoGiven _ _) -> pure ()
+          Left e -> assertFailure ("expected NoGiven, got: " ++ show e)
+          Right t -> assertFailure ("expected failure but resolved: " ++ show t),
+      testCase "Cycle with escape hatch resolves via the escape" $ do
+        -- given baseFoo : Foo (no premises)
+        -- given fooFromBar : Foo, requires Bar
+        -- given barFromFoo : Bar, requires Foo
+        -- Goal: Foo. The cyclic candidate fails per-branch, but the
+        -- base instance succeeds, so the overall resolution succeeds.
+        let pool =
+              poolFromList
+                [ Given "baseFoo" [] [] fooC Ambient,
+                  Given "fooFromBar" [] [barC] fooC Ambient,
+                  Given "barFromFoo" [] [fooC] barC Ambient
+                ]
+        -- With two ways to resolve Foo (the base and via Bar->Foo),
+        -- both succeed, which is ambiguous; we expect either a
+        -- successful pick or Ambiguous, but never a hang. Most
+        -- importantly: completes in finite time.
+        case resolve pool fooC of
+          Right _ -> pure ()
+          Left (Ambiguous _ _) -> pure ()
+          Left e -> assertFailure ("unexpected error: " ++ show e)
+    ]
+
+------------------------------------------------------------------------------
+-- 2. Specificity ordering: Show (List Nat) beats Show (List a)
+------------------------------------------------------------------------------
+
+testCriterion2_specificity :: TestTree
+testCriterion2_specificity =
+  testGroup
+    "2. specificity ordering"
+    [ testCase "Show (List Nat) is preferred over Show (List a)" $ do
+        let showListA =
+              Given
+                { givenName = "Show.list",
+                  givenTyVars = [tvA],
+                  givenPremises = [appOne showC (TVar tvA)],
+                  givenConclusion = appOne showC (appOne listC (TVar tvA)),
+                  givenScope = Ambient
+                }
+            showListNat =
+              Given
+                { givenName = "Show.listNat",
+                  givenTyVars = [],
+                  givenPremises = [],
+                  givenConclusion = appOne showC (appOne listC natC),
+                  givenScope = Ambient
+                }
+            showNat =
+              Given
+                { givenName = "Show.nat",
+                  givenTyVars = [],
+                  givenPremises = [],
+                  givenConclusion = appOne showC natC,
+                  givenScope = Ambient
+                }
+            pool = poolFromList [showListA, showListNat, showNat]
+            goal = appOne showC (appOne listC natC)
+        case resolve pool goal of
+          Right rt ->
+            assertEqual
+              "more-specific given chosen"
+              "Show.listNat"
+              (givenName (rtChosen rt))
+          Left e -> assertFailure ("expected success, got: " ++ show e),
+      testCase "Show (List a) wins when no Nat-specific given is available" $ do
+        let showListA =
+              Given
+                "Show.list"
+                [tvA]
+                [appOne showC (TVar tvA)]
+                (appOne showC (appOne listC (TVar tvA)))
+                Ambient
+            showNat = Given "Show.nat" [] [] (appOne showC natC) Ambient
+            pool = poolFromList [showListA, showNat]
+            goal = appOne showC (appOne listC natC)
+        case resolve pool goal of
+          Right rt ->
+            assertEqual
+              "polymorphic given chosen"
+              "Show.list"
+              (givenName (rtChosen rt))
+          Left e -> assertFailure ("expected success, got: " ++ show e)
+    ]
+
+------------------------------------------------------------------------------
+-- 3. HKT: resolve Functor List, Functor Optional
+------------------------------------------------------------------------------
+
+testCriterion3_hkt :: TestTree
+testCriterion3_hkt =
+  testGroup
+    "3. HKT support"
+    [ testCase "Functor List resolves" $ do
+        let pool =
+              poolFromList
+                [ Given "Functor.list" [] [] (appOne functorC listC) Ambient,
+                  Given "Functor.optional" [] [] (appOne functorC optionalC) Ambient
+                ]
+            goal = appOne functorC listC
+        case resolve pool goal of
+          Right rt ->
+            assertEqual "Functor.list chosen" "Functor.list" (givenName (rtChosen rt))
+          Left e -> assertFailure ("expected success, got: " ++ show e),
+      testCase "Functor Optional resolves" $ do
+        let pool =
+              poolFromList
+                [ Given "Functor.list" [] [] (appOne functorC listC) Ambient,
+                  Given "Functor.optional" [] [] (appOne functorC optionalC) Ambient
+                ]
+            goal = appOne functorC optionalC
+        case resolve pool goal of
+          Right rt ->
+            assertEqual "Functor.optional chosen" "Functor.optional" (givenName (rtChosen rt))
+          Left e -> assertFailure ("expected success, got: " ++ show e),
+      testCase "Polymorphic Functor f matches a fresh constructor" $ do
+        -- given Functor.list : Functor List
+        -- given Functor.id   : forall f. Functor f
+        -- Goal: Functor List should pick the more-specific one.
+        let pool =
+              poolFromList
+                [ Given "Functor.id" [tvF] [] (appOne functorC (TVar tvF)) Ambient,
+                  Given "Functor.list" [] [] (appOne functorC listC) Ambient
+                ]
+        case resolve pool (appOne functorC listC) of
+          Right rt ->
+            assertEqual "specific HKT given wins" "Functor.list" (givenName (rtChosen rt))
+          Left e -> assertFailure ("expected success, got: " ++ show e)
+    ]
+
+------------------------------------------------------------------------------
+-- 4. Ambiguity
+------------------------------------------------------------------------------
+
+testCriterion4_ambiguity :: TestTree
+testCriterion4_ambiguity =
+  testGroup
+    "4. ambiguity"
+    [ testCase "Two givens of identical type produce Ambiguous" $ do
+        let g1 = Given "Show.nat.A" [] [] (appOne showC natC) Ambient
+            g2 = Given "Show.nat.B" [] [] (appOne showC natC) Ambient
+            pool = poolFromList [g1, g2]
+        case resolve pool (appOne showC natC) of
+          Left (Ambiguous _ candidates) -> do
+            let names = sort (map givenName candidates)
+            assertEqual "both candidates listed" ["Show.nat.A", "Show.nat.B"] names
+          other -> assertFailure ("expected Ambiguous, got: " ++ show other)
+    ]
+
+------------------------------------------------------------------------------
+-- 5. Performance: ~1000 givens, chains ~20 deep
+------------------------------------------------------------------------------
+
+testCriterion5_performance :: TestTree
+testCriterion5_performance =
+  testCase "5. performance: 1000 givens, depth-20 chain in <2s" $ do
+    -- Build a chain Cn0 -> Cn1 -> ... -> Cn20, each step a "given Cn_k
+    -- requires Cn_{k+1}" pair. Pad the pool with 980 noise givens that
+    -- never match.
+    let chainCons k = TCon (ConName ("Cn" ++ show (k :: Int)))
+        chainGivens =
+          [ Given
+              ("chain" ++ show k)
+              []
+              [chainCons (k + 1)]
+              (chainCons k)
+              Ambient
+          | k <- [0 .. 19]
+          ]
+        baseGiven = Given "chainBase" [] [] (chainCons 20) Ambient
+        noise =
+          [ Given
+              ("noise" ++ show k)
+              []
+              []
+              (TCon (ConName ("Noise" ++ show k)))
+              Ambient
+          | k <- [0 .. 979 :: Int]
+          ]
+        pool = poolFromList (chainGivens ++ [baseGiven] ++ noise)
+        goal = chainCons 0
+    t0 <- getCurrentTime
+    let !res = resolve pool goal
+    t1 <- getCurrentTime
+    case res of
+      Right _ -> pure ()
+      Left e -> assertFailure ("expected success, got: " ++ show e)
+    let elapsed = realToFrac (diffUTCTime t1 t0) :: Double
+    -- Generous bound; on a modern laptop we expect <0.1s.
+    assertBool
+      ("chain resolved too slowly: " ++ show elapsed ++ "s")
+      (elapsed < 2.0)
+
+------------------------------------------------------------------------------
+-- 6. Diamond dependencies don't blow up
+------------------------------------------------------------------------------
+
+testCriterion6_diamond :: TestTree
+testCriterion6_diamond =
+  testGroup
+    "6. diamond dependencies"
+    [ testCase "Show (Map (List Nat) Nat) memoizes Show Nat exactly once" $ do
+        -- Givens:
+        --   Show.nat            : Show Nat
+        --   Show.list <a>       : Show a => Show (List a)
+        --   Show.map  <k v>     : Show k => Show v => Show (Map k v)
+        -- Goal: Show (Map (List Nat) Nat).
+        --
+        -- The dependency tree contains two paths to "Show Nat":
+        --   Show (Map (List Nat) Nat)
+        --     -> Show (List Nat)         (via Show.map's first premise)
+        --          -> Show Nat            (path 1)
+        --     -> Show Nat                 (via Show.map's second premise; path 2)
+        -- Without memoization, Show Nat would be solved twice. With
+        -- per-resolution memoization, it must be solved exactly once.
+        --
+        -- The instrumented counter 'sWork' tracks distinct sub-goals
+        -- attempted, so we can assert that exactly four sub-goals are
+        -- considered in total: the top-level goal, Show (List Nat),
+        -- Show Nat, and (the candidate Show.map's other Show Nat
+        -- premise must be a memo hit, NOT a fresh attempt).
+        let pool =
+              poolFromList
+                [ Given "Show.nat" [] [] (appOne showC natC) Ambient,
+                  Given
+                    "Show.list"
+                    [tvA]
+                    [appOne showC (TVar tvA)]
+                    (appOne showC (appOne listC (TVar tvA)))
+                    Ambient,
+                  Given
+                    "Show.map"
+                    [tvK, tvV]
+                    [ appOne showC (TVar tvK),
+                      appOne showC (TVar tvV)
+                    ]
+                    (appOne showC (appTwo mapC (TVar tvK) (TVar tvV)))
+                    Ambient
+                ]
+            goal =
+              appOne showC (appTwo mapC (appOne listC natC) natC)
+            (res, work) = resolveCounted defaultOptions pool goal
+        case res of
+          Right rt -> do
+            assertEqual
+              "outer chosen given is Show.map"
+              "Show.map"
+              (givenName (rtChosen rt))
+            -- Three distinct sub-goal types in the dependency tree:
+            --   Show (Map (List Nat) Nat), Show (List Nat), Show Nat
+            assertEqual
+              "memoization: each unique sub-goal solved exactly once"
+              3
+              work
+          Left e -> assertFailure ("expected success, got: " ++ show e),
+      testCase "Wider diamond: Show (Map (List Nat) (List Nat)) memoizes Show (List Nat) once" $ do
+        let pool =
+              poolFromList
+                [ Given "Show.nat" [] [] (appOne showC natC) Ambient,
+                  Given
+                    "Show.list"
+                    [tvA]
+                    [appOne showC (TVar tvA)]
+                    (appOne showC (appOne listC (TVar tvA)))
+                    Ambient,
+                  Given
+                    "Show.map"
+                    [tvK, tvV]
+                    [ appOne showC (TVar tvK),
+                      appOne showC (TVar tvV)
+                    ]
+                    (appOne showC (appTwo mapC (TVar tvK) (TVar tvV)))
+                    Ambient
+                ]
+            goal =
+              appOne
+                showC
+                (appTwo mapC (appOne listC natC) (appOne listC natC))
+            (res, work) = resolveCounted defaultOptions pool goal
+        case res of
+          Right _ ->
+            -- Distinct sub-goals: top-level, Show (List Nat), Show Nat.
+            assertEqual
+              "memoization across symmetric arguments"
+              3
+              work
+          Left e -> assertFailure ("expected success, got: " ++ show e)
+    ]
+
+------------------------------------------------------------------------------
+-- Sanity checks
+------------------------------------------------------------------------------
+
+testTrivialResolve :: TestTree
+testTrivialResolve = testCase "Trivial: Show Nat" $ do
+  let pool = poolFromList [Given "Show.nat" [] [] (appOne showC natC) Ambient]
+  case resolve pool (appOne showC natC) of
+    Right rt -> assertEqual "Show.nat chosen" "Show.nat" (givenName (rtChosen rt))
+    Left e -> assertFailure ("expected success, got: " ++ show e)
+
+testChainedResolve :: TestTree
+testChainedResolve = testCase "Chained: Show (List Nat) via Show.list & Show.nat" $ do
+  let pool =
+        poolFromList
+          [ Given "Show.nat" [] [] (appOne showC natC) Ambient,
+            Given
+              "Show.list"
+              [tvA]
+              [appOne showC (TVar tvA)]
+              (appOne showC (appOne listC (TVar tvA)))
+              Ambient
+          ]
+      goal = appOne showC (appOne listC natC)
+  case resolve pool goal of
+    Right rt -> do
+      assertEqual "outer Show.list" "Show.list" (givenName (rtChosen rt))
+      case rtPremises rt of
+        [inner] ->
+          assertEqual "inner Show.nat" "Show.nat" (givenName (rtChosen inner))
+        ps ->
+          assertFailure ("expected exactly one premise, got: " ++ show (length ps))
+    Left e -> assertFailure ("expected success, got: " ++ show e)
+
+testDepthLimit :: TestTree
+testDepthLimit = testCase "Depth limit triggers DepthExceeded" $ do
+  -- An infinite chain: Self requires Self. Without a base case and with
+  -- a small depth limit, this should produce DepthExceeded (per-branch
+  -- cycle would *also* catch it, but here the unifier will alpha-vary
+  -- so we exercise the depth limit too).
+  let selfC = TCon (ConName "Self")
+      pool = poolFromList [Given "selfFromSelf" [] [selfC] selfC Ambient]
+      opts = ResolveOptions {optMaxDepth = 5}
+  case resolveWith opts pool selfC of
+    Left _ -> pure () -- either DepthExceeded or NoGiven (cycle path) is fine
+    Right t -> assertFailure ("expected failure, got: " ++ show t)
+
+testLexicalInnerWins :: TestTree
+testLexicalInnerWins =
+  testCase "lexical-inner local given beats ambient" $ do
+    let local =
+          Given "Ord.flip.local" [] [] (appOne ordC natC) (Lexical 0)
+        ambient =
+          Given "Ord.nat" [] [] (appOne ordC natC) Ambient
+        pool = poolFromList [ambient, local]
+    case resolve pool (appOne ordC natC) of
+      Right rt ->
+        assertEqual
+          "local lexical given wins"
+          "Ord.flip.local"
+          (givenName (rtChosen rt))
+      Left e -> assertFailure ("expected success, got: " ++ show e)
+
+-- Silence unused-import warnings when we tweak imports during development.
+_unused :: a -> a
+_unused x = case find (const True) ([] :: [()]) of
+  _ -> x
+
+_unusedRefs :: [Ty]
+_unusedRefs = [eqC, monadC, textC, TVar tvB]

--- a/spike/implicits/unison-implicits-spike.cabal
+++ b/spike/implicits/unison-implicits-spike.cabal
@@ -1,0 +1,59 @@
+cabal-version:      2.2
+name:               unison-implicits-spike
+version:            0.0.0
+synopsis:           Phase 1 spike for Unison implicit-parameter resolution
+description:
+  Throwaway prototype for the resolution algorithm described in
+  docs/implicits-plan.md (sections 1.3 and 4). Not part of the main
+  Unison build; lives outside stack.yaml. Build with plain
+  @cabal build@ / @cabal test@ from this directory.
+
+license:            MIT
+author:             Unison contributors
+maintainer:         core@unison-lang.org
+build-type:         Simple
+category:           Compiler
+stability:          experimental
+
+common common-opts
+  default-language: Haskell2010
+  default-extensions:
+    BangPatterns
+    DeriveFunctor
+    DerivingStrategies
+    FlexibleContexts
+    GeneralizedNewtypeDeriving
+    LambdaCase
+    OverloadedStrings
+    ScopedTypeVariables
+    TupleSections
+  ghc-options:
+    -Wall
+    -Wno-name-shadowing
+
+library
+  import:           common-opts
+  hs-source-dirs:   src
+  exposed-modules:
+    Implicits.Resolve
+    Implicits.Types
+    Implicits.Unify
+  build-depends:
+    base       >= 4.18 && < 5,
+    containers >= 0.6  && < 0.9,
+    mtl        >= 2.2  && < 2.4
+
+test-suite spike-tests
+  import:           common-opts
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   test
+  main-is:          Main.hs
+  ghc-options:      -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+    base                   >= 4.18 && < 5,
+    containers             >= 0.6  && < 0.9,
+    mtl                    >= 2.2  && < 2.4,
+    tasty                  >= 1.4  && < 1.6,
+    tasty-hunit            >= 0.10 && < 0.11,
+    time                   >= 1.12 && < 1.15,
+    unison-implicits-spike

--- a/unison-cli/package.yaml
+++ b/unison-cli/package.yaml
@@ -116,6 +116,7 @@ tests:
       - condition: false
         other-modules: Paths_unison_cli
     dependencies:
+      - IntervalMap
       - base
       - code-page
       - containers
@@ -124,6 +125,7 @@ tests:
       - easytest
       - extra
       - here
+      - IntervalMap
       - lens
       - lsp
       - lsp-types

--- a/unison-cli/src/Unison/Cli/Pretty.hs
+++ b/unison-cli/src/Unison/Cli/Pretty.hs
@@ -112,6 +112,7 @@ import Unison.Syntax.Name qualified as Name (unsafeParseVar)
 import Unison.Syntax.NamePrinter (SyntaxText, prettyHashQualified, styleHashQualified')
 import Unison.Syntax.NameSegment qualified as NameSegment
 import Unison.Syntax.TermPrinter qualified as TermPrinter
+import Unison.Typechecker.GivenApply qualified as GivenApply
 import Unison.Syntax.TypePrinter qualified as TypePrinter
 import Unison.Term (Term)
 import Unison.Type (Type)
@@ -462,9 +463,14 @@ prettyTerm pped isSourceFile isTest (n, r, dt) =
           ("builtin " <> prettyHashQualified n <> " :")
           (TypePrinter.prettySyntax (ppeBody n r) typ)
     UserObject tm ->
-      if isTest
-        then WK.TestWatch <> "> " <> TermPrinter.prettyBindingWithoutTypeSignature (ppeBody n r) n tm
-        else TermPrinter.prettyBinding (ppeBody n r) n tm
+      -- ADR-015 default elide-mode: drop any apply-site argument
+      -- the elaborator marked 'Ann.Synthetic' (a resolved
+      -- implicit-dictionary insertion) before handing the term to
+      -- the surface pretty-printer.
+      let tm' = GivenApply.stripSyntheticArgs tm
+       in if isTest
+            then WK.TestWatch <> "> " <> TermPrinter.prettyBindingWithoutTypeSignature (ppeBody n r) n tm'
+            else TermPrinter.prettyBinding (ppeBody n r) n tm'
   where
     commentBuiltin txt =
       if isSourceFile

--- a/unison-cli/src/Unison/Cli/Pretty.hs
+++ b/unison-cli/src/Unison/Cli/Pretty.hs
@@ -39,6 +39,7 @@ module Unison.Cli.Pretty
     prettyTerm,
     prettyTermName,
     prettyType,
+    prettyTypeWithClasses,
     prettyTypeName,
     prettyTypeResultHeader',
     prettyTypeResultHeaderFull',
@@ -392,13 +393,29 @@ prettyLibdepName =
   P.blue . P.text . NameSegment.toEscapedText
 
 prettyUnisonFile :: forall v a. (Var v, Ord a) => PPED.PrettyPrintEnvDecl -> UF.UnisonFile v a -> P.Pretty P.ColorText
-prettyUnisonFile ppe uf@(UF.UnisonFileId _fn datas effects terms watches _gbs) =
+prettyUnisonFile ppe uf@(UF.UnisonFileId _fn datas effects terms watches _gbs cbs) =
   P.sep "\n\n" (map snd . sortOn fst $ prettyEffects <> prettyDatas <> catMaybes prettyTerms <> prettyWatches)
   where
     prettyEffects = map prettyEffectDecl (Map.toList effects)
     (prettyDatas, accessorNames) = runWriter $ traverse prettyDataDecl (Map.toList datas)
     prettyTerms = Map.foldrWithKey (\k v -> (prettyTerm accessorNames k v :)) [] terms
     prettyWatches = Map.toList watches >>= \(wk, tms) -> map (prettyWatch . (wk,)) tms
+
+    -- ADR-007: rendering the file from the typechecked form should
+    -- preserve the @class@ keyword for any data declaration whose
+    -- parser-side var name was recorded in 'classBindings'. Without
+    -- this, the dependents-update path re-renders @class@es as plain
+    -- @type@s and loses both the field syntax and (eventually) the
+    -- ability to round-trip.
+    classRefSet :: Set TypeReference
+    classRefSet =
+      Set.fromList
+        [ Reference.DerivedId r
+        | (n, (r, _)) <- Map.toList datas,
+          Set.member n cbs
+        ]
+    isClassRef :: DeclPrinter.IsClassRef
+    isClassRef r = Set.member r classRefSet
 
     prettyEffectDecl :: (v, (TypeReferenceId, DD.EffectDeclaration v a)) -> (a, P.Pretty P.ColorText)
     prettyEffectDecl (n, (r, et)) =
@@ -414,7 +431,8 @@ prettyUnisonFile ppe uf@(UF.UnisonFileId _fn datas effects terms watches _gbs) =
     prettyDataDecl :: (v, (TypeReferenceId, DD.DataDeclaration v a)) -> Writer (Set AccessorName) (a, P.Pretty P.ColorText)
     prettyDataDecl (n, (r, dt)) =
       (DD.annotation dt,) . st
-        <$> DeclPrinter.prettyDeclW
+        <$> DeclPrinter.prettyDeclWWithClasses
+          isClassRef
           ppe'
           DeclPrinter.RenderUniqueTypeGuids'No
           (rd r)
@@ -479,12 +497,20 @@ prettyTerm pped isSourceFile isTest (n, r, dt) =
     ppeBody n r = PPE.biasTo (maybeToList $ HQ.toName n) $ PPE.declarationPPE pped r
 
 prettyType :: PPED.PrettyPrintEnvDecl -> (HQ.HashQualified Name, TypeReference, DisplayObject () (DD.Decl Symbol Ann)) -> P.Pretty SyntaxText
-prettyType pped (n, r, dt) =
+prettyType = prettyTypeWithClasses DeclPrinter.noClasses
+
+prettyTypeWithClasses ::
+  DeclPrinter.IsClassRef ->
+  PPED.PrettyPrintEnvDecl ->
+  (HQ.HashQualified Name, TypeReference, DisplayObject () (DD.Decl Symbol Ann)) ->
+  P.Pretty SyntaxText
+prettyTypeWithClasses isClassRef pped (n, r, dt) =
   case dt of
     MissingObject r -> missingDefinitionMsg n r
     BuiltinObject _ -> builtin n
     UserObject decl ->
-      DeclPrinter.prettyDecl
+      DeclPrinter.prettyDeclWithClasses
+        isClassRef
         (PPED.biasTo (maybeToList $ HQ.toName n) $ pped)
         DeclPrinter.RenderUniqueTypeGuids'No
         r

--- a/unison-cli/src/Unison/Cli/Pretty.hs
+++ b/unison-cli/src/Unison/Cli/Pretty.hs
@@ -391,7 +391,7 @@ prettyLibdepName =
   P.blue . P.text . NameSegment.toEscapedText
 
 prettyUnisonFile :: forall v a. (Var v, Ord a) => PPED.PrettyPrintEnvDecl -> UF.UnisonFile v a -> P.Pretty P.ColorText
-prettyUnisonFile ppe uf@(UF.UnisonFileId _fn datas effects terms watches) =
+prettyUnisonFile ppe uf@(UF.UnisonFileId _fn datas effects terms watches _gbs) =
   P.sep "\n\n" (map snd . sortOn fst $ prettyEffects <> prettyDatas <> catMaybes prettyTerms <> prettyWatches)
   where
     prettyEffects = map prettyEffectDecl (Map.toList effects)

--- a/unison-cli/src/Unison/Cli/Pretty.hs
+++ b/unison-cli/src/Unison/Cli/Pretty.hs
@@ -112,10 +112,10 @@ import Unison.Syntax.Name qualified as Name (unsafeParseVar)
 import Unison.Syntax.NamePrinter (SyntaxText, prettyHashQualified, styleHashQualified')
 import Unison.Syntax.NameSegment qualified as NameSegment
 import Unison.Syntax.TermPrinter qualified as TermPrinter
-import Unison.Typechecker.GivenApply qualified as GivenApply
 import Unison.Syntax.TypePrinter qualified as TypePrinter
 import Unison.Term (Term)
 import Unison.Type (Type)
+import Unison.Typechecker.GivenApply qualified as GivenApply
 import Unison.UnisonFile qualified as UF
 import Unison.UnisonFile.Names qualified as UF
 import Unison.Util.Monoid qualified as Monoid

--- a/unison-cli/src/Unison/Cli/TypeCheck.hs
+++ b/unison-cli/src/Unison/Cli/TypeCheck.hs
@@ -12,8 +12,6 @@ import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Branch (Branch0)
 import Unison.Codebase.Branch qualified as Branch
 import Unison.Codebase.Givens qualified as Givens
-import Unison.Util.Relation qualified as Relation
-import Unison.Util.Star2 qualified as Star2
 import Unison.FileParsers qualified as FileParsers
 import Unison.Parser.Ann (Ann (..))
 import Unison.Prelude
@@ -30,6 +28,8 @@ import Unison.Typechecker.GivenResolver qualified as GivenResolver
 import Unison.Typechecker.Variance qualified as Variance
 import Unison.UnisonFile (UnisonFile)
 import Unison.UnisonFile qualified as UF
+import Unison.Util.Relation qualified as Relation
+import Unison.Util.Star2 qualified as Star2
 import Unison.Var qualified as Var
 
 computeTypecheckingEnvironment ::

--- a/unison-cli/src/Unison/Cli/TypeCheck.hs
+++ b/unison-cli/src/Unison/Cli/TypeCheck.hs
@@ -12,6 +12,8 @@ import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Branch (Branch0)
 import Unison.Codebase.Branch qualified as Branch
 import Unison.Codebase.Givens qualified as Givens
+import Unison.Util.Relation qualified as Relation
+import Unison.Util.Star2 qualified as Star2
 import Unison.FileParsers qualified as FileParsers
 import Unison.Parser.Ann (Ann (..))
 import Unison.Prelude
@@ -62,14 +64,17 @@ ambientGivensFromBranch ::
   Branch0 m ->
   Sqlite.Transaction [GivenElaborator.AmbientGiven Symbol Ann]
 ambientGivensFromBranch codebase b0 = do
+  -- Walk the namespace recursively so we catch givens nested in
+  -- sub-branches. The metadata that marks a referent as a given is
+  -- stored in the *enclosing* sub-branch's @terms_@, not in the
+  -- project root, so a flat scan of 'deepReferents b0' followed by
+  -- 'Givens.isGiven r b0' never finds anything past the top level.
+  -- 'Unison.Codebase.Editor.HandleInput.Givens.handleGivens' uses the
+  -- same recursive pattern. Per ADR-005, ambient resolution includes
+  -- the @lib@ subtree, so we do *not* prune libraries here.
   let givenRefs :: [Reference.TermReference]
-      givenRefs =
-        [ ref
-        | r <- Set.toList (Branch.deepReferents b0),
-          Givens.isGiven r b0,
-          Just ref <- [Referent.toTermReference r]
-        ]
-  fmap catMaybes . for givenRefs $ \r -> do
+      givenRefs = Set.toList (collectGivenRefs b0)
+  fmap catMaybes . for givenRefs $ \r ->
     Codebase.getTypeOfTerm codebase r >>= \case
       Nothing -> pure Nothing
       Just ty ->
@@ -79,6 +84,26 @@ ambientGivensFromBranch codebase b0 = do
               { GivenElaborator.ambientName = r,
                 GivenElaborator.ambientType = ty
               }
+  where
+    -- Mirror 'handleGivens': at each level, check the *direct* term
+    -- referents (via 'Star2.d1' of 'terms_') against this level's
+    -- metadata, then recurse into each child.
+    collectGivenRefs :: Branch0 m -> Set.Set Reference.TermReference
+    collectGivenRefs b =
+      let here :: Set.Set Reference.TermReference
+          here =
+            Set.fromList
+              [ ref
+              | (r, _seg) <- Relation.toList (Star2.d1 (view Branch.terms_ b)),
+                Givens.isGiven r b,
+                Just ref <- [Referent.toTermReference r]
+              ]
+          there :: Set.Set Reference.TermReference
+          there =
+            foldMap
+              (collectGivenRefs . Branch.head . snd)
+              (Map.toList (view Branch.children_ b))
+       in Set.union here there
 
 typecheckTerm ::
   Codebase IO Symbol Ann ->

--- a/unison-cli/src/Unison/Cli/TypeCheck.hs
+++ b/unison-cli/src/Unison/Cli/TypeCheck.hs
@@ -115,7 +115,7 @@ typecheckTerm ::
     )
 typecheckTerm codebase tm = do
   let v = Symbol 0 (Var.Inference Var.Other)
-  let file = UF.UnisonFileId Nothing mempty mempty (Map.singleton v (External, tm)) mempty mempty
+  let file = UF.UnisonFileId Nothing mempty mempty (Map.singleton v (External, tm)) mempty mempty mempty
   typeLookup <- Codebase.typeLookupForDependencies codebase (UF.dependencies file)
   let typecheckingEnv =
         Typechecker.Env

--- a/unison-cli/src/Unison/Cli/TypeCheck.hs
+++ b/unison-cli/src/Unison/Cli/TypeCheck.hs
@@ -1,21 +1,30 @@
 module Unison.Cli.TypeCheck
   ( computeTypecheckingEnvironment,
+    ambientGivensFromBranch,
     typecheckTerm,
   )
 where
 
 import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
 import Unison.Codebase (Codebase)
 import Unison.Codebase qualified as Codebase
+import Unison.Codebase.Branch (Branch0)
+import Unison.Codebase.Branch qualified as Branch
+import Unison.Codebase.Givens qualified as Givens
 import Unison.FileParsers qualified as FileParsers
 import Unison.Parser.Ann (Ann (..))
 import Unison.Prelude
+import Unison.Reference qualified as Reference
+import Unison.Referent qualified as Referent
 import Unison.Result qualified as Result
 import Unison.Sqlite qualified as Sqlite
 import Unison.Symbol (Symbol (Symbol))
 import Unison.Term (Term)
 import Unison.Type (Type)
 import Unison.Typechecker qualified as Typechecker
+import Unison.Typechecker.GivenElaborator qualified as GivenElaborator
+import Unison.Typechecker.GivenResolver qualified as GivenResolver
 import Unison.Typechecker.Variance qualified as Variance
 import Unison.UnisonFile (UnisonFile)
 import Unison.UnisonFile qualified as UF
@@ -25,14 +34,51 @@ computeTypecheckingEnvironment ::
   FileParsers.ShouldUseTndr Sqlite.Transaction ->
   Codebase IO Symbol Ann ->
   [Type Symbol Ann] ->
+  -- | Ambient givens harvested from the namespace (chunk L1).
+  -- Build with 'ambientGivensFromBranch' or pass @[]@ if no namespace
+  -- is in scope.
+  [GivenElaborator.AmbientGiven Symbol Ann] ->
   UnisonFile Symbol Ann ->
   Sqlite.Transaction (Typechecker.Env Symbol Ann)
-computeTypecheckingEnvironment shouldUseTndr codebase ambientAbilities unisonFile =
+computeTypecheckingEnvironment shouldUseTndr codebase ambientAbilities ambientGivens unisonFile =
   FileParsers.computeTypecheckingEnvironment
     shouldUseTndr
     ambientAbilities
     (Codebase.typeLookupForDependencies codebase)
+    ambientGivens
     unisonFile
+
+-- | Phase-2 chunk L1: harvest the ambient given pool from a 'Branch0'.
+--
+-- Walks the branch's 'deepReferents' and keeps any term referent
+-- carrying 'Unison.Codebase.Givens.givenSentinel' in its metadata.
+-- For each such referent (assumed to be 'Referent.Ref'; constructors
+-- cannot be marked as givens at the term level), the term's declared
+-- type is fetched via 'Codebase.getTypeOfTerm' and packaged as an
+-- 'AmbientGiven'. Callers pass the result to
+-- 'computeTypecheckingEnvironment'.
+ambientGivensFromBranch ::
+  Codebase IO Symbol Ann ->
+  Branch0 m ->
+  Sqlite.Transaction [GivenElaborator.AmbientGiven Symbol Ann]
+ambientGivensFromBranch codebase b0 = do
+  let givenRefs :: [Reference.TermReference]
+      givenRefs =
+        [ ref
+        | r <- Set.toList (Branch.deepReferents b0),
+          Givens.isGiven r b0,
+          Just ref <- [Referent.toTermReference r]
+        ]
+  fmap catMaybes . for givenRefs $ \r -> do
+    Codebase.getTypeOfTerm codebase r >>= \case
+      Nothing -> pure Nothing
+      Just ty ->
+        pure $
+          Just
+            GivenElaborator.AmbientGiven
+              { GivenElaborator.ambientName = r,
+                GivenElaborator.ambientType = ty
+              }
 
 typecheckTerm ::
   Codebase IO Symbol Ann ->
@@ -44,7 +90,7 @@ typecheckTerm ::
     )
 typecheckTerm codebase tm = do
   let v = Symbol 0 (Var.Inference Var.Other)
-  let file = UF.UnisonFileId Nothing mempty mempty (Map.singleton v (External, tm)) mempty
+  let file = UF.UnisonFileId Nothing mempty mempty (Map.singleton v (External, tm)) mempty mempty
   typeLookup <- Codebase.typeLookupForDependencies codebase (UF.dependencies file)
   let typecheckingEnv =
         Typechecker.Env
@@ -53,7 +99,9 @@ typecheckTerm codebase tm = do
             termsByShortname = Map.empty,
             freeNameToFuzzyTermsByShortName = Map.empty,
             topLevelComponents = Map.empty,
-            variances = Variance.fromTypeLookup typeLookup
+            variances = Variance.fromTypeLookup typeLookup,
+            ambientGivens = GivenResolver.poolFromList [],
+            givenBindings = mempty
           }
   pure $ fmap extract $ FileParsers.synthesizeFile typecheckingEnv file
   where

--- a/unison-cli/src/Unison/Cli/UpdateUtils.hs
+++ b/unison-cli/src/Unison/Cli/UpdateUtils.hs
@@ -32,7 +32,9 @@ import U.Codebase.Reference (Reference' (..), TermReferenceId, TypeReferenceId)
 import U.Codebase.Sqlite.Operations qualified as Operations
 import Unison.Cli.Monad (Cli, Env (..))
 import Unison.Cli.Monad qualified as Cli
+import Unison.Cli.MonadUtils qualified as Cli
 import Unison.Cli.TypeCheck (computeTypecheckingEnvironment)
+import Unison.Cli.TypeCheck qualified as Cli.TypeCheck
 import Unison.Codebase (Codebase)
 import Unison.Codebase qualified as Codebase
 import Unison.ConstructorReference (GConstructorReference (..))
@@ -225,10 +227,16 @@ parseAndTypecheck prettyUf parsingEnv = do
     liftIO do
       putStrLn "--- Scratch ---"
       putStrLn stringUf
+  -- Chunk L1: harvest the ambient given pool from the current branch
+  -- before entering the transaction. The branch fetch is an IO action
+  -- that runs in 'Cli'; the transaction itself stays IO-free apart
+  -- from the type lookups needed for each given's declared type.
+  branch0 <- Cli.getCurrentBranch0
   Cli.runTransaction do
     Parsers.parseFile "<update>" stringUf parsingEnv >>= \case
       Left _ -> pure Nothing
       Right uf -> do
+        ambientGivens <- Cli.TypeCheck.ambientGivensFromBranch env.codebase branch0
         typecheckingEnv <-
-          computeTypecheckingEnvironment (FileParsers.ShouldUseTndr'Yes parsingEnv) env.codebase [] uf
+          computeTypecheckingEnvironment (FileParsers.ShouldUseTndr'Yes parsingEnv) env.codebase [] ambientGivens uf
         pure (Result.result (FileParsers.synthesizeFile typecheckingEnv uf))

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -549,6 +549,7 @@ loop e = do
                   (Map.fromList Builtin.builtinEffectDecls)
                   [Builtin.builtinTermsSrc Intrinsic]
                   mempty
+                  mempty
           Cli.runTransaction (Codebase.addDefsToCodebase env.codebase uf)
           -- add the names; note, there are more names than definitions
           -- due to builtin terms; so we don't just reuse `uf` above.
@@ -573,6 +574,7 @@ loop e = do
                   (Map.fromList Builtin.builtinDataDecls)
                   (Map.fromList Builtin.builtinEffectDecls)
                   [Builtin.builtinTermsSrc Intrinsic]
+                  mempty
                   mempty
           Cli.runTransaction do
             Codebase.addDefsToCodebase env.codebase uf
@@ -1318,6 +1320,7 @@ addWatch watchName (Just uf) = do
                 (UF.effectDeclarationsId' uf)
                 (UF.topLevelComponents' uf)
                 (UF.watchComponents uf <> [(WK.RegularWatch, [(v2, ann, Term.var a v, ty)])])
+                (UF.givenBindings' uf)
             )
     _ -> addWatch watchName Nothing
 

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -550,6 +550,7 @@ loop e = do
                   [Builtin.builtinTermsSrc Intrinsic]
                   mempty
                   mempty
+                  mempty
           Cli.runTransaction (Codebase.addDefsToCodebase env.codebase uf)
           -- add the names; note, there are more names than definitions
           -- due to builtin terms; so we don't just reuse `uf` above.
@@ -574,6 +575,7 @@ loop e = do
                   (Map.fromList Builtin.builtinDataDecls)
                   (Map.fromList Builtin.builtinEffectDecls)
                   [Builtin.builtinTermsSrc Intrinsic]
+                  mempty
                   mempty
                   mempty
           Cli.runTransaction do
@@ -1321,6 +1323,7 @@ addWatch watchName (Just uf) = do
                 (UF.topLevelComponents' uf)
                 (UF.watchComponents uf <> [(WK.RegularWatch, [(v2, ann, Term.var a v, ty)])])
                 (UF.givenBindings' uf)
+                (UF.classBindings' uf)
             )
     _ -> addWatch watchName Nothing
 

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -69,6 +69,7 @@ import Unison.Codebase.Editor.HandleInput.EditDependents (handleEditDependents)
 import Unison.Codebase.Editor.HandleInput.EditNamespace (handleEditNamespace)
 import Unison.Codebase.Editor.HandleInput.FindAndReplace (handleStructuredFindI, handleStructuredFindReplaceI, handleTextFindI)
 import Unison.Codebase.Editor.HandleInput.FormatFile qualified as Format
+import Unison.Codebase.Editor.HandleInput.Givens (handleGivens, handleMarkGiven, handleUnmarkGiven)
 import Unison.Codebase.Editor.HandleInput.Global qualified as Global
 import Unison.Codebase.Editor.HandleInput.History (handleHistory)
 import Unison.Codebase.Editor.HandleInput.HistoryComment (handleHistoryComment)
@@ -112,6 +113,7 @@ import Unison.Codebase.Editor.Output.DumpNamespace qualified as Output.DN
 import Unison.Codebase.Editor.RemoteRepo qualified as RemoteRepo
 import Unison.Codebase.Editor.StructuredArgument qualified as SA
 import Unison.Codebase.Execute qualified as Codebase
+import Unison.Codebase.Givens qualified as Givens
 import Unison.Codebase.IntegrityCheck qualified as IntegrityCheck (integrityCheckFullCodebase)
 import Unison.Codebase.Metadata qualified as Metadata
 import Unison.Codebase.Path (Path, Path' (..))
@@ -599,6 +601,9 @@ loop e = do
         MoveTermI src' dest' -> doMoveTerm src' dest' =<< inputDescription input
         MoveToI sources dest -> handleMoveTo sources dest =<< inputDescription input
         MoveTypeI src' dest' -> doMoveType src' dest' =<< inputDescription input
+        MarkGivenI hq -> handleMarkGiven hq
+        UnmarkGivenI hq -> handleUnmarkGiven hq
+        GivensI -> handleGivens
         NamesI global queries -> mapM_ (handleNames global) queries
         RenameI src newNameSeg -> handleRename src newNameSeg =<< inputDescription input
         NamespaceDependenciesI _ ->
@@ -831,6 +836,7 @@ inputDescription input =
     EditDependentsI {} -> wat
     FindI {} -> wat
     FindShallowI {} -> wat
+    GivensI {} -> wat
     HistoryI {} -> wat
     IOTestAllI -> wat
     IOTestI {} -> wat
@@ -841,6 +847,8 @@ inputDescription input =
     ListDependentsI {} -> wat
     LoadI {} -> wat
     MakeStandaloneI {} -> wat
+    MarkGivenI {} -> wat
+    UnmarkGivenI {} -> wat
     MergeCommitI {} -> wat
     MergeI {} -> wat
     NamesI {} -> wat
@@ -960,6 +968,19 @@ handleFindI isVerbose fscope ws input = do
     searchBranch0 codebase searchBranch names =
       case ws of
         [] -> pure (List.sortBy SR.compareByName (SR.fromNames names))
+        -- given-set filter: list every term in the search branch whose
+        -- metadata carries the @##Builtin.Given@ sentinel (ADR-013).
+        -- Consumes 'Unison.Codebase.Givens.metadataValuesFor' through
+        -- 'isGiven'. The metadata for a referent at @ns.foo@ lives
+        -- in @ns@'s 'Star2', not in the parent's, so we must walk
+        -- children and consult 'isGiven' at each level rather than
+        -- checking the top-level branch alone.
+        [":given"] -> do
+          let givenReferents :: Set Referent
+              givenReferents = collectGivenReferents searchBranch
+          pure $
+            (if isVerbose then uniqueBy SR.toReferent else id) $
+              searchResultsFor names (Set.toList givenReferents) []
         -- type query
         ":" : ws -> do
           typ <- parseSearchType (show input) (unwords ws)
@@ -993,6 +1014,30 @@ handleFindI isVerbose fscope ws input = do
       Cli.setNumberedArgs $ fmap (SA.SearchResult searchRoot) results
       results' <- Cli.runTransaction (Backend.loadSearchResults codebase results)
       Cli.respond $ ListOfDefinitions fscope ppe isVerbose results'
+
+-- | All referents under the supplied branch (recursive) whose
+-- metadata at their containing namespace carries the given sentinel.
+-- The metadata for a referent at @ns.foo@ lives in @ns@'s 'Star2',
+-- so we walk children and consult 'Givens.isGiven' at each level
+-- rather than checking the top-level branch alone.
+collectGivenReferents :: Branch0 m -> Set Referent
+collectGivenReferents = go
+  where
+    go b0 =
+      let here :: Set Referent
+          here =
+            Set.fromList
+              [ r
+              | r <- Set.toList (R.dom (Star2.d1 (view Branch.terms_ b0))),
+                Givens.isGiven r b0
+              ]
+          there :: Set Referent
+          there =
+            Set.unions
+              [ go (Branch.head child)
+              | child <- Map.elems (view Branch.children_ b0)
+              ]
+       in Set.union here there
 
 doDisplay :: OutputLocation -> Names -> Term Symbol () -> Cli ()
 doDisplay outputLoc names tm = do

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/AddRun.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/AddRun.hs
@@ -53,6 +53,7 @@ handleAddRun input resultName = do
           (UF.effectDeclarationsId' uf0)
           ([(resultSymbol, External, trm, typ)] : UF.topLevelComponents' uf0)
           (UF.watchComponents uf0)
+          (UF.givenBindings' uf0)
   Cli.Env {codebase} <- ask
   currentNames <- Cli.currentNames
   let sr = Slurp.slurpFile uf resultVar currentNames

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/AddRun.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/AddRun.hs
@@ -54,6 +54,7 @@ handleAddRun input resultName = do
           ([(resultSymbol, External, trm, typ)] : UF.topLevelComponents' uf0)
           (UF.watchComponents uf0)
           (UF.givenBindings' uf0)
+          (UF.classBindings' uf0)
   Cli.Env {codebase} <- ask
   currentNames <- Cli.currentNames
   let sr = Slurp.slurpFile uf resultVar currentNames

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/EditDependents.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/EditDependents.hs
@@ -16,6 +16,7 @@ import Unison.Codebase.Editor.HandleInput.EditNamespace (getNamesForEdit)
 import Unison.Codebase.Editor.HandleInput.ShowDefinition (showDefinitions)
 import Unison.Codebase.Editor.Input (OutputLocation (..), RelativeToFold (..))
 import Unison.Codebase.Editor.Output qualified as Output
+import Unison.Codebase.Classes qualified as Classes
 import Unison.Codebase.Givens qualified as Givens
 import Unison.ConstructorReference qualified as ConstructorReference
 import Unison.HashQualified qualified as HQ
@@ -103,7 +104,8 @@ handleEditDependents name = do
 
   let misses = []
   -- Re-read the current branch so we can highlight given-tagged
-  -- definitions in the rendered output.
+  -- and class-tagged definitions in the rendered output.
   branchForGivens <- Cli.getCurrentBranch0
   let isGivenRef r = Givens.isGiven (Referent.Ref r) branchForGivens
-  showDefinitions (LatestFileLocation WithinFold) (const True) isGivenRef ppe terms types misses
+      isClassRef r = Classes.isClass r branchForGivens
+  showDefinitions (LatestFileLocation WithinFold) (const True) isGivenRef isClassRef ppe terms types misses

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/EditDependents.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/EditDependents.hs
@@ -16,6 +16,7 @@ import Unison.Codebase.Editor.HandleInput.EditNamespace (getNamesForEdit)
 import Unison.Codebase.Editor.HandleInput.ShowDefinition (showDefinitions)
 import Unison.Codebase.Editor.Input (OutputLocation (..), RelativeToFold (..))
 import Unison.Codebase.Editor.Output qualified as Output
+import Unison.Codebase.Givens qualified as Givens
 import Unison.ConstructorReference qualified as ConstructorReference
 import Unison.HashQualified qualified as HQ
 import Unison.Name (Name)
@@ -101,4 +102,8 @@ handleEditDependents name = do
       pure (ppe, types, terms)
 
   let misses = []
-  showDefinitions (LatestFileLocation WithinFold) (const True) ppe terms types misses
+  -- Re-read the current branch so we can highlight given-tagged
+  -- definitions in the rendered output.
+  branchForGivens <- Cli.getCurrentBranch0
+  let isGivenRef r = Givens.isGiven (Referent.Ref r) branchForGivens
+  showDefinitions (LatestFileLocation WithinFold) (const True) isGivenRef ppe terms types misses

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/EditDependents.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/EditDependents.hs
@@ -12,11 +12,11 @@ import Unison.Cli.MonadUtils qualified as Cli
 import Unison.Cli.NameResolutionUtils (resolveHQName)
 import Unison.Codebase.Branch qualified as Branch
 import Unison.Codebase.Branch.Names qualified as Branch
+import Unison.Codebase.Classes qualified as Classes
 import Unison.Codebase.Editor.HandleInput.EditNamespace (getNamesForEdit)
 import Unison.Codebase.Editor.HandleInput.ShowDefinition (showDefinitions)
 import Unison.Codebase.Editor.Input (OutputLocation (..), RelativeToFold (..))
 import Unison.Codebase.Editor.Output qualified as Output
-import Unison.Codebase.Classes qualified as Classes
 import Unison.Codebase.Givens qualified as Givens
 import Unison.ConstructorReference qualified as ConstructorReference
 import Unison.HashQualified qualified as HQ

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/EditNamespace.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/EditNamespace.hs
@@ -21,6 +21,7 @@ import Unison.Codebase.Editor.DisplayObject (DisplayObject)
 import Unison.Codebase.Editor.DisplayObject qualified as DisplayObject
 import Unison.Codebase.Editor.HandleInput.ShowDefinition (showDefinitions)
 import Unison.Codebase.Editor.Input (OutputLocation (..))
+import Unison.Codebase.Givens qualified as Givens
 import Unison.Codebase.Path qualified as Path
 import Unison.DataDeclaration (Decl)
 import Unison.HashQualified qualified as HQ
@@ -69,7 +70,8 @@ handleEditNamespace outputLoc paths0 = do
 
   (types, terms) <- Cli.runTransaction (getNamesForEdit codebase ppe allNamesToEdit)
   let misses = []
-  showDefinitions outputLoc (const True) ppe terms types misses
+  let isGivenRef r = Givens.isGiven (Referent.Ref r) currentBranch
+  showDefinitions outputLoc (const True) isGivenRef ppe terms types misses
 
 -- | Get names "for edit": gets types and terms out the codebase as display objects, but is careful not to get an
 -- auto-generated record accessor term like `Foo.bar.set` if it's also getting the corresponding type `Foo`. This is

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/EditNamespace.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/EditNamespace.hs
@@ -21,6 +21,7 @@ import Unison.Codebase.Editor.DisplayObject (DisplayObject)
 import Unison.Codebase.Editor.DisplayObject qualified as DisplayObject
 import Unison.Codebase.Editor.HandleInput.ShowDefinition (showDefinitions)
 import Unison.Codebase.Editor.Input (OutputLocation (..))
+import Unison.Codebase.Classes qualified as Classes
 import Unison.Codebase.Givens qualified as Givens
 import Unison.Codebase.Path qualified as Path
 import Unison.DataDeclaration (Decl)
@@ -71,7 +72,8 @@ handleEditNamespace outputLoc paths0 = do
   (types, terms) <- Cli.runTransaction (getNamesForEdit codebase ppe allNamesToEdit)
   let misses = []
   let isGivenRef r = Givens.isGiven (Referent.Ref r) currentBranch
-  showDefinitions outputLoc (const True) isGivenRef ppe terms types misses
+      isClassRef r = Classes.isClass r currentBranch
+  showDefinitions outputLoc (const True) isGivenRef isClassRef ppe terms types misses
 
 -- | Get names "for edit": gets types and terms out the codebase as display objects, but is careful not to get an
 -- auto-generated record accessor term like `Foo.bar.set` if it's also getting the corresponding type `Foo`. This is

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/EditNamespace.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/EditNamespace.hs
@@ -17,11 +17,11 @@ import Unison.Codebase (Codebase)
 import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Branch qualified as Branch
 import Unison.Codebase.Branch.Names qualified as Branch
+import Unison.Codebase.Classes qualified as Classes
 import Unison.Codebase.Editor.DisplayObject (DisplayObject)
 import Unison.Codebase.Editor.DisplayObject qualified as DisplayObject
 import Unison.Codebase.Editor.HandleInput.ShowDefinition (showDefinitions)
 import Unison.Codebase.Editor.Input (OutputLocation (..))
-import Unison.Codebase.Classes qualified as Classes
 import Unison.Codebase.Givens qualified as Givens
 import Unison.Codebase.Path qualified as Path
 import Unison.DataDeclaration (Decl)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/FormatFile.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/FormatFile.hs
@@ -187,6 +187,7 @@ annToRange = \case
   Ann.Intrinsic -> Nothing
   Ann.External -> Nothing
   Ann.GeneratedFrom a -> annToRange a
+  Ann.Synthetic a -> annToRange a
   Ann.Ann start end -> Just $ Range start end
 
 rangeToInterval :: Range -> Interval.Interval Pos.Pos

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/FormatFile.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/FormatFile.hs
@@ -188,6 +188,7 @@ annToRange = \case
   Ann.External -> Nothing
   Ann.GeneratedFrom a -> annToRange a
   Ann.Synthetic a -> annToRange a
+  Ann.Lowered a -> annToRange a
   Ann.Ann start end -> Just $ Range start end
 
 rangeToInterval :: Range -> Interval.Interval Pos.Pos

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Givens.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Givens.hs
@@ -1,0 +1,140 @@
+-- | Handlers for the @mark.given@, @unmark.given@, and @givens@
+-- commands.
+--
+-- These commands toggle and inspect the @##Builtin.Given@ sentinel
+-- stored in 'Unison.Codebase.Branch.Type.MdValues' (ADR-013). They
+-- are pure namespace operations: per ADR-014, the term hash of the
+-- referent is unchanged when (un)marking, so dependents are not
+-- disturbed.
+module Unison.Codebase.Editor.HandleInput.Givens
+  ( handleMarkGiven,
+    handleUnmarkGiven,
+    handleGivens,
+  )
+where
+
+import Data.List.NonEmpty (NonEmpty ((:|)))
+import Data.Map qualified as Map
+import Data.Set qualified as Set
+import Unison.Cli.Monad (Cli)
+import Unison.Cli.Monad qualified as Cli
+import Unison.Cli.MonadUtils qualified as Cli
+import Unison.Codebase.Branch (Branch0)
+import Unison.Codebase.Branch qualified as Branch
+import Unison.Codebase.Editor.Output (Output (..))
+import Unison.Codebase.Givens qualified as Givens
+import Unison.Codebase.Path (Path')
+import Unison.Codebase.Path qualified as Path
+import Unison.Codebase.ProjectPath qualified as PP
+import Unison.HashQualifiedPrime qualified as HQ'
+import Unison.Name (Name)
+import Unison.Name qualified as Name
+import Unison.NameSegment (NameSegment)
+import Unison.Prelude
+import Unison.Referent (Referent)
+import Unison.Syntax.Name qualified as Name (toText)
+import Unison.Util.Relation qualified as Relation
+import Unison.Util.Star2 qualified as Star2
+
+-- | Resolve a hash-qualified name to a unique 'Referent' at the given
+-- split path within the current project. Returns the referent, the
+-- absolute parent path together with the trailing name segment, and
+-- the bare hash-qualified name (for diagnostic output).
+resolveSingleTerm ::
+  HQ'.HashQualified (Path.Split Path') ->
+  Cli (Referent, Path.Split Path.Absolute, HQ'.HashQualified Name)
+resolveSingleTerm hq = do
+  hqResolved <- traverse Cli.resolveSplit' hq
+  termsAt <- Cli.getTermsAt hqResolved
+  case Set.toList termsAt of
+    [r] -> do
+      let absSplit :: Path.Split Path.Absolute
+          absSplit = first (view PP.absPath_) (HQ'.toName hqResolved)
+      let nameOnly :: HQ'.HashQualified Name
+          nameOnly = fmap Path.nameFromSplit hq
+      pure (r, absSplit, nameOnly)
+    [] -> Cli.returnEarly (TermNotFound hq)
+    _ -> Cli.returnEarly (DeleteNameAmbiguous 10 hq termsAt Set.empty)
+
+handleMarkGiven :: HQ'.HashQualified (Path.Split Path') -> Cli ()
+handleMarkGiven hq = do
+  (referent, absSplit, hqName) <- resolveSingleTerm hq
+  -- Walk the parent path from the *project root*, not from the
+  -- current namespace: 'absSplit' is rooted at the project root, so
+  -- starting from 'getCurrentBranch0' (which is already at the
+  -- current sub-namespace) would walk into an already-deep branch
+  -- and mis-locate the parent. Using the project root makes the
+  -- read path consistent with the write side ('stepManyAt' below,
+  -- which also takes a project-root-absolute path).
+  projectRoot <- Cli.getCurrentProjectRoot0
+  let (parentAbsPath, seg) = absSplit
+  -- Resolve the branch at the parent path so we can ask if the
+  -- referent is already marked /there/.
+  let parentBranch :: Branch0 IO
+      parentBranch =
+        Branch.getAt0 (Path.unabsolute parentAbsPath) projectRoot
+  if Givens.isGivenAt referent seg parentBranch
+    then Cli.respond (AlreadyMarkedGiven hqName)
+    else do
+      pb <- Cli.getCurrentProjectBranch
+      Cli.stepManyAt
+        pb
+        ("mark.given " <> HQ'.toTextWith Name.toText hqName)
+        [(parentAbsPath, Givens.markGivenAt referent seg)]
+      Cli.respond (MarkedGiven hqName)
+
+handleUnmarkGiven :: HQ'.HashQualified (Path.Split Path') -> Cli ()
+handleUnmarkGiven hq = do
+  (referent, absSplit, hqName) <- resolveSingleTerm hq
+  -- See comment in 'handleMarkGiven' for why we read from the
+  -- project root rather than from the current branch.
+  projectRoot <- Cli.getCurrentProjectRoot0
+  let (parentAbsPath, seg) = absSplit
+  let parentBranch :: Branch0 IO
+      parentBranch =
+        Branch.getAt0 (Path.unabsolute parentAbsPath) projectRoot
+  if not (Givens.isGivenAt referent seg parentBranch)
+    then Cli.respond (NotMarkedGiven hqName)
+    else do
+      pb <- Cli.getCurrentProjectBranch
+      Cli.stepManyAt
+        pb
+        ("unmark.given " <> HQ'.toTextWith Name.toText hqName)
+        [(parentAbsPath, Givens.unmarkGivenAt referent seg)]
+      Cli.respond (UnmarkedGiven hqName)
+
+-- | List the (deep) referents under the current namespace whose
+-- metadata carries the given sentinel, paired with the names they are
+-- known by within the namespace. Per-referent: a referent that
+-- appears under several aliases will appear once per alias.
+--
+-- 'Givens.isGiven' inspects the metadata stored on the supplied
+-- branch alone, so to find nested givens we walk children recursively
+-- and consult @isGiven@ at each level.
+handleGivens :: Cli ()
+handleGivens = do
+  branch0 <- Cli.getCurrentBranch0
+  -- Skip the 'lib' subtree so 'givens' does not surface dependency
+  -- givens. This matches 'find', 'edit.namespace', and the
+  -- dependents commands, which all consult 'Branch.withoutLib'
+  -- before walking the namespace.
+  let searchBranch = Branch.withoutLib branch0
+  let givens :: [(Name, Referent)]
+      givens = collectGivens [] searchBranch
+  Cli.respond (ListGivens givens)
+  where
+    collectGivens :: [NameSegment] -> Branch0 m -> [(Name, Referent)]
+    collectGivens revPrefix b0 =
+      let here :: [(Name, Referent)]
+          here =
+            [ (Name.fromReverseSegments (seg :| revPrefix), r)
+            | (r, seg) <- Relation.toList (Star2.d1 (view Branch.terms_ b0)),
+              Givens.isGiven r b0
+            ]
+          there =
+            concatMap
+              ( \(seg, child) ->
+                  collectGivens (seg : revPrefix) (Branch.head child)
+              )
+              (Map.toList (view Branch.children_ b0))
+       in here ++ there

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Load.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Load.hs
@@ -24,6 +24,7 @@ import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
 import Unison.Cli.MonadUtils qualified as Cli
 import Unison.Cli.TypeCheck (computeTypecheckingEnvironment)
+import Unison.Cli.TypeCheck qualified as Cli.TypeCheck
 import Unison.Cli.UniqueTypeGuidLookup qualified as Cli
 import Unison.Codebase (Codebase)
 import Unison.Codebase qualified as Codebase
@@ -384,9 +385,15 @@ parseAndTypecheckUnisonFile names sourceName text = do
       & onLeftM \err -> Cli.returnEarly (Output.ParseErrors text [err])
   -- set that the file at least parsed (but didn't typecheck)
   State.modify' (& #latestTypecheckedFile .~ Just (Left unisonFile))
+  -- Chunk L1: harvest namespace-level givens before entering the
+  -- typechecking transaction. The branch read happens in 'Cli'; the
+  -- pool itself is built inside the transaction with the codebase's
+  -- type lookup.
+  branch0 <- Cli.getCurrentBranch0
   typecheckingEnv <-
     Cli.runTransaction do
-      computeTypecheckingEnvironment (FileParsers.ShouldUseTndr'Yes parsingEnv) codebase [] unisonFile
+      ambientGivens <- Cli.TypeCheck.ambientGivensFromBranch codebase branch0
+      computeTypecheckingEnvironment (FileParsers.ShouldUseTndr'Yes parsingEnv) codebase [] ambientGivens unisonFile
   let Result.Result notes maybeTypecheckedUnisonFile = FileParsers.synthesizeFile typecheckingEnv unisonFile
       tws = reverse [wrn | Result.TypeWarning wrn <- toList notes]
       suffixifiedPPE = PPED.suffixifiedPPE pped

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Load.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Load.hs
@@ -182,7 +182,14 @@ loadUnisonFile sourceName text = do
       aliases =
         getTermAliases existingTerms slurpEntries.terms
 
-  Cli.respond (Output.Typechecked oldPpe newPpe slurpEntries aliases pp.branch.isMerge)
+  let classNames =
+        Set.fromList
+          [ Name.unsafeParseVar v
+          | v <- Set.toList (UF.classBindings' unisonFile),
+            Map.member v (UF.dataDeclarationsId' unisonFile)
+              || Map.member v (UF.effectDeclarationsId' unisonFile)
+          ]
+  Cli.respond (Output.Typechecked oldPpe newPpe slurpEntries aliases classNames pp.branch.isMerge)
 
   when (not . null $ UF.watchComponents unisonFile) do
     Timing.time "evaluating watches" do

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Load.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Load.hs
@@ -428,6 +428,10 @@ parseAndTypecheckUnisonFile names sourceName text = do
 
   maybeTypecheckedUnisonFile & onNothing do
     let tes = [err | Result.TypeError err <- toList notes]
+        ues =
+          [ (loc, goal, err)
+          | Result.UnresolvedImplicit loc goal err <- toList notes
+          ]
         cbs =
           [ bug
           | Result.CompilerBug (Result.TypecheckerBug bug) <-
@@ -437,6 +441,9 @@ parseAndTypecheckUnisonFile names sourceName text = do
     when (not (null tes)) do
       currentPath <- Cli.getCurrentPath
       Cli.respond (Output.TypeErrors currentPath text suffixifiedPPE tes)
+    when (not (null ues)) do
+      currentPath <- Cli.getCurrentPath
+      Cli.respond (Output.UnresolvedImplicits currentPath text suffixifiedPPE ues)
     when (not (null cbs)) do
       Cli.respond (Output.CompilerBugs text suffixifiedPPE cbs)
     Cli.returnEarlyWithoutOutput

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Run.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Run.hs
@@ -159,7 +159,7 @@ getTerm mainName =
 createWatcherFile :: Symbol -> Term Symbol Ann -> Type Symbol Ann -> Cli (TypecheckedUnisonFile Symbol Ann)
 createWatcherFile v tm typ =
   Cli.getLatestTypecheckedFile >>= \case
-    Nothing -> pure (UF.typecheckedUnisonFile mempty mempty mempty [(magicMainWatcherString, [(v, External, tm, typ)])])
+    Nothing -> pure (UF.typecheckedUnisonFile mempty mempty mempty [(magicMainWatcherString, [(v, External, tm, typ)])] mempty)
     Just uf ->
       let v2 = Var.freshIn (Set.fromList [v]) v
        in pure $
@@ -169,6 +169,7 @@ createWatcherFile v tm typ =
               (UF.topLevelComponents' uf)
               -- what about main's component? we have dropped them if they existed.
               [(magicMainWatcherString, [(v2, External, tm, typ)])]
+              (UF.givenBindings' uf)
 
 -- | synthesize the type of forcing a term
 --

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Run.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Run.hs
@@ -54,6 +54,7 @@ import Unison.Term qualified as Term
 import Unison.Type (Type)
 import Unison.Type qualified as Type
 import Unison.Typechecker qualified as Typechecker
+import Unison.Typechecker.GivenResolver qualified as GivenResolver
 import Unison.Typechecker.TypeLookup (TypeLookup)
 import Unison.Typechecker.TypeLookup qualified as TypeLookup
 import Unison.Typechecker.Variance qualified as Variance
@@ -184,7 +185,9 @@ synthesizeForce tl typeOfFunc = do
             termsByShortname = Map.empty,
             freeNameToFuzzyTermsByShortName = Map.empty,
             topLevelComponents = Map.empty,
-            variances = Variance.fromTypeLookup tl
+            variances = Variance.fromTypeLookup tl,
+            ambientGivens = GivenResolver.poolFromList [],
+            givenBindings = mempty
           }
   case Result.runResultT
     ( Typechecker.synthesize

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Run.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Run.hs
@@ -159,7 +159,7 @@ getTerm mainName =
 createWatcherFile :: Symbol -> Term Symbol Ann -> Type Symbol Ann -> Cli (TypecheckedUnisonFile Symbol Ann)
 createWatcherFile v tm typ =
   Cli.getLatestTypecheckedFile >>= \case
-    Nothing -> pure (UF.typecheckedUnisonFile mempty mempty mempty [(magicMainWatcherString, [(v, External, tm, typ)])] mempty)
+    Nothing -> pure (UF.typecheckedUnisonFile mempty mempty mempty [(magicMainWatcherString, [(v, External, tm, typ)])] mempty mempty)
     Just uf ->
       let v2 = Var.freshIn (Set.fromList [v]) v
        in pure $
@@ -170,6 +170,7 @@ createWatcherFile v tm typ =
               -- what about main's component? we have dropped them if they existed.
               [(magicMainWatcherString, [(v2, External, tm, typ)])]
               (UF.givenBindings' uf)
+              (UF.classBindings' uf)
 
 -- | synthesize the type of forcing a term
 --

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/ShowDefinition.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/ShowDefinition.hs
@@ -30,6 +30,7 @@ import Unison.Codebase.Editor.DisplayObject (DisplayObject)
 import Unison.Codebase.Editor.DisplayObject qualified as DisplayObject
 import Unison.Codebase.Editor.Input (OutputLocation (..), RelativeToFold (..), ShowDefinitionScope (..))
 import Unison.Codebase.Editor.Output
+import Unison.Codebase.Givens qualified as Givens
 import Unison.DataDeclaration (Decl)
 import Unison.HashQualified qualified as HQ
 import Unison.Name (Name)
@@ -120,7 +121,13 @@ handleShowDefinition outputLoc showDefinitionScope originalQuery = do
         -- Unlikely that both original query list and misses list are both very long, but make a set out of original
         -- query anyway, to replace pathological O(n^2) with O(n log n)
         filter (`Set.member` originalQuerySet) misses0
-  showDefinitions outputLoc (`Set.member` originalQuerySet) pped terms types misses
+  -- Compute the set of term references in the result that are tagged
+  -- as givens in the current namespace (ADR-013). The renderer will
+  -- prefix these with the `given` marker.
+  currentBranch0 <- Cli.getCurrentBranch0
+  let isGivenRef :: TermReference -> Bool
+      isGivenRef r = Givens.isGiven (Referent.Ref r) currentBranch0
+  showDefinitions outputLoc (`Set.member` originalQuerySet) isGivenRef pped terms types misses
   where
     suffixify =
       case outputLoc of
@@ -141,20 +148,30 @@ handleShowDefinition outputLoc showDefinitionScope originalQuery = do
 showDefinitions ::
   OutputLocation ->
   (HQ.HashQualified Name -> Bool) ->
+  -- | Predicate: is this term reference tagged as a given (ADR-013)?
+  -- Tagged terms are rendered with a leading @given@ marker so the
+  -- output round-trips with the parser-side @given@ keyword (chunk
+  -- A2). Until A2 lands, the marker is emitted as a leading comment
+  -- line so the output stays parseable.
+  -- TODO Phase 4: drop the @-- given@ comment scaffold once the
+  -- parser-side @given@ keyword (chunk A2) lands and the printer
+  -- can emit the bare keyword. Search for "TODO Phase 4: -- given"
+  -- to find every site that needs to be reconciled.
+  (TermReference -> Bool) ->
   PPED.PrettyPrintEnvDecl ->
   Map TermReference (DisplayObject (Type Symbol Ann) (Term Symbol Ann)) ->
   Map TypeReference (DisplayObject () (Decl Symbol Ann)) ->
   [HQ.HashQualified Name] ->
   Cli ()
-showDefinitions outputLoc nameInOriginalQuery pped terms types misses = do
+showDefinitions outputLoc nameInOriginalQuery isGivenRef pped terms types misses = do
   Cli.Env {codebase, writeSource} <- ask
   outputPath <- getOutputPath
   case outputPath of
     _ | null terms && null types -> pure ()
-    Nothing -> renderToConsole nameInOriginalQuery pped terms types
+    Nothing -> renderToConsole nameInOriginalQuery isGivenRef pped terms types
     Just (fp, relToFold) -> do
       mayTF <- use #latestTypecheckedFile
-      numRendered <- renderToFile codebase nameInOriginalQuery writeSource mayTF fp relToFold pped terms types
+      numRendered <- renderToFile codebase nameInOriginalQuery isGivenRef writeSource mayTF fp relToFold pped terms types
 
       when (numRendered > 0) do
         -- We set latestFile to be programmatically generated, if we
@@ -179,6 +196,8 @@ showDefinitions outputLoc nameInOriginalQuery pped terms types misses = do
 
 renderCodePretty ::
   (HQ.HashQualified Name -> Bool) ->
+  -- | Predicate: is this term reference a given? See 'showDefinitions'.
+  (TermReference -> Bool) ->
   PPED.PrettyPrintEnvDecl ->
   Bool ->
   (TermReferenceId -> Bool) ->
@@ -187,7 +206,7 @@ renderCodePretty ::
   Defns (Set Symbol) (Set Symbol) ->
   -- Result is Nothing if nothing was rendered
   Maybe (Pretty Pretty.ColorText, Int)
-renderCodePretty nameInOriginalQuery pped isSourceFile isTest terms types excludeNames =
+renderCodePretty nameInOriginalQuery isGivenRef pped isSourceFile isTest terms types excludeNames =
   let -- Associate each term and type with their best unsuffixified name
       namedTerms :: Map (HQ.HashQualified Name) (TermReference, DisplayObject (Type Symbol Ann) (Term Symbol Ann))
       namedTerms =
@@ -297,24 +316,38 @@ renderCodePretty nameInOriginalQuery pped isSourceFile isTest terms types exclud
             maybe mempty (<> Pretty.newline) maybeDoc
               <> Pretty.prettyType pped (name, ref, typ)
 
+      -- Prefix used in front of given-tagged terms so the round-trip
+      -- to source includes the marker. Until the parser-side `given`
+      -- keyword lands (chunk A2) we emit it as a leading comment so
+      -- the output stays parseable. This is the read-side half of the
+      -- ADR-017 surface.
+      -- TODO Phase 4: -- given scaffold. Replace this leading
+      -- comment with the bare @given@ keyword once chunk A2 lands;
+      -- see the matching marker in 'showDefinitions' parameter
+      -- documentation.
+      givenMarker :: Pretty SyntaxText
+      givenMarker = "-- given\n"
+
       prettyTerms :: [Pretty SyntaxText]
       prettyTerms =
         termsWithMaybeDocs1
           & Map.toList
           & List.sortBy (\(n0, _) (n1, _) -> Name.compareAlphabetical n0 n1)
           & map \(name, ((ref, term), maybeDoc)) ->
-            maybe mempty (<> Pretty.newline) maybeDoc
+            (if isGivenRef ref then givenMarker else mempty)
+              <> maybe mempty (<> Pretty.newline) maybeDoc
               <> Pretty.prettyTerm pped isSourceFile (maybe False isTest (Reference.toId ref)) (name, ref, term)
    in NEL.nonEmpty (prettyTypes ++ prettyTerms)
         $> (Pretty.syntaxToColor (Pretty.sep "\n\n" (prettyTypes ++ prettyTerms)), length prettyTerms + length prettyTypes)
 
 renderToConsole ::
   (HQ.HashQualified Name -> Bool) ->
+  (TermReference -> Bool) ->
   PPED.PrettyPrintEnvDecl ->
   Map TermReference (DisplayObject (Type Symbol Ann) (Term Symbol Ann)) ->
   Map TypeReference (DisplayObject () (Decl Symbol Ann)) ->
   Cli ()
-renderToConsole nameInOriginalQuery pped terms types = do
+renderToConsole nameInOriginalQuery isGivenRef pped terms types = do
   -- If we're writing to console we don't add test-watch syntax
   let isTest _ = False
   let isSourceFile = False
@@ -323,6 +356,7 @@ renderToConsole nameInOriginalQuery pped terms types = do
         fst
           <$> renderCodePretty
             nameInOriginalQuery
+            isGivenRef
             pped
             isSourceFile
             isTest
@@ -338,6 +372,7 @@ renderToFile ::
   (MonadIO m, Monoid a) =>
   Codebase IO Symbol a ->
   (HQ.HashQualified Name -> Bool) ->
+  (TermReference -> Bool) ->
   (Text -> Text -> Bool -> IO ()) ->
   Maybe (Either (UnisonFile.UnisonFile Symbol Ann) (UnisonFile.TypecheckedUnisonFile Symbol a)) ->
   FilePath ->
@@ -346,7 +381,7 @@ renderToFile ::
   Map TermReference (DisplayObject (Type Symbol Ann) (Term Symbol Ann)) ->
   Map TypeReference (DisplayObject () (Decl Symbol Ann)) ->
   (m Int)
-renderToFile codebase nameInOriginalQuery writeSource mayTF fp relToFold pped terms types = do
+renderToFile codebase nameInOriginalQuery isGivenRef writeSource mayTF fp relToFold pped terms types = do
   -- Of all the names we were asked to show, if this is a `WithinFold` showing, then exclude the ones that are
   -- already bound in the file
   let excludeNames =
@@ -379,7 +414,7 @@ renderToFile codebase nameInOriginalQuery writeSource mayTF fp relToFold pped te
         (Map.keysSet terms & Set.mapMaybe Reference.toId)
   let isTest r = Set.member r testRefs
   let isSourceFile = True
-  let mayRenderedCodePretty = renderCodePretty nameInOriginalQuery pped isSourceFile isTest terms types excludeNames
+  let mayRenderedCodePretty = renderCodePretty nameInOriginalQuery isGivenRef pped isSourceFile isTest terms types excludeNames
   case mayRenderedCodePretty of
     Just (renderedCodePretty, numRendered) -> do
       let (renderedCodeText) = Pretty.toPlain 80 renderedCodePretty

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/ShowDefinition.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/ShowDefinition.hs
@@ -26,8 +26,12 @@ import Unison.Codebase (Codebase)
 import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Branch qualified as Branch
 import Unison.Codebase.Branch.Names qualified as Branch
-import Unison.Codebase.Editor.DisplayObject (DisplayObject)
+import Unison.ABT qualified as ABT
+import Unison.Codebase.Editor.DisplayObject (DisplayObject (UserObject))
 import Unison.Codebase.Editor.DisplayObject qualified as DisplayObject
+import Unison.LabeledDependency qualified as LD
+import Unison.Term qualified as Term
+import Unison.Typechecker.GivenApply qualified as GivenApply
 import Unison.Codebase.Editor.Input (OutputLocation (..), RelativeToFold (..), ShowDefinitionScope (..))
 import Unison.Codebase.Editor.Output
 import Unison.Codebase.Givens qualified as Givens
@@ -163,8 +167,77 @@ showDefinitions ::
   Map TypeReference (DisplayObject () (Decl Symbol Ann)) ->
   [HQ.HashQualified Name] ->
   Cli ()
-showDefinitions outputLoc nameInOriginalQuery isGivenRef pped terms types misses = do
+showDefinitions outputLoc nameInOriginalQuery isGivenRef pped terms0 types misses = do
   Cli.Env {codebase, writeSource} <- ask
+  -- ADR-015 default elide-mode: pre-process every term being shown
+  -- by dropping apply-site arguments that fill leading @=>@ slots
+  -- in the function's declared type. The type lookup goes through
+  -- the codebase (terms loaded by 'view' have their source
+  -- annotations stripped, so the in-memory 'Ann.Synthetic' marker
+  -- is no longer present; the only reliable signal is the
+  -- function's declared type).
+  -- Term references whose types we need to look up to strip
+  -- implicit-fill arguments: every direct reference inside a body
+  -- (so we know which apply-site args are implicit) /and/ every
+  -- binding's own reference (so we can strip the parser-injected
+  -- leading lambda for the binding's @=>@ parameters).
+  let refsInTerms :: Set TermReference
+      refsInTerms =
+        Map.foldlWithKey'
+          ( \acc bindingRef dt -> case dt of
+              UserObject tm ->
+                let deps :: Set LD.LabeledDependency
+                    deps = Term.labeledDependencies tm
+                    trs =
+                      Set.fromList
+                        [ r | LD.TermReference r <- Set.toList deps
+                        ]
+                 in acc <> Set.insert bindingRef trs
+              _ -> Set.insert bindingRef acc
+          )
+          Set.empty
+          terms0
+  typesByRef <-
+    Cli.runTransaction $
+      Foldable.foldlM
+        ( \acc r -> case r of
+            Reference.DerivedId rid ->
+              Codebase.getTypeOfTerm codebase r >>= \case
+                Just ty -> pure (Map.insert (Reference.DerivedId rid) ty acc)
+                Nothing -> pure acc
+            Reference.Builtin _ ->
+              -- Builtin types live in 'Builtin' (no @=>@ arrows in
+              -- practice), so skipping them is safe and saves an
+              -- 'expectTypeOfTerm' lookup.
+              pure acc
+        )
+        Map.empty
+        (Set.toList refsInTerms)
+  let lookupTermType :: Term Symbol Ann -> Maybe (Type Symbol Ann)
+      lookupTermType t = case ABT.out t of
+        ABT.Tm (Term.Ref r) -> Map.lookup r typesByRef
+        ABT.Tm (Term.Ann _ ty) -> Just ty
+        _ -> Nothing
+      stripTerm :: Term Symbol Ann -> Term Symbol Ann
+      stripTerm = GivenApply.stripImplicitArgsByType lookupTermType
+      -- A top-level binding whose declared type starts with
+      -- @=>@ has a parser-injected @\\_implicit_<name>_<i> -> …@
+      -- prefix in its body. Strip the corresponding leading lambdas
+      -- before rendering so the surface form matches what the user
+      -- wrote.
+      terms :: Map TermReference (DisplayObject (Type Symbol Ann) (Term Symbol Ann))
+      terms =
+        Map.mapWithKey
+          ( \ref dt -> case dt of
+              UserObject tm ->
+                let tm' = stripTerm tm
+                    tm'' = case Map.lookup ref typesByRef of
+                      Just ty -> GivenApply.stripLeadingImplicitLambdas ty tm'
+                      Nothing -> tm'
+                 in UserObject tm''
+              other -> other
+          )
+          terms0
   outputPath <- getOutputPath
   case outputPath of
     _ | null terms && null types -> pure ()

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/ShowDefinition.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/ShowDefinition.hs
@@ -17,6 +17,7 @@ import Data.Map qualified as Map
 import Data.Set qualified as Set
 import Data.Text qualified as Text
 import Unison.ABT qualified as ABT
+import Unison.Builtin qualified as Builtin
 import Unison.Builtin.Decls qualified as DD
 import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
@@ -31,6 +32,7 @@ import Unison.Codebase.Editor.DisplayObject (DisplayObject (UserObject))
 import Unison.Codebase.Editor.DisplayObject qualified as DisplayObject
 import Unison.Codebase.Editor.Input (OutputLocation (..), RelativeToFold (..), ShowDefinitionScope (..))
 import Unison.Codebase.Editor.Output
+import Unison.Codebase.Classes qualified as Classes
 import Unison.Codebase.Givens qualified as Givens
 import Unison.DataDeclaration (Decl)
 import Unison.HashQualified qualified as HQ
@@ -40,19 +42,22 @@ import Unison.Name qualified as Name
 import Unison.NameSegment qualified as NameSegment
 import Unison.Names qualified as Names
 import Unison.NamesWithHistory qualified as Names
-import Unison.Parser.Ann (Ann)
+import Unison.Parser.Ann (Ann (Intrinsic))
 import Unison.Prelude
 import Unison.PrettyPrintEnv qualified as PPE
 import Unison.PrettyPrintEnv.Names qualified as PPE
 import Unison.PrettyPrintEnvDecl qualified as PPED
 import Unison.Reference (TermReference, TermReferenceId, TypeReference)
 import Unison.Reference qualified as Reference
+import Unison.Referent (Referent)
 import Unison.Referent qualified as Referent
 import Unison.Server.Backend qualified as Backend
 import Unison.Server.NameSearch.FromNames qualified as NameSearch
 import Unison.Symbol (Symbol)
 import Unison.Syntax.Name qualified as Name (toVar)
 import Unison.Syntax.NamePrinter (SyntaxText)
+import Unison.Util.Pretty qualified as Pretty.Util
+import Unison.Util.SyntaxText qualified as S
 import Unison.Syntax.TermPrinter qualified as TermPrinter
 import Unison.Term (Term)
 import Unison.Term qualified as Term
@@ -129,9 +134,33 @@ handleShowDefinition outputLoc showDefinitionScope originalQuery = do
   -- as givens in the current namespace (ADR-013). The renderer will
   -- prefix these with the `given` marker.
   currentBranch0 <- Cli.getCurrentBranch0
-  let isGivenRef :: TermReference -> Bool
-      isGivenRef r = Givens.isGiven (Referent.Ref r) currentBranch0
-  showDefinitions outputLoc (`Set.member` originalQuerySet) isGivenRef pped terms types misses
+  -- 'Givens.isGiven' only inspects the supplied branch's own
+  -- metadata; given-marked terms living in sub-namespaces (the
+  -- common case for class accessors and dot-qualified givens like
+  -- @Monoid.nat@) wouldn't be detected. Walk the whole tree once
+  -- and collect every given-marked referent.
+  let givenReferents :: Set Referent =
+        let go b acc =
+              let here = Set.filter (\r -> Givens.isGiven r b) (Branch.deepReferents b)
+                  acc' = acc <> here
+                  children = b ^. Branch.children_
+               in foldr (\child a -> go (Branch.head child) a) acc' (Map.elems children)
+         in go currentBranch0 Set.empty
+      isGivenRef :: TermReference -> Bool
+      isGivenRef r = Set.member (Referent.Ref r) givenReferents
+      -- Walk the whole tree to collect every class-marked type, so
+      -- the printer renders them with the @class@ keyword and
+      -- record-style field syntax.
+      classTypeRefs :: Set TypeReference =
+        let go b acc =
+              let here = Set.filter (\r -> Classes.isClass r b) (Branch.deepTypeReferences b)
+                  acc' = acc <> here
+                  children = b ^. Branch.children_
+               in foldr (\child a -> go (Branch.head child) a) acc' (Map.elems children)
+         in go currentBranch0 Set.empty
+      isClassRef :: TypeReference -> Bool
+      isClassRef r = Set.member r classTypeRefs
+  showDefinitions outputLoc (`Set.member` originalQuerySet) isGivenRef isClassRef pped terms types misses
   where
     suffixify =
       case outputLoc of
@@ -162,12 +191,15 @@ showDefinitions ::
   -- can emit the bare keyword. Search for "TODO Phase 4: -- given"
   -- to find every site that needs to be reconciled.
   (TermReference -> Bool) ->
+  -- | Predicate: is this type tagged as a class? Class-tagged types
+  -- render with the @class@ keyword and record-style field syntax.
+  (TypeReference -> Bool) ->
   PPED.PrettyPrintEnvDecl ->
   Map TermReference (DisplayObject (Type Symbol Ann) (Term Symbol Ann)) ->
   Map TypeReference (DisplayObject () (Decl Symbol Ann)) ->
   [HQ.HashQualified Name] ->
   Cli ()
-showDefinitions outputLoc nameInOriginalQuery isGivenRef pped terms0 types misses = do
+showDefinitions outputLoc nameInOriginalQuery isGivenRef isClassRef pped terms0 types misses = do
   Cli.Env {codebase, writeSource} <- ask
   -- ADR-015 default elide-mode: pre-process every term being shown
   -- by dropping apply-site arguments that fill leading @=>@ slots
@@ -206,10 +238,15 @@ showDefinitions outputLoc nameInOriginalQuery isGivenRef pped terms0 types misse
                 Just ty -> pure (Map.insert (Reference.DerivedId rid) ty acc)
                 Nothing -> pure acc
             Reference.Builtin _ ->
-              -- Builtin types live in 'Builtin' (no @=>@ arrows in
-              -- practice), so skipping them is safe and saves an
-              -- 'expectTypeOfTerm' lookup.
-              pure acc
+              -- ADR-006: the @summon@ builtin (and any future builtin
+              -- with a @=>@ in its declared type) needs to be known
+              -- to 'stripImplicitArgsByType' so the elaborator-filled
+              -- dictionary argument can be elided from @view@ output.
+              -- 'Builtin.termRefTypes' carries unit annotations; promote
+              -- them to 'Intrinsic' so they fit the @Ann@-typed map.
+              case Map.lookup r Builtin.termRefTypes of
+                Just ty -> pure (Map.insert r ((const Intrinsic) <$> ty) acc)
+                Nothing -> pure acc
         )
         Map.empty
         (Set.toList refsInTerms)
@@ -219,7 +256,7 @@ showDefinitions outputLoc nameInOriginalQuery isGivenRef pped terms0 types misse
         ABT.Tm (Term.Ann _ ty) -> Just ty
         _ -> Nothing
       stripTerm :: Term Symbol Ann -> Term Symbol Ann
-      stripTerm = GivenApply.stripImplicitArgsByType lookupTermType
+      stripTerm = GivenApply.stripImplicitArgsByType isGivenRef lookupTermType
       -- A top-level binding whose declared type starts with
       -- @=>@ has a parser-injected @\\_implicit_<name>_<i> -> …@
       -- prefix in its body. Strip the corresponding leading lambdas
@@ -241,10 +278,10 @@ showDefinitions outputLoc nameInOriginalQuery isGivenRef pped terms0 types misse
   outputPath <- getOutputPath
   case outputPath of
     _ | null terms && null types -> pure ()
-    Nothing -> renderToConsole nameInOriginalQuery isGivenRef pped terms types
+    Nothing -> renderToConsole nameInOriginalQuery isGivenRef isClassRef pped terms types
     Just (fp, relToFold) -> do
       mayTF <- use #latestTypecheckedFile
-      numRendered <- renderToFile codebase nameInOriginalQuery isGivenRef writeSource mayTF fp relToFold pped terms types
+      numRendered <- renderToFile codebase nameInOriginalQuery isGivenRef isClassRef writeSource mayTF fp relToFold pped terms types
 
       when (numRendered > 0) do
         -- We set latestFile to be programmatically generated, if we
@@ -271,6 +308,8 @@ renderCodePretty ::
   (HQ.HashQualified Name -> Bool) ->
   -- | Predicate: is this term reference a given? See 'showDefinitions'.
   (TermReference -> Bool) ->
+  -- | Predicate: is this type a class? See 'showDefinitions'.
+  (TypeReference -> Bool) ->
   PPED.PrettyPrintEnvDecl ->
   Bool ->
   (TermReferenceId -> Bool) ->
@@ -279,7 +318,7 @@ renderCodePretty ::
   Defns (Set Symbol) (Set Symbol) ->
   -- Result is Nothing if nothing was rendered
   Maybe (Pretty Pretty.ColorText, Int)
-renderCodePretty nameInOriginalQuery isGivenRef pped isSourceFile isTest terms types excludeNames =
+renderCodePretty nameInOriginalQuery isGivenRef isClassRef pped isSourceFile isTest terms types excludeNames =
   let -- Associate each term and type with their best unsuffixified name
       namedTerms :: Map (HQ.HashQualified Name) (TermReference, DisplayObject (Type Symbol Ann) (Term Symbol Ann))
       namedTerms =
@@ -387,19 +426,14 @@ renderCodePretty nameInOriginalQuery isGivenRef pped isSourceFile isTest terms t
           & List.sortBy (\(n0, _) (n1, _) -> Name.compareAlphabetical n0 n1)
           & map \(name, ((ref, typ), maybeDoc)) ->
             maybe mempty (<> Pretty.newline) maybeDoc
-              <> Pretty.prettyType pped (name, ref, typ)
+              <> Pretty.prettyTypeWithClasses isClassRef pped (name, ref, typ)
 
-      -- Prefix used in front of given-tagged terms so the round-trip
-      -- to source includes the marker. Until the parser-side `given`
-      -- keyword lands (chunk A2) we emit it as a leading comment so
-      -- the output stays parseable. This is the read-side half of the
-      -- ADR-017 surface.
-      -- TODO Phase 4: -- given scaffold. Replace this leading
-      -- comment with the bare @given@ keyword once chunk A2 lands;
-      -- see the matching marker in 'showDefinitions' parameter
-      -- documentation.
+      -- ADR-007: emit the `given` keyword as the actual surface
+      -- syntax now that the parser recognises it. The leading
+      -- `given ` reads as a prefix to the binding's signature line,
+      -- matching how the user originally wrote @given Show.nat : T = …@.
       givenMarker :: Pretty SyntaxText
-      givenMarker = "-- given\n"
+      givenMarker = Pretty.Util.withSyntax S.DataTypeKeyword "given "
 
       prettyTerms :: [Pretty SyntaxText]
       prettyTerms =
@@ -416,11 +450,12 @@ renderCodePretty nameInOriginalQuery isGivenRef pped isSourceFile isTest terms t
 renderToConsole ::
   (HQ.HashQualified Name -> Bool) ->
   (TermReference -> Bool) ->
+  (TypeReference -> Bool) ->
   PPED.PrettyPrintEnvDecl ->
   Map TermReference (DisplayObject (Type Symbol Ann) (Term Symbol Ann)) ->
   Map TypeReference (DisplayObject () (Decl Symbol Ann)) ->
   Cli ()
-renderToConsole nameInOriginalQuery isGivenRef pped terms types = do
+renderToConsole nameInOriginalQuery isGivenRef isClassRef pped terms types = do
   -- If we're writing to console we don't add test-watch syntax
   let isTest _ = False
   let isSourceFile = False
@@ -430,6 +465,7 @@ renderToConsole nameInOriginalQuery isGivenRef pped terms types = do
           <$> renderCodePretty
             nameInOriginalQuery
             isGivenRef
+            isClassRef
             pped
             isSourceFile
             isTest
@@ -446,6 +482,7 @@ renderToFile ::
   Codebase IO Symbol a ->
   (HQ.HashQualified Name -> Bool) ->
   (TermReference -> Bool) ->
+  (TypeReference -> Bool) ->
   (Text -> Text -> Bool -> IO ()) ->
   Maybe (Either (UnisonFile.UnisonFile Symbol Ann) (UnisonFile.TypecheckedUnisonFile Symbol a)) ->
   FilePath ->
@@ -454,7 +491,7 @@ renderToFile ::
   Map TermReference (DisplayObject (Type Symbol Ann) (Term Symbol Ann)) ->
   Map TypeReference (DisplayObject () (Decl Symbol Ann)) ->
   (m Int)
-renderToFile codebase nameInOriginalQuery isGivenRef writeSource mayTF fp relToFold pped terms types = do
+renderToFile codebase nameInOriginalQuery isGivenRef isClassRef writeSource mayTF fp relToFold pped terms types = do
   -- Of all the names we were asked to show, if this is a `WithinFold` showing, then exclude the ones that are
   -- already bound in the file
   let excludeNames =
@@ -487,7 +524,7 @@ renderToFile codebase nameInOriginalQuery isGivenRef writeSource mayTF fp relToF
         (Map.keysSet terms & Set.mapMaybe Reference.toId)
   let isTest r = Set.member r testRefs
   let isSourceFile = True
-  let mayRenderedCodePretty = renderCodePretty nameInOriginalQuery isGivenRef pped isSourceFile isTest terms types excludeNames
+  let mayRenderedCodePretty = renderCodePretty nameInOriginalQuery isGivenRef isClassRef pped isSourceFile isTest terms types excludeNames
   case mayRenderedCodePretty of
     Just (renderedCodePretty, numRendered) -> do
       let (renderedCodeText) = Pretty.toPlain 80 renderedCodePretty

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/ShowDefinition.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/ShowDefinition.hs
@@ -28,11 +28,11 @@ import Unison.Codebase (Codebase)
 import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Branch qualified as Branch
 import Unison.Codebase.Branch.Names qualified as Branch
+import Unison.Codebase.Classes qualified as Classes
 import Unison.Codebase.Editor.DisplayObject (DisplayObject (UserObject))
 import Unison.Codebase.Editor.DisplayObject qualified as DisplayObject
 import Unison.Codebase.Editor.Input (OutputLocation (..), RelativeToFold (..), ShowDefinitionScope (..))
 import Unison.Codebase.Editor.Output
-import Unison.Codebase.Classes qualified as Classes
 import Unison.Codebase.Givens qualified as Givens
 import Unison.DataDeclaration (Decl)
 import Unison.HashQualified qualified as HQ
@@ -56,8 +56,6 @@ import Unison.Server.NameSearch.FromNames qualified as NameSearch
 import Unison.Symbol (Symbol)
 import Unison.Syntax.Name qualified as Name (toVar)
 import Unison.Syntax.NamePrinter (SyntaxText)
-import Unison.Util.Pretty qualified as Pretty.Util
-import Unison.Util.SyntaxText qualified as S
 import Unison.Syntax.TermPrinter qualified as TermPrinter
 import Unison.Term (Term)
 import Unison.Term qualified as Term
@@ -67,7 +65,9 @@ import Unison.UnisonFile qualified as UnisonFile
 import Unison.Util.Defns (Defns (..))
 import Unison.Util.Pretty (Pretty)
 import Unison.Util.Pretty qualified as Pretty
+import Unison.Util.Pretty qualified as Pretty.Util
 import Unison.Util.Set qualified as Set
+import Unison.Util.SyntaxText qualified as S
 import Unison.WatchKind qualified as WatchKind
 
 -- | Handle a @ShowDefinitionI@ input command, i.e. `view` or `edit`.

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/ShowDefinition.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/ShowDefinition.hs
@@ -16,6 +16,7 @@ import Data.List.NonEmpty qualified as NEL
 import Data.Map qualified as Map
 import Data.Set qualified as Set
 import Data.Text qualified as Text
+import Unison.ABT qualified as ABT
 import Unison.Builtin.Decls qualified as DD
 import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
@@ -26,17 +27,14 @@ import Unison.Codebase (Codebase)
 import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Branch qualified as Branch
 import Unison.Codebase.Branch.Names qualified as Branch
-import Unison.ABT qualified as ABT
 import Unison.Codebase.Editor.DisplayObject (DisplayObject (UserObject))
 import Unison.Codebase.Editor.DisplayObject qualified as DisplayObject
-import Unison.LabeledDependency qualified as LD
-import Unison.Term qualified as Term
-import Unison.Typechecker.GivenApply qualified as GivenApply
 import Unison.Codebase.Editor.Input (OutputLocation (..), RelativeToFold (..), ShowDefinitionScope (..))
 import Unison.Codebase.Editor.Output
 import Unison.Codebase.Givens qualified as Givens
 import Unison.DataDeclaration (Decl)
 import Unison.HashQualified qualified as HQ
+import Unison.LabeledDependency qualified as LD
 import Unison.Name (Name)
 import Unison.Name qualified as Name
 import Unison.NameSegment qualified as NameSegment
@@ -57,7 +55,9 @@ import Unison.Syntax.Name qualified as Name (toVar)
 import Unison.Syntax.NamePrinter (SyntaxText)
 import Unison.Syntax.TermPrinter qualified as TermPrinter
 import Unison.Term (Term)
+import Unison.Term qualified as Term
 import Unison.Type (Type)
+import Unison.Typechecker.GivenApply qualified as GivenApply
 import Unison.UnisonFile qualified as UnisonFile
 import Unison.Util.Defns (Defns (..))
 import Unison.Util.Pretty (Pretty)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
@@ -34,12 +34,12 @@ import Unison.Codebase.Branch (Branch, Branch0)
 import Unison.Codebase.Branch qualified as Branch
 import Unison.Codebase.Branch.Names qualified as Branch
 import Unison.Codebase.BranchUtil qualified as BranchUtil
+import Unison.Codebase.Classes qualified as Classes
 import Unison.Codebase.Editor.HandleInput.Branch qualified as HandleInput.Branch
 import Unison.Codebase.Editor.HandleInput.DeleteBranch qualified as DeleteBranch
 import Unison.Codebase.Editor.HandleInput.Merge2 qualified as Merge
 import Unison.Codebase.Editor.Output (Output)
 import Unison.Codebase.Editor.Output qualified as Output
-import Unison.Codebase.Classes qualified as Classes
 import Unison.Codebase.Givens qualified as Givens
 import Unison.Codebase.Path (Path)
 import Unison.Codebase.Path qualified as Path

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
@@ -39,6 +39,7 @@ import Unison.Codebase.Editor.HandleInput.DeleteBranch qualified as DeleteBranch
 import Unison.Codebase.Editor.HandleInput.Merge2 qualified as Merge
 import Unison.Codebase.Editor.Output (Output)
 import Unison.Codebase.Editor.Output qualified as Output
+import Unison.Codebase.Classes qualified as Classes
 import Unison.Codebase.Givens qualified as Givens
 import Unison.Codebase.Path (Path)
 import Unison.Codebase.Path qualified as Path
@@ -314,6 +315,17 @@ handleUpdate2 = do
                 Map.member v (UF.hashTermsId secondTuf)
               ]
         autoMarkGivens path givenNames
+        -- ADR-007: also auto-mark every type the parser tagged with
+        -- the @class@ keyword. Same pattern as givens, but on the
+        -- type namespace instead of the term namespace.
+        let classNames :: [Name]
+            classNames =
+              [ Name.unsafeParseVar v
+              | v <- Set.toList (UF.classBindings' secondTuf),
+                Map.member v (UF.dataDeclarationsId' secondTuf)
+                  || Map.member v (UF.effectDeclarationsId' secondTuf)
+              ]
+        autoMarkClasses path classNames
         #latestTypecheckedFile .= Nothing
 
         -- Special case: we are running a successful `update` on a merge/update/upgrade branch that has a parent (such
@@ -505,3 +517,31 @@ autoMarkGivens _path names = do
       steps = concatMap stepsForName names
   when (not (null steps)) $
     Cli.stepManyAt pb "update.auto-mark.given" steps
+
+-- | After @update@ persists the typechecked file, mark every type
+-- name the parser tagged with @class@ as a namespace class. Mirrors
+-- 'autoMarkGivens' but consults the type-namespace ('Branch.types_')
+-- and uses 'Classes.markClassAt'. @view@ later reads the marker to
+-- render the declaration with the @class@ keyword and record syntax.
+autoMarkClasses :: ProjectPath -> [Name] -> Cli ()
+autoMarkClasses _path [] = pure ()
+autoMarkClasses _path names = do
+  projectRoot <- Cli.getCurrentProjectRoot0
+  pb <- Cli.getCurrentProjectBranch
+  let stepsForName :: Name -> [(Path.Absolute, Branch0 IO -> Branch0 IO)]
+      stepsForName name =
+        let revSegs = Name.reverseSegments name
+            seg = NonEmpty.head revSegs
+            parentSegsRev = NonEmpty.tail revSegs
+            parentPath = Path.fromList (reverse parentSegsRev)
+            parentAbs = Path.Absolute parentPath
+            parentBranch = Branch.getAt0 parentPath projectRoot
+            refs =
+              [ r
+              | (r, s) <- Relation.toList (Star2.d1 (view Branch.types_ parentBranch)),
+                s == seg
+              ]
+         in [(parentAbs, Classes.markClassAt r seg) | r <- refs]
+      steps = concatMap stepsForName names
+  when (not (null steps)) $
+    Cli.stepManyAt pb "update.auto-mark.class" steps

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
@@ -10,6 +10,7 @@ where
 import Control.Lens (mapped, (.=), (?=))
 import Control.Monad.Reader.Class (ask)
 import Data.Bifoldable (bifoldMap)
+import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map qualified as Map
 import Data.Map.Merge.Strict qualified as Map
 import Data.Set qualified as Set
@@ -33,6 +34,7 @@ import Unison.Codebase.Branch (Branch, Branch0)
 import Unison.Codebase.Branch qualified as Branch
 import Unison.Codebase.Branch.Names qualified as Branch
 import Unison.Codebase.BranchUtil qualified as BranchUtil
+import Unison.Codebase.Givens qualified as Givens
 import Unison.Codebase.Editor.HandleInput.Branch qualified as HandleInput.Branch
 import Unison.Codebase.Editor.HandleInput.DeleteBranch qualified as DeleteBranch
 import Unison.Codebase.Editor.HandleInput.Merge2 qualified as Merge
@@ -40,7 +42,7 @@ import Unison.Codebase.Editor.Output (Output)
 import Unison.Codebase.Editor.Output qualified as Output
 import Unison.Codebase.Path (Path)
 import Unison.Codebase.Path qualified as Path
-import Unison.Codebase.ProjectPath (ProjectPathG (..))
+import Unison.Codebase.ProjectPath (ProjectPath, ProjectPathG (..))
 import Unison.DataDeclaration (Decl)
 import Unison.DataDeclaration qualified as Decl
 import Unison.DeclCoherencyCheck qualified as DeclCoherencyCheck
@@ -77,6 +79,7 @@ import Unison.Util.Pretty (ColorText, Pretty)
 import Unison.Util.Pretty qualified as Pretty
 import Unison.Util.Relation (Relation)
 import Unison.Util.Relation qualified as Relation
+import Unison.Util.Star2 qualified as Star2
 import Unison.Util.Set qualified as Set
 import Unison.WatchKind qualified as WK
 import Witch (unsafeFrom)
@@ -298,6 +301,19 @@ handleUpdate2 = do
               (\typeName -> Right (Map.lookup typeName declNameLookup.declToConstructors))
               secondTuf
         Cli.stepAt "update" (path, Branch.batchUpdates branchUpdates)
+        -- Auto-mark every name the parser tagged with the @given@
+        -- keyword as a namespace given. This avoids requiring a
+        -- separate @mark.given@ for each declaration after @add@ /
+        -- @update@. The metadata write is idempotent: re-running
+        -- @add@ on an already-marked given is a no-op (see
+        -- 'Unison.Codebase.Givens.markGivenAt').
+        let givenNames :: [Name]
+            givenNames =
+              [ Name.unsafeParseVar v
+              | v <- Set.toList (UF.givenBindings' secondTuf),
+                Map.member v (UF.hashTermsId secondTuf)
+              ]
+        autoMarkGivens path givenNames
         #latestTypecheckedFile .= Nothing
 
         -- Special case: we are running a successful `update` on a merge/update/upgrade branch that has a parent (such
@@ -461,3 +477,31 @@ makePPE hashLen namespaceNames initialFileNames dependents =
         -- RHS (the initial file names, i.e. what was originally saved) that don't already exist in the LHS.
         (PPE.suffixifyByHash (Names.shadowing namespaceNames initialFileNames))
     ]
+
+-- | After @update@ persists the typechecked file, mark every name
+-- the parser tagged with @given@ as a namespace given. Each name is
+-- resolved relative to the project root; if no referent is present
+-- at the name in the freshly-updated branch the step is silently
+-- skipped (this mirrors 'Givens.markGivenAt's no-op behavior).
+autoMarkGivens :: ProjectPath -> [Name] -> Cli ()
+autoMarkGivens _path [] = pure ()
+autoMarkGivens _path names = do
+  projectRoot <- Cli.getCurrentProjectRoot0
+  pb <- Cli.getCurrentProjectBranch
+  let stepsForName :: Name -> [(Path.Absolute, Branch0 IO -> Branch0 IO)]
+      stepsForName name =
+        let revSegs = Name.reverseSegments name
+            seg = NonEmpty.head revSegs
+            parentSegsRev = NonEmpty.tail revSegs
+            parentPath = Path.fromList (reverse parentSegsRev)
+            parentAbs = Path.Absolute parentPath
+            parentBranch = Branch.getAt0 parentPath projectRoot
+            refs =
+              [ r
+              | (r, s) <- Relation.toList (Star2.d1 (view Branch.terms_ parentBranch)),
+                s == seg
+              ]
+         in [(parentAbs, Givens.markGivenAt r seg) | r <- refs]
+      steps = concatMap stepsForName names
+  when (not (null steps)) $
+    Cli.stepManyAt pb "update.auto-mark.given" steps

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
@@ -34,12 +34,12 @@ import Unison.Codebase.Branch (Branch, Branch0)
 import Unison.Codebase.Branch qualified as Branch
 import Unison.Codebase.Branch.Names qualified as Branch
 import Unison.Codebase.BranchUtil qualified as BranchUtil
-import Unison.Codebase.Givens qualified as Givens
 import Unison.Codebase.Editor.HandleInput.Branch qualified as HandleInput.Branch
 import Unison.Codebase.Editor.HandleInput.DeleteBranch qualified as DeleteBranch
 import Unison.Codebase.Editor.HandleInput.Merge2 qualified as Merge
 import Unison.Codebase.Editor.Output (Output)
 import Unison.Codebase.Editor.Output qualified as Output
+import Unison.Codebase.Givens qualified as Givens
 import Unison.Codebase.Path (Path)
 import Unison.Codebase.Path qualified as Path
 import Unison.Codebase.ProjectPath (ProjectPath, ProjectPathG (..))
@@ -79,8 +79,8 @@ import Unison.Util.Pretty (ColorText, Pretty)
 import Unison.Util.Pretty qualified as Pretty
 import Unison.Util.Relation (Relation)
 import Unison.Util.Relation qualified as Relation
-import Unison.Util.Star2 qualified as Star2
 import Unison.Util.Set qualified as Set
+import Unison.Util.Star2 qualified as Star2
 import Unison.WatchKind qualified as WK
 import Witch (unsafeFrom)
 

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -165,6 +165,9 @@ data Input
   | FindI Bool FindScope [String] -- isVerbose, findScope, query
   | FindShallowI Path'
   | ForkLocalBranchI (Either ShortCausalHash BranchRelativePath) BranchRelativePath
+  | -- | List every term in the current namespace whose metadata
+    -- contains the @##Builtin.Given@ sentinel.
+    GivensI
   | HistoryI (Maybe Int {- cap on number of results -}) (Maybe Int {- cap on diff elements shown -}) BranchId
   | -- An optional causal hash or branch to annotate.
     HistoryCommentI (Maybe BranchId2 {- causal to annotate -}) (Maybe Text {- comment -})
@@ -182,6 +185,12 @@ data Input
   | ListDependentsI (HQ.HashQualified Name)
   | LoadI (Maybe FilePath)
   | MakeStandaloneI String (HQ.HashQualified Name)
+  | -- | Mark the term at the given hash-qualified name as a given by
+    -- adding the @##Builtin.Given@ sentinel to its 'MdValues' (ADR-013).
+    MarkGivenI !(HQ'.HashQualified (Path.Split Path'))
+  | -- | Remove the @##Builtin.Given@ sentinel from the term at the
+    -- given hash-qualified name.
+    UnmarkGivenI !(HQ'.HashQualified (Path.Split Path'))
   | MergeBuiltinsI (Maybe Path)
   | MergeCommitI
   | MergeI (ProjectAndBranch (Maybe ProjectName) ProjectBranchName)

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -92,6 +92,7 @@ import Unison.SyncV2.Types qualified as SyncV2
 import Unison.Syntax.Parser qualified as Parser
 import Unison.Term (Term)
 import Unison.Type (Type)
+import Unison.Typechecker.GivenResolver qualified as GR
 import Unison.Typechecker.Context qualified as Context
 import Unison.Util.Conflicted (Conflicted)
 import Unison.Util.Defn (Defn)
@@ -286,6 +287,10 @@ data Output
     ParseErrors Text [Parser.Err Symbol]
   | TypeErrors Path.Absolute Text PPE.PrettyPrintEnv [Context.ErrorNote Symbol Ann]
   | TypeWarns Path.Absolute Text PPE.PrettyPrintEnv [Context.Warn Symbol Ann]
+  | -- | An implicit-resolution failure surfaced from
+    -- 'Unison.FileParsers.synthesizeFile'. The payload list mirrors
+    -- 'Result.UnresolvedImplicit': @(loc, goal, error)@.
+    UnresolvedImplicits Path.Absolute Text PPE.PrettyPrintEnv [(Ann, Type Symbol Ann, GR.ResolveError Symbol Ann)]
   | CompilerBugs Text PPE.PrettyPrintEnv [Context.CompilerBug Symbol Ann]
   | DisplayConflicts (Relation Name Referent) (Relation Name Reference)
   | EvaluationFailure
@@ -588,6 +593,7 @@ outputShouldUsePager o = case o of
   LoadingFile {} -> False
   Typechecked {} -> False
   TypeErrors {} -> False
+  UnresolvedImplicits {} -> False
   Evaluated {} -> False
   EvaluationFailure {} -> False
   _ -> True
@@ -656,6 +662,7 @@ isFailure o = case o of
   ParseErrors {} -> True
   TypeWarns {} -> False
   TypeErrors {} -> True
+  UnresolvedImplicits {} -> True
   CompilerBugs {} -> True
   DisplayConflicts {} -> False
   EvaluationFailure {} -> True

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -309,6 +309,7 @@ data Output
       !PPE.PrettyPrintEnv
       !(DefnsF (Map Name) SR.TermSlurp SR.TypeSlurp)
       !(Map Referent (NESet Name))
+      !(Set Name) -- names the parser tagged as 'class' bindings
       !Bool -- merging? (can expand later to include: upgrading?)
   | DisplayRendered (Maybe FilePath) (P.Pretty P.ColorText)
   | -- "display" the provided code to the console.

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -515,6 +515,20 @@ data Output
     WatchAddResult !(Maybe FilePath) !FilePath
   | -- `update` was attempted, but it would have either added or edited something in lib.*
     CantUpdateLib !(NESet Name)
+  | -- | The user ran `mark.given <name>` and the marking was applied.
+    -- The 'HQ'.HashQualified Name' identifies the name that was marked.
+    MarkedGiven !(HQ'.HashQualified Name)
+  | -- | The user ran `mark.given <name>` but the name was already
+    -- tagged. Idempotent no-op.
+    AlreadyMarkedGiven !(HQ'.HashQualified Name)
+  | -- | The user ran `unmark.given <name>` and the tag was removed.
+    UnmarkedGiven !(HQ'.HashQualified Name)
+  | -- | The user ran `unmark.given <name>` but no sentinel was
+    -- present. Idempotent no-op.
+    NotMarkedGiven !(HQ'.HashQualified Name)
+  | -- | Result of `givens`: the list of (name, referent) pairs in the
+    -- current namespace whose metadata carries the given sentinel.
+    ListGivens ![(Name, Referent)]
 
 data MoreEntriesThanShown = MoreEntriesThanShown | AllEntriesShown
   deriving (Eq, Show)
@@ -784,6 +798,11 @@ isFailure o = case o of
   WatchAddResult Nothing _ -> True
   WatchAddResult (Just _) _ -> False
   CantUpdateLib _ -> True
+  MarkedGiven {} -> False
+  AlreadyMarkedGiven {} -> False
+  UnmarkedGiven {} -> False
+  NotMarkedGiven {} -> False
+  ListGivens {} -> False
 
 isNumberedFailure :: NumberedOutput -> Bool
 isNumberedFailure = \case

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -92,8 +92,8 @@ import Unison.SyncV2.Types qualified as SyncV2
 import Unison.Syntax.Parser qualified as Parser
 import Unison.Term (Term)
 import Unison.Type (Type)
-import Unison.Typechecker.GivenResolver qualified as GR
 import Unison.Typechecker.Context qualified as Context
+import Unison.Typechecker.GivenResolver qualified as GR
 import Unison.Util.Conflicted (Conflicted)
 import Unison.Util.Defn (Defn)
 import Unison.Util.Defns (Defns, DefnsF, DefnsF2, defnsAreEmpty)

--- a/unison-cli/src/Unison/Codebase/Editor/SlurpResult.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/SlurpResult.hs
@@ -31,12 +31,14 @@ import Data.Set qualified as Set
 import Unison.Codebase.Editor.SlurpComponent (SlurpComponent (..))
 import Unison.Codebase.Editor.SlurpComponent qualified as SC
 import Unison.DataDeclaration (DeclOrBuiltin)
+import Unison.DataDeclaration qualified as DD
 import Unison.Merge (Updated)
 import Unison.Name (Name)
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
 import Unison.PrettyPrintEnv qualified as PPE
-import Unison.Reference (TermReference)
+import Unison.Reference (Reference, TermReference)
+import Unison.Reference qualified as Reference
 import Unison.Referent (Referent)
 import Unison.Symbol (Symbol)
 import Unison.Syntax.DeclPrinter qualified as DeclPrinter
@@ -132,9 +134,37 @@ pretty isPast ppe sr =
           shown ++ case sz of
             0 -> []
             n -> [P.shown n <> " more"]
+      -- ADR-007: surface the @class@ keyword in slurp summaries for
+      -- types whose parser-side var name was recorded as a class
+      -- binding. Mirrors the @view@ render path.
+      classRefSet :: Set Reference =
+        Set.fromList
+          [ Reference.DerivedId r
+          | (n, (r, _)) <- Map.toList (UF.dataDeclarationsId' (originalFile sr)),
+            Set.member n (UF.classBindings' (originalFile sr))
+          ]
+      isClassRef :: Reference -> Bool
+      isClassRef r = Set.member r classRefSet
+      declRefFor v = Reference.DerivedId <$> declRefFor' v
+      declRefFor' v =
+        fst
+          <$> ( Map.lookup v (UF.dataDeclarationsId' (originalFile sr))
+                  <|> (fmap . fmap) DD.toDataDecl (Map.lookup v (UF.effectDeclarationsId' (originalFile sr)))
+              )
+      headerFor v dd =
+        case declRefFor v of
+          Just r ->
+            DeclPrinter.prettyDeclHeaderWithClasses
+              isClassRef
+              DeclPrinter.RenderUniqueTypeGuids'No
+              r
+              (HQ.unsafeFromVar v)
+              dd
+          Nothing ->
+            DeclPrinter.prettyDeclHeader DeclPrinter.RenderUniqueTypeGuids'No (HQ.unsafeFromVar v) dd
       okType v = (plus <>) $ case UF.lookupDecl v (originalFile sr) of
         Just (_, dd) ->
-          P.syntaxToColor (DeclPrinter.prettyDeclHeader DeclPrinter.RenderUniqueTypeGuids'No (HQ.unsafeFromVar v) dd)
+          P.syntaxToColor (headerFor v dd)
             <> if null aliases
               then mempty
               else P.newline <> P.indentN 2 (P.lines aliases)
@@ -210,8 +240,7 @@ pretty isPast ppe sr =
             typeLineFor status v = case UF.lookupDecl v (originalFile sr) of
               Just (_, dd) ->
                 ( prettyStatus status,
-                  P.syntaxToColor $
-                    DeclPrinter.prettyDeclHeader DeclPrinter.RenderUniqueTypeGuids'No (HQ.unsafeFromVar v) dd
+                  P.syntaxToColor (headerFor v dd)
                 )
               Nothing ->
                 ( prettyStatus status,
@@ -319,8 +348,9 @@ filterUnisonFile
       watchComponents
       hashTerms
       gbs
+      cbs
     ) =
-    UF.TypecheckedUnisonFileId fileNamespace' datas effects tlcs watches hashTerms' gbs
+    UF.TypecheckedUnisonFileId fileNamespace' datas effects tlcs watches hashTerms' gbs cbs
     where
       keep = adds
       keepTerms = SC.terms keep

--- a/unison-cli/src/Unison/Codebase/Editor/SlurpResult.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/SlurpResult.hs
@@ -318,8 +318,9 @@ filterUnisonFile
       topLevelComponents'
       watchComponents
       hashTerms
+      gbs
     ) =
-    UF.TypecheckedUnisonFileId fileNamespace' datas effects tlcs watches hashTerms'
+    UF.TypecheckedUnisonFileId fileNamespace' datas effects tlcs watches hashTerms' gbs
     where
       keep = adds
       keepTerms = SC.terms keep

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -1226,6 +1226,9 @@ findHelp =
         ),
         ( "debug.find.global foo",
           "Iteratively searches all projects and branches and lists all definitions with a name similar to 'foo'. Note that this is a very slow operation."
+        ),
+        ( "`find :given`",
+          "lists every term in the current namespace tagged as a given (see also `givens`)."
         )
       ]
   )
@@ -1312,6 +1315,51 @@ renameTerm =
     \case
       oldName : newName : _ -> Input.MoveTermI <$> handleHashQualifiedSplit'Arg oldName <*> handleNewName newName
       _ -> Left $ P.wrap "`rename.term` takes two arguments, like `rename.term oldname newname`."
+
+markGiven :: InputPattern
+markGiven =
+  InputPattern
+    "mark.given"
+    []
+    I.Visible
+    (Parameters [("definition to mark", exactDefinitionTermQueryArg)] $ Optional [] Nothing)
+    ( P.wrap $
+        makeExample markGiven ["foo"]
+          <> "marks `foo` as a given so it participates in implicit resolution."
+          <> "The term hash of `foo` is unchanged; only the namespace hash changes."
+    )
+    \case
+      [name] -> Input.MarkGivenI <$> handleHashQualifiedSplit'Arg name
+      _ -> Left $ P.wrap "`mark.given` takes one argument, like `mark.given foo`."
+
+unmarkGiven :: InputPattern
+unmarkGiven =
+  InputPattern
+    "unmark.given"
+    []
+    I.Visible
+    (Parameters [("definition to unmark", exactDefinitionTermQueryArg)] $ Optional [] Nothing)
+    ( P.wrap $
+        makeExample unmarkGiven ["foo"]
+          <> "removes the given tag from `foo`."
+    )
+    \case
+      [name] -> Input.UnmarkGivenI <$> handleHashQualifiedSplit'Arg name
+      _ -> Left $ P.wrap "`unmark.given` takes one argument, like `unmark.given foo`."
+
+givens :: InputPattern
+givens =
+  InputPattern
+    "givens"
+    []
+    I.Visible
+    noParams
+    ( P.wrap $
+        makeExample' givens
+          <> "lists every definition in the current namespace that has been marked as a given."
+    )
+    . const
+    $ pure Input.GivensI
 
 moveAll :: InputPattern
 moveAll =
@@ -3978,6 +4026,7 @@ validInputs =
       textfind False,
       textfind True,
       forkLocal,
+      givens,
       help,
       helpTopics,
       history,
@@ -3988,6 +4037,7 @@ validInputs =
       libInstallLocalInputPattern,
       load,
       makeStandalone,
+      markGiven,
       mergeBuiltins,
       mergeIOBuiltins,
       mergeInputPattern,
@@ -4027,6 +4077,7 @@ validInputs =
       todo,
       ui,
       undo,
+      unmarkGiven,
       up,
       update,
       diffUpdate,

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1088,7 +1088,7 @@ notifyUser dir issueFn = \case
   LoadingFile sourceName -> do
     fileName <- renderFileName $ Text.unpack sourceName
     pure $ P.wrap $ "Loading changes detected in " <> P.group (fileName <> ".")
-  Typechecked oldPpe newPpe slurpEntries aliases isMergeBranch -> do
+  Typechecked oldPpe newPpe slurpEntries aliases classRefs isMergeBranch -> do
     let newTypes0 :: [(Name, DeclOrBuiltin Symbol Ann)]
         updatedTypes0 :: [(Name, DeclOrBuiltin Symbol Ann, DeclOrBuiltin Symbol Ann)]
         deletedTypes0 :: [(Name, DeclOrBuiltin Symbol Ann)]
@@ -1143,10 +1143,20 @@ notifyUser dir issueFn = \case
         existDeletes = not (List.null deletedTypes && List.null deletedTerms)
         existChanges = existAdds || existUpdates || existDeletes
 
-    let renderType :: Name -> DeclOrBuiltin Symbol Ann -> Pretty
+    -- ADR-007: when the parser tagged the type as a @class@,
+    -- render its slurp entry with the @class@ keyword in place of
+    -- @type@.
+    let isClassName n = Set.member n classRefs
+        renderType :: Name -> DeclOrBuiltin Symbol Ann -> Pretty
         renderType name decl =
           P.syntaxToColor
-            (DeclPrinter.prettyDeclOrBuiltinHeader DeclPrinter.RenderUniqueTypeGuids'No (HQ.fromName name) decl)
+            ( DeclPrinter.prettyDeclOrBuiltinHeaderWithClasses
+                (const (isClassName name))
+                DeclPrinter.RenderUniqueTypeGuids'No
+                (Reference.Builtin "")
+                (HQ.fromName name)
+                decl
+            )
 
     let renderTerm :: PPE.PrettyPrintEnv -> (Pretty -> Pretty) -> Name -> Type Symbol Ann -> (Pretty, Pretty)
         renderTerm ppe colored name ty =

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -2956,6 +2956,34 @@ notifyUser dir issueFn = \case
           <> "it didn't seem to exist."
   CantUpdateLib names ->
     pure (P.fatalCallout (modifyingLibNotAllowed names))
+  MarkedGiven hq ->
+    pure . P.wrap $
+      "Marked"
+        <> P.group (P.syntaxToColor (prettyHashQualified' hq) <> ".")
+        <> "It will now participate in implicit resolution."
+  AlreadyMarkedGiven hq ->
+    pure . P.wrap $
+      P.group (P.syntaxToColor (prettyHashQualified' hq))
+        <> "is already marked as a given. No changes were made."
+  UnmarkedGiven hq ->
+    pure . P.wrap $
+      "Unmarked"
+        <> P.group (P.syntaxToColor (prettyHashQualified' hq) <> ".")
+        <> "It will no longer participate in implicit resolution."
+  NotMarkedGiven hq ->
+    pure . P.wrap $
+      P.group (P.syntaxToColor (prettyHashQualified' hq))
+        <> "is not marked as a given. No changes were made."
+  ListGivens entries ->
+    pure $
+      if null entries
+        then P.wrap "No definitions in the current namespace are marked as givens."
+        else
+          P.lines
+            ( P.wrap "Definitions marked as givens in the current namespace:"
+                : ""
+                : map (\(n, _r) -> "  " <> prettyName n) entries
+            )
   where
     iveCreatedATemporaryBranch scratchFile =
       P.wrap $

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1028,6 +1028,11 @@ notifyUser dir issueFn = \case
           intercalateMap "\n\n" (printNoteWithSource ppenv (Text.unpack src))
             . map Result.TypeError
     pure $ showNote notes
+  UnresolvedImplicits _curPath src ppenv items -> do
+    let showNote =
+          intercalateMap "\n\n" (printNoteWithSource ppenv (Text.unpack src))
+            . map (\(loc, goal, err) -> Result.UnresolvedImplicit loc goal err)
+    pure $ showNote items
   TypeWarns _curPath src ppenv warns ->
     pure $ renderTypeWarnings ppenv (Text.unpack src) warns
   CompilerBugs src env bugs -> pure $ intercalateMap "\n\n" bug bugs

--- a/unison-cli/src/Unison/LSP/Conversions.hs
+++ b/unison-cli/src/Unison/LSP/Conversions.hs
@@ -56,6 +56,7 @@ annToRange = \case
   Ann.External -> Nothing
   Ann.GeneratedFrom a -> annToRange a
   Ann.Synthetic a -> annToRange a
+  Ann.Lowered a -> annToRange a
   Ann.Ann start end -> Just $ Range (uToLspPos start) (uToLspPos end)
 
 annToURange :: Ann.Ann -> Maybe Range.Range
@@ -64,4 +65,5 @@ annToURange = \case
   Ann.External -> Nothing
   Ann.GeneratedFrom a -> annToURange a
   Ann.Synthetic a -> annToURange a
+  Ann.Lowered a -> annToURange a
   Ann.Ann start end -> Just $ Range.Range start end

--- a/unison-cli/src/Unison/LSP/Conversions.hs
+++ b/unison-cli/src/Unison/LSP/Conversions.hs
@@ -55,6 +55,7 @@ annToRange = \case
   Ann.Intrinsic -> Nothing
   Ann.External -> Nothing
   Ann.GeneratedFrom a -> annToRange a
+  Ann.Synthetic a -> annToRange a
   Ann.Ann start end -> Just $ Range (uToLspPos start) (uToLspPos end)
 
 annToURange :: Ann.Ann -> Maybe Range.Range
@@ -62,4 +63,5 @@ annToURange = \case
   Ann.Intrinsic -> Nothing
   Ann.External -> Nothing
   Ann.GeneratedFrom a -> annToURange a
+  Ann.Synthetic a -> annToURange a
   Ann.Ann start end -> Just $ Range.Range start end

--- a/unison-cli/src/Unison/LSP/Diagnostics.hs
+++ b/unison-cli/src/Unison/LSP/Diagnostics.hs
@@ -1,6 +1,7 @@
 module Unison.LSP.Diagnostics
   ( reportDiagnostics,
     mkDiagnostic,
+    setDiagnosticCode,
     DiagnosticSeverity (..),
   )
 where
@@ -44,3 +45,9 @@ mkDiagnostic uri r severity tags msg references =
       _codeDescription = Nothing,
       _data_ = Nothing
     }
+
+-- | Tag a diagnostic with a short string code (chunk F2). The LSP
+-- protocol allows either an integer or a string here; we use string
+-- codes so the categories are self-describing in the editor UI.
+setDiagnosticCode :: Text -> Diagnostic -> Diagnostic
+setDiagnosticCode c d = d {_code = Just (InR c)}

--- a/unison-cli/src/Unison/LSP/FileAnalysis.hs
+++ b/unison-cli/src/Unison/LSP/FileAnalysis.hs
@@ -28,19 +28,23 @@ import Data.Set qualified as Set
 import Data.Text qualified as Text
 import Data.These
 import Data.Zip qualified as Zip
-import Language.LSP.Protocol.Lens (HasCodeAction (codeAction), HasIsPreferred (isPreferred), HasRange (range), HasUri (uri))
+import Language.LSP.Protocol.Lens (HasCodeAction (codeAction), HasEdit (edit), HasIsPreferred (isPreferred), HasRange (range), HasUri (uri))
 import Language.LSP.Protocol.Lens qualified as LSPTypes
 import Language.LSP.Protocol.Types
   ( Diagnostic,
-    Position,
-    Range,
+    Position (Position),
+    Range (Range),
     TextDocumentIdentifier (TextDocumentIdentifier),
+    TextEdit (TextEdit),
     Uri (getUri),
+    WorkspaceEdit (..),
   )
 import Unison.ABT qualified as ABT
 import Unison.Cli.TypeCheck (computeTypecheckingEnvironment)
+import Unison.Cli.TypeCheck qualified as Cli.TypeCheck
 import Unison.Cli.UniqueTypeGuidLookup qualified as Cli
 import Unison.Codebase qualified as Codebase
+import Unison.Codebase.Branch qualified as Branch
 import Unison.DataDeclaration qualified as DD
 import Unison.Debug qualified as Debug
 import Unison.FileParsers (ShouldUseTndr (..))
@@ -48,7 +52,7 @@ import Unison.FileParsers qualified as FileParsers
 import Unison.KindInference.Error qualified as KindInference
 import Unison.LSP.Conversions
 import Unison.LSP.Conversions qualified as Cv
-import Unison.LSP.Diagnostics (DiagnosticSeverity (..), mkDiagnostic, reportDiagnostics)
+import Unison.LSP.Diagnostics (DiagnosticSeverity (..), mkDiagnostic, reportDiagnostics, setDiagnosticCode)
 import Unison.LSP.FileAnalysis.UnusedBindings qualified as UnusedBindings
 import Unison.LSP.Orphans ()
 import Unison.LSP.Types
@@ -66,6 +70,7 @@ import Unison.PrettyPrintEnv qualified as PPE
 import Unison.PrettyPrintEnv.Names qualified as PPE
 import Unison.PrettyPrintEnvDecl qualified as PPED
 import Unison.PrintError qualified as PrintError
+import Unison.Reference (Reference)
 import Unison.Referent qualified as Referent
 import Unison.Result (Note)
 import Unison.Result qualified as Result
@@ -77,8 +82,10 @@ import Unison.Syntax.NameSegment qualified as NameSegment
 import Unison.Syntax.Parser qualified as Parser
 import Unison.Syntax.TypePrinter qualified as TypePrinter
 import Unison.Term qualified as Term
+import Unison.Type qualified as Type
 import Unison.Typechecker qualified as Typechecker
 import Unison.Typechecker.Context qualified as Context
+import Unison.Typechecker.GivenResolver qualified as GR
 import Unison.Typechecker.TypeError qualified as TypeError
 import Unison.UnisonFile qualified as UF
 import Unison.UnisonFile.Names qualified as UF
@@ -118,14 +125,19 @@ checkFileContents fileUri sourceName fileVersion contents = do
             maybeNamespace = Nothing,
             localNamespacePrefixedTypesAndConstructors = mempty
           }
-  (localBindingInfo, notes, parsedFile, typecheckedFile) <- do
+  -- Chunk L1: harvest the namespace's ambient given pool. The branch
+  -- read happens in IO above the transaction; the pool itself is built
+  -- inside the transaction so we can use the codebase's type lookup.
+  branch0 <- liftIO (Branch.head . fromMaybe Branch.empty <$> Codebase.getBranchAtProjectPath cb pp)
+  (localBindingInfo, implicitArgInfo, notes, parsedFile, typecheckedFile) <- do
     liftIO do
       Codebase.runTransaction cb do
         parseResult <- Parsers.parseFile (Text.unpack sourceName) (Text.unpack srcText) parsingEnv
         case Result.fromParsing parseResult of
-          Result.Result parsingNotes Nothing -> pure (mempty, parsingNotes, Nothing, Nothing)
+          Result.Result parsingNotes Nothing -> pure (mempty, mempty, parsingNotes, Nothing, Nothing)
           Result.Result _ (Just parsedFile) -> do
-            typecheckingEnv <- computeTypecheckingEnvironment (ShouldUseTndr'Yes parsingEnv) cb ambientAbilities parsedFile
+            ambientGivens <- Cli.TypeCheck.ambientGivensFromBranch cb branch0
+            typecheckingEnv <- computeTypecheckingEnvironment (ShouldUseTndr'Yes parsingEnv) cb ambientAbilities ambientGivens parsedFile
             let Result.Result typecheckingNotes maybeTypecheckedFile = FileParsers.synthesizeFile typecheckingEnv parsedFile
 
             symbolInfo <-
@@ -154,7 +166,22 @@ checkFileContents fileUri sourceName fileVersion contents = do
                             ((annToInterval loc) & foldMap \interval -> (IM.singleton interval (typ, definitionSite)))
                           _ -> mempty
                       _ -> mempty
-            pure (localBindingInfo, typecheckingNotes, Just parsedFile, maybeTypecheckedFile)
+            -- Chunk F1: collect 'ImplicitArgRef' notes emitted by D3's
+            -- 'applyGivenDecisions'. We index by the call-site interval
+            -- so the LSP hover/goto-def handlers can detect cursors on
+            -- a function whose call has synthesized implicit args.
+            -- Multiple implicit slots at the same call site each
+            -- contribute one note with the same loc; we accumulate the
+            -- references in left-to-right order.
+            let implicitArgInfo :: IntervalMap Position [Reference] =
+                  typecheckingNotes
+                    & Foldable.toList
+                    & foldMap \case
+                      Result.TypeInfo (Context.ImplicitArgRef loc ref) ->
+                        annToInterval loc
+                          & foldMap \interval -> IM.singleton interval [ref]
+                      _ -> mempty
+            pure (localBindingInfo, implicitArgInfo, typecheckingNotes, Just parsedFile, maybeTypecheckedFile)
 
   filePPED <- ppedForFileHelper parsedFile typecheckedFile
   (errDiagnostics, codeActions) <- analyseFile fileUri srcText filePPED notes
@@ -188,6 +215,7 @@ checkFileContents fileUri sourceName fileVersion contents = do
             typecheckedFile,
             notes,
             localBindingInfo,
+            implicitArgInfo,
             documentSymbols
           }
   pure fileAnalysis
@@ -377,6 +405,21 @@ analyseNotes codebase fileUri ppe src notes = do
         pure (diags, [])
       Result.UnknownSymbol _ loc ->
         pure (noteDiagnostic note (singleRange loc), [])
+      Result.UnresolvedImplicit loc goal err -> do
+        -- Phase-2 chunk F2: surface implicit-resolution failures as
+        -- categorized diagnostics, plus per-category code actions.
+        --
+        -- The diagnostic message is rendered by D4's
+        -- 'renderImplicitResolutionError' (via 'printNoteWithSource')
+        -- so we share text with the CLI. We additionally tag each
+        -- diagnostic with a short string code so editors can dispatch
+        -- on the category, and (for the actionable categories) emit
+        -- code actions that provide a starting point for the user.
+        let baseDiags = noteDiagnostic note (singleRange loc)
+            codeStr = resolveErrorCode err
+            diags = setDiagnosticCode codeStr <$> baseDiags
+            actions = resolveErrorCodeActions fileUri ppe diags goal err
+        pure (diags, actions)
       Result.TypeInfo {} -> pure ([], [])
       Result.CompilerBug cbug -> do
         let ranges = case cbug of
@@ -472,6 +515,79 @@ analyseNotes codebase fileUri ppe src notes = do
 toRangeMap :: (Foldable f) => f (Range, a) -> IntervalMap Position [a]
 toRangeMap vs =
   IM.fromListWith (<>) (toList vs <&> \(r, a) -> (rangeToInterval r, [a]))
+
+-- | Chunk F2: short, stable string code per implicit-resolution
+-- failure category. Editors and tests dispatch on these.
+resolveErrorCode :: GR.ResolveError v loc -> Text
+resolveErrorCode = \case
+  GR.NoGiven {} -> "implicit-no-given"
+  GR.Ambiguous {} -> "implicit-ambiguous"
+  GR.DepthExceeded {} -> "implicit-depth-exceeded"
+  GR.Cycle {} -> "implicit-cycle"
+  GR.UnresolvedMetavarInGoal {} -> "implicit-unresolved-metavar"
+
+-- | Chunk F2: per-category code actions for implicit-resolution
+-- failures. The 'NoGiven' action is the highest-leverage: insert a
+-- 'given _ : <T> = todo' skeleton at file scope so the user has a
+-- correctly-shaped placeholder to fill in. 'Ambiguous' inserts a
+-- local 'given' skeleton. 'DepthExceeded' attaches an informational
+-- code action that explains how to raise the limit. 'Cycle' and
+-- 'UnresolvedMetavarInGoal' get no action — the former requires
+-- breaking the cycle by hand, the latter requires adding a type
+-- annotation at a site only the user knows.
+resolveErrorCodeActions ::
+  Uri ->
+  PrettyPrintEnv ->
+  [Diagnostic] ->
+  Type.Type Symbol Ann ->
+  GR.ResolveError Symbol Ann ->
+  [RangedCodeAction]
+resolveErrorCodeActions fileUri ppe diags goal err = case err of
+  GR.NoGiven {} ->
+    let prettyGoal = TypePrinter.prettyStr 80 ppe goal
+        title = "Define given for " <> prettyGoal
+        snippet =
+          Text.unlines
+            [ "",
+              "given _ : " <> prettyGoal <> " =",
+              "  todo \"implement given for " <> prettyGoal <> "\"",
+              ""
+            ]
+        ranges = diags ^.. folded . range
+        rca = rangedCodeAction title diags ranges
+     in [insertAtFileTop fileUri snippet rca]
+  GR.Ambiguous {} ->
+    let prettyGoal = TypePrinter.prettyStr 80 ppe goal
+        title = "Shadow with local given " <> prettyGoal
+        snippet = "given _ : " <> prettyGoal <> " = ?\n"
+        ranges = diags ^.. folded . range
+        rca = rangedCodeAction title diags ranges
+     in [insertAtFileTop fileUri snippet rca]
+  GR.DepthExceeded {} ->
+    -- Informational: there's no project-config knob for this yet,
+    -- so we surface the suggestion as a no-edit code action.
+    let title = "Increase implicit-resolution depth limit"
+        ranges = diags ^.. folded . range
+        rca = rangedCodeAction title diags ranges
+     in [rca]
+  GR.Cycle {} -> []
+  GR.UnresolvedMetavarInGoal {} -> []
+
+-- | Build a code action that inserts the given text at the very top
+-- of the file (line 0, column 0). Used for the 'NoGiven' /
+-- 'Ambiguous' code actions, which are coarse skeletons the user is
+-- expected to move and edit.
+insertAtFileTop :: Uri -> Text -> RangedCodeAction -> RangedCodeAction
+insertAtFileTop fileUri txt rca =
+  let topRange = Range (Position 0 0) (Position 0 0)
+      edits = [TextEdit topRange txt]
+      workspaceEdit =
+        WorkspaceEdit
+          { _changes = Just $ Map.singleton fileUri edits,
+            _documentChanges = Nothing,
+            _changeAnnotations = Nothing
+          }
+   in rca & codeAction . edit ?~ workspaceEdit
 
 getFileAnalysis :: (Lspish m) => Uri -> MaybeT m FileAnalysis
 getFileAnalysis uri = do

--- a/unison-cli/src/Unison/LSP/GoToDefinition.hs
+++ b/unison-cli/src/Unison/LSP/GoToDefinition.hs
@@ -3,17 +3,24 @@ module Unison.LSP.GoToDefinition
   ( goToDefinitionHandler,
     goToDeclarationHandler,
     goToImplementationHandler,
+
+    -- * Exposed for tests
+    locationInfo,
   )
 where
 
 import Control.Lens hiding (List)
 import Data.IntervalMap.Lazy qualified as IM
+import Data.Map.Strict qualified as Map
 import Language.LSP.Protocol.Lens
 import Language.LSP.Protocol.Message qualified as Msg
 import Language.LSP.Protocol.Types
+import Unison.LSP.Conversions (annToRange)
 import Unison.LSP.FileAnalysis qualified as FileAnalysis
 import Unison.LSP.Types
 import Unison.Prelude
+import Unison.Reference qualified as Reference
+import Unison.UnisonFile.Summary (FileSummary (..))
 
 -- | Go to Definition handler
 goToDefinitionHandler :: Msg.TRequestMessage 'Msg.Method_TextDocumentDefinition -> (Either (Msg.TResponseError m) (Msg.MessageResult 'Msg.Method_TextDocumentDefinition) -> Lsp ()) -> Lsp ()
@@ -47,11 +54,42 @@ goToImplementationHandler m respond = do
     pure $
       [DefinitionLink (LocationLink originLoc targetUri targetRange targetRange)]
 
-locationInfo :: Uri -> Position -> MaybeT Lsp Range
-locationInfo uri pos = do
-  FileAnalysis {localBindingInfo} <- FileAnalysis.getFileAnalysis uri
-  (_interval, (_typ, range)) <- hoistMaybe $ IM.lookupMin $ IM.intersecting localBindingInfo (IM.ClosedInterval pos pos)
-  pure range
+locationInfo :: (Lspish m) => Uri -> Position -> MaybeT m Range
+locationInfo uri pos =
+  -- Chunk F1: try implicit-arg goto-def first; otherwise fall back
+  -- to local-binding goto-def (the prior behavior). If the cursor is
+  -- on a function whose call has a synthesized implicit argument, we
+  -- jump to the resolved given's definition.
+  implicitArgLocation <|> localBindingLocation
   where
-    hoistMaybe :: Maybe a -> MaybeT Lsp a
+    hoistMaybe :: (Monad m) => Maybe a -> MaybeT m a
     hoistMaybe = MaybeT . pure
+
+    localBindingLocation = do
+      FileAnalysis {localBindingInfo} <- FileAnalysis.getFileAnalysis uri
+      (_interval, (_typ, range)) <- hoistMaybe $ IM.lookupMin $ IM.intersecting localBindingInfo (IM.ClosedInterval pos pos)
+      pure range
+
+    -- For each reference recorded at the cursor's position, look up
+    -- its definition site. Currently we only resolve in-file givens
+    -- (a 'Reference.DerivedId' pointing at a term defined in this
+    -- file); a future revision can plumb cross-file/codebase goto-def
+    -- through @Codebase.runTransaction@.
+    implicitArgLocation = do
+      FileAnalysis {implicitArgInfo, fileSummary} <- FileAnalysis.getFileAnalysis uri
+      summary <- hoistMaybe fileSummary
+      let refs =
+            IM.intersecting implicitArgInfo (IM.ClosedInterval pos pos)
+              & IM.toAscList
+              & concatMap snd
+      hoistMaybe $ asum (refToFileRange summary <$> refs)
+
+    refToFileRange :: FileSummary -> Reference.Reference -> Maybe Range
+    refToFileRange summary = \case
+      Reference.DerivedId refId -> do
+        -- 'termsByReference' is keyed by 'Maybe Reference.Id'; the
+        -- 'Just' branch holds typechecked entries.
+        let symMap = Map.findWithDefault mempty (Just refId) (termsByReference summary)
+        (ann, _trm, _typ) <- listToMaybe (Map.elems symMap)
+        annToRange ann
+      Reference.Builtin _ -> Nothing

--- a/unison-cli/src/Unison/LSP/Hover.hs
+++ b/unison-cli/src/Unison/LSP/Hover.hs
@@ -20,7 +20,9 @@ import Unison.Pattern qualified as Pattern
 import Unison.Prelude
 import Unison.PrettyPrintEnv qualified as PPE
 import Unison.PrettyPrintEnvDecl qualified as PPED
+import Unison.Reference (Reference)
 import Unison.Reference qualified as Reference
+import Unison.Referent qualified as Referent
 import Unison.Runtime.IOSource qualified as IOSource
 import Unison.Symbol (Symbol)
 import Unison.Symbol qualified as Symbol
@@ -47,8 +49,20 @@ hoverHandler m respond = do
         }
 
 hoverInfo :: forall m. (Lspish m, MonadUnliftIO m) => Uri -> Position -> MaybeT m Text
-hoverInfo uri pos =
-  (hoverInfoForRef <|> hoverInfoForLiteral <|> hoverInfoForLocalVar)
+hoverInfo uri pos = do
+  -- Chunk F1: combine the regular hover content (type signature,
+  -- docs, local-binding info) with any implicit-arg info recorded by
+  -- D3's 'applyGivenDecisions'. The regular hover content takes
+  -- priority; the implicit info is appended below it. If only one of
+  -- the two is available, return that one alone. If neither, fail (so
+  -- the LSP returns @null@).
+  baseHover <- lift . runMaybeT $ hoverInfoForRef <|> hoverInfoForLiteral <|> hoverInfoForLocalVar
+  implicits <- lift . runMaybeT $ implicitArgHover
+  case (baseHover, implicits) of
+    (Nothing, Nothing) -> empty
+    (Just b, Nothing) -> pure b
+    (Nothing, Just i) -> pure i
+    (Just b, Just i) -> pure (b <> "\n---\n" <> i)
   where
     markdownify :: Text -> Text
     markdownify rendered = Text.unlines ["``` unison", rendered, "```"]
@@ -138,6 +152,30 @@ hoverInfo uri pos =
             (Symbol.Symbol _ (Var.User name)) -> name
             _ -> tShow localVar
       pure $ renderTypeSigForHover pped varName typ
+
+    -- Chunk F1: render an "Implicit argument; resolved from given …"
+    -- line for each synthesized implicit slot at this cursor position.
+    -- Multiple slots produce multiple lines, in left-to-right
+    -- synthesis order.
+    implicitArgHover :: MaybeT m Text
+    implicitArgHover = do
+      FileAnalysis {implicitArgInfo} <- FileAnalysis.getFileAnalysis uri
+      let refs =
+            IM.intersecting implicitArgInfo (IM.ClosedInterval pos pos)
+              & IM.toAscList
+              & concatMap snd
+      case refs of
+        [] -> empty
+        _ -> do
+          pped <- lift $ ppedForFile uri
+          pure . Text.unlines $ renderImplicitLine pped <$> refs
+
+    renderImplicitLine :: PPED.PrettyPrintEnvDecl -> Reference -> Text
+    renderImplicitLine pped ref =
+      let unsuffixifiedPPE = PPED.unsuffixifiedPPE pped
+          name = HQ.toTextWith Name.toText (PPE.termName unsuffixifiedPPE (Referent.Ref ref))
+          hashPrefix = Reference.showShort 9 ref
+       in "Implicit argument; resolved from given `" <> name <> "` (" <> hashPrefix <> ")"
 
     hoistMaybe :: Maybe a -> MaybeT m a
     hoistMaybe = MaybeT . pure

--- a/unison-cli/src/Unison/LSP/Queries.hs
+++ b/unison-cli/src/Unison/LSP/Queries.hs
@@ -424,6 +424,7 @@ annIsFilePosition = \case
   Ann.External -> False
   Ann.Ann {} -> True
   Ann.GeneratedFrom ann -> annIsFilePosition ann
+  Ann.Synthetic ann -> annIsFilePosition ann
 
 -- | Okay, so currently during synthesis in typechecking the typechecker adds `Ann` nodes
 -- to the term specifying types of subterms. This is a problem because we the types in these

--- a/unison-cli/src/Unison/LSP/Queries.hs
+++ b/unison-cli/src/Unison/LSP/Queries.hs
@@ -425,6 +425,7 @@ annIsFilePosition = \case
   Ann.Ann {} -> True
   Ann.GeneratedFrom ann -> annIsFilePosition ann
   Ann.Synthetic ann -> annIsFilePosition ann
+  Ann.Lowered ann -> annIsFilePosition ann
 
 -- | Okay, so currently during synthesis in typechecking the typechecker adds `Ann` nodes
 -- to the term specifying types of subterms. This is a problem because we the types in these

--- a/unison-cli/src/Unison/LSP/Queries.hs
+++ b/unison-cli/src/Unison/LSP/Queries.hs
@@ -160,6 +160,8 @@ refInType typ = case ABT.out typ of
   ABT.Tm f -> case f of
     Type.Ref ref -> Just ref
     Type.Arrow _a _b -> Nothing
+    -- ADR-019: 'ImplicitArrow' has no top-level reference, same as 'Arrow'.
+    Type.ImplicitArrow _a _b -> Nothing
     Type.Effect _a _b -> Nothing
     Type.App _a _b -> Nothing
     Type.Forall _r -> Nothing
@@ -365,6 +367,8 @@ findSmallestEnclosingTypeMatching pos pred typ
             ABT.Tm f -> case f of
               Type.Ref {} -> guardInFile *> pred typ
               Type.Arrow a b -> findSmallestEnclosingTypeMatching pos pred a <|> findSmallestEnclosingTypeMatching pos pred b
+              -- ADR-019: 'ImplicitArrow' descends like 'Arrow'.
+              Type.ImplicitArrow a b -> findSmallestEnclosingTypeMatching pos pred a <|> findSmallestEnclosingTypeMatching pos pred b
               Type.Effect effs rhs ->
                 -- There's currently a bug in the annotations for effects which cause them to
                 -- span larger than they should. As  a workaround for now we just make sure to

--- a/unison-cli/src/Unison/LSP/Types.hs
+++ b/unison-cli/src/Unison/LSP/Types.hs
@@ -35,6 +35,7 @@ import Unison.Names (Names)
 import Unison.Parser.Ann
 import Unison.Prelude
 import Unison.PrettyPrintEnvDecl (PrettyPrintEnvDecl)
+import Unison.Reference (Reference)
 import Unison.Referent (Referent)
 import Unison.Result (Note)
 import Unison.Runtime (Runtime)
@@ -150,6 +151,12 @@ data FileAnalysis = FileAnalysis
     codeActions :: IntervalMap Position [CodeAction],
     -- | The types of local variable bindings keyed by the mention's location.
     localBindingInfo :: IntervalMap Position (Context.Type Symbol Ann {- type of binding -}, Range {- binding definition site -}),
+    -- | Chunk F1: synthesized implicit arguments produced by D3's
+    -- 'applyGivenDecisions'. Indexed by the source position of the
+    -- function head whose call has implicit slots; the list collects
+    -- references to the resolved givens (one per implicit slot, in
+    -- left-to-right order).
+    implicitArgInfo :: IntervalMap Position [Reference],
     typeSignatureHints :: Map Symbol TypeSignatureHint,
     fileSummary :: Maybe FileSummary,
     documentSymbols :: [UDocumentSymbol]

--- a/unison-cli/src/Unison/LSP/Util/Wrappers.hs
+++ b/unison-cli/src/Unison/LSP/Util/Wrappers.hs
@@ -59,7 +59,8 @@ editDefinitionByFQN fileURI fqn = do
         void $ sendRequest Msg.SMethod_WorkspaceApplyEdit params $ \case
           Left err -> Debug.debugM Debug.LSP "Error applying workspace edit" err
           Right _ -> pure ()
-  -- The LSP edit-on-FQN path doesn't surface the `given` marker; it's
-  -- a write-back path, not a user-facing view. Pass @const False@.
-  numRendered <- renderToFile codebase (const True) (const False) appendText mayUnisonFile fp WithinFold pped termResults typeResults
+  -- The LSP edit-on-FQN path doesn't surface the `given` marker or
+  -- the @class@ keyword; it's a write-back path, not a user-facing
+  -- view. Pass @const False@ for both predicates.
+  numRendered <- renderToFile codebase (const True) (const False) (const False) appendText mayUnisonFile fp WithinFold pped termResults typeResults
   pure (numRendered > 0)

--- a/unison-cli/src/Unison/LSP/Util/Wrappers.hs
+++ b/unison-cli/src/Unison/LSP/Util/Wrappers.hs
@@ -59,5 +59,7 @@ editDefinitionByFQN fileURI fqn = do
         void $ sendRequest Msg.SMethod_WorkspaceApplyEdit params $ \case
           Left err -> Debug.debugM Debug.LSP "Error applying workspace edit" err
           Right _ -> pure ()
-  numRendered <- renderToFile codebase (const True) appendText mayUnisonFile fp WithinFold pped termResults typeResults
+  -- The LSP edit-on-FQN path doesn't surface the `given` marker; it's
+  -- a write-back path, not a user-facing view. Pass @const False@.
+  numRendered <- renderToFile codebase (const True) (const False) appendText mayUnisonFile fp WithinFold pped termResults typeResults
   pure (numRendered > 0)

--- a/unison-cli/tests/Main.hs
+++ b/unison-cli/tests/Main.hs
@@ -6,6 +6,7 @@ import System.IO
 import System.IO.CodePage (withCP65001)
 import Unison.Test.ClearCache qualified as ClearCache
 import Unison.Test.Cli.Monad qualified as Cli.Monad
+import Unison.Test.Givens qualified as Givens
 import Unison.Test.LSP qualified as LSP
 import Unison.Test.UriParser qualified as UriParser
 
@@ -15,6 +16,7 @@ test =
     [ LSP.test,
       ClearCache.test,
       Cli.Monad.test,
+      Givens.test,
       UriParser.test
     ]
 

--- a/unison-cli/tests/Unison/Test/Givens.hs
+++ b/unison-cli/tests/Unison/Test/Givens.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Round-trip tests that exercise marking a definition as a given via
+-- 'Unison.Codebase.Givens', then saving and reloading the namespace
+-- through a SQLite codebase.
+module Unison.Test.Givens
+  ( test,
+  )
+where
+
+import Data.Function ((&))
+import Data.Set qualified as Set
+import EasyTest
+import Unison.Codebase qualified as Codebase
+import Unison.Codebase.Branch (Branch)
+import Unison.Codebase.Branch qualified as Branch
+import Unison.Codebase.Givens qualified as Givens
+import Unison.NameSegment.Internal (NameSegment (NameSegment))
+import Unison.Reference qualified as Reference
+import Unison.Referent (Referent)
+import Unison.Referent qualified as Referent
+import Unison.Test.Ucm qualified as Ucm
+
+-- A builtin referent that does not require a separate term entry in
+-- the codebase. We are exercising the namespace metadata pipeline
+-- here, not term storage.
+sampleReferent :: Referent
+sampleReferent = Referent.Ref (Reference.Builtin "Nat.+")
+
+sampleName :: NameSegment
+sampleName = NameSegment "myGivenAlias"
+
+mkMarkedBranch :: Branch m
+mkMarkedBranch =
+  let b0 =
+        Branch.empty0
+          & Branch.addTermName sampleReferent sampleName
+          & Givens.markGivenAt sampleReferent sampleName
+   in Branch.one b0
+
+mkUnmarkedBranch :: Branch m
+mkUnmarkedBranch =
+  let b0 =
+        Branch.empty0
+          & Branch.addTermName sampleReferent sampleName
+   in Branch.one b0
+
+data RoundTripResult = RoundTripResult
+  { reloadedMarkedIsGiven :: !Bool,
+    reloadedMarkedIsGivenAt :: !Bool,
+    reloadedUnmarkedIsGiven :: !Bool,
+    reloadedMarkedSentinelInMd :: !Bool,
+    -- | Whether the namespace hashes of the marked and unmarked
+    -- branches differ (they should: the sentinel is in 'MdValues' which
+    -- is part of the namespace hash).
+    namespaceHashesDiffer :: !Bool
+  }
+
+doRoundTrip :: Ucm.Codebase -> IO RoundTripResult
+doRoundTrip c = Ucm.lowLevel c \codebase -> do
+  let marked = mkMarkedBranch
+      unmarked = mkUnmarkedBranch
+      markedH = Branch.headHash marked
+      unmarkedH = Branch.headHash unmarked
+  Codebase.putBranch codebase marked
+  Codebase.putBranch codebase unmarked
+  Just reloadedMarked <- Codebase.getBranchForHash codebase markedH
+  Just reloadedUnmarked <- Codebase.getBranchForHash codebase unmarkedH
+  let m0 = Branch.head reloadedMarked
+      u0 = Branch.head reloadedUnmarked
+  pure
+    RoundTripResult
+      { reloadedMarkedIsGiven = Givens.isGiven sampleReferent m0,
+        reloadedMarkedIsGivenAt = Givens.isGivenAt sampleReferent sampleName m0,
+        reloadedUnmarkedIsGiven = Givens.isGiven sampleReferent u0,
+        reloadedMarkedSentinelInMd =
+          Set.member Givens.givenSentinel (Givens.metadataValuesFor sampleReferent m0),
+        namespaceHashesDiffer = markedH /= unmarkedH
+      }
+
+test :: Test ()
+test = scope "givens.roundtrip" $ do
+  c <- io $ Ucm.initCodebase Ucm.CodebaseFormat2
+  result <- io $ doRoundTrip c
+  io $ Ucm.deleteCodebase c
+  scope "given sentinel survives save/load" do
+    expect (reloadedMarkedIsGiven result)
+    expect (reloadedMarkedIsGivenAt result)
+  scope "unmarked branch reloads as not-given" do
+    expect (not (reloadedUnmarkedIsGiven result))
+  scope "sentinel survives metadata round-trip" do
+    expect (reloadedMarkedSentinelInMd result)
+  scope "namespace hash changes when sentinel is added (ADR-013)" do
+    expect (namespaceHashesDiffer result)

--- a/unison-cli/tests/Unison/Test/LSP.hs
+++ b/unison-cli/tests/Unison/Test/LSP.hs
@@ -5,6 +5,7 @@ module Unison.Test.LSP (test) where
 
 import Control.Monad.Reader
 import Crypto.Random qualified as Random
+import Data.IntervalMap.Lazy qualified as IM
 import Data.List.Extra (firstJust)
 import Data.Map.Strict qualified as Map
 import Data.String.Here.Uninterpolated (here)
@@ -28,8 +29,10 @@ import Unison.LSP.Conversions
 import Unison.LSP.Conversions qualified as Cv
 import Unison.LSP.FileAnalysis qualified as FileAnalysis
 import Unison.LSP.FileAnalysis.UnusedBindings qualified as UnusedBindings
+import Unison.LSP.GoToDefinition qualified as GoToDefinition
 import Unison.LSP.Hover qualified as Hover
 import Unison.LSP.Queries qualified as LSPQ
+import Unison.LSP.Types (FileAnalysis (..))
 import Unison.LSP.Types qualified as ULSP
 import Unison.Lexer.Pos qualified as Lexer
 import Unison.Parser.Ann (Ann (..))
@@ -45,9 +48,12 @@ import Unison.Symbol (Symbol)
 import Unison.Syntax.Parser qualified as Parser
 import Unison.Term qualified as Term
 import Unison.Type qualified as Type
+import Unison.Typechecker.GivenResolver qualified as GR
 import Unison.UnisonFile qualified as UF
+import Unison.UnisonFile.Summary (FileSummary (..))
 import Unison.Util.Monoid (foldMapM)
 import Unison.Util.Recursion
+import Unison.Var qualified as Var
 import UnliftIO qualified
 
 test :: Test ()
@@ -62,9 +68,19 @@ test = do
       [ unusedBindingLocations,
         typeMismatchLocations
       ]
+  scope "implicit-resolution" $
+    tests
+      [ implicitResolveDiagnosticCodes,
+        implicitResolveNoGivenCodeAction
+      ]
   scope "hover" $
     tests
-      [ localBindingHoverTest
+      [ localBindingHoverTest,
+        implicitArgHoverTest
+      ]
+  scope "goto-def" $
+    tests
+      [ implicitArgGotoDefTest
       ]
 
 newtype TestLsp a = TestLsp {unTestLsp :: ReaderT ULSP.Env IO a}
@@ -452,6 +468,7 @@ typecheckSrc name src = do
                 (FileParsers.ShouldUseTndr'Yes parsingEnv)
                 codebase
                 ambientAbilities
+                []
                 unisonFile
             typecheckingResult <-
               Result.runResultT (FileParsers.synthesizeFile typecheckingEnv unisonFile) <&> \case
@@ -668,3 +685,279 @@ term =
 |]
       )
     ]
+
+------------------------------------------------------------------------------
+-- Chunk F1: LSP hover and goto-def on synthesized implicit arguments.
+--
+-- Strategy: D3's 'Unison.Typechecker.GivenApply.applyGivenDecisions'
+-- emits 'Context.ImplicitArgRef' info notes (anchored at the call
+-- site of each implicit-arrow function) which 'FileAnalysis' indexes
+-- into 'implicitArgInfo'. The hover and goto-def handlers consult
+-- this map. Because the typechecker integration for sourced @given@s
+-- isn't fully wired (let-given doesn't currently extend the
+-- lexical-given environment, and the file-level ambient pool is
+-- empty), we drive the LSP layer by constructing a 'FileAnalysis'
+-- directly with a populated 'implicitArgInfo' and installing it in
+-- the checked-files cache. This is the same shape the LSP would see
+-- if D3 had emitted notes against a real file.
+
+-- | Build a synthetic 'FileAnalysis' carrying the supplied
+-- 'implicitArgInfo' map, with empty defaults for everything else.
+mkSyntheticFileAnalysis ::
+  LSP.Uri ->
+  IM.IntervalMap LSP.Position [Reference.Reference] ->
+  Maybe (UF.TypecheckedUnisonFile Symbol Ann) ->
+  Maybe (UF.UnisonFile Symbol Ann) ->
+  Maybe FileSummary ->
+  FileAnalysis
+mkSyntheticFileAnalysis uri implicitInfo mtf mpf mfs =
+  FileAnalysis
+    { fileUri = uri,
+      fileVersion = 0,
+      lexedSource = ("", []),
+      tokenMap = mempty,
+      parsedFile = mpf,
+      typecheckedFile = mtf,
+      notes = mempty,
+      diagnostics = mempty,
+      codeActions = mempty,
+      localBindingInfo = mempty,
+      implicitArgInfo = implicitInfo,
+      typeSignatureHints = mempty,
+      fileSummary = mfs,
+      documentSymbols = mempty
+    }
+
+-- | Build an empty 'FileSummary' with only 'termsByReference'
+-- populated. Used by the goto-def positive path test.
+mkSyntheticFileSummary ::
+  Map (Maybe Reference.Id) (Map Symbol (Ann, Term.Term Symbol Ann, Maybe (Type.Type Symbol Ann))) ->
+  FileSummary
+mkSyntheticFileSummary trmsByRef =
+  FileSummary
+    { dataDeclsBySymbol = mempty,
+      dataDeclsByReference = mempty,
+      effectDeclsBySymbol = mempty,
+      effectDeclsByReference = mempty,
+      termsBySymbol = mempty,
+      termsByReference = trmsByRef,
+      testWatchSummary = mempty,
+      exprWatchSummary = mempty,
+      fileNames = mempty
+    }
+
+-- | Hover should mention "Implicit argument; resolved from given …"
+-- when the cursor lands on a position recorded in 'implicitArgInfo'.
+implicitArgHoverTest :: Test ()
+implicitArgHoverTest = scope "implicit-arg hover" $ do
+  -- Anchor the implicit-arg note at line 1, columns 8-9 (LSP 0-based:
+  -- line 0, char 7-8). The chosen given is a builtin reference for
+  -- which the empty PPED falls back to printing the hash, giving us
+  -- a stable expected text.
+  let anchorInterval =
+        IM.ClosedInterval
+          (LSP.Position 0 7)
+          (LSP.Position 0 9)
+      givenRef = Reference.Builtin "Show.Nat"
+      implicitInfo = IM.singleton anchorInterval [givenRef]
+      uri = LSP.Uri "test-implicit"
+  hoverTxt <- runTestLsp $ do
+    let fa = mkSyntheticFileAnalysis uri implicitInfo Nothing Nothing Nothing
+    filesVar <- asks ULSP.checkedFilesVar
+    liftIO $ UnliftIO.atomically do
+      mvar <- UnliftIO.newTMVar fa
+      UnliftIO.modifyTVar' filesVar (Map.insert uri mvar)
+    -- Hover at line 0, char 8 (inside the recorded interval).
+    runMaybeT (Hover.hoverInfo uri (LSP.Position 0 8))
+  case hoverTxt of
+    Nothing -> crash "expected implicit-arg hover, got Nothing"
+    Just t -> do
+      let txt = Text.unpack t
+      let needle = "Implicit argument; resolved from given"
+      if Text.isInfixOf (Text.pack needle) t
+        then ok
+        else crash ("hover text missing implicit-arg phrase: " <> txt)
+
+-- | Goto-def should jump to the resolved given when the cursor lands
+-- on a position recorded in 'implicitArgInfo' and the given resolves
+-- to an in-file 'DerivedId'.
+implicitArgGotoDefTest :: Test ()
+implicitArgGotoDefTest = scope "implicit-arg goto-def" $ do
+  -- Negative case: builtin refs have no in-file location, so goto-def
+  -- should fail (return Nothing). This confirms that the implicit-arg
+  -- branch is consulted but produces no result — the localBinding
+  -- fallback also has nothing to return.
+  let anchorInterval =
+        IM.ClosedInterval
+          (LSP.Position 0 7)
+          (LSP.Position 0 9)
+      builtinRef = Reference.Builtin "Show.Nat"
+      builtinImplicitInfo = IM.singleton anchorInterval [builtinRef]
+      builtinUri = LSP.Uri "test-implicit-goto-builtin"
+  scope "builtin given returns Nothing" $ do
+    builtinResult <- runTestLsp $ do
+      let fa = mkSyntheticFileAnalysis builtinUri builtinImplicitInfo Nothing Nothing Nothing
+      filesVar <- asks ULSP.checkedFilesVar
+      liftIO $ UnliftIO.atomically do
+        mvar <- UnliftIO.newTMVar fa
+        UnliftIO.modifyTVar' filesVar (Map.insert builtinUri mvar)
+      runMaybeT (GoToDefinition.locationInfo builtinUri (LSP.Position 0 8))
+    case builtinResult of
+      Nothing -> ok -- expected: builtins have no source location
+      Just r -> crash ("expected no goto-def for builtin given, got: " <> show r)
+
+  -- Positive case: a 'DerivedId' given that points at a term defined
+  -- in the file resolves to the term's annotation range.
+  scope "in-file derived given returns its range" $ do
+    -- The resolved given lives at line 2, columns 3-7 in the file
+    -- (Unison file positions are 1-based). After uToLspPos this maps
+    -- to LSP Range (Position 1 2) (Position 1 6).
+    let givenAnn = Ann.Ann (Lexer.Pos 2 3) (Lexer.Pos 2 7)
+        expectedRange = LSP.Range (LSP.Position 1 2) (LSP.Position 1 6)
+    -- Build a 'Reference.Id' by parsing a derived reference text and
+    -- extracting its 'Id'. This avoids manually constructing a Hash.
+    derivedRefId <- case Reference.unsafeFromText "#abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd" of
+      Reference.DerivedId rid -> pure rid
+      _ -> crash "expected DerivedId from unsafeFromText"
+    let givenSym :: Symbol
+        givenSym = Var.named "myGiven"
+        givenTerm = Term.boolean givenAnn True -- placeholder, never inspected
+        termsByRef =
+          Map.singleton
+            (Just derivedRefId)
+            (Map.singleton givenSym (givenAnn, givenTerm, Nothing))
+        fileSummary' = mkSyntheticFileSummary termsByRef
+        givenRef = Reference.DerivedId derivedRefId
+        implicitInfo' = IM.singleton anchorInterval [givenRef]
+        uri = LSP.Uri "test-implicit-goto-derived"
+    derivedResult <- runTestLsp $ do
+      let fa = mkSyntheticFileAnalysis uri implicitInfo' Nothing Nothing (Just fileSummary')
+      filesVar <- asks ULSP.checkedFilesVar
+      liftIO $ UnliftIO.atomically do
+        mvar <- UnliftIO.newTMVar fa
+        UnliftIO.modifyTVar' filesVar (Map.insert uri mvar)
+      runMaybeT (GoToDefinition.locationInfo uri (LSP.Position 0 8))
+    expectEqual (Just expectedRange) derivedResult
+
+------------------------------------------------------------------------------
+-- Chunk F2: LSP diagnostics + code actions for implicit-resolution
+-- failures.
+--
+-- We exercise 'analyseNotes' directly with a synthetic
+-- 'Result.UnresolvedImplicit' note for each 'GR.ResolveError'
+-- variant, and verify the resulting diagnostic carries the expected
+-- string code and that the right code actions are produced.
+
+-- | Build a sample goal type. The renderer ('PrintError') falls back
+-- to a hash for an unknown 'Reference.Builtin' under an empty PPE,
+-- which is fine — F2's tests only check the diagnostic 'code' field
+-- and code-action shape, not the prose.
+fakeGoalType :: Type.Type Symbol Ann
+fakeGoalType = Type.builtin Ann.External "F2.TestGoal"
+
+-- | Construct an 'UnresolvedImplicit' note carrying the supplied
+-- 'ResolveError'. The apply-site location is fixed at line 1, col 1
+-- (one-based) for predictable diagnostic ranges.
+mkImplicitNote :: GR.ResolveError Symbol Ann -> Result.Note Symbol Ann
+mkImplicitNote err =
+  let pos = Lexer.Pos 1 1
+      pos' = Lexer.Pos 1 2
+      ann = Ann pos pos'
+   in Result.UnresolvedImplicit ann fakeGoalType err
+
+-- | Run 'FileAnalysis.analyseNotes' on a single 'UnresolvedImplicit'
+-- note and return the (diagnostics, code-actions) pair.
+runAnalyseImplicit ::
+  GR.ResolveError Symbol Ann ->
+  Test ([LSP.Diagnostic], [ULSP.RangedCodeAction])
+runAnalyseImplicit err = io do
+  let codebase = error "F2 test: codebase unused"
+  let ppe = PPE.empty
+  FileAnalysis.analyseNotes
+    codebase
+    (LSP.Uri "f2-test")
+    ppe
+    "f2-test"
+    [mkImplicitNote err]
+
+-- | Each 'ResolveError' variant should produce exactly one
+-- diagnostic, tagged with the expected string code, at Error
+-- severity, with source "unison".
+implicitResolveDiagnosticCodes :: Test ()
+implicitResolveDiagnosticCodes = scope "diagnostic codes per category" $ do
+  let cases :: [(String, GR.ResolveError Symbol Ann, Text)]
+      cases =
+        [ ( "NoGiven",
+            GR.NoGiven fakeGoalType [],
+            "implicit-no-given"
+          ),
+          ( "Ambiguous",
+            GR.Ambiguous fakeGoalType [],
+            "implicit-ambiguous"
+          ),
+          ( "DepthExceeded",
+            GR.DepthExceeded [],
+            "implicit-depth-exceeded"
+          ),
+          ( "Cycle",
+            GR.Cycle [],
+            "implicit-cycle"
+          ),
+          ( "UnresolvedMetavarInGoal",
+            GR.UnresolvedMetavarInGoal fakeGoalType,
+            "implicit-unresolved-metavar"
+          )
+        ]
+  for_ cases $ \(name, err, expectedCode) -> scope name $ do
+    (diags, _actions) <- runAnalyseImplicit err
+    case diags of
+      [d] -> do
+        let actualCode = d ^. LSP.code
+        let expected = Just (LSP.InR expectedCode)
+        if actualCode == expected
+          then pure ()
+          else
+            crash $
+              "expected diagnostic code "
+                <> show expected
+                <> " but got "
+                <> show actualCode
+        let sev = d ^. LSP.severity
+        when (sev /= Just LSP.DiagnosticSeverity_Error) $
+          crash $
+            "expected Error severity, got " <> show sev
+        ok
+      ds -> crash ("expected exactly one diagnostic, got " <> show (Prelude.length ds))
+
+-- | The 'NoGiven' code action must include a workspace edit that
+-- inserts a 'given _ : <T> = todo' skeleton at the top of the file
+-- (line 0, column 0).
+implicitResolveNoGivenCodeAction :: Test ()
+implicitResolveNoGivenCodeAction = scope "NoGiven code action inserts skeleton at file top" $ do
+  (_diags, actions) <- runAnalyseImplicit (GR.NoGiven fakeGoalType [])
+  case actions of
+    [rca] -> do
+      let ca = rca ^. LSP.codeAction
+      let title = ca ^. LSP.title
+      when (not (Text.isInfixOf "Define given" title)) $
+        crash ("expected title to mention 'Define given', got: " <> Text.unpack title)
+      case ca ^. LSP.edit of
+        Nothing -> crash "expected workspace edit on the NoGiven code action"
+        Just we -> case we ^. LSP.changes of
+          Nothing -> crash "expected workspace edit changes map"
+          Just changes -> case Map.lookup (LSP.Uri "f2-test") changes of
+            Nothing -> crash "expected an edit targeting the test URI"
+            Just edits -> case edits of
+              [e] -> do
+                let editRange = e ^. LSP.range
+                let expectedRange =
+                      LSP.Range (LSP.Position 0 0) (LSP.Position 0 0)
+                when (editRange /= expectedRange) $
+                  crash $
+                    "expected edit at file top, got " <> show editRange
+                let txt = e ^. LSP.newText
+                when (not (Text.isInfixOf "given" txt)) $
+                  crash ("expected 'given' in edit text, got: " <> Text.unpack txt)
+                ok
+              es -> crash ("expected one TextEdit, got " <> show (Prelude.length es))
+    _ -> crash ("expected exactly one code action, got " <> show (Prelude.length actions))

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -69,6 +69,7 @@ library
       Unison.Codebase.Editor.HandleInput.EditNamespace
       Unison.Codebase.Editor.HandleInput.FindAndReplace
       Unison.Codebase.Editor.HandleInput.FormatFile
+      Unison.Codebase.Editor.HandleInput.Givens
       Unison.Codebase.Editor.HandleInput.Global
       Unison.Codebase.Editor.HandleInput.History
       Unison.Codebase.Editor.HandleInput.HistoryComment
@@ -388,6 +389,7 @@ test-suite cli-tests
   other-modules:
       Unison.Test.ClearCache
       Unison.Test.Cli.Monad
+      Unison.Test.Givens
       Unison.Test.LSP
       Unison.Test.Ucm
       Unison.Test.UriParser
@@ -432,7 +434,8 @@ test-suite cli-tests
       ViewPatterns
   ghc-options: -Wall
   build-depends:
-      base
+      IntervalMap
+    , base
     , code-page
     , containers
     , crypton

--- a/unison-core/src/Unison/Blank.hs
+++ b/unison-core/src/Unison/Blank.hs
@@ -12,6 +12,7 @@ loc :: Recorded loc -> loc
 loc (Placeholder loc _) = loc
 loc (Resolve loc _) = loc
 loc (MissingResultPlaceholder loc) = loc
+loc (Implicit loc) = loc
 
 nameb :: Blank loc -> Maybe String
 nameb (Recorded (Placeholder _ n)) = Just n
@@ -25,6 +26,11 @@ data Recorded loc
     Resolve loc String
   | -- A placeholder for a missing result at the end of a block
     MissingResultPlaceholder loc
+  | -- ADR-019 / chunk C2.2: a constraint-goal hole left at an
+    -- 'ImplicitArrow' apply-site by the typechecker. Filled by the
+    -- elaborator in chunk D1+ via given-resolution. Mirrors the way
+    -- TDNR's 'Resolve' blank is filled by 'applyTdnrDecisions'.
+    Implicit loc
   deriving (Show, Eq, Ord, Functor, Generic)
 
 -- | Blank is just a dummy annotation.

--- a/unison-core/src/Unison/DataDeclaration/Records.hs
+++ b/unison-core/src/Unison/DataDeclaration/Records.hs
@@ -1,6 +1,7 @@
 -- | This module contains various utilities related to the implementation of record types.
 module Unison.DataDeclaration.Records
   ( generateRecordAccessors,
+    RecordKind (..),
   )
 where
 
@@ -17,23 +18,42 @@ import Unison.Term qualified as Term
 import Unison.Var (Var)
 import Unison.Var qualified as Var
 
+-- | Which surface keyword introduced the record. 'ClassRecord' is for
+-- @class T a = { ... }@ declarations: the accessors elide setters and
+-- modifiers, and the caller is expected to attach a type annotation
+-- whose @T a@ parameter is implicit (an @=>@ arrow) so the dictionary
+-- gets threaded through by the implicit-resolution elaborator. See
+-- @Unison.Syntax.FileParser@ where this is wired.
+data RecordKind = TypeRecord | ClassRecord
+  deriving stock (Eq, Show)
+
 generateRecordAccessors ::
   (Semigroup a, Var v) =>
+  RecordKind ->
   (List.NonEmpty v -> v) ->
   (a -> a) ->
   [(v, a)] ->
   v ->
   TypeReference ->
   [(v, a, Term v a)]
-generateRecordAccessors namespaced generatedAnn fields typename typ =
+generateRecordAccessors kind namespaced generatedAnn fields typename typ =
   join [tm t i | (t, i) <- fields `zip` [(0 :: Int) ..]]
   where
     argname = Var.uncapitalize typename
-    tm (fname, fieldAnn) i =
-      [ (namespaced (typename :| [fname]), ann, get),
-        (namespaced (typename :| [fname, Var.named "set"]), ann, set),
-        (namespaced (typename :| [fname, Var.named "modify"]), ann, modify)
-      ]
+    tm (fname, fieldAnn) i = case kind of
+      TypeRecord ->
+        [ (namespaced (typename :| [fname]), ann, get),
+          (namespaced (typename :| [fname, Var.named "set"]), ann, set),
+          (namespaced (typename :| [fname, Var.named "modify"]), ann, modify)
+        ]
+      ClassRecord ->
+        -- 'class' accessors emit only the getter; setters and
+        -- modifiers do not make sense when the dictionary is
+        -- threaded implicitly. The getter term is identical to the
+        -- type-record getter — the caller attaches the @=>@-bearing
+        -- type annotation that turns the leading lambda's binder
+        -- into a lexical given for the body.
+        [(namespaced (typename :| [fname]), ann, get)]
       where
         ann = generatedAnn fieldAnn
         conref = ConstructorReference typ 0

--- a/unison-core/src/Unison/Term.hs
+++ b/unison-core/src/Unison/Term.hs
@@ -1665,6 +1665,11 @@ instance (Show v, Show a) => Show (F v a0 p a) where
         B.Recorded (B.Placeholder _ r) -> s ("_" ++ r)
         B.Recorded (B.Resolve _ r) -> s r
         B.Recorded (B.MissingResultPlaceholder _) -> s "_"
+        -- ADR-019 / chunk C2.2: an unresolved implicit-argument hole.
+        -- Printed like a generic blank; the elaborator (chunk D1+)
+        -- substitutes the resolved dictionary term before this ever
+        -- needs a richer rendering.
+        B.Recorded (B.Implicit _) -> s "_"
         B.Retain -> s "_"
       go _ (Ref r) = s "Ref(" <> shows r <> s ")"
       go _ (TermLink r) = s "TermLink(" <> shows r <> s ")"

--- a/unison-core/src/Unison/Type.hs
+++ b/unison-core/src/Unison/Type.hs
@@ -373,11 +373,17 @@ listRef = Reference.Builtin "Sequence"
 -- accidentally summon it.
 giveMarkerRef :: TypeReference
 giveMarkerRef = Reference.Builtin "@@give-marker"
+
 bytesRef = Reference.Builtin "Bytes"
+
 effectRef = Reference.Builtin "Effect"
+
 termLinkRef = Reference.Builtin "Link.Term"
+
 typeLinkRef = Reference.Builtin "Link.Type"
+
 integerRef = Reference.Builtin "Integer"
+
 naturalRef = Reference.Builtin "Natural"
 
 builtinIORef, fileHandleRef, filePathRef, threadIdRef, socketRef :: TypeReference

--- a/unison-core/src/Unison/Type.hs
+++ b/unison-core/src/Unison/Type.hs
@@ -363,6 +363,16 @@ booleanRef = Reference.Builtin "Boolean"
 textRef = Reference.Builtin "Text"
 charRef = Reference.Builtin "Char"
 listRef = Reference.Builtin "Sequence"
+
+-- | ADR-007: sentinel type reference used by 'GivenApply.stripImplicitArgsByType'
+-- to mark an apply-chain head whose declared @=>@ arrows were
+-- filled by the user via the @give@ keyword. The marker is purely
+-- print-time: 'TermPrinter' recognises @t : giveMarker@ on the head
+-- of an apply chain and emits @give @ at the surface. The reference
+-- name is unparseable as a regular identifier so user code can't
+-- accidentally summon it.
+giveMarkerRef :: TypeReference
+giveMarkerRef = Reference.Builtin "@@give-marker"
 bytesRef = Reference.Builtin "Bytes"
 effectRef = Reference.Builtin "Effect"
 termLinkRef = Reference.Builtin "Link.Term"
@@ -778,8 +788,21 @@ existentializeArrows newVar t = ABT.visit go t
     -- effect-attach the same way 'Arrow' does. Constraint resolution
     -- does not introduce abilities, but the codomain may still be an
     -- effectful arrow that needs a fresh ability variable.
+    --
+    -- Exception: when the codomain is itself an 'ImplicitArrow' (i.e.
+    -- chained constraints like @C1 => C2 => T@), we skip the
+    -- effect-row insertion. Per ADR-019 @=>@ carries no abilities, and
+    -- inserting an effect row between two @=>@s would break the
+    -- 'ImplicitArrow'' pattern in the @=>I@ checkWanted rule — the
+    -- pattern only sees through @Arrow'@/@Effect''@ tuples, not bare
+    -- 'Effect1'' wrappers — so the lambda binder for the second
+    -- constraint wouldn't be recognised.
     go t@(ImplicitArrow' a b) = case b of
       Effect1' _ _ -> Just $ do
+        a <- existentializeArrows newVar a
+        b <- existentializeArrows newVar b
+        pure $ implicitArrow (ABT.annotation t) a b
+      ImplicitArrow' _ _ -> Just $ do
         a <- existentializeArrows newVar a
         b <- existentializeArrows newVar b
         pure $ implicitArrow (ABT.annotation t) a b

--- a/unison-core/src/Unison/Type.hs
+++ b/unison-core/src/Unison/Type.hs
@@ -48,6 +48,17 @@ data F a
   | IntroOuter a -- binder like ∀, used to introduce variables that are
   -- bound by outer type signatures, to support scoped type
   -- variables
+  | -- | An implicit-arrow position. Behaves at the term level like 'Arrow',
+    -- but the elaborator (Phase 2.D) fills the argument by given-resolution
+    -- rather than the user supplying it explicitly. Multi-constraint
+    -- signatures @(C1 a, C2 b) => T@ desugar to nested @ImplicitArrow@:
+    -- @ImplicitArrow C1a (ImplicitArrow C2b T)@.
+    --
+    -- See ADR-019 for the representation choice and ADR-014 for hashing.
+    -- Divergent typechecker behavior between 'Arrow' and 'ImplicitArrow'
+    -- is introduced by chunks D2 and D3; until then most consumers treat
+    -- 'ImplicitArrow' identically to 'Arrow'.
+    ImplicitArrow a a
   deriving (Foldable, Functor, Generic, Generic1, Eq, Ord, Traversable)
 
 _Ref :: Prism' (F a) TypeReference
@@ -100,6 +111,10 @@ monotype t = Monotype <$> ABT.visit isMono t
 arity :: Type v a -> Int
 arity (ForallNamed' _ body) = arity body
 arity (Arrow' _ o) = 1 + arity o
+-- ADR-019: 'ImplicitArrow' contributes to arity like 'Arrow' for now.
+-- Chunks D2/D3 may revisit so that implicit parameters are counted
+-- separately from explicit ones.
+arity (ImplicitArrow' _ o) = 1 + arity o
 arity (Ann' a _) = arity a
 arity _ = 0
 
@@ -110,6 +125,7 @@ arity _ = 0
 arityIgnoringEffects :: Type v a -> Int
 arityIgnoringEffects (ForallNamed' _ body) = arityIgnoringEffects body
 arityIgnoringEffects (Arrow' _ o) = 1 + arityIgnoringEffects o
+arityIgnoringEffects (ImplicitArrow' _ o) = 1 + arityIgnoringEffects o
 arityIgnoringEffects (Ann' a _) = arityIgnoringEffects a
 arityIgnoringEffects (Effect' _ o) = arityIgnoringEffects o
 arityIgnoringEffects _ = 0
@@ -123,6 +139,12 @@ pattern Arrow' i o <- ABT.Tm' (Arrow i o)
 
 pattern Arrow'' :: (Ord v) => ABT.Term F v a -> [Type v a] -> Type v a -> ABT.Term F v a
 pattern Arrow'' i es o <- Arrow' i (Effect'' es o)
+
+-- | Smart pattern for 'ImplicitArrow'. Currently no consumer except the
+-- elaborator (Phase 2.D, chunks D2/D3) needs to distinguish this from
+-- 'Arrow', but pattern is provided for future use.
+pattern ImplicitArrow' :: ABT.Term F v a -> ABT.Term F v a -> ABT.Term F v a
+pattern ImplicitArrow' i o <- ABT.Tm' (ImplicitArrow i o)
 
 pattern Arrows' :: [Type v a] -> Type v a
 pattern Arrows' spine <- (unArrows -> Just spine)
@@ -198,24 +220,76 @@ unPure (Effect'' [] t) = Just t
 unPure (Effect'' _ _) = Nothing
 unPure t = Just t
 
+-- | Extract the spine of a (possibly mixed) chain of explicit and implicit
+-- arrows. ADR-019: 'ImplicitArrow' contributes to the spine the same way
+-- 'Arrow' does — its left-hand side becomes one element of the spine.
+-- Consumers that need to distinguish implicit vs explicit positions
+-- (i.e. the elaborator, chunks D2/D3) must walk the AST directly rather
+-- than rely on this view; existing consumers like 'DeclPrinter',
+-- 'TypePrinter', 'Variance.split', and 'Context.checkWanted's
+-- argument-extractor only care about argument count, which is what this
+-- view preserves.
 unArrows :: Type v a -> Maybe [Type v a]
 unArrows t =
   case go t of [_] -> Nothing; l -> Just l
   where
     go (Arrow' i o) = i : go o
+    go (ImplicitArrow' i o) = i : go o
     go o = [o]
 
+-- | Like 'unArrows' but also surfaces effect annotations. ADR-019:
+-- 'ImplicitArrow' contributes a spine element with no attached effects
+-- (constraint resolution does not introduce abilities). When mixing
+-- implicit and explicit arrows, each implicit position adds an entry to
+-- the result list.
 unEffectfulArrows ::
   Type v a -> Maybe (Type v a, [(Maybe [Type v a], Type v a)])
 unEffectfulArrows t = case t of
   Arrow' i o -> Just (i, go o)
+  ImplicitArrow' i o -> Just (i, go o)
   _ -> Nothing
   where
     go (Effect1' (Effects' es) (Arrow' i o)) =
       (Just $ es >>= flattenEffects, i) : go o
+    go (Effect1' (Effects' es) (ImplicitArrow' i o)) =
+      (Just $ es >>= flattenEffects, i) : go o
     go (Effect1' (Effects' es) t) = [(Just $ es >>= flattenEffects, t)]
     go (Arrow' i o) = (Nothing, i) : go o
+    go (ImplicitArrow' i o) = (Nothing, i) : go o
     go t = [(Nothing, t)]
+
+-- | ADR-019 / chunk C2.3: strip the leading constraint context from a
+-- type, returning the list of constraint types and the conclusion.
+--
+-- For a type of shape
+--
+-- @
+-- forall a b. C1 a => C2 b => T
+-- @
+--
+-- (which is what the parser produces from @C1 a, C2 b => T@), this
+-- returns @([C1 a, C2 b], T)@. Outermost 'Forall' binders are first
+-- looked through using 'unForalls'; if the body does not begin with
+-- 'ImplicitArrow', the empty list and the original (un-foralled) body
+-- are returned.
+--
+-- The 'Forall' binders are /preserved/ in the conclusion via the
+-- @vs@ list returned in the second component for callers that need to
+-- reconstruct the polytype. Most consumers (e.g. C2.3's @given@-decl
+-- validator) only care about the structural shape and can ignore the
+-- binders.
+--
+-- Note: this does not look through ability annotations; constraint
+-- arrows from @=>@ never carry abilities (per ADR-019), so a
+-- well-formed implicit-arrow chain has no intervening 'Effect1'.
+unImplicitArrows :: Type v a -> ([Type v a], Type v a)
+unImplicitArrows t = case unForalls t of
+  Just (_vs, body) -> goImplicit body
+  Nothing -> goImplicit t
+  where
+    goImplicit (ImplicitArrow' i o) =
+      let (cs, conc) = goImplicit o in (i : cs, conc)
+    goImplicit other = ([], other)
 
 unApps :: Type v a -> Maybe (Type v a, [Type v a])
 unApps t = case go t [] of
@@ -260,6 +334,8 @@ unEffects1 _ = Nothing
 isArrow :: (ABT.Var v) => Type v a -> Bool
 isArrow (ForallNamed' _ t) = isArrow t
 isArrow (Arrow' _ _) = True
+-- ADR-019: 'ImplicitArrow' is also a function-shaped type.
+isArrow (ImplicitArrow' _ _) = True
 isArrow _ = False
 
 -- some smart constructors
@@ -502,6 +578,14 @@ arrow a i o = ABT.tm' a (Arrow i o)
 arrow' :: (Semigroup a, Ord v) => Type v a -> Type v a -> Type v a
 arrow' i o = arrow (ABT.annotation i <> ABT.annotation o) i o
 
+-- | Smart constructor for 'ImplicitArrow'. Used by the parser for @=>@
+-- (Phase 2 chunk A1) and by the elaborator (Phase 2.D).
+implicitArrow :: (Ord v) => a -> Type v a -> Type v a -> Type v a
+implicitArrow a i o = ABT.tm' a (ImplicitArrow i o)
+
+implicitArrow' :: (Semigroup a, Ord v) => Type v a -> Type v a -> Type v a
+implicitArrow' i o = implicitArrow (ABT.annotation i <> ABT.annotation o) i o
+
 ann :: (Ord v) => a -> Type v a -> K.Kind -> Type v a
 ann a e t = ABT.tm' a (Ann e t)
 
@@ -690,6 +774,21 @@ existentializeArrows newVar t = ABT.visit go t
         b <- existentializeArrows newVar b
         let ann = ABT.annotation t
         pure $ arrow ann a (effect ann [var ann e] b)
+    -- ADR-019 / chunk C2.1 carry-over: 'ImplicitArrow' participates in
+    -- effect-attach the same way 'Arrow' does. Constraint resolution
+    -- does not introduce abilities, but the codomain may still be an
+    -- effectful arrow that needs a fresh ability variable.
+    go t@(ImplicitArrow' a b) = case b of
+      Effect1' _ _ -> Just $ do
+        a <- existentializeArrows newVar a
+        b <- existentializeArrows newVar b
+        pure $ implicitArrow (ABT.annotation t) a b
+      _ -> Just $ do
+        e <- newVar
+        a <- existentializeArrows newVar a
+        b <- existentializeArrows newVar b
+        let ann = ABT.annotation t
+        pure $ implicitArrow ann a (effect ann [var ann e] b)
     go _ = Nothing
 
 purifyArrows :: (Ord v) => Type v a -> Type v a
@@ -698,6 +797,13 @@ purifyArrows = ABT.visitPure go
     go t@(Arrow' a b) = case b of
       Effect1' _ _ -> Nothing
       _ -> Just $ arrow ann a (effect ann [] b)
+      where
+        ann = ABT.annotation t
+    -- ADR-019 / chunk C2.1 carry-over: strip in 'ImplicitArrow' codomain
+    -- the same way as 'Arrow' so effect-stripping is uniform.
+    go t@(ImplicitArrow' a b) = case b of
+      Effect1' _ _ -> Nothing
+      _ -> Just $ implicitArrow ann a (effect ann [] b)
       where
         ann = ABT.annotation t
     go _ = Nothing
@@ -763,6 +869,9 @@ removePureEffects keepEmptied t
 
     keepVarsT pos (Arrow' i o) =
       keepVarsT (not pos) i <> keepVarsT pos o
+    -- ADR-019: 'ImplicitArrow' has the same variance as 'Arrow'.
+    keepVarsT pos (ImplicitArrow' i o) =
+      keepVarsT (not pos) i <> keepVarsT pos o
     keepVarsT pos (Effect1' e o) =
       keepVarsT pos e <> keepVarsT pos o
     keepVarsT pos (Effects' es) = foldMap (keepVarsE pos) es
@@ -791,6 +900,11 @@ editFunctionResult f = go
         (\x -> ABT.Term (s <> freeVars x) a . ABT.Tm $ Forall x) $ go t
       ABT.Tm (Arrow i o) ->
         (\x -> ABT.Term (s <> freeVars x) a . ABT.Tm $ Arrow i x) $ go o
+      -- 'ImplicitArrow' behaves like 'Arrow' here for purposes of
+      -- following the function-result spine. (Divergent treatment
+      -- arrives in chunks D2/D3.)
+      ABT.Tm (ImplicitArrow i o) ->
+        (\x -> ABT.Term (s <> freeVars x) a . ABT.Tm $ ImplicitArrow i x) $ go o
       ABT.Abs v r ->
         (\x -> ABT.Term (s <> freeVars x) a $ ABT.Abs v x) $ go r
       _ -> f (ABT.Term s a t)
@@ -800,6 +914,9 @@ functionResult = go False
   where
     go inArr (ForallNamed' _ body) = go inArr body
     go _inArr (Arrow' _i o) = go True o
+    -- ADR-019: traverse 'ImplicitArrow' like 'Arrow' to find the
+    -- ultimate function result.
+    go _inArr (ImplicitArrow' _i o) = go True o
     go _inArr (Effect1' _e body) = go True body
     go inArr t = if inArr then Just t else Nothing
 
@@ -902,6 +1019,11 @@ instance (Show a) => Show (F a) where
       go _ (Ref r) = shows r
       go p (Arrow i o) =
         showParen (p > 0) $ showsPrec (p + 1) i <> s " -> " <> showsPrec p o
+      -- For 'Show', render 'ImplicitArrow' as @=>@ to make debugging
+      -- output unambiguous; the user-facing pretty-printer renders it as
+      -- @->@ until Phase 4. See ADR-019/ADR-015.
+      go p (ImplicitArrow i o) =
+        showParen (p > 0) $ showsPrec (p + 1) i <> s " => " <> showsPrec p o
       go p (Ann t k) =
         showParen (p > 1) $ shows t <> s ":" <> shows k
       go p (App f x) =

--- a/unison-hashing-v2/src/Unison/Hashing/V2/Term.hs
+++ b/unison-hashing-v2/src/Unison/Hashing/V2/Term.hs
@@ -166,6 +166,15 @@ instance (Var v) => Hashable1 (TermF v a p) where
                         [tag 2, Hashable.Text (Text.pack s)]
                       B.Recorded (B.MissingResultPlaceholder _) -> [tag 3]
                       B.Retain -> [tag 4]
+                      -- ADR-019 / chunk C2.2: an unresolved implicit hole.
+                      -- Hashing-wise it should never reach this point —
+                      -- the elaborator (chunk D1+) substitutes the
+                      -- resolved dictionary term before we hash. The tag
+                      -- is allocated for completeness; if a future
+                      -- pipeline change leaks an unresolved 'Implicit'
+                      -- into hashing, we'd rather get a stable hash than
+                      -- a non-exhaustive-pattern crash.
+                      B.Recorded (B.Implicit _) -> [tag 5]
                   TermRef (ReferenceBuiltin name) -> [tag 2, accumulateToken name]
                   TermApp a a2 -> [tag 3, hashed (hash a), hashed (hash a2)]
                   TermAnn a t -> [tag 4, hashed (hash a), hashed (ABT.hash t)]

--- a/unison-hashing-v2/src/Unison/Hashing/V2/Type.hs
+++ b/unison-hashing-v2/src/Unison/Hashing/V2/Type.hs
@@ -47,6 +47,9 @@ data TypeF a
   | TypeIntroOuter a -- binder like ∀, used to introduce variables that are
   -- bound by outer type signatures, to support scoped type
   -- variables
+  | -- | Hashing-side mirror of 'Unison.Type.ImplicitArrow'. Hashes with
+    -- a distinct tag (8) from 'TypeArrow' (1); see ADR-014/ADR-019.
+    TypeImplicitArrow a a
   deriving (Foldable, Functor, Traversable)
 
 -- | Types are represented as ABTs over the base functor F, with variables in `v`
@@ -151,3 +154,7 @@ instance Hashable1 TypeF where
             TypeEffect e t -> [tag 5, hashed (hash e), hashed (hash t)]
             TypeForall a -> [tag 6, hashed (hash a)]
             TypeIntroOuter a -> [tag 7, hashed (hash a)]
+            -- New tag for implicit arrows (ADR-019). MUST differ from
+            -- 'TypeArrow' (tag 1) so that @C => T@ and @C -> T@ hash
+            -- distinctly. See ADR-014.
+            TypeImplicitArrow a b -> [tag 8, hashed (hash a), hashed (hash b)]

--- a/unison-merge/package.yaml
+++ b/unison-merge/package.yaml
@@ -4,34 +4,50 @@ copyright: Copyright (C) 2013-2018 Unison Computing, PBC and contributors
 
 ghc-options: -Wall
 
-dependencies:
-  - base
-  - containers
-  - deepseq
-  - lens
-  - nonempty-containers
-  - semialign
-  - semigroups
-  - text
-  - these
-  - transformers
-  - unison-core
-  - unison-core1
-  - unison-hash
-  - unison-parser-typechecker
-  - unison-prelude
-  - unison-pretty-printer
-  - unison-syntax
-  - unison-util-bytes
-  - unison-util-relation
-  - witch
-  - witherable
-
 library:
   source-dirs: src
   when:
     - condition: false
       other-modules: Paths_unison_merge
+  dependencies:
+    - base
+    - containers
+    - deepseq
+    - lens
+    - nonempty-containers
+    - semialign
+    - semigroups
+    - text
+    - these
+    - transformers
+    - unison-core
+    - unison-core1
+    - unison-hash
+    - unison-parser-typechecker
+    - unison-prelude
+    - unison-pretty-printer
+    - unison-syntax
+    - unison-util-bytes
+    - unison-util-relation
+    - witch
+    - witherable
+
+tests:
+  unison-merge-tests:
+    when:
+      - condition: false
+        other-modules: Paths_unison_merge
+    dependencies:
+      - base
+      - code-page
+      - containers
+      - easytest
+      - text
+      - unison-core
+      - unison-core1
+      - unison-merge
+    main: Main.hs
+    source-dirs: tests
 
 default-extensions:
   - ApplicativeDo

--- a/unison-merge/src/Unison/Merge.hs
+++ b/unison-merge/src/Unison/Merge.hs
@@ -24,6 +24,16 @@ module Unison.Merge
     TwoWayI (..),
     Unconflicts (..),
     Updated,
+
+    -- * Given-set conflict resolution (per ADR-021)
+    GivenMarks,
+    GivenSetConflict (..),
+    GivenSetMergeOutcome (..),
+    GivenSetSide (..),
+    MergeMode (..),
+    SurvivorMap,
+    applyGivenSet,
+    mergeGivenSets,
   )
 where
 
@@ -32,6 +42,16 @@ import Unison.Merge.DiffOp (DiffOp (..))
 import Unison.Merge.Diffblob (Diffblob (..), DiffblobLog (..), emptyDiffblobLog, makeDiffblob)
 import Unison.Merge.EitherWay (EitherWay (..))
 import Unison.Merge.EitherWayI (EitherWayI (..))
+import Unison.Merge.GivenSet
+  ( GivenMarks,
+    GivenSetConflict (..),
+    GivenSetMergeOutcome (..),
+    GivenSetSide (..),
+    MergeMode (..),
+    SurvivorMap,
+    applyGivenSet,
+    mergeGivenSets,
+  )
 import Unison.Merge.Libdeps (LibdepDiffOp (..))
 import Unison.Merge.Mergeblob (Mergeblob (..), MergeblobError (..), makeMergeblob)
 import Unison.Merge.Rename (Rename (..), SimpleRenames (..))

--- a/unison-merge/src/Unison/Merge/GivenSet.hs
+++ b/unison-merge/src/Unison/Merge/GivenSet.hs
@@ -1,0 +1,255 @@
+-- | Three-way merge for namespace given-sets, per ADR-021.
+--
+-- A /given/ is a name marked with the @##Builtin.Given@ sentinel
+-- reference inside the namespace's 'MdValues' (see 'Unison.Codebase.Givens').
+-- During a three-way namespace merge, four distinct cases must be
+-- resolved when the given marks differ across LCA, Alice, and Bob:
+--
+--   * (a) Both branches mark the same hash given - no-op; the merged
+--     namespace keeps the mark.
+--   * (b) One branch marks, the other does not - mark wins by default,
+--     user-confirmable in interactive mode. Non-interactive merges
+--     (CI) default to the mark surviving.
+--   * (c) Both branches rename the same given to different names - the
+--     existing rename-conflict path drives name resolution; whichever
+--     name the user picks, the resulting hash retains the given tag.
+--   * (d) One branch marks, the other deletes the definition - the
+--     existing delete-conflict path drives the resolution. If the
+--     surviving definition exists, it inherits the mark.
+--
+-- This module operates as a parallel structure to the rest of the
+-- merge pipeline: callers extract the given-marks per branch from
+-- their 'Branch0' (using 'Unison.Codebase.Givens') and pass them in
+-- alongside the existing merge inputs. The merged given-set returned
+-- by 'mergeGivenSets' is then projected back onto the merged branch
+-- by 'applyGivenSet'.
+--
+-- Cases (c) and (d) require no new conflict category in the merge
+-- itself - they layer atop the existing rename-conflict and
+-- delete-conflict paths. The single new conflict category introduced
+-- by this chunk is case (b)'s metadata-only conflict, exposed to
+-- callers via 'GivenSetConflict' for optional confirmation.
+module Unison.Merge.GivenSet
+  ( -- * Per-branch given-marks
+    GivenMarks,
+    emptyGivenMarks,
+    isMarked,
+    insertMark,
+    fromList,
+    toMarkList,
+
+    -- * Merge mode
+    MergeMode (..),
+
+    -- * Three-way merge
+    GivenSetMergeOutcome (..),
+    GivenSetConflict (..),
+    GivenSetSide (..),
+    mergeGivenSets,
+
+    -- * Applying the merge result
+    SurvivorMap,
+    applyGivenSet,
+
+    -- * Sentinel
+    sentinel,
+  )
+where
+
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
+import Unison.Codebase.Givens qualified as Givens
+import Unison.Merge.ThreeWay (ThreeWay (..))
+import Unison.Name (Name)
+import Unison.Prelude
+import Unison.Reference (TermReference)
+import Unison.Referent (Referent)
+
+-- | The givenness sentinel reference, re-exported from
+-- 'Unison.Codebase.Givens' so this module is the single import in the
+-- merge pipeline. Per chunk B4 the merge code never compares against a
+-- hardcoded string; it always asks B1 what the sentinel is.
+sentinel :: TermReference
+sentinel = Givens.givenSentinel
+
+-- | A snapshot of one branch's given-marks. Keyed by 'Name' since a
+-- mark applies at a particular name; the 'Referent' is the term being
+-- marked. Per ADR-013, marking is per-name, but V1 'MdValues' is keyed
+-- on referent, so the same referent at multiple names is marked at all
+-- of them. We carry the 'Referent' here so case (c) (rename) and case
+-- (d) (delete) can match marks against the merged namespace.
+newtype GivenMarks = GivenMarks (Map Name Referent)
+  deriving stock (Eq, Generic, Show)
+
+emptyGivenMarks :: GivenMarks
+emptyGivenMarks = GivenMarks Map.empty
+
+isMarked :: Name -> GivenMarks -> Bool
+isMarked name (GivenMarks m) = Map.member name m
+
+-- | Insert a given-mark for the supplied @(name, referent)@.
+insertMark :: Name -> Referent -> GivenMarks -> GivenMarks
+insertMark name ref (GivenMarks m) = GivenMarks (Map.insert name ref m)
+
+fromList :: [(Name, Referent)] -> GivenMarks
+fromList = GivenMarks . Map.fromList
+
+toMarkList :: GivenMarks -> [(Name, Referent)]
+toMarkList (GivenMarks m) = Map.toList m
+
+-- | Whether to prompt the user for case (b) ambiguities. ADR-021
+-- specifies that non-interactive (CI) merges default to keeping the
+-- mark; 'NonInteractive' captures that. 'Interactive' mode reports
+-- prompts in the outcome so the caller (UCM, B2) can present them.
+data MergeMode
+  = -- | Surface case (b) ambiguities as prompts; the caller decides.
+    Interactive
+  | -- | Apply the default ("mark wins") to every case (b) without
+    -- prompting. Per ADR-021 this is the documented CI default.
+    NonInteractive
+  deriving stock (Eq, Show)
+
+-- | Which side mark differs from the other in a case (b).
+data GivenSetSide
+  = AliceMarked
+  | BobMarked
+  deriving stock (Eq, Show)
+
+-- | A user-visible conflict where one branch marks a name as a given
+-- and the other does not. Surfaced by 'mergeGivenSets' in 'Interactive'
+-- mode; in 'NonInteractive' mode these are auto-resolved and not
+-- returned. The 'def' is the referent at the conflict's 'name' on the
+-- side that holds the mark.
+data GivenSetConflict = GivenSetConflict
+  { name :: Name,
+    def :: Referent,
+    side :: GivenSetSide
+  }
+  deriving stock (Eq, Generic, Show)
+
+-- | The outcome of merging three given-set snapshots.
+data GivenSetMergeOutcome = GivenSetMergeOutcome
+  { -- | Marks that should appear in the merged namespace, before
+    -- pruning by 'applyGivenSet'. In 'NonInteractive' mode this is the
+    -- final answer; in 'Interactive' mode it reflects the default
+    -- ("mark wins") and is what to apply if the user accepts every
+    -- prompt.
+    merged :: GivenMarks,
+    -- | Case (b) prompts. Empty in 'NonInteractive' mode.
+    prompts :: [GivenSetConflict]
+  }
+  deriving stock (Eq, Generic, Show)
+
+-- | Three-way merge of given-mark snapshots.
+--
+-- The four ADR-021 cases are resolved as follows:
+--
+--   * Case (a) (both mark, same name): the mark survives unchanged.
+--   * Case (b) (one marks, one doesn't): the mark survives. In
+--     'Interactive' mode a 'GivenSetConflict' is emitted for caller
+--     confirmation; in 'NonInteractive' mode the resolution is silent.
+--   * Cases (c) and (d): handled downstream by 'applyGivenSet', which
+--     prunes marks for names that don't survive the rename-conflict /
+--     delete-conflict path. Their marks ride along here regardless;
+--     'applyGivenSet' filters.
+mergeGivenSets ::
+  MergeMode ->
+  ThreeWay GivenMarks ->
+  GivenSetMergeOutcome
+mergeGivenSets mode ThreeWay {lca, alice, bob} =
+  let GivenMarks lcaM = lca
+      GivenMarks aliceM = alice
+      GivenMarks bobM = bob
+
+      -- Names that appear marked anywhere across the three branches.
+      -- Including the LCA's keys ensures we still see names where both
+      -- sides removed the mark - those resolve silently to "no mark."
+      allMarkedNames :: Set Name
+      allMarkedNames =
+        Map.keysSet lcaM
+          <> Map.keysSet aliceM
+          <> Map.keysSet bobM
+
+      step ::
+        (Map Name Referent, [GivenSetConflict]) ->
+        Name ->
+        (Map Name Referent, [GivenSetConflict])
+      step (acc, conflicts) name =
+        case (Map.lookup name aliceM, Map.lookup name bobM) of
+          -- Case (a): both branches still mark this name. Per
+          -- ADR-021 the mark survives unchanged - no prompt. We use
+          -- Alice's referent as the canonical witness; if the
+          -- underlying definition diverges, the existing update-update
+          -- conflict path will surface it separately.
+          (Just refA, Just _) ->
+            (Map.insert name refA acc, conflicts)
+          -- Case (b): only Alice marks. Mark wins by default; in
+          -- Interactive mode emit a prompt for caller confirmation.
+          -- Per ADR-021 this fires whether the LCA was marked or not:
+          -- "a merge that drops a deliberate mark is more surprising
+          -- than one that keeps it."
+          (Just refA, Nothing) ->
+            ( Map.insert name refA acc,
+              case mode of
+                NonInteractive -> conflicts
+                Interactive ->
+                  GivenSetConflict {name, def = refA, side = AliceMarked} : conflicts
+            )
+          -- Case (b): only Bob marks. Symmetric to the Alice case.
+          (Nothing, Just refB) ->
+            ( Map.insert name refB acc,
+              case mode of
+                NonInteractive -> conflicts
+                Interactive ->
+                  GivenSetConflict {name, def = refB, side = BobMarked} : conflicts
+            )
+          -- Neither branch marks. If the LCA had a mark and both
+          -- sides explicitly removed it, that's not a conflict - both
+          -- agreed - so the result has no mark. (Ditto if the LCA
+          -- never had it.)
+          (Nothing, Nothing) -> (acc, conflicts)
+
+      (mergedMap, prompts0) =
+        foldl' step (Map.empty, []) (Set.toList allMarkedNames)
+   in GivenSetMergeOutcome
+        { merged = GivenMarks mergedMap,
+          prompts = reverse prompts0
+        }
+
+-- | A map describing which @(name, referent)@ pairs survive in the
+-- merged namespace, used by 'applyGivenSet' to prune marks for names
+-- that lost the rename-conflict or delete-conflict path.
+type SurvivorMap = Map Name Referent
+
+-- | Project a merged given-set onto the surviving namespace. Any mark
+-- whose name no longer exists in the merged namespace is dropped
+-- (case (d), delete won). Any mark whose name now refers to a
+-- different referent than was originally marked is kept iff that name
+-- is the survivor of a rename - in which case the rename-conflict
+-- path already resolved which name maps to the marked hash, and the
+-- mark travels with the hash (case (c)).
+--
+-- The semantics: a mark @(n, r)@ survives if either
+--
+--   * @n@ maps to @r@ in the survivor map (the obvious case), or
+--   * the survivor map contains @r@ under any name (the rename case),
+--     in which case we relocate the mark to @r@'s new name.
+applyGivenSet :: SurvivorMap -> GivenMarks -> GivenMarks
+applyGivenSet survivors (GivenMarks marks) =
+  let survivorByRef :: Map Referent Name
+      survivorByRef =
+        Map.foldlWithKey' (\acc n r -> Map.insert r n acc) Map.empty survivors
+
+      step :: Map Name Referent -> Name -> Referent -> Map Name Referent
+      step acc n r =
+        case Map.lookup n survivors of
+          Just r' | r' == r -> Map.insert n r acc
+          _ ->
+            -- Either the name was deleted (Map.lookup returned Nothing)
+            -- or the name now refers to a different referent (rename
+            -- handled below). In the rename case, find the new home
+            -- of @r@ in the survivor map.
+            case Map.lookup r survivorByRef of
+              Just n' -> Map.insert n' r acc
+              Nothing -> acc -- definitively deleted
+   in GivenMarks (Map.foldlWithKey' step Map.empty marks)

--- a/unison-merge/src/Unison/Merge/Mergeblob.hs
+++ b/unison-merge/src/Unison/Merge/Mergeblob.hs
@@ -52,6 +52,7 @@ import Unison.Syntax.Parser qualified as Parser
 import Unison.Term (Term)
 import Unison.Type (Type)
 import Unison.Typechecker qualified as Typechecker
+import Unison.Typechecker.GivenResolver qualified as GivenResolver
 import Unison.Typechecker.TypeLookup (TypeLookup)
 import Unison.Typechecker.Variance qualified as Variance
 import Unison.UnconflictedLocalDefnsView (UnconflictedLocalDefnsView (..))
@@ -233,7 +234,9 @@ makeMergeblob hydrate loadDependents loadLibdepsNames loadTypeLookup blob author
                             typeLookup,
                             freeNameToFuzzyTermsByShortName = Map.empty,
                             topLevelComponents = Map.empty,
-                            variances = Variance.fromTypeLookup typeLookup
+                            variances = Variance.fromTypeLookup typeLookup,
+                            ambientGivens = GivenResolver.poolFromList [],
+                            givenBindings = file.givenBindings
                           }
                   FileParsers.synthesizeFile typecheckingEnv file
                     & Result.runResultT

--- a/unison-merge/src/Unison/Merge/Synhash.hs
+++ b/unison-merge/src/Unison/Merge/Synhash.hs
@@ -378,6 +378,9 @@ hashTypeFTokens ppe = \case
   Type.Effects es -> [H.Tag 5, hashLengthToken es]
   Type.Forall {} -> [H.Tag 6]
   Type.IntroOuter {} -> [H.Tag 7]
+  -- ADR-019: implicit arrows synhash with a distinct tag (8) from
+  -- ordinary arrows (1).
+  Type.ImplicitArrow {} -> [H.Tag 8]
 
 hashTypeReferenceToken :: PrettyPrintEnv -> TypeReference -> Token
 hashTypeReferenceToken ppe =

--- a/unison-merge/tests/Main.hs
+++ b/unison-merge/tests/Main.hs
@@ -1,0 +1,15 @@
+module Main (main) where
+
+import EasyTest
+import System.IO.CodePage (withCP65001)
+import Unison.Test.Merge.GivenSet qualified as GivenSet
+
+main :: IO ()
+main =
+  withCP65001 (run (scope "unison-merge" tests))
+  where
+    tests :: Test ()
+    tests =
+      EasyTest.tests
+        [ GivenSet.test
+        ]

--- a/unison-merge/tests/Unison/Test/Merge/GivenSet.hs
+++ b/unison-merge/tests/Unison/Test/Merge/GivenSet.hs
@@ -1,0 +1,253 @@
+-- | Tests for given-set conflict resolution per ADR-021.
+--
+-- Each of the four ADR-021 cases has a dedicated scope:
+--
+--   * Case (a) — both branches mark the same hash given.
+--   * Case (b) — one branch marks, the other does not.
+--   * Case (c) — both branches rename the same given to different
+--     names (post-resolution: the surviving name carries the mark).
+--   * Case (d) — one branch marks, the other deletes the definition
+--     (post-resolution: surviving definition carries the mark; if the
+--     delete won, the mark is dropped).
+module Unison.Test.Merge.GivenSet
+  ( test,
+  )
+where
+
+import Data.List.NonEmpty qualified as NonEmpty
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+import Data.Text qualified as Text
+import EasyTest
+import Unison.Merge (MergeMode (..), ThreeWay (..))
+import Unison.Merge.GivenSet qualified as GivenSet
+import Unison.Name (Name)
+import Unison.Name qualified as Name
+import Unison.NameSegment (NameSegment)
+import Unison.NameSegment.Internal qualified as NameSegment
+import Unison.Reference qualified as Reference
+import Unison.Referent (Referent)
+import Unison.Referent qualified as Referent
+
+-- ---------------------------------------------------------------------------
+-- Test fixtures
+-- ---------------------------------------------------------------------------
+
+-- Construct a 'Name' from a dot-separated string. We bypass the
+-- syntax parser here because the test suite is intentionally lean on
+-- dependencies; we only need names that participate in 'Eq'/'Ord'
+-- comparisons, not parser-driven name validation.
+n :: Text -> Name
+n s =
+  Name.fromSegments . NonEmpty.fromList . map seg . filter (not . nullText) $ splitDots s
+  where
+    seg :: Text -> NameSegment
+    seg = NameSegment.NameSegment
+
+    nullText :: Text -> Bool
+    nullText t = t == ""
+
+    splitDots :: Text -> [Text]
+    splitDots = goDots []
+
+    goDots :: [Text] -> Text -> [Text]
+    goDots acc t =
+      case Text.break (== '.') t of
+        (a, "") -> reverse (a : acc)
+        (a, rest) -> goDots (a : acc) (Text.drop 1 rest)
+
+-- An arbitrary builtin term referent used as a stand-in for the
+-- referent that's marked given. The merge logic only cares that the
+-- referent is 'Eq'/'Ord'-able.
+refA :: Referent
+refA = Referent.Ref (Reference.Builtin "Test.refA")
+
+-- Convenience: a one-element 'GivenMarks'.
+single :: Text -> Referent -> GivenSet.GivenMarks
+single name ref = GivenSet.fromList [(n name, ref)]
+
+empty :: GivenSet.GivenMarks
+empty = GivenSet.emptyGivenMarks
+
+-- ---------------------------------------------------------------------------
+-- Tests
+-- ---------------------------------------------------------------------------
+
+test :: Test ()
+test =
+  scope "given-set-merge" . tests $
+    [ caseA,
+      caseB,
+      caseB_lcaHadMark,
+      caseB_nonInteractive,
+      caseC,
+      caseD_deleteWon,
+      caseD_markSurvives,
+      regression_emptyIsNoOp
+    ]
+
+-- Case (a): both branches mark the same name. Per ADR-021 the merged
+-- branch keeps the mark; no prompt is produced.
+caseA :: Test ()
+caseA =
+  scope "case (a) — both mark same hash" do
+    let outcome =
+          GivenSet.mergeGivenSets
+            Interactive
+            ThreeWay
+              { lca = empty,
+                alice = single "Show.nat" refA,
+                bob = single "Show.nat" refA
+              }
+    expect (outcome.merged == single "Show.nat" refA)
+    expect (null outcome.prompts)
+
+-- Case (b), interactive: only one side has the mark. The mark wins by
+-- default and a prompt is emitted for caller confirmation.
+caseB :: Test ()
+caseB =
+  scope "case (b) — one marks, the other doesn't (interactive)" do
+    let outcome =
+          GivenSet.mergeGivenSets
+            Interactive
+            ThreeWay
+              { lca = empty,
+                alice = single "Show.nat" refA,
+                bob = empty
+              }
+    -- Default: mark wins.
+    expect (outcome.merged == single "Show.nat" refA)
+    -- One prompt, attributed to Alice.
+    case outcome.prompts of
+      [c] -> do
+        expect (c.name == n "Show.nat")
+        expect (c.def == refA)
+        expect (c.side == GivenSet.AliceMarked)
+      _ -> crash "expected exactly one prompt"
+
+-- Case (b) variant: LCA had the mark, Bob explicitly removed it,
+-- Alice kept it. Per ADR-021, dropping a deliberate mark is the
+-- surprising direction; we keep the mark by default and surface a
+-- prompt.
+caseB_lcaHadMark :: Test ()
+caseB_lcaHadMark =
+  scope "case (b) — LCA had mark, Bob unmarked, Alice kept" do
+    let outcome =
+          GivenSet.mergeGivenSets
+            Interactive
+            ThreeWay
+              { lca = single "Show.nat" refA,
+                alice = single "Show.nat" refA,
+                bob = empty
+              }
+    expect (outcome.merged == single "Show.nat" refA)
+    case outcome.prompts of
+      [c] -> do
+        expect (c.name == n "Show.nat")
+        expect (c.side == GivenSet.AliceMarked)
+      _ -> crash "expected exactly one prompt"
+
+-- Case (b), non-interactive (CI default): same input as caseB, but
+-- mode is NonInteractive so prompts are auto-resolved silently. The
+-- mark still wins.
+caseB_nonInteractive :: Test ()
+caseB_nonInteractive =
+  scope "case (b) — non-interactive default is mark-wins (CI mode)" do
+    let outcome =
+          GivenSet.mergeGivenSets
+            NonInteractive
+            ThreeWay
+              { lca = empty,
+                alice = single "Show.nat" refA,
+                bob = empty
+              }
+    expect (outcome.merged == single "Show.nat" refA)
+    expect (null outcome.prompts)
+
+-- Case (c): both branches rename the same given to different names.
+-- The merge logic itself doesn't pick the winning name (that's the
+-- existing rename-conflict path), but it must travel the mark with
+-- the surviving hash. We model this by running 'mergeGivenSets'
+-- followed by 'applyGivenSet' against a survivor map representing
+-- the rename outcome.
+caseC :: Test ()
+caseC =
+  scope "case (c) — rename conflict; mark travels with hash" do
+    -- LCA: Show.nat = refA (marked given).
+    -- Alice renames to ShowNat (still refA, still marked).
+    -- Bob renames to Show.Nat (still refA, still marked).
+    -- Pretend the rename-conflict path picks "ShowNat" as the winner.
+    let outcome =
+          GivenSet.mergeGivenSets
+            NonInteractive
+            ThreeWay
+              { lca = single "Show.nat" refA,
+                alice = single "ShowNat" refA,
+                bob = single "Show.Nat" refA
+              }
+        survivors :: GivenSet.SurvivorMap
+        survivors = Map.fromList [(n "ShowNat", refA)]
+        pruned = GivenSet.applyGivenSet survivors outcome.merged
+    -- After applying, the mark lives at the surviving name with the
+    -- original hash.
+    expect (pruned == single "ShowNat" refA)
+    -- Symmetric check: if "Show.Nat" had won instead, the mark would
+    -- live there.
+    let survivors' = Map.fromList [(n "Show.Nat", refA)]
+        pruned' = GivenSet.applyGivenSet survivors' outcome.merged
+    expect (pruned' == single "Show.Nat" refA)
+
+-- Case (d), delete-won variant: Alice marks, Bob deletes, the user
+-- (or merge policy) accepts the delete. The mark is dropped because
+-- there's no definition to attach it to.
+caseD_deleteWon :: Test ()
+caseD_deleteWon =
+  scope "case (d) — mark vs delete; delete wins, mark is dropped" do
+    let outcome =
+          GivenSet.mergeGivenSets
+            NonInteractive
+            ThreeWay
+              { lca = empty,
+                alice = single "Show.nat" refA,
+                bob = empty
+              }
+        -- No survivors: the definition was deleted.
+        survivors :: GivenSet.SurvivorMap
+        survivors = Map.empty
+        pruned = GivenSet.applyGivenSet survivors outcome.merged
+    expect (pruned == empty)
+
+-- Case (d), mark-survives variant: Alice marks, Bob deletes, the
+-- existing delete-conflict path restores Alice's definition. The
+-- mark must travel with the restored hash.
+caseD_markSurvives :: Test ()
+caseD_markSurvives =
+  scope "case (d) — mark vs delete; restore wins, mark survives" do
+    let outcome =
+          GivenSet.mergeGivenSets
+            NonInteractive
+            ThreeWay
+              { lca = empty,
+                alice = single "Show.nat" refA,
+                bob = empty
+              }
+        survivors :: GivenSet.SurvivorMap
+        survivors = Map.fromList [(n "Show.nat", refA)]
+        pruned = GivenSet.applyGivenSet survivors outcome.merged
+    expect (pruned == single "Show.nat" refA)
+
+-- Regression: when no givens are involved anywhere, the merge is a
+-- no-op and produces no prompts (per ADR-021 "regression test that
+-- today's metadata-free merges still produce identical results when
+-- no givens are involved").
+regression_emptyIsNoOp :: Test ()
+regression_emptyIsNoOp =
+  scope "no givens anywhere is a no-op" do
+    let outcome =
+          GivenSet.mergeGivenSets
+            Interactive
+            ThreeWay {lca = empty, alice = empty, bob = empty}
+    expect (outcome.merged == empty)
+    expect (null outcome.prompts)
+    -- And the identity holds for 'applyGivenSet' as well.
+    expect (GivenSet.applyGivenSet Map.empty outcome.merged == empty)

--- a/unison-merge/unison-merge.cabal
+++ b/unison-merge/unison-merge.cabal
@@ -25,6 +25,7 @@ library
       Unison.Merge.EitherWay
       Unison.Merge.EitherWayI
       Unison.Merge.FindConflictedAlias
+      Unison.Merge.GivenSet
       Unison.Merge.Internal.Types
       Unison.Merge.Libdeps
       Unison.Merge.Mergeblob
@@ -100,4 +101,57 @@ library
     , unison-util-relation
     , witch
     , witherable
+  default-language: Haskell2010
+
+test-suite unison-merge-tests
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      Unison.Test.Merge.GivenSet
+  hs-source-dirs:
+      tests
+  default-extensions:
+      ApplicativeDo
+      BangPatterns
+      BlockArguments
+      DeriveAnyClass
+      DeriveFunctor
+      DeriveFoldable
+      DeriveTraversable
+      DeriveGeneric
+      DerivingStrategies
+      DerivingVia
+      DoAndIfThenElse
+      DuplicateRecordFields
+      FlexibleContexts
+      FlexibleInstances
+      GADTs
+      GeneralizedNewtypeDeriving
+      ImportQualifiedPost
+      InstanceSigs
+      LambdaCase
+      MultiParamTypeClasses
+      MultiWayIf
+      NamedFieldPuns
+      NumericUnderscores
+      OverloadedLabels
+      OverloadedRecordDot
+      OverloadedStrings
+      PatternSynonyms
+      QuantifiedConstraints
+      RankNTypes
+      ScopedTypeVariables
+      TupleSections
+      TypeApplications
+      ViewPatterns
+  ghc-options: -Wall
+  build-depends:
+      base
+    , code-page
+    , containers
+    , easytest
+    , text
+    , unison-core
+    , unison-core1
+    , unison-merge
   default-language: Haskell2010

--- a/unison-runtime/src/Unison/Runtime/Builtin.hs
+++ b/unison-runtime/src/Unison/Runtime/Builtin.hs
@@ -614,6 +614,14 @@ any'extract =
       TMatch v $
         MatchData Ty.anyRef (mapSingleton 0 $ ([BX], TAbs v1 (TVar v1))) Nothing
 
+-- | ADR-006: @summon : forall a. a => a@ is the identity function.
+-- The leading @=>@ on its declared type makes the elaborator insert
+-- the resolved dictionary as the argument, and we just hand that
+-- dictionary back unchanged.
+summon'id :: SuperNormal Reference Symbol
+summon'id =
+  unop0 0 $ \[v] -> TVar v
+
 -- Refs
 
 -- The docs for IORef state that IORef operations can be observed
@@ -899,6 +907,7 @@ builtinLookup =
         ("Value.value", (Tracked, value'create)),
         ("Any.Any", (Untracked, any'construct)),
         ("Any.unsafeExtract", (Untracked, any'extract)),
+        ("summon", (Untracked, summon'id)),
         ("Link.Term.toText", (Untracked, term'link'to'text)),
         ("STM.atomically", (Tracked, stm'atomic)),
         ("validateSandboxed", (Untracked, check'sandbox)),

--- a/unison-runtime/src/Unison/Runtime/IOSource.hs
+++ b/unison-runtime/src/Unison/Runtime/IOSource.hs
@@ -53,6 +53,7 @@ typecheckingEnv =
       (ShouldUseTndr'Yes parsingEnv)
       []
       (\_ -> pure (External <$ Builtin.typeLookup))
+      []
       parsedFile
 
 parsedFile :: UF.UnisonFile Symbol Ann

--- a/unison-runtime/src/Unison/Runtime/Interface.hs
+++ b/unison-runtime/src/Unison/Runtime/Interface.hs
@@ -488,6 +488,10 @@ checkCacheability cl ctx (r, sg) =
     hasArrows abt = case ABT.out' abt of
       (ABT.Tm f) -> case f of
         Type.Arrow _ _ -> True
+        -- ADR-019: 'ImplicitArrow' is still an arrow at the term level
+        -- (the elaborator turns it into 'Arrow' before runtime, but for
+        -- this caching predicate we treat it identically to 'Arrow').
+        Type.ImplicitArrow _ _ -> True
         other -> or other
       t -> or t
 

--- a/unison-runtime/tests/Unison/Test/Common.hs
+++ b/unison-runtime/tests/Unison/Test/Common.hs
@@ -78,6 +78,7 @@ parseAndSynthesizeAsFile ambient filename s = do
             (FP.ShouldUseTndr'Yes parsingEnv)
             ambient
             (\_deps -> pure B.typeLookup)
+            []
             file
   case FP.synthesizeFile typecheckingEnv file of
     Result.Result notes Nothing -> tell notes >> pure (Left file)

--- a/unison-share-api/package.yaml
+++ b/unison-share-api/package.yaml
@@ -81,7 +81,9 @@ tests:
       - condition: false
         other-modules: Paths_unison_share_api
     dependencies:
+      - bytes
       - code-page
+      - containers
       - easytest
       - hedgehog
       - unison-share-api
@@ -90,10 +92,13 @@ tests:
       - raw-strings-qq
       - serialise
       - text
+      - unison-core
       - unison-hash
       - unison-prelude
+      - unison-codebase
       - unison-codebase-sqlite
       - unison-pretty-printer
+      - unison-util-serialization
       - vector
 
     main: Main.hs

--- a/unison-share-api/tests/Main.hs
+++ b/unison-share-api/tests/Main.hs
@@ -5,12 +5,14 @@ import System.Environment (getArgs)
 import System.IO
 import System.IO.CodePage (withCP65001)
 import Unison.Test.Server.Backend.DefinitionDiff qualified as DefinitionDiff
+import Unison.Test.Sync.GivenRoundtrip qualified as SyncGivenRoundtrip
 import Unison.Test.Sync.Roundtrip qualified as SyncRoundtrip
 
 test :: Test ()
 test =
   tests
     [ SyncRoundtrip.test,
+      SyncGivenRoundtrip.test,
       DefinitionDiff.test
     ]
 

--- a/unison-share-api/tests/Unison/Test/Sync/GivenRoundtrip.hs
+++ b/unison-share-api/tests/Unison/Test/Sync/GivenRoundtrip.hs
@@ -1,0 +1,201 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Round-trip tests covering the @##Builtin.Given@ sentinel through the
+-- sharing API wire format.
+--
+-- The sharing API encodes a namespace as @LocalBranchBytes@: an opaque
+-- 'ByteString' produced by 'putLocalBranch' and consumed by
+-- 'getLocalBranch'. 'MdValues' (per-name metadata) is part of that byte
+-- payload, encoded as @putMetadataSetFormat = putWord8 0 *> putFoldable
+-- putReference s@. The given sentinel is just an ordinary
+-- 'ReferenceBuiltin' inside that set, so no schema change is required to
+-- carry it across push/pull: the wire format already round-trips it.
+--
+-- These tests pin that property in place so future protocol changes
+-- don't accidentally regress it. They cover:
+--
+-- * Direct round-trip of a 'LocalBranch' containing the sentinel via
+--   'putLocalBranch' / 'getLocalBranch'.
+-- * Round-trip through the 'TempEntity' CBOR wire format
+--   (@instance Serialise TempEntity@) — i.e. through a full sync
+--   payload — preserves the @LocalBranchBytes@ exactly.
+-- * Graceful degradation: a payload whose metadata set contains the
+--   sentinel alongside an unknown reference round-trips identically. An
+--   "older" client that doesn't understand the sentinel sees it as just
+--   another opaque metadata reference and copies it through unchanged.
+module Unison.Test.Sync.GivenRoundtrip (test) where
+
+import Codec.Serialise qualified as Serialise
+import Data.ByteString (ByteString)
+import Data.Bytes.Get (runGetS)
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
+import Data.Text (Text)
+import Data.Vector qualified as Vector
+import EasyTest
+import U.Codebase.Reference (Reference' (..))
+import U.Codebase.Referent qualified as Referent
+import U.Codebase.Sqlite.Branch.Format qualified as BranchFormat
+import U.Codebase.Sqlite.Branch.Full qualified as BranchFull
+import U.Codebase.Sqlite.Entity qualified as Entity
+import U.Codebase.Sqlite.LocalIds (LocalDefnId (..), LocalTextId (..))
+import U.Codebase.Sqlite.Serialization qualified as S
+import U.Codebase.Sqlite.TempEntity (TempEntity)
+import U.Util.Serialization qualified as Put
+import Unison.Server.Orphans ()
+
+-- | The textual name of the given sentinel. Mirrors
+-- 'Unison.Builtin.givenSentinelName' from chunk B1; we hard-code it
+-- here so this test package doesn't depend on parser-typechecker.
+givenSentinelText :: Text
+givenSentinelText = "Builtin.Given"
+
+-- | A second, unrelated builtin tag used to model an arbitrary
+-- metadata reference that an older client wouldn't recognise.
+otherMetadataText :: Text
+otherMetadataText = "Builtin.OtherTag"
+
+-- The text-table layout for our test payload. Index 0 is the term name
+-- under which the referent is published; index 1 is the builtin name
+-- referred to by the given sentinel reference.
+nameSegmentTextIx, sentinelTextIx, otherMetadataTextIx :: LocalTextId
+nameSegmentTextIx = LocalTextId 0
+sentinelTextIx = LocalTextId 1
+otherMetadataTextIx = LocalTextId 2
+
+-- The sentinel itself, expressed in 'LocalBranch' coordinates.
+sentinelLocal :: BranchFull.MetadataSetFormat' LocalTextId LocalDefnId
+sentinelLocal =
+  BranchFull.Inline (Set.singleton (ReferenceBuiltin sentinelTextIx))
+
+-- A second metadata reference (a different, unrelated builtin tag) so
+-- we can verify multi-element metadata sets round-trip too.
+sentinelPlusOtherLocal :: BranchFull.MetadataSetFormat' LocalTextId LocalDefnId
+sentinelPlusOtherLocal =
+  BranchFull.Inline
+    ( Set.fromList
+        [ ReferenceBuiltin sentinelTextIx,
+          ReferenceBuiltin otherMetadataTextIx
+        ]
+    )
+
+-- A single-term branch where that term carries the supplied metadata
+-- set. The term itself is a builtin referent (@##SomeTerm@ encoded as
+-- 'ReferenceBuiltin 0' for simplicity — index 0 is also the name's
+-- text id, but that's fine; in 'LocalBranch' the text-id space is
+-- shared and 'Builtin' refs name distinct entities).
+branchWithMetadata ::
+  BranchFull.MetadataSetFormat' LocalTextId LocalDefnId ->
+  BranchFull.LocalBranch
+branchWithMetadata md =
+  BranchFull.Branch
+    ( Map.singleton
+        nameSegmentTextIx
+        ( Map.singleton
+            (Referent.Ref (ReferenceBuiltin nameSegmentTextIx))
+            md
+        )
+    )
+    Map.empty
+    Map.empty
+    Map.empty
+
+branchLocalIds :: BranchFormat.BranchLocalIds' Text hash p c
+branchLocalIds =
+  BranchFormat.LocalIds
+    { BranchFormat.branchTextLookup =
+        Vector.fromList ["fooName", givenSentinelText, otherMetadataText],
+      BranchFormat.branchDefnLookup = Vector.empty,
+      BranchFormat.branchPatchLookup = Vector.empty,
+      BranchFormat.branchChildLookup = Vector.empty
+    }
+
+-- | Encode a 'LocalBranch' the same way SQLite + sharing do.
+encodeLocalBranchBytes :: BranchFull.LocalBranch -> ByteString
+encodeLocalBranchBytes = Put.putBytes S.putLocalBranch
+
+-- | Decode bytes back into a 'LocalBranch'.
+decodeLocalBranchBytes :: ByteString -> Either String BranchFull.LocalBranch
+decodeLocalBranchBytes = runGetS S.getLocalBranch
+
+-- | Wrap a 'LocalBranch' in the same 'TempEntity' shape that travels
+-- through the sharing wire format.
+namespaceTempEntity :: BranchFull.LocalBranch -> TempEntity
+namespaceTempEntity lb =
+  Entity.N
+    ( BranchFormat.SyncFull
+        branchLocalIds
+        (BranchFormat.LocalBranchBytes (encodeLocalBranchBytes lb))
+    )
+
+-- | Extract the 'LocalBranchBytes' payload from a 'TempEntity', if it
+-- is a @SyncFull@ namespace.
+namespaceBytes :: TempEntity -> Maybe ByteString
+namespaceBytes = \case
+  Entity.N (BranchFormat.SyncFull _ (BranchFormat.LocalBranchBytes bs)) -> Just bs
+  _ -> Nothing
+
+-- | Pull the metadata reference set off the (sole) term in the (sole)
+-- name of the supplied 'LocalBranch'.
+extractMetadata ::
+  BranchFull.LocalBranch ->
+  Maybe (Set.Set (Reference' LocalTextId LocalDefnId))
+extractMetadata (BranchFull.Branch terms _ _ _) = do
+  byName <- Map.lookup nameSegmentTextIx terms
+  BranchFull.Inline refs <-
+    Map.lookup
+      (Referent.Ref (ReferenceBuiltin nameSegmentTextIx))
+      byName
+  pure refs
+
+test :: Test ()
+test =
+  scope "syncv1.givenRoundtrip" . tests $
+    [ scope "LocalBranch with given sentinel round-trips through putLocalBranch/getLocalBranch" do
+        let original = branchWithMetadata sentinelLocal
+            bytes = encodeLocalBranchBytes original
+        case decodeLocalBranchBytes bytes of
+          Left err -> crash $ "decode failed: " <> err
+          Right decoded ->
+            case extractMetadata decoded of
+              Nothing -> crash "decoded branch missing the term metadata entry"
+              Just refs ->
+                expect (refs == Set.singleton (ReferenceBuiltin sentinelTextIx)),
+      scope "LocalBranchBytes survives the TempEntity CBOR wire format byte-for-byte" do
+        let original = branchWithMetadata sentinelLocal
+            entity = namespaceTempEntity original
+            roundTripped = Serialise.deserialise (Serialise.serialise entity)
+        expect (entity == roundTripped)
+        case (namespaceBytes entity, namespaceBytes roundTripped) of
+          (Just before, Just after) -> expect (before == after)
+          _ -> crash "expected SyncFull namespace before and after wire round-trip",
+      scope "metadata round-trips through wire format and decodes to the same MdValues" do
+        let original = branchWithMetadata sentinelLocal
+            entity = namespaceTempEntity original
+            wireRoundTripped =
+              Serialise.deserialise (Serialise.serialise entity) :: TempEntity
+        case namespaceBytes wireRoundTripped >>= either (const Nothing) Just . decodeLocalBranchBytes of
+          Nothing -> crash "could not extract LocalBranch from wire-roundtripped entity"
+          Just decoded ->
+            expect (extractMetadata decoded == extractMetadata original),
+      scope "graceful degradation: sentinel coexists with unknown metadata refs through the wire" do
+        -- Models the "older client / newer server" and "newer client /
+        -- older server" cases. The wire format treats any
+        -- 'MetadataSet' member as an opaque 'Reference', so a client
+        -- that doesn't recognise '##Builtin.Given' (resp.
+        -- '##Builtin.OtherTag') still copies it through unchanged.
+        let original = branchWithMetadata sentinelPlusOtherLocal
+            entity = namespaceTempEntity original
+            roundTripped =
+              Serialise.deserialise (Serialise.serialise entity) :: TempEntity
+        expect (entity == roundTripped)
+        case namespaceBytes roundTripped >>= either (const Nothing) Just . decodeLocalBranchBytes of
+          Nothing -> crash "could not decode LocalBranch from round-tripped entity"
+          Just decoded ->
+            case extractMetadata decoded of
+              Nothing -> crash "decoded branch missing metadata set"
+              Just refs -> do
+                expect (Set.member (ReferenceBuiltin sentinelTextIx) refs)
+                expect (Set.member (ReferenceBuiltin otherMetadataTextIx) refs)
+                expect (Set.size refs == 2)
+    ]

--- a/unison-share-api/unison-share-api.cabal
+++ b/unison-share-api/unison-share-api.cabal
@@ -164,6 +164,7 @@ test-suite unison-share-api-tests
   other-modules:
       Unison.Test.Server.Backend.DefinitionDiff
       Unison.Test.Sync.Gen
+      Unison.Test.Sync.GivenRoundtrip
       Unison.Test.Sync.Roundtrip
   hs-source-dirs:
       tests
@@ -202,17 +203,22 @@ test-suite unison-share-api-tests
   ghc-options: -Wall
   build-depends:
       base
+    , bytes
     , bytestring
     , code-page
+    , containers
     , easytest
     , hedgehog
     , raw-strings-qq
     , serialise
     , text
+    , unison-codebase
     , unison-codebase-sqlite
+    , unison-core
     , unison-hash
     , unison-prelude
     , unison-pretty-printer
     , unison-share-api
+    , unison-util-serialization
     , vector
   default-language: Haskell2010

--- a/unison-src/implicits-tutorial.u
+++ b/unison-src/implicits-tutorial.u
@@ -1,0 +1,276 @@
+-- Implicit parameters tutorial (Phase 2 prototype)
+--
+-- This file walks through the surface syntax of implicit parameters
+-- as introduced by the implicits RFC (see docs/implicits-plan.md and
+-- docs/architecture/decisions/ADR-001..023).
+--
+-- Status note: chunks L1 + L2 closed the last-mile typechecker
+-- wiring. The ambient given pool is now harvested from the
+-- namespace's `given`-tagged definitions (L1), and `let given` /
+-- file-internal `given` declarations register lexically inside the
+-- typechecker (L2). With those in place, constraint goals raised at
+-- apply sites now actually resolve against in-scope givens (see the
+-- `testSourceLevel*` tests in `Unison.Test.Typechecker.GivenApply`).
+--
+-- One last-mile gap remains in the term-level elaborator (chunk D3,
+-- `applyGivenDecisions`): when the chosen given is a *local* (file-
+-- internal `given` or `let given`), the decision is recorded against
+-- a synthetic `Reference.Builtin "Local.given.<name>"` rather than
+-- the source-level variable. Resolution succeeds in the type-checker
+-- — `SolvedImplicit` notes are emitted with a sensible decision —
+-- but the rewritten term carries the synthetic ref, so the runtime
+-- can't actually evaluate it (`prepareEvaluation` reports a missing
+-- cache entry for `Local.given.*`). See "Known limits" at the
+-- bottom for specifics.
+--
+-- The tutorial therefore favors examples that exercise the syntax
+-- *and* evaluate cleanly today — the by-name-reference pattern of
+-- sections 2 and 8 — and notes for each `=>` example whether it
+-- fully evaluates (load + watch) or only typechecks/parses.
+
+
+-- ===========================================================================
+-- 1. A "class" is just an ordinary record (ADR-003).
+-- ===========================================================================
+--
+-- There is no `class` keyword in Unison. A "class" is just a unique
+-- type that holds the methods. Single-method classes look like a
+-- record with one field; multi-method classes hold a tuple/several
+-- fields.
+--
+-- Below, `Show a` is the "Show class": a record with a single field
+-- `show` of type `a -> Text`.
+
+type Show a = Show (a -> Text)
+
+
+-- ===========================================================================
+-- 2. A `given` declaration is an instance.
+-- ===========================================================================
+--
+-- The `given` keyword (ADR-010, ADR-022) marks a definition as
+-- eligible for implicit resolution. A `given` is otherwise an
+-- ordinary term binding -- you can call it by name, view it, edit it,
+-- and update it like any other definition.
+--
+-- The givenness is recorded as namespace metadata (ADR-002), so it
+-- survives merges, doesn't change the term's hash, and doesn't
+-- require a special declaration form for the type.
+--
+-- The `given` keyword tags this binding for the L2 lexical pool
+-- (file-internal scope) and, after `add` + `mark.given`, also for
+-- the L1 ambient pool (namespace scope).
+
+given Show.nat : Show Nat = Show.Show Nat.toText
+
+
+-- ===========================================================================
+-- 3. The constraint arrow `=>` (ADR-001, chunk A1).
+-- ===========================================================================
+--
+-- The `=>` arrow introduces an implicit parameter. The signature
+--
+--     printIt : Show a => a -> Text
+--
+-- means "to use `printIt` you need a `Show a` in scope; the
+-- elaborator will fill it in for you when one is available."
+--
+-- The constraint arrow round-trips through the printer; if you `view`
+-- a definition you'll see the `=>` preserved.
+--
+-- Calling-by-name pattern: you can always reference the given
+-- dictionary by name and destructure it directly. This is the
+-- pattern the chunk-D3 transcripts and the testEndToEndChained
+-- end-to-end test use, and it is the only pattern in this tutorial
+-- that *evaluates* end-to-end today (see the watch below).
+
+printNat : Nat -> Text
+printNat n = match Show.nat with Show.Show f -> f n
+
+> printNat 42
+
+
+-- ===========================================================================
+-- 4. Tuple constraints and higher-kinded constraints (ADR-001, ADR-011).
+-- ===========================================================================
+--
+-- Multiple constraints are written as a tuple to the left of `=>`:
+--
+--     sortByCompare : (Show a, Eq a) => [a] -> [a]
+--
+-- Higher-kinded constraints work too:
+--
+--     mapAll : Functor f => (a -> b) -> f a -> f b
+--
+-- These signatures parse and round-trip; the resolver treats each
+-- constraint as a separate goal and discharges them independently.
+-- We don't include runnable bodies here because the surrounding
+-- standard library (Functor, Eq, ...) isn't part of the prototype's
+-- builtins; in a real codebase you'd write these against your
+-- project's `Show`/`Eq`/`Functor` types.
+
+
+-- ===========================================================================
+-- 5. `summon` (ADR-006, chunk A2).
+-- ===========================================================================
+--
+-- `summon T` is an expression that asks the resolver to find a
+-- dictionary of type `T` in the ambient given pool. It's how you'd
+-- pull out a dictionary explicitly, e.g. to inspect or pass it on.
+--
+-- Surface example:
+--
+--     showVia : Show Nat => Nat -> Text
+--     showVia n = match summon (Show Nat) with Show.Show f -> f n
+--
+-- Status today (post-L1): `summon` parses and the typechecker
+-- emits a constraint goal that the resolver discharges from the
+-- ambient pool. End-to-end *evaluation* of a `summon`-using term
+-- still hits the local-synthetic-ref runtime gap when the chosen
+-- given is file-internal (this file's `Show.nat` is). See "Known
+-- limits" below; we leave the example commented out so the file
+-- loads cleanly:
+--
+-- showVia : Show Nat => Nat -> Text
+-- showVia n = match summon (Show Nat) with Show.Show f -> f n
+
+
+-- ===========================================================================
+-- 6. `let given` for local givens (ADR-010, chunk A2 + L2).
+-- ===========================================================================
+--
+-- Inside a `let` block you can introduce a local given that is in
+-- scope for the rest of the block. This is the implicits equivalent
+-- of an `implicit val` in Scala or a `where` clause in Haskell.
+--
+-- Chunk L2 wires `let given` into the typechecker's lexical given
+-- environment, so the resolver picks the local in preference to any
+-- ambient given (per ADR-008's lexical-inner-wins rule). The
+-- corresponding `testSourceLevelLetGivenShadowsAmbient` test
+-- exercises this end-to-end at the parse=>synthesize=>resolve
+-- level.
+--
+-- Surface example:
+--
+--     useLocal : Nat -> Text
+--     useLocal n =
+--       let
+--         given local : Show Nat = Show.Show (m -> "n=" ++ Nat.toText m)
+--         match local with Show.Show f -> f n
+--
+-- The same caveat as section 5 applies: the resolver picks the
+-- local, but the elaborated term carries `Local.given.local` as
+-- the chosen reference, which the runtime can't yet evaluate.
+
+
+-- ===========================================================================
+-- 7. `@`-positional override (ADR-007, chunk A3).
+-- ===========================================================================
+--
+-- At a call site, `f @ d x` passes `d` as the implicit dictionary
+-- argument and `x` as the next positional argument. The override
+-- short-circuits resolution -- the elaborator does NOT look in the
+-- ambient pool for that slot.
+--
+-- The parser produces ordinary positional application; the source
+-- range of each override argument is widened to include the leading
+-- `@` so the elaborator's chunk D3 can recognise it. The grammar
+-- doesn't conflict with as-patterns (which use `@` in pattern
+-- position).
+--
+-- Surface example:
+--
+--     useOverride : Nat -> Text
+--     useOverride n =
+--       altShow = Show.Show (m -> "alt=" ++ Nat.toText m)
+--       printVia @ altShow n
+--
+-- (where `printVia : Show Nat => Nat -> Text` consumes the
+-- dictionary). The override-only path through `applyGivenDecisions`
+-- inserts `altShow` directly without consulting the ambient pool, so
+-- the synthetic-ref runtime gap doesn't apply -- but writing a
+-- self-contained runnable example here would require us to also
+-- declare `printVia` against `=>`, which does hit the gap. We
+-- therefore document the form rather than evaluate it.
+
+
+-- ===========================================================================
+-- 8. The pattern that works end-to-end today (chunk D4 transcripts).
+-- ===========================================================================
+--
+-- The transcripts in unison-src/transcripts/idempotent/given-*.md
+-- exercise the round-trip that *does* work today end-to-end:
+--
+--   * declare a class type;
+--   * declare a `given` instance for it;
+--   * write a function that references the given by name and
+--     destructures it.
+--
+-- The hashing properties from ADR-014 / ADR-016 hold on this pattern:
+-- updating the given changes the dependent term's hash on
+-- re-elaboration, which is the property the design needs for
+-- compile-time-resolved dictionaries to participate cleanly in
+-- Unison's content-addressed codebase.
+
+double : Nat -> Text
+double n =
+  use Text ++
+  match Show.nat with Show.Show f -> f n ++ ", " ++ f n
+
+> double 7
+
+
+-- ===========================================================================
+-- What works today
+-- ===========================================================================
+--
+-- - All of the syntax above PARSES correctly (chunks A1, A2, A3).
+-- - All of it ROUND-TRIPS through the pretty printer, so `view`,
+--   `edit`, and `update` preserve `=>`, `given`, `summon`, and `@`.
+-- - Hash-stable resolution semantics (ADR-014/016) work
+--   programmatically; see GivenApply.testEndToEndChained for the
+--   end-to-end proof and the given-update-changes-hash transcript
+--   for the user-visible property.
+-- - The LSP surfaces resolver failures as diagnostics with code
+--   actions (chunk F1).
+-- - L1: the file-level resolver consults the namespace's
+--   given-marked definitions when raising constraint goals at
+--   apply sites. `testSourceLevelEndToEnd` shows the
+--   parse=>synthesize=>resolve pipeline picks the ambient given.
+-- - L2: file-internal `given` declarations and `let given`
+--   bindings register as lexical givens via the parser's
+--   given-bound-var side channel; the resolver chooses them in
+--   preference to ambient candidates per ADR-008.
+-- - The "call-by-name" pattern in sections 2 and 8 typechecks and
+--   evaluates today (the `> printNat 42` and `> double 7` watches
+--   above are the proof).
+--
+-- ===========================================================================
+-- Known limits
+-- ===========================================================================
+--
+-- 1. D3's `applyGivenDecisions` (in
+--    parser-typechecker/src/Unison/Typechecker/GivenApply.hs)
+--    builds the synthesized dictionary as
+--    `Term.ref (givenName tree)`. For a *local* given (file-internal
+--    `given` / `let given`), `givenName` is a synthetic
+--    `Reference.Builtin "Local.given.<name>"`, not the source-level
+--    variable that actually holds the value. So although the
+--    elaborator emits a `SolvedImplicit` decision pointing at the
+--    correct given, the rewritten term carries a ref the runtime
+--    can't evaluate; `prepareEvaluation` reports
+--    `cache is missing: [ReferenceBuiltin "Local.given.<name>"]`.
+--    The fix is for `applyGivenDecisions` (or `buildDictionary`) to
+--    consult a name=>variable map and substitute a `Term.var` when
+--    the chosen given is local. Until that lands, only the
+--    by-name-reference pattern (sections 2 and 8) evaluates.
+--
+-- 2. The pretty-printer doesn't yet render local synthetic refs as
+--    their source-level names. `view` on an elaborated term that
+--    chose a local given currently shows the `Local.given.<name>`
+--    builtin reference verbatim. This is cosmetic and will be
+--    addressed alongside (1).
+--
+-- Both gaps are scoped follow-ups in `docs/implicits-phase-2-chunks.md`.
+-- The L1 + L2 typechecker wiring that the rest of this tutorial
+-- depends on is now in place.

--- a/unison-src/transcripts/idempotent/addupdatemessages.md
+++ b/unison-src/transcripts/idempotent/addupdatemessages.md
@@ -31,9 +31,6 @@ Expected: `x` and `y`, `X`, and `Y` exist as above. UCM tells you this.
 ``` ucm
 > add
 
-  Okay, I'm searching the branch for code that needs to be
-  updated...
-
   Done.
 ```
 
@@ -61,9 +58,6 @@ Also, `Z` is an alias for `X`.
 
 ``` ucm
 > add
-
-  Okay, I'm searching the branch for code that needs to be
-  updated...
 
   Done.
 ```
@@ -93,9 +87,6 @@ Expected: `x` is now `3` and `X` has constructor `Three`. UCM tells you the old 
 ``` ucm
 > update
 
-  Okay, I'm searching the branch for code that needs to be
-  updated...
-
   Done.
 ```
 
@@ -123,9 +114,6 @@ Expected: `x` is now `2` and `X` is `Two`. UCM says the old definition was also 
 
 ``` ucm
 > update
-
-  Okay, I'm searching the branch for code that needs to be
-  updated...
 
   Done.
 ```

--- a/unison-src/transcripts/idempotent/fix-4536.md
+++ b/unison-src/transcripts/idempotent/fix-4536.md
@@ -34,6 +34,7 @@ foo =
   * newline or semicolon
   * pattern
   * quote
+  * summon
   * termLink
   * true
   * tuple
@@ -119,6 +120,7 @@ foo.> 17
   * namespace
   * newline or semicolon
   * quote
+  * summon
   * termLink
   * true
   * tuple

--- a/unison-src/transcripts/idempotent/fix-5575.md
+++ b/unison-src/transcripts/idempotent/fix-5575.md
@@ -29,6 +29,7 @@ foo =
   * let
   * newline or semicolon
   * quote
+  * summon
   * termLink
   * true
   * tuple

--- a/unison-src/transcripts/idempotent/fix5349.md
+++ b/unison-src/transcripts/idempotent/fix5349.md
@@ -41,6 +41,7 @@ README = {{ {{ }} }}
   * lambda
   * let
   * quote
+  * summon
   * termLink
   * true
   * tuple
@@ -70,6 +71,7 @@ README = {{ `` `` }}
   * lambda
   * let
   * quote
+  * summon
   * termLink
   * true
   * tuple

--- a/unison-src/transcripts/idempotent/generic-parse-errors.md
+++ b/unison-src/transcripts/idempotent/generic-parse-errors.md
@@ -63,6 +63,7 @@ x = a.#abc
   I was surprised to find a '.' here.
   I was expecting one of these instead:
 
+  * @
   * and
   * bang
   * do
@@ -75,6 +76,7 @@ x = a.#abc
   * newline or semicolon
   * or
   * quote
+  * summon
   * termLink
   * true
   * tuple

--- a/unison-src/transcripts/idempotent/given-broken-leaves-old-valid.md
+++ b/unison-src/transcripts/idempotent/given-broken-leaves-old-valid.md
@@ -41,9 +41,6 @@ foo n = match Show.nat with Show.Show f -> f n
 ``` ucm
 > add
 
-  Okay, I'm searching the branch for code that needs to be
-  updated...
-
   Done.
 ```
 

--- a/unison-src/transcripts/idempotent/given-broken-leaves-old-valid.md
+++ b/unison-src/transcripts/idempotent/given-broken-leaves-old-valid.md
@@ -1,0 +1,128 @@
+# ADR-016 scenario (b): breaking a given leaves dependent terms valid
+
+The exit criterion from `docs/implicits-plan.md` §5.6: *"breaking a
+given leaves dependent terms valid (hashed against the old) but
+breaks new code."*
+
+ADR-014 grounds this: an elaborated term hashes against the resolved
+dictionary's hash via the existing `App` machinery, so the dependent
+term retains its old resolution after the given is removed (content
+addressing — ADR-002 principle 2). New code that *would* re-elaborate
+against the missing given fails fresh.
+
+``` ucm :hide
+> builtins.merge
+```
+
+Define `Show`, the given `Show.nat`, and a consumer `foo`. As in
+scenario (a), the consumer references the given by name until D4
+wires the namespace ambient pool.
+
+``` unison
+unique type Show a = Show (a -> Text)
+
+given Show.nat : Show Nat = Show.Show Nat.toText
+
+foo : Nat -> Text
+foo n = match Show.nat with Show.Show f -> f n
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  + type Show a
+
+  + foo      : Nat -> Text
+  + Show.nat : Show Nat
+
+  Run `update` to apply these changes to your codebase.
+```
+
+``` ucm
+> add
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+```
+
+Record `foo`'s and `Show.nat`'s hashes; `foo`'s body references
+`Show.nat`'s hash via the elaborated `App`, exactly as ADR-014
+prescribes.
+
+``` ucm
+> names foo
+
+  'foo':
+  Hash          Kind   Names
+  #9qoq16jvg3   Term   foo
+
+> names Show.nat
+
+  'Show.nat':
+  Hash          Kind   Names
+  #06rjmokfst   Term   Show.nat
+```
+
+Delete `Show.nat`. The name binding goes away; the underlying term
+referent remains in storage, so any term that already hashed against
+it is unaffected (this is the entire point of content addressing).
+
+``` ucm
+> delete.term.force Show.nat
+
+  I deleted these terms:
+
+    1. Show.nat
+
+  Tip: You can use `undo` or use a hash from `reflog` to undo
+       this change.
+```
+
+`foo` is still valid: it was hashed against the old `Show.nat`'s
+referent, which the codebase still keeps. `view` and `names` still
+work.
+
+``` ucm
+> names foo
+
+  'foo':
+  Hash          Kind   Names
+  #9qoq16jvg3   Term   foo
+
+> view foo
+
+  foo : Nat -> Text
+  foo n =
+    (Show f) = #06rjmokfst
+    f n
+```
+
+Now try to add a new definition `bar` that re-elaborates against the
+(now missing) `Show.nat`. The reference is unbound; typechecking
+fails.
+
+``` unison :error
+bar : Nat -> Text
+bar n = match Show.nat with Show.Show f -> f n
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  I couldn't figure out what Show.nat refers to here:
+
+      2 | bar n = match Show.nat with Show.Show f -> f n
+
+  I think its type should be:
+
+      Show Nat
+
+  Some common causes of this error include:
+    * Your current namespace is too deep to contain the
+      definition in its subtree
+    * The definition is part of a library which hasn't been
+      added to this project
+    * You have a typo in the name
+```

--- a/unison-src/transcripts/idempotent/given-new-ambiguous-spares-old.md
+++ b/unison-src/transcripts/idempotent/given-new-ambiguous-spares-old.md
@@ -46,9 +46,6 @@ foo n = match Show.nat with Show.Show f -> f n
 ``` ucm
 > add
 
-  Okay, I'm searching the branch for code that needs to be
-  updated...
-
   Done.
 ```
 
@@ -80,9 +77,6 @@ given Show.alternateNat : Show Nat = Show.Show (n -> "n=" ++ Nat.toText n)
 
 ``` ucm
 > add
-
-  Okay, I'm searching the branch for code that needs to be
-  updated...
 
   Done.
 ```

--- a/unison-src/transcripts/idempotent/given-new-ambiguous-spares-old.md
+++ b/unison-src/transcripts/idempotent/given-new-ambiguous-spares-old.md
@@ -1,0 +1,112 @@
+# ADR-016 scenario (c): a new ambiguous given doesn't disturb old code
+
+The exit criterion from `docs/implicits-plan.md` §5.6: *"introducing
+a second matching given causes new code to fail with ambiguity but
+doesn't disturb existing code."*
+
+ADR-014 explains why old code is undisturbed: an elaborated term
+hashes against the resolved dictionary's hash via the existing `App`
+machinery, so the old term has a fixed reference and a fixed hash
+regardless of what new givens appear. New code re-elaborates fresh
+and the resolver (D4) reports `Ambiguous` per ADR-005.
+
+For D3 we exercise the parser/typechecker plumbing only: the
+resolver pool is supplied externally (the namespace ambient pool is
+empty until D4), so the "Ambiguous" error itself surfaces in chunk D4.
+Here we pin the codebase shape — two equally-good `Show Nat` givens
+present — and confirm pre-existing code's hash is unchanged.
+
+``` ucm :hide
+> builtins.merge
+```
+
+Define `Show`, the original given `Show.nat`, and a consumer `foo`
+that depends on it.
+
+``` unison
+unique type Show a = Show (a -> Text)
+
+given Show.nat : Show Nat = Show.Show Nat.toText
+
+foo : Nat -> Text
+foo n = match Show.nat with Show.Show f -> f n
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  + type Show a
+
+  + foo      : Nat -> Text
+  + Show.nat : Show Nat
+
+  Run `update` to apply these changes to your codebase.
+```
+
+``` ucm
+> add
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+```
+
+Capture the original hash of `foo` (call it H1).
+
+``` ucm
+> names foo
+
+  'foo':
+  Hash          Kind   Names
+  #9qoq16jvg3   Term   foo
+```
+
+Now add a *second* given of the same type, `Show.alternateNat`. The
+elaborator (D4) will see two equally-applicable candidates for any
+fresh `Show Nat` constraint and must report `Ambiguous`.
+
+``` unison
+given Show.alternateNat : Show Nat = Show.Show (n -> "n=" ++ Nat.toText n)
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  + Show.alternateNat : Show Nat
+
+  Run `update` to apply these changes to your codebase.
+```
+
+``` ucm
+> add
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+```
+
+`foo`'s hash is unchanged (still H1). It was elaborated against
+`Show.nat` at original definition time and that resolution is baked
+into the term's hash forever (ADR-014, ADR-002 principle 2).
+
+``` ucm
+> names foo
+
+  'foo':
+  Hash          Kind   Names
+  #9qoq16jvg3   Term   foo
+
+> names Show.nat
+
+  'Show.nat':
+  Hash          Kind   Names
+  #06rjmokfst   Term   Show.nat
+
+> names Show.alternateNat
+
+  'Show.alternateNat':
+  Hash          Kind   Names
+  #igvikkkjns   Term   Show.alternateNat
+```

--- a/unison-src/transcripts/idempotent/given-update-changes-hash.md
+++ b/unison-src/transcripts/idempotent/given-update-changes-hash.md
@@ -48,9 +48,6 @@ foo n = match Show.nat with Show.Show f -> f n
 ``` ucm
 > add
 
-  Okay, I'm searching the branch for code that needs to be
-  updated...
-
   Done.
 ```
 
@@ -86,13 +83,6 @@ Show.nat = Show.Show (n -> "n=" ++ Nat.toText n)
 
 ``` ucm
 > update
-
-  Okay, I'm searching the branch for code that needs to be
-  updated...
-
-  That's done. Now I'm making sure everything typechecks...
-
-  Everything typechecks, so I'm saving the results...
 
   Done.
 ```

--- a/unison-src/transcripts/idempotent/given-update-changes-hash.md
+++ b/unison-src/transcripts/idempotent/given-update-changes-hash.md
@@ -1,0 +1,116 @@
+# ADR-016 scenario (a): updating a given changes the dependent term's hash
+
+When a definition is annotated as a `given` in the namespace, the
+elaborator can resolve constraint goals against it (chunk D4 wires
+the namespace ambient pool; for D3 we exercise the parser/typechecker
+plumbing only).
+
+The exit criterion from `docs/implicits-plan.md` §5.6: *"working update
+through a given changes the hash."* This transcript captures the hash
+of an elaborated term, updates the given it elaborates against, and
+confirms the dependent term acquires a new hash on re-elaboration.
+
+ADR-014 spells out *why*: an elaborated term hashes against the
+resolved dictionary's hash via the existing `App` machinery. So when
+the dictionary's hash changes, so does the elaborated term's hash.
+
+``` ucm :hide
+> builtins.merge
+```
+
+Define a tiny `Show` ability stand-in (a record-style data type
+holding the rendering function), a given `Show.nat` that conforms to
+it, and a consumer `foo` that depends on it. Until D4 wires the
+namespace ambient pool we make the dependency explicit by calling
+`Show.nat` by name; D4's resolver substitutes that call automatically
+from a constraint goal.
+
+``` unison
+unique type Show a = Show (a -> Text)
+
+given Show.nat : Show Nat = Show.Show Nat.toText
+
+foo : Nat -> Text
+foo n = match Show.nat with Show.Show f -> f n
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  + type Show a
+
+  + foo      : Nat -> Text
+  + Show.nat : Show Nat
+
+  Run `update` to apply these changes to your codebase.
+```
+
+``` ucm
+> add
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+```
+
+Capture the original hash of `foo` (call it H1).
+
+``` ucm
+> names foo
+
+  'foo':
+  Hash          Kind   Names
+  #9qoq16jvg3   Term   foo
+```
+
+Now update `Show.nat` to a different (but type-compatible)
+implementation. The body changes, so `Show.nat`'s term hash must
+change; everything that references `Show.nat` re-elaborates and
+re-hashes.
+
+``` unison
+Show.nat : Show Nat
+Show.nat = Show.Show (n -> "n=" ++ Nat.toText n)
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  ~ Show.nat : Show Nat
+
+  ~ (modified)
+
+  Run `update` to apply these changes to your codebase.
+```
+
+``` ucm
+> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
+
+  Done.
+```
+
+Re-record `foo`'s hash (call it H2). Per ADR-016 + ADR-014: the new
+hash differs from H1; the old hash H1 remains valid for any code
+that already references it (content addressing — ADR-002 principle 2).
+
+``` ucm
+> names foo
+
+  'foo':
+  Hash          Kind   Names
+  #058ts2h1fa   Term   foo
+
+> names Show.nat
+
+  'Show.nat':
+  Hash          Kind   Names
+  #igvikkkjns   Term   Show.nat
+```

--- a/unison-src/transcripts/idempotent/givens.md
+++ b/unison-src/transcripts/idempotent/givens.md
@@ -30,9 +30,6 @@ bar = 99
 ``` ucm
 > add
 
-  Okay, I'm searching the branch for code that needs to be
-  updated...
-
   Done.
 ```
 
@@ -132,8 +129,7 @@ namespace tag. Until A2 lands, the marker is rendered as a leading
 
 > view foo
 
-  -- given
-  foo : Nat
+  given foo : Nat
   foo = 42
 ```
 
@@ -183,9 +179,6 @@ myNs.alpha = 1
 
 ``` ucm
 > add
-
-  Okay, I'm searching the branch for code that needs to be
-  updated...
 
   Done.
 ```
@@ -248,9 +241,6 @@ deep.nested.beta = 7
 
 ``` ucm
 > add
-
-  Okay, I'm searching the branch for code that needs to be
-  updated...
 
   Done.
 

--- a/unison-src/transcripts/idempotent/givens.md
+++ b/unison-src/transcripts/idempotent/givens.md
@@ -1,0 +1,280 @@
+# `mark.given`, `unmark.given`, and `givens`
+
+These commands toggle and inspect the @\#\#Builtin.Given@ sentinel
+stored in namespace metadata (ADR-013). The term hash of the marked
+definition is unchanged (ADR-014); only the namespace hash changes.
+
+``` ucm :hide
+> builtins.mergeio lib.builtins
+```
+
+## Happy path: mark, list, unmark, list
+
+``` unison
+foo : Nat
+foo = 42
+
+bar : Nat
+bar = 99
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  + bar : Nat
+  + foo : Nat
+
+  Run `update` to apply these changes to your codebase.
+```
+
+``` ucm
+> add
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+```
+
+Initially, no givens.
+
+``` ucm
+> givens
+
+  No definitions in the current namespace are marked as givens.
+```
+
+Mark `foo`.
+
+``` ucm
+> mark.given foo
+
+  Marked foo. It will now participate in implicit resolution.
+```
+
+Now `givens` lists `foo`.
+
+``` ucm
+> givens
+
+  Definitions marked as givens in the current namespace:
+
+    foo
+```
+
+The `find :given` filter returns the same set.
+
+``` ucm
+> find :given
+
+  1. foo : Nat
+```
+
+Unmark `foo`.
+
+``` ucm
+> unmark.given foo
+
+  Unmarked foo. It will no longer participate in implicit
+  resolution.
+```
+
+The list is empty again.
+
+``` ucm
+> givens
+
+  No definitions in the current namespace are marked as givens.
+```
+
+## Idempotence
+
+Marking an already-marked definition is a no-op with a clear message.
+
+``` ucm
+> mark.given foo
+
+  Marked foo. It will now participate in implicit resolution.
+
+> mark.given foo
+
+  foo is already marked as a given. No changes were made.
+```
+
+Unmarking returns to the empty state.
+
+``` ucm
+> unmark.given foo
+
+  Unmarked foo. It will no longer participate in implicit
+  resolution.
+```
+
+Unmarking an unmarked definition is a no-op with a clear message.
+
+``` ucm
+> unmark.given foo
+
+  foo is not marked as a given. No changes were made.
+```
+
+## `view` surfaces a given marker
+
+When a definition is tagged as a given, `view` prepends a marker so
+the parser-side @given@ keyword (chunk A2) can round-trip with the
+namespace tag. Until A2 lands, the marker is rendered as a leading
+@-- given@ comment.
+
+``` ucm
+> mark.given foo
+
+  Marked foo. It will now participate in implicit resolution.
+
+> view foo
+
+  -- given
+  foo : Nat
+  foo = 42
+```
+
+``` ucm
+> unmark.given foo
+
+  Unmarked foo. It will no longer participate in implicit
+  resolution.
+
+> view foo
+
+  foo : Nat
+  foo = 42
+```
+
+## Error: marking a missing name
+
+``` ucm :error
+> mark.given doesNotExist
+
+  ⚠️
+
+  I don't know about that term.
+```
+
+## `mark.given` / `unmark.given` from a sub-namespace
+
+`mark.given` and `unmark.given` resolve their argument relative to
+the *current* namespace, but the metadata write must land at the
+correct absolute path within the project root. Regression test for
+the bug where these commands read the parent branch via the
+already-deep current branch and so could not see (or could not
+toggle off) a marking made from a sub-namespace.
+
+``` unison
+myNs.alpha : Nat
+myNs.alpha = 1
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  + myNs.alpha : Nat
+
+  Run `update` to apply these changes to your codebase.
+```
+
+``` ucm
+> add
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+```
+
+``` ucm
+> deprecated.cd myNs
+
+> mark.given alpha
+
+  Marked alpha. It will now participate in implicit resolution.
+```
+
+A second `mark.given` from the same sub-namespace must report
+`AlreadyMarkedGiven`, which only works if the read-side parent
+branch lookup uses the project root.
+
+``` ucm
+> mark.given alpha
+
+  alpha is already marked as a given. No changes were made.
+```
+
+`unmark.given` from the same sub-namespace toggles the marking
+off, again exercising the read path.
+
+``` ucm
+> unmark.given alpha
+
+  Unmarked alpha. It will no longer participate in implicit
+  resolution.
+
+> unmark.given alpha
+
+  alpha is not marked as a given. No changes were made.
+```
+
+``` ucm :hide
+> deprecated.cd ..
+```
+
+## `find :given` finds deeply-nested givens
+
+`find :given` filters by checking the given-sentinel metadata at
+each containing namespace, not just at the top level. Regression
+test for the bug where the filter consulted only the top-level
+'Star2' and so silently dropped givens nested under sub-namespaces.
+
+``` unison
+deep.nested.beta : Nat
+deep.nested.beta = 7
+```
+
+``` ucm :added-by-ucm
+  Loading changes detected in scratch.u.
+
+  + deep.nested.beta : Nat
+
+  Run `update` to apply these changes to your codebase.
+```
+
+``` ucm
+> add
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+
+> mark.given deep.nested.beta
+
+  Marked deep.nested.beta. It will now participate in implicit
+  resolution.
+```
+
+`find :given` from the parent namespace must surface the
+deeply-nested marking.
+
+``` ucm
+> find :given
+
+  1. deep.nested.beta : Nat
+```
+
+`givens` likewise lists the deeply-nested marking.
+
+``` ucm
+> givens
+
+  Definitions marked as givens in the current namespace:
+
+    deep.nested.beta
+```

--- a/unison-src/transcripts/idempotent/help.md
+++ b/unison-src/transcripts/idempotent/help.md
@@ -168,6 +168,9 @@
                                    name similar to 'foo'. Note
                                    that this is a very slow
                                    operation.
+  `find :given`                    lists every term in the
+                                   current namespace tagged as a
+                                   given (see also `givens`).
 
   debug.names.global
   Iteratively search names or hashes across all projects and branches.
@@ -356,6 +359,9 @@
                                    name similar to 'foo'. Note
                                    that this is a very slow
                                    operation.
+  `find :given`                    lists every term in the
+                                   current namespace tagged as a
+                                   given (see also `givens`).
 
   find-in
   `find`                           lists all definitions in the
@@ -394,6 +400,9 @@
                                    name similar to 'foo'. Note
                                    that this is a very slow
                                    operation.
+  `find :given`                    lists every term in the
+                                   current namespace tagged as a
+                                   given (see also `givens`).
 
   find-in.all
   `find`                           lists all definitions in the
@@ -432,6 +441,9 @@
                                    name similar to 'foo'. Note
                                    that this is a very slow
                                    operation.
+  `find :given`                    lists every term in the
+                                   current namespace tagged as a
+                                   given (see also `givens`).
 
   find.all
   `find`                           lists all definitions in the
@@ -470,6 +482,9 @@
                                    name similar to 'foo'. Note
                                    that this is a very slow
                                    operation.
+  `find :given`                    lists every term in the
+                                   current namespace tagged as a
+                                   given (see also `givens`).
 
   find.all.verbose
   `find.all.verbose` searches for definitions like `find.all`, but includes hashes and aliases in the results.
@@ -506,6 +521,10 @@
                                                        `srcbranch`
                                                        of
                                                        `srcproject`.
+
+  givens
+  `givens` lists every definition in the current namespace that
+  has been marked as a given.
 
   help (or ?)
   `help` shows general help and `help <cmd>` shows help for one command.
@@ -638,6 +657,11 @@
                          most recent scratch file.
   `load <scratch file>`  parses, typechecks, and evaluates the
                          given scratch file.
+
+  mark.given
+  `mark.given foo` marks `foo` as a given so it participates in
+  implicit resolution. The term hash of `foo` is unchanged; only
+  the namespace hash changes.
 
   merge
   `merge /branch` merges `branch` into the current branch
@@ -1011,6 +1035,9 @@
 
   undo
   `undo` reverts the most recent change to the codebase.
+
+  unmark.given
+  `unmark.given foo` removes the given tag from `foo`.
 
   unsafe.force-push (or push.unsafe-force)
   Like `push`, but forcibly overwrites the remote namespace.

--- a/unison-src/transcripts/idempotent/implicit-project-context.md
+++ b/unison-src/transcripts/idempotent/implicit-project-context.md
@@ -19,9 +19,6 @@ And then add them to the default project & branch.
 ``` ucm
 > add
 
-  Okay, I'm searching the branch for code that needs to be
-  updated...
-
   Done.
 ```
 
@@ -49,9 +46,6 @@ And then add them to the default project & branch.
 
 ``` ucm
 other/trunk> add
-
-  Okay, I'm searching the branch for code that needs to be
-  updated...
 
   Done.
 ```
@@ -190,9 +184,6 @@ b = ((), ())
 
 ``` ucm
 > add
-
-  Okay, I'm searching the branch for code that needs to be
-  updated...
 
   Done.
 

--- a/unison-src/transcripts/idempotent/propagate.md
+++ b/unison-src/transcripts/idempotent/propagate.md
@@ -28,9 +28,6 @@ And then we add it.
 ``` ucm
 > add
 
-  Okay, I'm searching the branch for code that needs to be
-  updated...
-
   Done.
 
 > find.verbose
@@ -72,13 +69,6 @@ and update the codebase to use the new type `Foo`...
 ``` ucm
 > update
 
-  Okay, I'm searching the branch for code that needs to be
-  updated...
-
-  That's done. Now I'm making sure everything typechecks...
-
-  Everything typechecks, so I'm saving the results...
-
   Done.
 ```
 
@@ -118,9 +108,6 @@ Add that to the codebase:
 ``` ucm
 > add
 
-  Okay, I'm searching the branch for code that needs to be
-  updated...
-
   Done.
 ```
 
@@ -145,13 +132,6 @@ Update...
 
 ``` ucm
 > update
-
-  Okay, I'm searching the branch for code that needs to be
-  updated...
-
-  That's done. Now I'm making sure everything typechecks...
-
-  Everything typechecks, so I'm saving the results...
 
   Done.
 ```

--- a/unison-src/transcripts/pretty-print-libraries.output.md
+++ b/unison-src/transcripts/pretty-print-libraries.output.md
@@ -973,7 +973,7 @@ succeeds, and `` false `` if it fails:
      `` implies a b `` is `` true `` unless `a` is `` true `` and `b` is
      ``false``. This is the same as logical implication.
      
-     `` given a b `` is `` true `` unless `a` is `` false `` and `b` is
+     `` `given` a b `` is `` true `` unless `a` is `` false `` and `b` is
      ``true``. This is the converse of logical implication.
   
   ## Inhibition (not-implies)
@@ -13888,27 +13888,27 @@ Boolean.eq.doc =
     {{ binaryTruthTable "iff" Boolean.eq }}
   }}
 
-Boolean.given.doc : Doc
-Boolean.given.doc =
+Boolean.`given`.doc : Doc
+Boolean.`given`.doc =
   {{
-  Inverse {type Boolean} implication. An expression `` given a b `` Returns ``
-  false `` only if `a` is `` false `` and `b` is ``true``, otherwise returns
+  Inverse {type Boolean} implication. An expression `` `given` a b `` Returns
+  `` false `` only if `a` is `` false `` and `b` is ``true``, otherwise returns
   ``true``. Note that this function cannot short-circuit, as it's strict in
   both arguments. For a short-circuiting version, use the built-in syntax
   {{ docExample 2 do a b -> a || Boolean.not b }}.
   
   # Truth table
   
-    {{ binaryTruthTable "given" given }}
+    {{ binaryTruthTable "given" `given` }}
   }}
 
-test> Boolean.given.test =
+test> Boolean.`given`.test =
   deprecated.run
     (Test.tests
-      [ check' (given false false === true)
-      , check' (given false true === false)
-      , check' (given true false === true)
-      , check' (given true true === true)
+      [ check' (`given` false false === true)
+      , check' (`given` false true === false)
+      , check' (`given` true false === true)
+      , check' (`given` true true === true)
       ])
 
 Boolean.gt.doc : Doc
@@ -66275,13 +66275,23 @@ test.deprecated.gen.float = do Gen.sample Weighted.floats
 
 {{
 Generates one of the binary logical operators {Boolean.and}, {Boolean.or},
-{given}, {implies}, {iff}, and their complements {nand}, {nor}, etc.
+{`given`}, {implies}, {iff}, and their complements {nand}, {nor}, etc.
 }}
 test.deprecated.gen.functions.logic : '{Gen} (Boolean -> Boolean -> Boolean)
 test.deprecated.gen.functions.logic =
   use Boolean != < >
   gen.oneOf
-    [Boolean.and, given, implies, Boolean.or, (!=), nand, (<), (>), nor, (!=)]
+    [ Boolean.and
+    , `given`
+    , implies
+    , Boolean.or
+    , (!=)
+    , nand
+    , (<)
+    , (>)
+    , nor
+    , (!=)
+    ]
 
 {{
 `` someOrNone f b `` returns a generator of functions that are either ``

--- a/unison-syntax/src/Unison/Parser/Ann.hs
+++ b/unison-syntax/src/Unison/Parser/Ann.hs
@@ -18,6 +18,16 @@ data Ann
     -- E.g. generated record field accessors (get, modify, etc.) are generated from their field definition, so are tagged
     -- with @GeneratedFrom <field position>@
     GeneratedFrom Ann
+  | -- Indicates a synthesized term inserted by the elaborator that has
+    -- no surface representation in the user's source — currently used
+    -- for dictionary arguments filled into @=>@ slots by implicit
+    -- resolution. The wrapped 'Ann' is the source position the
+    -- synthesized term should be /associated/ with (typically the
+    -- apply-site of the function being called), so LSP queries that
+    -- find a node "at" a position still find this synthesised arg.
+    -- Pretty-printers detect this constructor and elide the arg from
+    -- the surface rendering (per ADR-015's default elide-mode).
+    Synthetic Ann
   | Ann {start :: L.Pos, end :: L.Pos}
   deriving (Eq, Ord, Show)
 
@@ -29,7 +39,17 @@ isFileAnn _ = False
 startingLine :: Ann -> Maybe L.Line
 startingLine (Ann (L.line -> line) _) = Just line
 startingLine (GeneratedFrom a) = startingLine a
+startingLine (Synthetic a) = startingLine a
 startingLine _ = Nothing
+
+-- | 'True' iff the annotation chain ends in a 'Synthetic' marker —
+-- i.e. this term was inserted by the elaborator (e.g. as a resolved
+-- dictionary for an @=>@ slot) and should be elided by surface
+-- printers.
+isSynthetic :: Ann -> Bool
+isSynthetic (Synthetic _) = True
+isSynthetic (GeneratedFrom a) = isSynthetic a
+isSynthetic _ = False
 
 instance Monoid Ann where
   mempty = External
@@ -44,6 +64,8 @@ instance Semigroup Ann where
   a <> Intrinsic = a
   GeneratedFrom a <> b = a <> b
   a <> GeneratedFrom b = a <> b
+  Synthetic a <> b = Synthetic (a <> b)
+  a <> Synthetic b = Synthetic (a <> b)
 
 -- | Checks whether an annotation contains a given position
 -- i.e. pos ∈ [start, end)
@@ -64,6 +86,7 @@ contains Intrinsic _ = False
 contains External _ = False
 contains (Ann start end) p = start <= p && p < end
 contains (GeneratedFrom ann) p = contains ann p
+contains (Synthetic ann) p = contains ann p
 
 -- | Checks whether an annotation contains another annotation.
 --
@@ -87,6 +110,8 @@ encompasses _ Intrinsic = Nothing
 encompasses _ External = Nothing
 encompasses (GeneratedFrom ann) other = encompasses ann other
 encompasses ann (GeneratedFrom other) = encompasses ann other
+encompasses (Synthetic ann) other = encompasses ann other
+encompasses ann (Synthetic other) = encompasses ann other
 encompasses (Ann start1 end1) (Ann start2 end2) =
   Just $ start1 <= start2 && end1 >= end2
 

--- a/unison-syntax/src/Unison/Parser/Ann.hs
+++ b/unison-syntax/src/Unison/Parser/Ann.hs
@@ -28,6 +28,15 @@ data Ann
     -- Pretty-printers detect this constructor and elide the arg from
     -- the surface rendering (per ADR-015's default elide-mode).
     Synthetic Ann
+  | -- ADR-007: tags a term whose leading @=>@ arrows should be
+    -- demoted to regular @->@ arrows at the typechecker site of
+    -- use. Produced by the @give@ keyword: writing @give f@ at the
+    -- source level means "give me the lowered version of f", so
+    -- subsequent application supplies the dictionary explicitly
+    -- instead of triggering implicit resolution. Annotation-aware
+    -- passes that don't care about the distinction should recurse
+    -- into the inner 'Ann' — same shape as 'Synthetic'.
+    Lowered Ann
   | Ann {start :: L.Pos, end :: L.Pos}
   deriving (Eq, Ord, Show)
 
@@ -40,6 +49,7 @@ startingLine :: Ann -> Maybe L.Line
 startingLine (Ann (L.line -> line) _) = Just line
 startingLine (GeneratedFrom a) = startingLine a
 startingLine (Synthetic a) = startingLine a
+startingLine (Lowered a) = startingLine a
 startingLine _ = Nothing
 
 -- | 'True' iff the annotation chain ends in a 'Synthetic' marker —
@@ -49,7 +59,20 @@ startingLine _ = Nothing
 isSynthetic :: Ann -> Bool
 isSynthetic (Synthetic _) = True
 isSynthetic (GeneratedFrom a) = isSynthetic a
+isSynthetic (Lowered a) = isSynthetic a
 isSynthetic _ = False
+
+-- | 'True' iff the annotation chain ends in a 'Lowered' marker —
+-- i.e. this term was the operand of the @give@ keyword (ADR-007)
+-- and its leading @=>@ arrows should be demoted to @->@ at the
+-- typechecker site of use, so dictionaries can be supplied as
+-- ordinary positional arguments instead of being filled by
+-- implicit resolution.
+isLowered :: Ann -> Bool
+isLowered (Lowered _) = True
+isLowered (GeneratedFrom a) = isLowered a
+isLowered (Synthetic a) = isLowered a
+isLowered _ = False
 
 instance Monoid Ann where
   mempty = External
@@ -66,6 +89,8 @@ instance Semigroup Ann where
   a <> GeneratedFrom b = a <> b
   Synthetic a <> b = Synthetic (a <> b)
   a <> Synthetic b = Synthetic (a <> b)
+  Lowered a <> b = Lowered (a <> b)
+  a <> Lowered b = Lowered (a <> b)
 
 -- | Checks whether an annotation contains a given position
 -- i.e. pos ∈ [start, end)
@@ -87,6 +112,7 @@ contains External _ = False
 contains (Ann start end) p = start <= p && p < end
 contains (GeneratedFrom ann) p = contains ann p
 contains (Synthetic ann) p = contains ann p
+contains (Lowered ann) p = contains ann p
 
 -- | Checks whether an annotation contains another annotation.
 --
@@ -112,11 +138,28 @@ encompasses (GeneratedFrom ann) other = encompasses ann other
 encompasses ann (GeneratedFrom other) = encompasses ann other
 encompasses (Synthetic ann) other = encompasses ann other
 encompasses ann (Synthetic other) = encompasses ann other
+encompasses (Lowered ann) other = encompasses ann other
+encompasses ann (Lowered other) = encompasses ann other
 encompasses (Ann start1 end1) (Ann start2 end2) =
   Just $ start1 <= start2 && end1 >= end2
 
 class Annotated a where
   ann :: a -> Ann
+
+-- | Predicate over a typechecker location indicating whether the
+-- term it annotates was wrapped with the @give@ keyword (ADR-007)
+-- and should have its leading @=>@ arrows demoted to @->@ during
+-- synthesis. Defaults to 'False' so that contexts whose @loc@ is
+-- not 'Ann' simply never see lowerings — the feature is purely
+-- source-level.
+class IsLoweredAnn loc where
+  isLoweredAnn :: loc -> Bool
+  isLoweredAnn _ = False
+
+instance IsLoweredAnn Ann where
+  isLoweredAnn = isLowered
+
+instance IsLoweredAnn ()
 
 instance Annotated Ann where
   ann = id

--- a/unison-syntax/src/Unison/Syntax/Lexer/Unison.hs
+++ b/unison-syntax/src/Unison/Syntax/Lexer/Unison.hs
@@ -664,7 +664,7 @@ lexemes eof =
               env <- S.get
               case topBlockName (layout env) of
                 -- '=' does not open a layout block if within a type declaration
-                Just t | t == "type" || Set.member (Text.pack t) typeModifiers -> pure [Token (Reserved "=") start end]
+                Just t | t == "type" || t == "class" || Set.member (Text.pack t) typeModifiers -> pure [Token (Reserved "=") start end]
                 Just _ -> S.put (env {opening = Just "="}) >> pure [Token (Open "=") start end]
                 _ -> err start LayoutError
 

--- a/unison-syntax/src/Unison/Syntax/Lexer/Unison.hs
+++ b/unison-syntax/src/Unison/Syntax/Lexer/Unison.hs
@@ -581,6 +581,18 @@ lexemes eof =
             <|> wordyKw "∀"
             <|> wordyKw "termLink"
             <|> wordyKw "typeLink"
+            -- The `given` and `summon` keywords introduced by the
+            -- implicit-parameter feature (chunk A2; ADRs 006, 010, 022).
+            -- Per ADR-022, the production rollout uses a one-release
+            -- deprecation cycle. For the prototype we hard-break here:
+            -- any user identifier named `given` or `summon` will need
+            -- to be backtick-escaped (`` `given` ``) or renamed.
+            -- The `given` token doubles as a top-level definition prefix
+            -- and as a let-block statement opener; `summon` is an
+            -- expression-position keyword that takes a parenthesized
+            -- type. Neither opens a layout block by itself.
+            <|> wordyKw "given"
+            <|> wordyKw "summon"
 
         wordyKw s = separated wordySep (kw s)
         symbolyKw s = separated (not . symbolyIdChar) (kw s)
@@ -597,6 +609,11 @@ lexemes eof =
             <|> typ
             <|> arr
             <|> rewriteArr
+            -- 'constraintArr' must come after 'rewriteArr' so that "==>" wins
+            -- maximal-munch over "=>" (per ADR-001). The literals are
+            -- distinguishable byte-by-byte, but we keep this ordering to make
+            -- the precedence intent explicit and robust to future edits.
+            <|> constraintArr
             <|> eq
             <|> openKw "cases"
             <|> openKw "where"
@@ -655,6 +672,14 @@ lexemes eof =
               [Token _ start end] <- symbolyKw "==>"
               env <- S.get
               S.put (env {opening = Just "==>"}) >> pure [Token (Open "==>") start end]
+
+            -- The implicit-parameter constraint arrow "=>" introduced by
+            -- ADR-001. Unlike "->", "==>", and "=", it does not influence
+            -- layout — it is a plain reserved token used only inside type
+            -- signatures (see 'Unison.Syntax.TypeParser').
+            constraintArr = do
+              [Token _ start end] <- symbolyKw "=>"
+              pure [Token (Reserved "=>") start end]
 
             arr = do
               [Token _ start end] <- symbolyKw "->"

--- a/unison-syntax/src/Unison/Syntax/Lexer/Unison.hs
+++ b/unison-syntax/src/Unison/Syntax/Lexer/Unison.hs
@@ -581,18 +581,23 @@ lexemes eof =
             <|> wordyKw "∀"
             <|> wordyKw "termLink"
             <|> wordyKw "typeLink"
-            -- The `given` and `summon` keywords introduced by the
-            -- implicit-parameter feature (chunk A2; ADRs 006, 010, 022).
-            -- Per ADR-022, the production rollout uses a one-release
-            -- deprecation cycle. For the prototype we hard-break here:
-            -- any user identifier named `given` or `summon` will need
-            -- to be backtick-escaped (`` `given` ``) or renamed.
-            -- The `given` token doubles as a top-level definition prefix
-            -- and as a let-block statement opener; `summon` is an
-            -- expression-position keyword that takes a parenthesized
-            -- type. Neither opens a layout block by itself.
+            -- The `given` keyword introduced by the implicit-parameter
+            -- feature (chunk A2; ADRs 006, 010, 022). Per ADR-022, the
+            -- production rollout uses a one-release deprecation cycle;
+            -- for the prototype we hard-break, so any user identifier
+            -- named `given` will need to be backtick-escaped
+            -- (`` `given` ``) or renamed. The `given` token doubles as
+            -- a top-level definition prefix and a let-block statement
+            -- opener; it does not open a layout block by itself.
+            -- (ADR-006: `summon` is no longer a keyword; it is a
+            -- regular builtin term reference whose declared type
+            -- @forall a. a => a@ drives implicit resolution via the
+            -- normal machinery.)
             <|> wordyKw "given"
-            <|> wordyKw "summon"
+            -- ADR-007: `give f` lowers f's leading `=>` arrows to
+            -- `->`. Must be a keyword because the type
+            -- transformation can't be encoded as a builtin's type.
+            <|> wordyKw "give"
 
         wordyKw s = separated wordySep (kw s)
         symbolyKw s = separated (not . symbolyIdChar) (kw s)

--- a/unison-syntax/src/Unison/Syntax/Parser.hs
+++ b/unison-syntax/src/Unison/Syntax/Parser.hs
@@ -45,6 +45,10 @@ module Unison.Syntax.Parser
     rootFile,
     run',
     run,
+    runFile,
+    runFile',
+    recordGivenVar,
+    getGivenVars,
     semi,
     Unison.Syntax.Parser.seq,
     Unison.Syntax.Parser.seq',
@@ -65,6 +69,7 @@ where
 
 import Control.Monad.Reader (ReaderT (..), ask)
 import Control.Monad.Reader.Class (asks)
+import Control.Monad.State.Strict (StateT, evalStateT, get, modify, runStateT)
 import Crypto.Random qualified as Random
 import Data.Bool (bool)
 import Data.Bytes.Put (runPutS)
@@ -110,7 +115,17 @@ import Unison.Var qualified as Var
 debug :: Bool
 debug = False
 
-type P v m = P.ParsecT (Error v) Input (ReaderT (ParsingEnv m) m)
+-- | The parser monad. The inner 'StateT' carries a 'Set v' of variable
+-- names that were bound via the @given@ keyword (see ADR-010 chunk L2
+-- fixup). The set is populated by 'recordGivenVar' inside
+-- 'givenBindingBody' and surfaces to the typechecker as the canonical
+-- way to identify @given@-keyword origins, replacing the previous
+-- type-shape inspection that silently dropped premise-free givens like
+-- @given local : Ord a = …@. The 'StateT' is /below/ 'ParsecT' so that
+-- registrations do not get rolled back on parser backtracking; this is
+-- safe because 'givenBindingBody' is committed (no @try@) once the
+-- @given@ keyword is consumed.
+type P v m = P.ParsecT (Error v) Input (StateT (Set v) (ReaderT (ParsingEnv m) m))
 
 type Err v = P.ParseError Input (Error v)
 
@@ -197,10 +212,10 @@ uniqueName lenInBase32Hex = do
 
 resolveUniqueTypeGuid :: (Monad m, Var v) => v -> P v m Modifier
 resolveUniqueTypeGuid name0 = do
-  ParsingEnv {maybeNamespace, uniqueTypeGuid} <- ask
+  ParsingEnv {maybeNamespace, uniqueTypeGuid} <- lift (lift ask)
   let name = Name.unsafeParseVar (maybe id (Var.namespaced2 . Name.toVar) maybeNamespace name0)
   guid <-
-    lift (lift (uniqueTypeGuid name)) >>= \case
+    lift (lift (lift (uniqueTypeGuid name))) >>= \case
       Nothing -> uniqueName 32
       Just guid -> pure guid
   pure (Unique guid)
@@ -287,12 +302,42 @@ run' :: (Monad m, Ord v) => P v m a -> String -> String -> ParsingEnv m -> m (Ei
 run' p s name env =
   let lex = bool id (traceWith L.debugPreParse) debug . L.preParse $ L.lexer name s
       pTraced = traceRemainingTokens "parser receives" *> p
-   in runReaderT (runParserT pTraced name . Input $ toList lex) env <&> \case
+   in runReaderT (evalStateT (runParserT pTraced name . Input $ toList lex) Set.empty) env <&> \case
         Left err -> Left (Nel.head (P.bundleErrors err))
         Right x -> Right x
 
 run :: (Monad m, Ord v) => P v m a -> String -> ParsingEnv m -> m (Either (Err v) a)
 run p s = run' p s ""
+
+-- | Variant of 'run'' that also returns the 'Set v' of @given@-bound
+-- variable names accumulated by 'recordGivenVar' during parsing.
+-- Callers that need this side channel (e.g.
+-- 'Unison.Syntax.FileParser.file') use this instead of plain 'run''
+-- so the typechecker can identify @given@-keyword origins per
+-- ADR-010 / chunk L2 fixup.
+runFile' :: (Monad m, Ord v) => P v m a -> String -> String -> ParsingEnv m -> m (Either (Err v) (a, Set v))
+runFile' p s name env =
+  let lex = bool id (traceWith L.debugPreParse) debug . L.preParse $ L.lexer name s
+      pTraced = traceRemainingTokens "parser receives" *> p
+   in runReaderT (runStateT (runParserT pTraced name . Input $ toList lex) Set.empty) env <&> \case
+        (Left err, _) -> Left (Nel.head (P.bundleErrors err))
+        (Right x, gs) -> Right (x, gs)
+
+runFile :: (Monad m, Ord v) => P v m a -> String -> ParsingEnv m -> m (Either (Err v) (a, Set v))
+runFile p s = runFile' p s ""
+
+-- | Record that a variable was bound via the @given@ keyword. Called
+-- from 'Unison.Syntax.TermParser.givenBindingBody' (and the file-level
+-- @given@ decl path) so the typechecker can recognise @given@ origins
+-- without inspecting the binding's type shape.
+recordGivenVar :: (Ord v, Monad m) => v -> P v m ()
+recordGivenVar v = lift (modify (Set.insert v))
+
+-- | Fetch the current accumulated set of @given@-bound variable names.
+-- Mostly useful for tests; production callers use 'runFile' / 'runFile''
+-- to capture the set at the end of a parse.
+getGivenVars :: (Monad m) => P v m (Set v)
+getGivenVars = lift get
 
 -- | Virtual pattern match on a lexeme.
 queryToken :: (Ord v) => (L.Lexeme -> Maybe a) -> P v m (L.Token a)

--- a/unison-syntax/src/Unison/Syntax/Parser.hs
+++ b/unison-syntax/src/Unison/Syntax/Parser.hs
@@ -49,6 +49,9 @@ module Unison.Syntax.Parser
     runFile',
     recordGivenVar,
     getGivenVars,
+    recordClassDeclVar,
+    getClassDeclVars,
+    ParserState (..),
     semi,
     Unison.Syntax.Parser.seq,
     Unison.Syntax.Parser.seq',
@@ -69,7 +72,7 @@ where
 
 import Control.Monad.Reader (ReaderT (..), ask)
 import Control.Monad.Reader.Class (asks)
-import Control.Monad.State.Strict (StateT, evalStateT, get, modify, runStateT)
+import Control.Monad.State.Strict (StateT, evalStateT, gets, modify, runStateT)
 import Crypto.Random qualified as Random
 import Data.Bool (bool)
 import Data.Bytes.Put (runPutS)
@@ -115,17 +118,37 @@ import Unison.Var qualified as Var
 debug :: Bool
 debug = False
 
--- | The parser monad. The inner 'StateT' carries a 'Set v' of variable
--- names that were bound via the @given@ keyword (see ADR-010 chunk L2
--- fixup). The set is populated by 'recordGivenVar' inside
--- 'givenBindingBody' and surfaces to the typechecker as the canonical
--- way to identify @given@-keyword origins, replacing the previous
--- type-shape inspection that silently dropped premise-free givens like
--- @given local : Ord a = …@. The 'StateT' is /below/ 'ParsecT' so that
--- registrations do not get rolled back on parser backtracking; this is
--- safe because 'givenBindingBody' is committed (no @try@) once the
--- @given@ keyword is consumed.
-type P v m = P.ParsecT (Error v) Input (StateT (Set v) (ReaderT (ParsingEnv m) m))
+-- | Parser-side state for tracking which surface-syntax forms each
+-- name originated from. Currently two parallel sets:
+--
+--   * @givenBoundVars@ — names bound via the @given@ keyword
+--     (ADR-010 chunk L2 fixup), populated by 'recordGivenVar'.
+--     The typechecker uses this to identify @given@-keyword origins
+--     without inspecting the binding's type shape.
+--
+--   * @classDeclVars@ — type names declared with the @class@
+--     keyword (ADR-007), populated by 'recordClassDeclVar'. The
+--     'add' / 'update' commands consult this set so the namespace
+--     can be marked with the class sentinel, which @view@ then
+--     reads when rendering the declaration.
+data ParserState v = ParserState
+  { givenBoundVars :: Set v,
+    classDeclVars :: Set v
+  }
+
+instance (Ord v) => Semigroup (ParserState v) where
+  ParserState g1 c1 <> ParserState g2 c2 = ParserState (g1 <> g2) (c1 <> c2)
+
+instance (Ord v) => Monoid (ParserState v) where
+  mempty = ParserState Set.empty Set.empty
+
+-- | The parser monad. The inner 'StateT' carries a 'ParserState v'
+-- of names accumulated during the parse — see the docs on
+-- 'ParserState' for the individual fields. The 'StateT' is /below/
+-- 'ParsecT' so that registrations do not get rolled back on parser
+-- backtracking; this is safe because each registration site is
+-- committed (no @try@) once the relevant keyword has been consumed.
+type P v m = P.ParsecT (Error v) Input (StateT (ParserState v) (ReaderT (ParsingEnv m) m))
 
 type Err v = P.ParseError Input (Error v)
 
@@ -302,28 +325,28 @@ run' :: (Monad m, Ord v) => P v m a -> String -> String -> ParsingEnv m -> m (Ei
 run' p s name env =
   let lex = bool id (traceWith L.debugPreParse) debug . L.preParse $ L.lexer name s
       pTraced = traceRemainingTokens "parser receives" *> p
-   in runReaderT (evalStateT (runParserT pTraced name . Input $ toList lex) Set.empty) env <&> \case
+   in runReaderT (evalStateT (runParserT pTraced name . Input $ toList lex) mempty) env <&> \case
         Left err -> Left (Nel.head (P.bundleErrors err))
         Right x -> Right x
 
 run :: (Monad m, Ord v) => P v m a -> String -> ParsingEnv m -> m (Either (Err v) a)
 run p s = run' p s ""
 
--- | Variant of 'run'' that also returns the 'Set v' of @given@-bound
--- variable names accumulated by 'recordGivenVar' during parsing.
--- Callers that need this side channel (e.g.
--- 'Unison.Syntax.FileParser.file') use this instead of plain 'run''
--- so the typechecker can identify @given@-keyword origins per
--- ADR-010 / chunk L2 fixup.
-runFile' :: (Monad m, Ord v) => P v m a -> String -> String -> ParsingEnv m -> m (Either (Err v) (a, Set v))
+-- | Variant of 'run'' that also returns the 'ParserState' of names
+-- accumulated by registrations during parsing. Callers that need
+-- these side channels (e.g. 'Unison.Syntax.FileParser.file') use this
+-- instead of plain 'run'' so the typechecker can identify @given@-keyword
+-- origins (ADR-010 / chunk L2 fixup) and the @add@ command can mark
+-- @class@-declared types (ADR-007) in namespace metadata.
+runFile' :: (Monad m, Ord v) => P v m a -> String -> String -> ParsingEnv m -> m (Either (Err v) (a, ParserState v))
 runFile' p s name env =
   let lex = bool id (traceWith L.debugPreParse) debug . L.preParse $ L.lexer name s
       pTraced = traceRemainingTokens "parser receives" *> p
-   in runReaderT (runStateT (runParserT pTraced name . Input $ toList lex) Set.empty) env <&> \case
+   in runReaderT (runStateT (runParserT pTraced name . Input $ toList lex) mempty) env <&> \case
         (Left err, _) -> Left (Nel.head (P.bundleErrors err))
         (Right x, gs) -> Right (x, gs)
 
-runFile :: (Monad m, Ord v) => P v m a -> String -> ParsingEnv m -> m (Either (Err v) (a, Set v))
+runFile :: (Monad m, Ord v) => P v m a -> String -> ParsingEnv m -> m (Either (Err v) (a, ParserState v))
 runFile p s = runFile' p s ""
 
 -- | Record that a variable was bound via the @given@ keyword. Called
@@ -331,13 +354,28 @@ runFile p s = runFile' p s ""
 -- @given@ decl path) so the typechecker can recognise @given@ origins
 -- without inspecting the binding's type shape.
 recordGivenVar :: (Ord v, Monad m) => v -> P v m ()
-recordGivenVar v = lift (modify (Set.insert v))
+recordGivenVar v = lift (modify (\s -> s {givenBoundVars = Set.insert v (givenBoundVars s)}))
 
 -- | Fetch the current accumulated set of @given@-bound variable names.
 -- Mostly useful for tests; production callers use 'runFile' / 'runFile''
--- to capture the set at the end of a parse.
+-- to capture the full 'ParserState' at the end of a parse.
 getGivenVars :: (Monad m) => P v m (Set v)
-getGivenVars = lift get
+getGivenVars = lift (gets givenBoundVars)
+
+-- | Record that a type variable was declared with the @class@
+-- keyword. Called from 'Unison.Syntax.DeclParser' when the @class@
+-- alternative of the type-or-class header fires (ADR-007). The
+-- 'add' / 'update' commands consult this set via 'classDeclVars' in
+-- 'ParserState' to mark the type in namespace metadata (via
+-- 'Unison.Codebase.Classes.markClassAt') so @view@ can later
+-- recover the @class@ keyword on the round-trip.
+recordClassDeclVar :: (Ord v, Monad m) => v -> P v m ()
+recordClassDeclVar v = lift (modify (\s -> s {classDeclVars = Set.insert v (classDeclVars s)}))
+
+-- | Fetch the current accumulated set of @class@-declared type
+-- variable names.
+getClassDeclVars :: (Monad m) => P v m (Set v)
+getClassDeclVars = lift (gets classDeclVars)
 
 -- | Virtual pattern match on a lexeme.
 queryToken :: (Ord v) => (L.Lexeme -> Maybe a) -> P v m (L.Token a)

--- a/unison-syntax/src/Unison/Syntax/ReservedWords.hs
+++ b/unison-syntax/src/Unison/Syntax/ReservedWords.hs
@@ -35,14 +35,21 @@ keywords =
       "∀",
       -- Implicit-parameter feature (chunk A2; ADRs 006, 010, 022).
       -- `given` is a top-level declaration prefix and a let-block
-      -- statement opener; `summon` is an expression-position keyword
-      -- that takes a parenthesized type. Per ADR-022 the eventual
-      -- production rollout uses a one-release deprecation cycle;
-      -- for the prototype we hard-break, so user code that names a
-      -- definition or local `given` / `summon` must rename or use
-      -- backtick escaping (`` `given` ``).
+      -- statement opener. Per ADR-022 the production rollout uses
+      -- a one-release deprecation cycle; for the prototype we
+      -- hard-break, so user code that names a definition or local
+      -- `given` must rename or use backtick escaping (`` `given` ``).
+      -- ('summon' was previously reserved too; ADR-006 now treats it
+      -- as a regular builtin term reference, since its type
+      -- @forall a. a => a@ already gets the right behaviour through
+      -- the normal implicit-resolution machinery.)
       "given",
-      "summon"
+      -- ADR-007: `give f` is a prefix syntactic transformation that
+      -- demotes f's leading `=>` arrows to `->`. Has to be a keyword
+      -- (not a builtin) because the type transformation cannot be
+      -- expressed as a regular polymorphic signature without the
+      -- typechecker's implicit-resolution rule firing first.
+      "give"
     ]
     <> typeModifiers
     <> typeOrAbility

--- a/unison-syntax/src/Unison/Syntax/ReservedWords.hs
+++ b/unison-syntax/src/Unison/Syntax/ReservedWords.hs
@@ -53,7 +53,7 @@ typeModifiers =
 
 typeOrAbility :: Set Text
 typeOrAbility =
-  Set.fromList ["type", "ability"]
+  Set.fromList ["type", "ability", "class"]
 
 reservedOperators :: Set Text
 reservedOperators =

--- a/unison-syntax/src/Unison/Syntax/ReservedWords.hs
+++ b/unison-syntax/src/Unison/Syntax/ReservedWords.hs
@@ -32,7 +32,17 @@ keywords =
       "use",
       "where",
       "with",
-      "∀"
+      "∀",
+      -- Implicit-parameter feature (chunk A2; ADRs 006, 010, 022).
+      -- `given` is a top-level declaration prefix and a let-block
+      -- statement opener; `summon` is an expression-position keyword
+      -- that takes a parenthesized type. Per ADR-022 the eventual
+      -- production rollout uses a one-release deprecation cycle;
+      -- for the prototype we hard-break, so user code that names a
+      -- definition or local `given` / `summon` must rename or use
+      -- backtick escaping (`` `given` ``).
+      "given",
+      "summon"
     ]
     <> typeModifiers
     <> typeOrAbility
@@ -56,7 +66,11 @@ reservedOperators =
       "|",
       "!",
       "'",
-      "==>"
+      "==>",
+      -- Implicit-parameter constraint arrow (per ADR-001).
+      -- Listed after "==>" so the longer match wins via the lexer's
+      -- alternation order (see 'symbolyKw' in Lexer/Unison.hs).
+      "=>"
     ]
 
 delimiters :: Set Char

--- a/unison-syntax/test/Unison/Test/Unison.hs
+++ b/unison-syntax/test/Unison/Test/Unison.hs
@@ -71,6 +71,44 @@ test =
       t "\"woot\" -- a comment 1.0" [Textual "woot"],
       t "0:Int" [Numeric "0", Reserved ":", simpleWordyId "Int"],
       t "0 : Int" [Numeric "0", Reserved ":", simpleWordyId "Int"],
+      -- Constraint arrow "=>" introduced by ADR-001 (chunk A1).
+      -- Distinct from "==>" (rewrite arrow), "->" (function arrow),
+      -- and "=" (definition arrow / layout-opener).
+      t "Show a => a" [simpleWordyId "Show", simpleWordyId "a", Reserved "=>", simpleWordyId "a"],
+      t "a=>b" [simpleWordyId "a", Reserved "=>", simpleWordyId "b"],
+      -- A2 carry-over: pin that `given` and `summon` lex as Reserved
+      -- (chunk A2, ADR-006/010/022). They are wordy keywords, so
+      -- they are emitted as `Reserved "given"` / `Reserved "summon"`,
+      -- not as `WordyId "given"` / `WordyId "summon"`. Without this,
+      -- a future identifier-leniency change to the lexer could
+      -- silently downgrade them to identifiers.
+      t "given" [Reserved "given"],
+      t "summon" [Reserved "summon"],
+      -- The keywords still lex as keywords when adjacent to other
+      -- content; `given x` is `Reserved "given"` followed by an
+      -- identifier, not `WordyId "givenx"`.
+      t "given x" [Reserved "given", simpleWordyId "x"],
+      t "summon Nat" [Reserved "summon", simpleWordyId "Nat"],
+      -- `given` and `summon` only lex as keywords as standalone
+      -- words; suffixed forms (e.g., `givens`, `summons`) remain
+      -- ordinary wordy identifiers. This protects user identifiers
+      -- whose prefix happens to be one of the new keywords.
+      t "givens" [simpleWordyId "givens"],
+      t "summons" [simpleWordyId "summons"],
+      -- "@"-positional explicit override (chunk A3, ADR-007). The
+      -- lexer just emits a single Reserved "@" token; the parser
+      -- decides between as-pattern, doc-prefix, and override based
+      -- on context. Confirms the token shape `f @ d x` relies on.
+      t
+        "f @ d x"
+        [ simpleWordyId "f",
+          Reserved "@",
+          simpleWordyId "d",
+          simpleWordyId "x"
+        ],
+      -- Tight spacing: "f@d" still tokenizes the "@" separately,
+      -- because '@' is not a wordy-id char.
+      t "f@d" [simpleWordyId "f", Reserved "@", simpleWordyId "d"],
       t
         ".Foo Foo `.` .foo.bar.baz"
         [ simpleWordyId ".Foo",


### PR DESCRIPTION
# RFC + working prototype

This PR proposes adding Scala-3-style **implicit parameters (`given` / `=>`)** to Unison and includes a working prototype. It exists to anchor RFC discussion: read the design, run the examples below, push back on anything that surprises you.

The end-to-end example from the design discussion typechecks, elaborates, runs, and round-trips through `view`:

```unison
class Monoid m = { op : m -> m -> m, zero : m }

given Monoid.nat : Monoid Nat = Monoid (Nat.+) 0

foldLeft : (b -> a -> b) -> b -> [a] -> b
foldLeft f z xs =
  match xs with
    [] -> z
    h +: t -> foldLeft f (f z h) t

foldMap : (Monoid m) => (a -> m) -> [a] -> m
foldMap f = foldLeft (acc a -> Monoid.op acc (f a)) Monoid.zero

foo : Nat
foo = foldMap Text.size ["one", "two", "three"]

> foo
```

UCM after `add`:

```
+ type Monoid m
+ foldLeft    : (b ->{g1} a ->{g} b) -> b -> [a] ->{g, g1} b
+ foldMap     : Monoid m => (a ->{g} m) -> [a] ->{g} m
+ foo         : Nat
+ Monoid.nat  : Monoid Nat
+ Monoid.op   : Monoid m => m -> m -> m
+ Monoid.zero : Monoid m => m

> foo
    ⧩
    11
```

A polymorphic-with-premise given also works end-to-end:

```unison
class Show s = { show : s -> Text }

given Show.nat : Show Nat = Show Nat.toText

given Show.list : forall a. Show a => Show [a] =
  Show (xs -> "[" ++ textJoin ", " (List.map Show.show xs) ++ "]")

foo : Text
foo = Show.show [1, 2, 3]

> foo
    ⧩
    "[1, 2, 3]"
```

`Show.list`'s premise `Show a` is discharged against the function's own lexical `=>` parameter while its body is checked, and at `foo`'s call site the resolver chains `Show.list` (premise `Show a`) → `Show.nat` to build `Show [Nat]`. The chosen dictionaries are wired into `foo`'s hash, and `view foo` round-trips to exactly what the user wrote.

`dependencies foo` lists `Show.nat` and `Show.list` — the resolved givens are permanently wired into `foo`'s hash. The same scratch works split across files: drop `class Show` / `given Show.nat` into one file, `add`, then write the rest in a new scratch and resolution finds the givens from the namespace automatically.

---

## How implicits/givens fit into Unison

Five principles are load-bearing:

1. **Givens are sugar for ordinary parameters.** After elaboration, a constraint is
   an ordinary positional argument. Runtime, codegen, ABT, and term hashing learn
   nothing new — the entire feature lives in the elaborator.

2. **Resolution is baked into the term hash.** A term that referenced `Show Nat`
   freezes the chosen dictionary's hash at typecheck time. Old terms never change
   instance. Unison gets something Scala and Haskell can't: implicits that are
   immune to "did adding this instance silently change my program?" — already-elaborated
   terms are pinned by content addressing.

3. **Namespace = instance set.** No orphan rules, no global registry. Two libraries
   that both define `given Show.nat` produce ambiguity at any call site that sees
   both, surfaced through the same machinery TDNR uses today.

4. **Givenness is namespace metadata, not a term-level concept.** Marking a
   definition `given` updates the namespace; term hashes are unchanged. The branch
   (causal) hash reflects the change. Aliasing, importing, forking work without
   rehashing terms.

5. **Givens extend TDNR rather than replace it.** TDNR resolves "which named
   definition fits this type"; given resolution adds "which value of this type
   exists, with chaining." Same elaborator pass, same ambiguity reporting.

## Surface syntax

A class declaration generates getter accessors whose dictionary parameter is an `=>` arrow (no setters, no modifiers):

```unison
class Show a = { show : a -> Text }
class Functor f = { fmap : forall a b. (a -> b) -> f a -> f b }
```

Plain records are still available with `type Show a = Show (a -> Text)`; the difference is that `class` accessors carry the constraint implicitly, so callers write `show x` instead of `Show.show dict x`.

Declaring givens:

```unison
given Show.nat : Show Nat = Show Nat.toText

given Show.list : Show a => Show (List a) =
  Show (xs -> "[" ++ Text.join ", " (List.map Show.show xs) ++ "]")

given Functor.optional : Functor Optional = Functor Optional.map
```

The `given` keyword tags the binding so that, on `add`/`update`, namespace metadata is automatically updated — no follow-up `mark.given` needed (but the explicit command is still there if you want to flip an existing definition).

Consuming givens:

```unison
print : Show a => a ->{IO} ()
print x = printLine (Show.show x)

mapM : (Monad m, Traversable t) => (a ->{e} m b) -> t a ->{e} m (t b)
```

The `summon` builtin retrieves the unique resolvable dictionary at the surrounding context's expected type. Its declared type is `forall a. a => a` — the leading `=>` makes the typechecker emit a constraint goal at every reference, which the resolver fills from lexical / ambient givens. At runtime `summon` is the identity function. Use it when you want to bind a dictionary explicitly:

```unison
sortReversed : Ord a => [a] -> [a]
sortReversed xs =
  given local : Ord a = Ord.flip (summon : Ord a)
  sort xs
```

`summon` is an ordinary term reference, so user code may shadow it.

The `give` keyword is the dual: `give f` demotes every leading `=>` in `f`'s declared type to `->`, so the dictionaries become ordinary positional arguments at the call site. Use it for testing, mocking, or any time you want to bypass the resolver entirely:

```unison
combined : Show Nat => Monoid Nat => Nat -> Nat -> Text
combined a b = …

combined 3 4                        -- resolver picks Show.nat + Monoid.nat
give combined mockShow mulMonoid 3 4 -- both dicts supplied positionally
```

`give` has to be a keyword (not a builtin) because the type transformation can't be expressed as a regular polymorphic signature — the existing implicit-resolution rule would fire first on a builtin reference and the dictionary would be auto-filled before `give` could see it. Partial overrides (override one dict, let the resolver pick the rest) use the existing `let given` shadowing.

## Resolution

For each constraint hole the elaborator searches visible givens whose conclusion
unifies with the goal type, recursively resolving each candidate's premises.
Ambiguity surfaces as the existing TDNR-style error. Cycles fail per-branch (the
candidate, not the whole search); a global depth limit (default 50) catches
runaway chains. Resolutions are memoized per top-level invocation, caching
successes and failures.

Specificity: A is strictly more specific than B iff some σ satisfies
`σ(B's declared conclusion) = A's declared conclusion`, with σ binding only B's
quantified variables. Local `given` beats outer `given`. Otherwise → ambiguity.

## Coherence by content-addressing

The interplay between resolution and Unison's hashes is what makes this design
distinctive. A term containing a constraint hole elaborates to one containing
the chosen dictionary's hash. If the namespace later gains a second matching
given, **the elaborated term is unchanged** — its hash already commits to the
original. Only *new* terms see ambiguity.

This is stronger than Haskell's coherence (depends on global instance discovery
and orphan rules) and stronger than Scala's (can silently change on recompile).
Unison's content addressing makes coherence a non-issue for already-elaborated
code, by construction.

## What's *not* in v1

- Functional dependencies / associated types
- Implicit conversions
- Default parameters
- `deriving` / macro derivation
- First-class implicit-function types
- Kind-polymorphic givens (Unison's kind system has only `Type`, `Ability`, and
  arrow kinds)

## What's in this PR

- **Parser** — `=>` constraints, `given` declarations, `let given`,
  `class` declarations, `@`-positional explicit overrides.
- **Namespace** — `##Builtin.Given` and `##Builtin.Class` sentinels +
  `MdValues` plumbing on the term and type Stars respectively
  (`Unison.Codebase.Givens` / `Unison.Codebase.Classes`); UCM commands
  `mark.given`, `unmark.given`, `givens`; sharing-API round-trip;
  `unison-merge` conflict resolution for given-set diffs.
  `given`-declared bindings and `class`-declared types are auto-marked
  on `add`/`update`, and the slurp summary surfaces the `class` /
  `given` keyword in place of `type` / the plain term signature.
- **Typechecker** — `Type.F` extended with `ImplicitArrow`; lexical given
  environment threaded through every binder; constraint goals emitted at apply
  sites *and* at any `Var`/`Ref` use of a function with leading `=>`; `=>I` rule
  recognises the parser-injected leading lambda for a binding's implicit
  parameters and registers it as a lexical given for the body, so a polymorphic
  function's own `=>`-param resolves constraints raised inside its own body
  (this is what makes `foldMap` and polymorphic `Show.list` above work).
- **Top-level givens promoted to the ambient pool** — file-local `given`-tagged
  bindings are exposed to every goal in the file via the resolver's ambient
  pool, sidestepping `minimize`'s reordering of independent SCCs (which could
  otherwise leave a sibling `given` invisible to an earlier user). Lexical
  registration is skipped for top-level givens so they don't tie with a
  function's own `=>`-parameter on the `Lexical 0` scope tag.
- **Speculative-pass info notes suppressed** — `annotateLetRecBindings`'s
  annotation-less redundancy pass and `noteTopLevelType`'s redundancy-check
  synthesis both used to leak `ConstraintGoal` notes with incomplete lexical
  scopes (because `=>I` never fires without the user's annotation). A
  `discardInfoNotes` combinator wraps both passes so only the
  official-typecheck constraint goals reach the resolver.
- **`summon` builtin** — `summon : forall a. a => a`, runtime identity. The
  `=>` on its declared type drives implicit resolution through the normal
  machinery; the user writes `(summon : T)` (or relies on context) and gets
  back the unique resolvable given of type `T`.
- **`give` keyword** — `give f` is a prefix syntactic transformation that
  demotes every leading `=>` in `f`'s declared type to `->`. Tagged with
  `Ann.Lowered` at parse time; the typechecker swaps `peelLeadingImplicits`
  for `lowerLeadingImplicit` at lowered references; `GivenApply.rewriteApply`
  pre-demotes the type — descending through any leading `forall` quantifiers
  first — before `interleave` sees it, so the decision queue stays aligned
  even for generalized signatures like `forall a. C a => a -> a`. (Without
  the forall-descent, the un-lowered `=>` would have caused `interleave` to
  pop a sibling binding's resolved dictionary off the FIFO queue and leak
  its locally-bound `_implicit_*` variable into the current scope.)
  `Type.existentializeArrows` no longer inserts an `Effect` row between
  adjacent `=>`s (ADR-019 says `=>` carries no abilities), which was
  previously breaking the `=>I` checkWanted pattern on chained constraints
  like `C1 => C2 => T`.
- **Resolver** — full algorithm above, integrated as a post-pass on the
  TDNR fixed point; resolved decisions applied in the term as ordinary `App`
  nodes against dictionary hashes. Decisions are looked up by source location
  to keep multi-binding files coherent. `decomposeGivenType` strips the empty
  effect wrapper that generalization leaves around a constraint's conclusion,
  so a generalized polymorphic given unifies with the plain-shape goal at the
  call site.
- **Errors** — categorised `NoGiven` / `Ambiguous` / `DepthExceeded` /
  `Cycle` rendering. Resolution failures now surface through the file
  loader (previously the file silently failed to add).
- **LSP** — hover and goto-definition on synthesized implicit args;
  diagnostics and code actions for resolution failures.
- **Pretty printer** — `=>` round-trips through `view` / `edit` /
  `update`. ADR-015 default elide-mode: dictionary arguments inserted by
  the elaborator are not shown in surface output (so `view foo` matches
  what the user wrote); the corresponding leading `\_implicit_*` lambdas
  on the binding are also elided. The hash dependency is preserved —
  `dependencies foo` still lists the chosen given, exactly as ADR-014
  prescribes. `view` for `class`-tagged types emits the `class` keyword
  and renders the constructor with `{ field : type, ... }` record syntax
  (driven by an `IsClassRef` predicate threaded through `DeclPrinter`,
  and `hashClassFieldAccessors` which reproduces the `=>`-bearing
  accessor hashes to recover field names from the namespace).
  `view` for `given`-tagged definitions emits the `given` keyword;
  `view` for terms that used `give` emits the `give` keyword with the
  user-supplied dictionary preserved (detected by walking each apply
  chain whose head has a `=>`-prefixed type and checking whether the
  dictionary argument is a namespace-tagged given or a local lexical
  given — anything else is treated as user-supplied via `give` and gets
  a sentinel `Type.giveMarkerRef` ascription that the surface printer
  recognises). The dependents-update path (`prettyUnisonFile`) consumes
  the file's `classBindings` so a `class` re-printed for re-typechecking
  keeps the `class` keyword and re-parses to the same hash.
- **Tests** — parser snapshot suite (60+ tests across `=>` / `given` /
  `summon` / `@`); printer round-trip property tests; typechecker
  integration; full resolver test matrix including diamond dependencies
  and HKT; source-level end-to-end test pinning the parser → resolver
  wiring; UCM transcripts for ADR-016 update-semantics scenarios.

`stack build --fast` clean. `stack test --fast unison-parser-typechecker` passes
(452/452).

## Not ready yet

- **`given` keyword migration** — the prototype hard-breaks identifiers using
  the `given` name. ADR-022's deprecation cycle is a release-engineering concern.
- **`unison-merge` pipeline integration** — the given-set conflict module
  is sidecar; wiring it into the merge engine is a follow-on.
- **Resolver polish** — cycle/metavar semantics, NearMiss substitution rendering,
  override-leaf parens diagnostic, partial-application handling, and more.



